### PR TITLE
fix: handle null/undefined options for SELECT parameter type

### DIFF
--- a/apps/cloud/src/app/@shared/xpert/parameters-form/parameters.component.ts
+++ b/apps/cloud/src/app/@shared/xpert/parameters-form/parameters.component.ts
@@ -46,7 +46,9 @@ export class XpertParametersFormComponent {
       if (parameter.type === XpertParameterTypeEnum.SELECT) {
         return {
           ...parameter,
-          selectOptions: parameter.options.map((key) => ({
+          // Handle null/undefined options to prevent "Cannot read properties of null (reading 'map')" error
+          // when user creates SELECT parameter with only name but no options
+          selectOptions: (parameter.options ?? []).map((key) => ({
             value: key,
             label: key
           }))

--- a/packages/server-ai/src/shared/agent/parameter.ts
+++ b/packages/server-ai/src/shared/agent/parameter.ts
@@ -27,7 +27,13 @@ export function createParameters(parameters: TXpertParameter[]): Record<string, 
 				break
 			}
 			case XpertParameterTypeEnum.SELECT: {
-				value = z.enum(parameter.options as any)
+				// If options are provided and not empty, use enum validation
+				// Otherwise, fall back to string type to avoid runtime errors
+				if (parameter.options && parameter.options.length > 0) {
+					value = z.enum(parameter.options as any)
+				} else {
+					value = z.string()
+				}
 				break
 			}
 			case XpertParameterTypeEnum.ARRAY_STRING: {
@@ -60,9 +66,9 @@ export function createParameters(parameters: TXpertParameter[]): Record<string, 
 
 /**
  * Complete parameter definitions, such as adding a list of file fields to file array.
- * 
- * @param parameters 
- * @returns 
+ *
+ * @param parameters
+ * @returns
  */
 export function completeParametersDef(parameters: TXpertParameter[]): TXpertParameter[] {
 	return parameters.map((parameter) => {


### PR DESCRIPTION
- Fix TypeError when SELECT parameter has no options in preview
- Add null check in frontend parameter form component
- Add fallback validation in server-side parameter schema creation
- Prevents 'Cannot read properties of null (reading map)' error

Fixes #305

# PR

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This PR fixes the error that occurs when a user selects the dropdown (SELECT) parameter type in the parameter column but only enters a name without adding any options. The preview panel would throw a `TypeError: Cannot read properties of null (reading 'map')` error.

## Changes

### Frontend Fix
- **File**: `apps/cloud/src/app/@shared/xpert/parameters-form/parameters.component.ts`
- **Change**: Added null coalescing operator (`??`) to handle null/undefined `options` when mapping to `selectOptions`
- **Impact**: Prevents runtime error when SELECT parameter has no options defined

### Backend Fix  
- **File**: `packages/server-ai/src/shared/agent/parameter.ts`
- **Change**: Added validation check for SELECT parameter options before creating zod enum schema
- **Impact**: Falls back to string validation when options are empty/undefined, preventing runtime errors during parameter schema creation

## Testing

1. Create a new parameter with SELECT type
2. Enter only the parameter name without adding any options
3. Open the preview panel
4. Verify that no error occurs and the dropdown displays empty (as expected)

## Related Issue

Fixes #305

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---
