### PR TITLE
fix: port shared infrastructure changes from xpert-pro

### DIFF
--- a/packages/plugin-sdk/src/lib/sandbox/protocol.ts
+++ b/packages/plugin-sdk/src/lib/sandbox/protocol.ts
@@ -381,6 +381,26 @@ export interface SandboxBackendProtocol extends BackendProtocol {
    */
   execute(command: string): MaybePromise<ExecuteResponse>;
 
+  /**
+   * Execute a command with line-by-line streaming output.
+   *
+   * When implemented, the middleware layer can push incremental output
+   * to the frontend as each line arrives, rather than waiting for the
+   * command to finish.  Implementations MUST buffer partial lines and
+   * only invoke `onLine` with complete lines (LF-terminated).
+   *
+   * The returned `ExecuteResponse.output` contains the full collected
+   * output, identical to what `execute()` would return.
+   *
+   * Falls back to `execute()` + single `onLine` call in `BaseSandbox`
+   * when a concrete backend does not override this method.
+   *
+   * @param command - Full shell command string to execute
+   * @param onLine  - Callback invoked once per complete output line
+   * @returns ExecuteResponse with combined output, exit code, and truncation flag
+   */
+  streamExecute?(command: string, onLine: (line: string) => void): MaybePromise<ExecuteResponse>;
+
   /** Unique identifier for the sandbox backend instance */
   readonly id: string;
 }

