### PR TITLE
fix: ECharts display width issue when only charts without text

### DIFF
--- a/apps/cloud/src/app/@shared/chat/echarts-wrapper/echarts-wrapper.component.ts
+++ b/apps/cloud/src/app/@shared/chat/echarts-wrapper/echarts-wrapper.component.ts
@@ -4,7 +4,8 @@ import { EchartsViewerComponent } from './echarts-viewer.component'
 @Component({
   selector: 'chat-echarts-wrapper',
   standalone: true,
-  template: ''
+  template: '',
+  styles: [`:host { display: block; min-width: 400px; width: 100%; }`]
 })
 export class EchartsWrapperComponent implements AfterViewInit {
   @Input() code = ''


### PR DESCRIPTION
## Summary
- Fixed ECharts chart container width issue when AI response contains only charts without text content
- Added `display: block`, `min-width: 400px`, and `width: 100%` styles to `echarts-wrapper` component to ensure proper rendering

Fixes #354

## Test plan
- [ ] Test AI response with only ECharts chart (no text) - should display correctly with proper width
- [ ] Test AI response with text + ECharts chart - should display correctly as before
- [ ] Test multiple consecutive ECharts charts - all should render properly