### PR TITLE
enable iterator inputs and vision file handling

### DIFF
--- a/apps/cloud/src/app/features/xpert/studio/panel/xpert-agent/agent.component.ts
+++ b/apps/cloud/src/app/features/xpert/studio/panel/xpert-agent/agent.component.ts
@@ -197,7 +197,7 @@ export class XpertStudioPanelAgentComponent {
     update: (options) => {
       this.apiService.updateXpertAgent(this.key(), {options})
     }
-  })  })
+  })
   readonly enableMessageHistory = computed(() => !this.agentOptions()?.disableMessageHistory)
   readonly historyVariable = attrModel(this.agentOptions, 'historyVariable')
   readonly promptTemplates = computed(() => this.xpertAgent()?.promptTemplates)
@@ -233,7 +233,7 @@ export class XpertStudioPanelAgentComponent {
       .map((conn) => draft.nodes.find((n) => n.type === 'toolset' && n.key === conn.to) as TXpertTeamNode & {type: 'toolset'})
       .filter(nonNullable)
   })
-
+  
   // Error handling
   readonly retry = computed(() => this.xpertAgent()?.options?.retry)
   readonly retryEnabled = computed(() => this.retry()?.enabled)


### PR DESCRIPTION
- Expose iterator `$item/$index` to agents inside iterator subgraphs
- Preserve iterator channel in subgraph state
- Allow vision input to accept single file objects (wrap to array)
 Changes
- apps/cloud/src/app/features/xpert/studio/panel/xpert-agent/agent.component.ts
  - add iteratorInputs and pass `inputs` to variable queries
  - disable vision when model lacks vision feature
- packages/server-ai/src/xpert-agent/plugins/iterator/strategy.ts
  - register iterator channel in subgraph variables
- packages/server-ai/src/shared/agent/message.ts
  - support single file object for vision input
 Validation
- Manual: iterator agent can select `$item/$index`
- Manual: vision model receives files inside iterator