--- a/packages/plugin-sdk/src/lib/sandbox/sandbox.ts
+++ b/packages/plugin-sdk/src/lib/sandbox/sandbox.ts
@@ -719,6 +719,14 @@ export abstract class BaseSandbox implements SandboxBackendProtocol {
    */
   abstract execute(command: string): MaybePromise<ExecuteResponse>;
 
+  async streamExecute(command: string, onLine: (line: string) => void): Promise<ExecuteResponse> {
+    const result = await this.execute(command);
+    if (result.output) {
+      onLine(result.output);
+    }
+    return result;
+  }
+
   /**
    * Upload multiple files to the sandbox.
    * Implementations must support partial success.

--- a/packages/plugins/agent-middlewares/src/lib/localShellSandbox.provider.ts
+++ b/packages/plugins/agent-middlewares/src/lib/localShellSandbox.provider.ts
@@ -135,11 +135,21 @@ export class LocalShellSandbox extends BaseSandbox {
    * Captures both stdout and stderr, respects timeout.
    */
   async execute(command: string): Promise<ExecuteResponse> {
+    return this.runCommand(command);
+  }
+
+  override async streamExecute(command: string, onLine: (line: string) => void): Promise<ExecuteResponse> {
+    return this.runCommand(command, onLine);
+  }
+
+  private runCommand(command: string, onChunk?: (line: string) => void): Promise<ExecuteResponse> {
     return new Promise((resolve) => {
       const chunks: string[] = [];
       let truncated = false;
       const maxOutputBytes = 1024 * 1024; // 1MB output limit
       let totalBytes = 0;
+      let lineBuffer = "";
+      let settled = false;
 
       const child = cp.spawn("/bin/bash", ["-c", command], {
         cwd: this.workingDirectory,
@@ -155,6 +165,28 @@ export class LocalShellSandbox extends BaseSandbox {
         } else {
           truncated = true;
         }
+
+        if (onChunk) {
+          lineBuffer += str.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+          const lines = lineBuffer.split("\n");
+          lineBuffer = lines.pop() ?? "";
+          for (const line of lines) {
+            onChunk(line);
+          }
+        }
+      };
+
+      const finalize = (response: ExecuteResponse) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        if (onChunk && lineBuffer) {
+          onChunk(lineBuffer);
+          lineBuffer = "";
+        }
+        resolve(response);
       };
 
       child.stdout.on("data", collectOutput);
@@ -163,7 +195,7 @@ export class LocalShellSandbox extends BaseSandbox {
       // Handle timeout
       const timer = setTimeout(() => {
         child.kill("SIGTERM");
-        resolve({
+        finalize({
           output: chunks.join("") + "\n[Command timed out]",
           exitCode: null,
           truncated,
@@ -171,8 +203,7 @@ export class LocalShellSandbox extends BaseSandbox {
       }, this.timeout);
 
       child.on("close", (exitCode) => {
-        clearTimeout(timer);
-        resolve({
+        finalize({
           output: chunks.join(""),
           exitCode,
           truncated,
@@ -180,8 +211,7 @@ export class LocalShellSandbox extends BaseSandbox {
       });
 
       child.on("error", (err) => {
-        clearTimeout(timer);
-        resolve({
+        finalize({
           output: `Error spawning process: ${err.message}`,
           exitCode: 1,
           truncated: false,

--- a/packages/plugins/agent-middlewares/src/lib/sandboxShell.ts
+++ b/packages/plugins/agent-middlewares/src/lib/sandboxShell.ts
@@ -1,5 +1,8 @@
 import { tool } from '@langchain/core/tools'
-import { TAgentMiddlewareMeta, TAgentRunnableConfigurable } from '@metad/contracts'
+import {
+  TAgentMiddlewareMeta,
+  TAgentRunnableConfigurable
+} from '@metad/contracts'
 import { Injectable } from '@nestjs/common'
 import {
   AgentMiddleware,
@@ -10,6 +13,7 @@ import {
   PromiseOrValue
 } from '@xpert-ai/plugin-sdk'
 import { z } from 'zod/v3'
+import { getToolCallId, withStreamingToolMessage } from './toolMessageUtils'
 
 const SANDBOX_SHELL_MIDDLEWARE_NAME = 'SandboxShell'
 const SANDBOX_SHELL_TOOL_NAME = 'sandbox_shell'
@@ -54,7 +58,17 @@ export class SandboxShellMiddleware implements IAgentMiddlewareStrategy {
           throw new Error('Sandbox backend is not available for SandboxShell.')
         }
 
-        return backend.execute(command)
+        const result = await withStreamingToolMessage(
+          getToolCallId(config),
+          SANDBOX_SHELL_TOOL_NAME,
+          command,
+          backend
+        )
+
+        if (result.exitCode !== 0) {
+          return `Exit code ${result.exitCode}\n${result.output}`
+        }
+        return result.output
       },
       {
         name: SANDBOX_SHELL_TOOL_NAME,

--- a/packages/plugins/agent-middlewares/src/lib/toolMessageUtils.ts
+++ b/packages/plugins/agent-middlewares/src/lib/toolMessageUtils.ts
@@ -1,0 +1,154 @@
+import { dispatchCustomEvent } from '@langchain/core/callbacks/dispatch'
+import {
+  ChatMessageEventTypeEnum,
+  ChatMessageStepCategory,
+  TChatMessageStep,
+  TProgramToolMessage
+} from '@metad/contracts'
+import { BaseSandbox, ExecuteResponse } from '@xpert-ai/plugin-sdk'
+import ShortUniqueId from 'short-unique-id'
+
+const uid = new ShortUniqueId({ length: 10 })
+
+export function shortuuid(): string {
+  return uid.randomUUID()
+}
+
+export function getToolCallId(config: any): string {
+  return (config?.metadata as Record<string, string>)?.['tool_call_id'] ?? shortuuid()
+}
+
+/**
+ * Wrap a simple (non-streaming) tool invocation with running / success / fail
+ * events dispatched to the frontend via LangChain custom events.
+ */
+export async function withToolMessage<T>(
+  toolCallId: string,
+  toolName: string,
+  title: string,
+  input: unknown,
+  fn: () => Promise<T>
+): Promise<T> {
+  await dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE, {
+    id: toolCallId,
+    category: 'Tool',
+    type: ChatMessageStepCategory.Program,
+    tool: toolName,
+    title: title || toolName,
+    status: 'running',
+    created_date: new Date(),
+    input
+  } as TChatMessageStep).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
+
+  try {
+    const result = await fn()
+    await dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE, {
+      id: toolCallId,
+      category: 'Tool',
+      type: ChatMessageStepCategory.Program,
+      tool: toolName,
+      title: title || toolName,
+      status: 'success',
+      end_date: new Date(),
+      output: typeof result === 'string' ? result : JSON.stringify(result)
+    } as TChatMessageStep).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
+    return result
+  } catch (err: any) {
+    await dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE, {
+      id: toolCallId,
+      category: 'Tool',
+      type: ChatMessageStepCategory.Program,
+      tool: toolName,
+      title: title || toolName,
+      status: 'fail',
+      end_date: new Date(),
+      error: err.message
+    } as TChatMessageStep).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
+    throw err
+  }
+}
+
+const STREAM_THROTTLE_MS = 100
+
+/**
+ * Execute a sandbox shell command with streaming line-by-line output.
+ *
+ * Dispatches three phases of events:
+ *  1. `running`  – immediately, before execution starts
+ *  2. `running`  – on each output line (throttled to avoid dispatch storms)
+ *  3. `success` / `fail` – when the command finishes
+ *
+ * The streaming updates are throttled so that at most one event is sent
+ * per `STREAM_THROTTLE_MS` milliseconds.  A final flush is guaranteed
+ * in the completion event which always carries `result.output`.
+ */
+export async function withStreamingToolMessage(
+  toolCallId: string,
+  toolName: string,
+  command: string,
+  backend: BaseSandbox
+): Promise<ExecuteResponse> {
+  const makeStep = (
+    overrides: Partial<TChatMessageStep<TProgramToolMessage>>
+  ): TChatMessageStep<TProgramToolMessage> =>
+    ({
+      id: toolCallId,
+      category: 'Tool',
+      type: ChatMessageStepCategory.Program,
+      tool: toolName,
+      title: toolName,
+      input: { command },
+      ...overrides
+    }) as TChatMessageStep<TProgramToolMessage>
+
+  // Phase 1: running
+  await dispatchCustomEvent(
+    ChatMessageEventTypeEnum.ON_TOOL_MESSAGE,
+    makeStep({
+      status: 'running',
+      created_date: new Date(),
+      output: '',
+      data: { code: command, output: '' }
+    })
+  ).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
+
+  // Phase 2: streaming execution
+  let result: ExecuteResponse
+  if (typeof backend.streamExecute === 'function') {
+    let accumulatedOutput = ''
+    let lastDispatchTime = 0
+
+    result = await backend.streamExecute(command, (line) => {
+      accumulatedOutput += (accumulatedOutput ? '\n' : '') + line
+      const now = Date.now()
+      if (now - lastDispatchTime >= STREAM_THROTTLE_MS) {
+        lastDispatchTime = now
+        dispatchCustomEvent(
+          ChatMessageEventTypeEnum.ON_TOOL_MESSAGE,
+          makeStep({
+            status: 'running',
+            output: accumulatedOutput,
+            data: { code: command, output: accumulatedOutput }
+          })
+        ).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
+      }
+    })
+  } else {
+    result = await backend.execute(command)
+  }
+
+  // Phase 3: completion
+  const finalOutput = result.output
+  await dispatchCustomEvent(
+    ChatMessageEventTypeEnum.ON_TOOL_MESSAGE,
+    makeStep({
+      status: result.exitCode === 0 ? 'success' : 'fail',
+      end_date: new Date(),
+      output: finalOutput,
+      data: { code: command, output: finalOutput },
+      error: result.exitCode !== 0 ? finalOutput : undefined
+    })
+  ).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
+
+  return result
+}

--- a/packages/server-ai/src/ai-model/ai-model.controller.ts
+++ b/packages/server-ai/src/ai-model/ai-model.controller.ts
@@ -1,5 +1,5 @@
 import { Public, TransformInterceptor } from '@metad/server-core'
-import { Controller, Get, HttpException, HttpStatus, Param, Res, UseInterceptors } from '@nestjs/common'
+import { Controller, Get, HttpException, HttpStatus, Param, Query, Res, UseInterceptors } from '@nestjs/common'
 import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger'
 import { ServerResponse } from 'http'
@@ -21,9 +21,12 @@ export class AIModelController {
 		@Param('name') provider: string,
 		@Param('iconType') iconType: string,
 		@Param('lang') lang: string,
+		@Query('organizationId') organizationId: string,
 		@Res() res: ServerResponse
 	) {
-		const [icon, mimetype] = await this.queryBus.execute(new AIModelGetIconQuery(provider, iconType, lang))
+		const [icon, mimetype] = await this.queryBus.execute(
+			new AIModelGetIconQuery(provider, iconType, lang, organizationId)
+		)
 
 		if (!icon) {
 			throw new HttpException('Icon not found', HttpStatus.NOT_FOUND)

--- a/packages/server-ai/src/ai-model/ai-model.service.ts
+++ b/packages/server-ai/src/ai-model/ai-model.service.ts
@@ -27,11 +27,11 @@ export class AIProvidersService {
 	 * @param throwError 
 	 * @returns 
 	 */
-	getProvider(name: string, throwError = false): IAIModelProviderStrategy | undefined {
+	getProvider(name: string, throwError = false, organizationId?: string): IAIModelProviderStrategy | undefined {
 		let provider: IAIModelProviderStrategy | undefined = null
 		if (name) {
 			try {
-				provider = this.strategyRegistry.get(name)
+				provider = this.strategyRegistry.get(name, organizationId)
 			} catch (error) {
 				provider = this.registry.getProvider(name)
 			}

--- a/packages/server-ai/src/ai-model/dto/provider.dto.ts
+++ b/packages/server-ai/src/ai-model/dto/provider.dto.ts
@@ -1,6 +1,7 @@
 import { I18nObject } from '@metad/contracts'
 import { Exclude, Expose, Transform } from 'class-transformer'
 import { IsOptional, IsString, ValidateNested } from 'class-validator'
+import { RequestContext } from '@xpert-ai/plugin-sdk'
 
 @Expose()
 export class AiProviderDto {
@@ -23,8 +24,8 @@ export class AiProviderDto {
 	@Transform(
 		({ value, obj }) =>
 			value && {
-				en_US: `${obj.urlPrefix}/icon_small/en_US`,
-				zh_Hans: `${obj.urlPrefix}/icon_small/zh_Hans`
+				en_US: `${obj.urlPrefix}/icon_small/en_US${obj.organizationQuery ?? ''}`,
+				zh_Hans: `${obj.urlPrefix}/icon_small/zh_Hans${obj.organizationQuery ?? ''}`
 			}
 	)
 	icon_small?: I18nObject
@@ -35,8 +36,8 @@ export class AiProviderDto {
 	@Transform(
 		({ value, obj }) =>
 			value && {
-				en_US: `${obj.urlPrefix}/icon_large/en_US`,
-				zh_Hans: `${obj.urlPrefix}/icon_large/zh_Hans`
+				en_US: `${obj.urlPrefix}/icon_large/en_US${obj.organizationQuery ?? ''}`,
+				zh_Hans: `${obj.urlPrefix}/icon_large/zh_Hans${obj.organizationQuery ?? ''}`
 			}
 	)
 	icon_large?: I18nObject
@@ -44,9 +45,19 @@ export class AiProviderDto {
 	@Exclude()
 	urlPrefix?: string
 
-	constructor(partial: Partial<AiProviderDto>, baseUrl: string) {
+	@Exclude()
+	organizationId?: string
+
+	@Exclude()
+	organizationQuery?: string
+
+	constructor(partial: Partial<AiProviderDto>, baseUrl: string, organizationId?: string) {
 		Object.assign(this, partial)
 
+		this.organizationId = organizationId ?? RequestContext.getOrganizationId()
+		this.organizationQuery = this.organizationId
+			? `?organizationId=${encodeURIComponent(this.organizationId)}`
+			: ''
 		this.urlPrefix = baseUrl + (baseUrl.endsWith('/') ? '' : '/') +  `api/ai-model/provider/${partial.provider}`
 	}
 }

--- a/packages/server-ai/src/ai-model/queries/get-model-icon.query.ts
+++ b/packages/server-ai/src/ai-model/queries/get-model-icon.query.ts
@@ -7,5 +7,6 @@ export class AIModelGetIconQuery implements IQuery {
 		public readonly provider: string,
 		public readonly iconType: string,
 		public readonly lang: string,
+		public readonly organizationId?: string,
 	) {}
 }

--- a/packages/server-ai/src/ai-model/queries/handlers/get-model-icon.handler.ts
+++ b/packages/server-ai/src/ai-model/queries/handlers/get-model-icon.handler.ts
@@ -3,6 +3,7 @@ import { CommandBus, IQueryHandler, QueryHandler } from '@nestjs/cqrs'
 import { existsSync, readFileSync } from 'fs'
 import * as mime from 'mime-types'
 import * as path from 'path'
+import { RequestContext } from '@xpert-ai/plugin-sdk'
 import { AIProvidersService } from '../../ai-model.service'
 import { AIModelGetIconQuery } from '../get-model-icon.query'
 
@@ -14,9 +15,13 @@ export class AIModelGetIconHandler implements IQueryHandler<AIModelGetIconQuery>
 	) {}
 
 	public async execute(command: AIModelGetIconQuery): Promise<[Buffer, string]> {
-		const { provider, iconType, lang } = command
+		const { provider, iconType, lang, organizationId } = command
+		const resolvedOrganizationId = organizationId ?? RequestContext.getOrganizationId()
 
-		const modelProvider = this.service.getProvider(provider)
+		const modelProvider = this.service.getProvider(provider, false, resolvedOrganizationId)
+		if (!modelProvider) {
+			throw new NotFoundException(`Provider ${provider} is not found.`)
+		}
 		const providerSchema = modelProvider.getProviderSchema()
 
 		let fileName: string

--- a/packages/server-ai/src/ai-model/queries/handlers/list-providers.handler.ts
+++ b/packages/server-ai/src/ai-model/queries/handlers/list-providers.handler.ts
@@ -1,3 +1,4 @@
+import { IAiProviderEntity } from '@metad/contracts'
 import { CommandBus, IQueryHandler, QueryHandler } from '@nestjs/cqrs'
 import { AIModelProviderRegistry } from '@xpert-ai/plugin-sdk'
 import { AIProvidersService } from '../../ai-model.service'
@@ -17,14 +18,21 @@ export class ListModelProvidersHandler implements IQueryHandler<ListModelProvide
 		const providers = this.registry.list()
 		providers.push(...this.service.getAllProviders())
 
-		return providers
-			.map((p) => p.getProviderSchema())
+		// Prefer plugin providers when provider names conflict with built-in ones.
+		const uniqueProviders = new Map<string, IAiProviderEntity>()
+		for (const provider of providers) {
+			const schema = provider.getProviderSchema()
+			if (!uniqueProviders.has(schema.provider)) {
+				uniqueProviders.set(schema.provider, schema)
+			}
+		}
+
+		return Array.from(uniqueProviders.values())
 			.filter((provider) => (names ? names.includes(provider.provider) : true))
-			.sort(
-			(a, b) =>
-				positionMap[a.provider] +
-				(a.not_implemented ? 999 : 0) -
-				(positionMap[b.provider] + (b.not_implemented ? 999 : 0))
-		)
+			.sort((a, b) => {
+				const ap = positionMap[a.provider] ?? Number.MAX_SAFE_INTEGER
+				const bp = positionMap[b.provider] ?? Number.MAX_SAFE_INTEGER
+				return ap + (a.not_implemented ? 999 : 0) - (bp + (b.not_implemented ? 999 : 0))
+			})
 	}
 }


### PR DESCRIPTION
## Summary
- Add organizationId support to provider icon URL for multi-tenant isolation
- Deduplicate provider list using Map (plugin providers take priority over built-in)
- Fix sorting bug where missing positionMap entries caused NaN comparison
- Throw NotFoundException instead of TypeError when provider not found in icon handler
- Add streamExecute support to sandbox protocol, BaseSandbox and LocalShellSandbox
- Emit tool messages for shell operations via LangChain custom events

## Changed files (11)
**Commit 4 (ai-model):** 6 files - organizationId isolation, provider dedup, sorting fix
**Commit 2 (sandbox):** 3 files - streamExecute in protocol/BaseSandbox/LocalShellSandbox
**Commit 1 (tool messages):** 1 new + 1 modified - toolMessageUtils.ts + sandboxShell.ts

## Skipped (pro-only)
- `docker.provider.ts` - pro sandbox backend
- `search.py` / `docker/grep.ts` - pro sandbox grep
- `sandboxFile.ts` - not present in xpert