### PR TITLE
fix: enable save button immediately when editing data source fields

### DIFF
--- a/apps/cloud/src/app/features/setting/data-sources/edit/edit.component.html
+++ b/apps/cloud/src/app/features/setting/data-sources/edit/edit.component.html
@@ -54,6 +54,7 @@
     <formly-form [form]="optionsFormGroup"
       [fields]="schema$()"
       [model]="model"
+      (modelChange)="onModelChange($event)"
     />
   } @else {
     <list-content-loader />

--- a/libs/formly/input/input.type.html
+++ b/libs/formly/input/input.type.html
@@ -6,7 +6,7 @@
   [type]="props?.type"
   [options]="selectOptions()"
   [ngModel]="newValue"
-  (ngModelChange)="newValue = $event"
+  (ngModelChange)="onModelChange($event)"
   (blur)="onBlur()"
   (focus)="onFocus()"
   >

--- a/libs/formly/input/input.type.ts
+++ b/libs/formly/input/input.type.ts
@@ -59,6 +59,18 @@ export class PACFormlyInputComponent extends FieldType implements OnInit {
     this.formControl.markAsTouched()
   }
 
+  onModelChange(value: any) {
+    this.newValue = value
+    // Immediately update formControl instead of waiting for blur
+    // This ensures formControl.valueChanges triggers on every input
+    if (this.oldValue !== value) {
+      this.formControl.setValue(value, { emitEvent: true })
+      this.formControl.markAsDirty()
+      // Keep oldValue in sync to avoid duplicate updates on blur
+      this.oldValue = value
+    }
+  }
+
   onBlur() {
     if (this.oldValue !== this.newValue) {
       this.formControl.setValue(this.newValue)


### PR DESCRIPTION
- Add modelSignal and formGroupValueSignal to track form changes
- Update dirty() computation to check both formGroup and options changes
- Listen to formGroup.valueChanges and optionsFormGroup.valueChanges
- Fix pac-formly-input to update formControl immediately on input change
- Ensure save button enables immediately when editing any field

Fixes #347

# PR

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Checklist

- [x] Have you followed the [contributing guidelines](https://github.com/xpert-ai/xpert/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: ✅ we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
