### PR TITLE
feat(studio): implement keyboard shortcuts and connection interaction optimizations

### DIFF
--- a/apps/cloud/src/app/@theme/flow-common.scss
+++ b/apps/cloud/src/app/@theme/flow-common.scss
@@ -47,6 +47,9 @@
     }
     .f-connection-selection {
       fill: none;
+      stroke: transparent;
+      stroke-width: 12;
+      pointer-events: stroke;
     }
     .f-connection-path {
       fill: none;

--- a/apps/cloud/src/app/features/xpert/studio/studio.component.html
+++ b/apps/cloud/src/app/features/xpert/studio/studio.component.html
@@ -20,6 +20,7 @@
     <f-snap-connection fType="bezier" [fSnapThreshold]="100"></f-snap-connection>
     @for (connection of connections(); track connection.key) {
       <f-connection #connComp [fType]="EFConnectionType.BEZIER" [fOffset]="6" [fRadius]="6"
+        [fConnectionId]="connection.key"
         [fReassignDisabled]="false"
         [fOutputId]="connection.from + '/' + connection.type"
         [fInputId]="connection.to + (connection.type === 'edge' ? '/edge' : '')"

--- a/apps/cloud/src/app/features/xpert/studio/studio.component.scss
+++ b/apps/cloud/src/app/features/xpert/studio/studio.component.scss
@@ -19,10 +19,28 @@
         fill: var(--connection-color);
       }
     }
+    // Hover effect for connection line
+    &:hover:not(.f-selected) {
+      z-index: 1;
+      .f-connection-path {
+        stroke: var(--f-component-hover-border);
+        stroke-width: 3;
+        filter: drop-shadow(0 0 4px var(--f-component-hover-border));
+        transition: stroke-width 0.15s ease, filter 0.15s ease;
+      }
+      .connection-marker {
+        circle, rect, path {
+          fill: var(--f-component-hover-border);
+        }
+      }
+    }
+    .f-connection-path {
+      transition: stroke-width 0.15s ease, filter 0.15s ease;
+    }
     &.connecting {
       stroke-dasharray: 4, 2;
       animation: dash-flow 2s linear infinite;
-    
+
       .f-connection-path {
         stroke: var(--f-component-hover-border);
       }


### PR DESCRIPTION
## Summary

Implements comprehensive keyboard shortcuts and interaction optimizations for the canvas editor to improve user experience and efficiency.

### Features Added

**Priority 1: Deletion & Selection Optimization**
- Support `Delete` / `Backspace` keys to remove selected nodes and connections
- Optimize connection line selection with wider hit area (12px transparent stroke)
- Add hover effect for connections: thicker stroke, highlight color, and glow effect

**Priority 2: Clipboard Operations**
- `Ctrl+C` / `Cmd+C` - Copy selected node
- `Ctrl+V` / `Cmd+V` - Paste node with position offset
- `Ctrl+D` / `Cmd+D` - Duplicate selected node

**Priority 3: History Management**
- `Ctrl+Z` / `Cmd+Z` - Undo canvas actions
- `Ctrl+Y` / `Cmd+Y` or `Ctrl+Shift+Z` / `Cmd+Shift+Z` - Redo canvas actions

### Files Changed
- `apps/cloud/src/app/@theme/flow-common.scss` - Connection selection hit area
- `apps/cloud/src/app/features/xpert/studio/studio.component.scss` - Connection hover effects
- `apps/cloud/src/app/features/xpert/studio/studio.component.html` - Set fConnectionId
- `apps/cloud/src/app/features/xpert/studio/studio.component.ts` - Keyboard event handlers

## Test Plan

- [ ] Test Delete/Backspace to remove nodes and connections
- [ ] Test connection line hover effect (thicker, highlight, glow)
- [ ] Test connection line is easier to select
- [ ] Test Ctrl+C/V/D for copy/paste/duplicate
- [ ] Test Ctrl+Z/Y for undo/redo
- [ ] Test shortcuts work on both Windows and Mac

Closes #351