### PR TITLE
fix: add validation for maximum length of numeric type agent parameters

### DIFF
--- a/apps/cloud/src/app/@shared/xpert/parameter-edit-form/form.component.html
+++ b/apps/cloud/src/app/@shared/xpert/parameter-edit-form/form.component.html
@@ -207,6 +207,7 @@
               [ngModel]="maximum()"
               [ngModelOptions]="{standalone: true}"
               (ngModelChange)="updateParameter('maximum', $event)"
+              (input)="onMaximumInput($event)"
             >
           </div>
         </div>

--- a/apps/cloud/src/app/@shared/xpert/parameter-edit-form/form.component.ts
+++ b/apps/cloud/src/app/@shared/xpert/parameter-edit-form/form.component.ts
@@ -59,6 +59,19 @@ export class XpertParameterFormComponent {
     this.cva.value$.update((state) => ({ ...(state ?? {}), [name]: value }) as TXpertParameter)
   }
 
+  /**
+   * Validates and limits the maximum length input to 256.
+   * Fixes #328: No validation for the maximum length of numeric type agent parameters.
+   */
+  onMaximumInput(event: Event) {
+    const input = event.target as HTMLInputElement
+    const numValue = Number(input.value)
+    if (!isNaN(numValue) && numValue > 256) {
+      input.value = '256'
+      this.updateParameter('maximum', 256)
+    }
+  }
+
   drop(event: CdkDragDrop<string, string>) {
     const options = Array.from(this.options() ?? [])
     moveItemInArray(options, event.previousIndex, event.currentIndex)

--- a/apps/cloud/src/app/@shared/xpert/parameters-edit/parameters.component.html
+++ b/apps/cloud/src/app/@shared/xpert/parameters-edit/parameters.component.html
@@ -330,6 +330,7 @@
               <div>
                 <input matInput max="256" min="1" class="w-full px-3 text-sm leading-9 text-gray-900 border-0 rounded-lg grow h-9 bg-gray-100 focus:outline-none focus:ring-1 focus:ring-inset focus:ring-gray-200" type="number"
                   formControlName="maximum"
+                  (input)="onMaximumInput(index, $event)"
                 >
               </div>
             </div>

--- a/apps/cloud/src/app/@shared/xpert/parameters-edit/parameters.component.ts
+++ b/apps/cloud/src/app/@shared/xpert/parameters-edit/parameters.component.ts
@@ -102,6 +102,21 @@ export class XpertParametersEditComponent {
     this.onChange()
   }
 
+  /**
+   * Validates and limits the maximum length input to 256.
+   * Fixes #328: No validation for the maximum length of numeric type agent parameters.
+   */
+  onMaximumInput(index: number, event: Event) {
+    const input = event.target as HTMLInputElement
+    const numValue = Number(input.value)
+    if (!isNaN(numValue) && numValue > 256) {
+      input.value = '256'
+      this.parameters.at(index).get('maximum').setValue(256, { emitEvent: true })
+      this.form.markAsDirty()
+      this.onChange()
+    }
+  }
+
   deleteParameter(i: number) {
     this.parameters.removeAt(i)
     this.onChange()


### PR DESCRIPTION
Limit the maximum length input to 256 for agent parameters. When user inputs a value greater than 256, it will be automatically corrected to 256.

Fixes #328

# PR

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Checklist

- [ ] Have you followed the [contributing guidelines](https://github.com/xpert-ai/xpert/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: ✅ we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
