### PR TITLE
fix: refresh strategy caches after plugin install/uninstall

### DIFF
--- a/apps/cloud/src/app/@core/services/knowledgebase.service.ts
+++ b/apps/cloud/src/app/@core/services/knowledgebase.service.ts
@@ -32,14 +32,35 @@ const API_KNOWLEDGEBASE = API_PREFIX + '/knowledgebase'
 export class KnowledgebaseService extends XpertWorkspaceBaseCrudService<IKnowledgebase> {
   readonly #logger = inject(NGXLogger)
 
-  // Package into hot stream + cache the last value
-  readonly documentSourceStrategies$ = this.getDocumentSourceStrategies().pipe(shareReplay(1))
-  readonly documentTransformerStrategies$ = this.getDocumentTransformerStrategies().pipe(shareReplay(1))
-  readonly understandingStrategies$ = this.getUnderstandingStrategies().pipe(shareReplay(1))
-  readonly textSplitterStrategies$ = this.getTextSplitterStrategies().pipe(shareReplay(1))
+  readonly #refresh$ = new BehaviorSubject<void>(null)
+
+  // Package into hot stream + cache the last value (refreshable via refresh$)
+  readonly documentSourceStrategies$ = this.#refresh$.pipe(
+    switchMap(() => this.getDocumentSourceStrategies()),
+    shareReplay(1)
+  )
+  readonly documentTransformerStrategies$ = this.#refresh$.pipe(
+    switchMap(() => this.getDocumentTransformerStrategies()),
+    shareReplay(1)
+  )
+  readonly understandingStrategies$ = this.#refresh$.pipe(
+    switchMap(() => this.getUnderstandingStrategies()),
+    shareReplay(1)
+  )
+  readonly textSplitterStrategies$ = this.#refresh$.pipe(
+    switchMap(() => this.getTextSplitterStrategies()),
+    shareReplay(1)
+  )
 
   constructor() {
     super(API_KNOWLEDGEBASE)
+  }
+
+  /**
+   * Refresh cached strategy data (e.g., after plugin install/uninstall)
+   */
+  refresh() {
+    this.#refresh$.next()
   }
 
   getMyAllInOrg(options?: PaginationParams<IKnowledgebase>) {

--- a/apps/cloud/src/app/@core/services/xpert-agent.service.ts
+++ b/apps/cloud/src/app/@core/services/xpert-agent.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core'
 import { NGXLogger } from 'ngx-logger'
-import { shareReplay } from 'rxjs'
+import { BehaviorSubject, shareReplay, switchMap } from 'rxjs'
 import { API_XPERT_AGENT } from '../constants/app.constants'
 import { injectApiBaseUrl } from '../providers'
 import { IXpertAgent, JsonSchemaObjectType, TAgentMiddlewareMeta, TChatAgentParams } from '../types'
@@ -13,7 +13,12 @@ export class XpertAgentService extends XpertWorkspaceBaseCrudService<IXpertAgent
   readonly baseUrl = injectApiBaseUrl()
   readonly fetchEventSource = injectFetchEventSource()
 
-  readonly agentMiddlewares$ = this.getAgentMiddlewareStrategies().pipe(shareReplay(1))
+  readonly #refresh$ = new BehaviorSubject<void>(null)
+
+  readonly agentMiddlewares$ = this.#refresh$.pipe(
+    switchMap(() => this.getAgentMiddlewareStrategies()),
+    shareReplay(1)
+  )
 
   constructor() {
     super(API_XPERT_AGENT)
@@ -41,6 +46,13 @@ export class XpertAgentService extends XpertWorkspaceBaseCrudService<IXpertAgent
       stateSchema?: JsonSchemaObjectType
       tools: { name: string; description?: string; schema: JsonSchemaObjectType }[]
     }>(this.apiBaseUrl + `/middlewares/${provider}/tools`, options)
+  }
+
+  /**
+   * Refresh cached strategy data (e.g., after plugin install/uninstall)
+   */
+  refresh() {
+    this.#refresh$.next()
   }
 
   testAgentMiddlewareTool(provider: string, toolName: string, options: any, parameters: Record<string, any>) {

--- a/apps/cloud/src/app/@core/services/xpert-toolset.service.ts
+++ b/apps/cloud/src/app/@core/services/xpert-toolset.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable, Signal } from '@angular/core'
 import { NGXLogger } from 'ngx-logger'
 import { derivedAsync } from 'ngxtension/derived-async'
-import { BehaviorSubject, catchError, map, of, shareReplay, startWith } from 'rxjs'
+import { BehaviorSubject, catchError, map, of, shareReplay, startWith, switchMap } from 'rxjs'
 import { API_XPERT_TOOLSET } from '../constants/app.constants'
 import {
   ApiProviderSchemaType,
@@ -27,14 +27,22 @@ export class XpertToolsetService extends XpertWorkspaceBaseCrudService<IXpertToo
   readonly baseUrl = injectApiBaseUrl()
   readonly fetchEventSource = injectFetchEventSource()
 
-  readonly #refresh = new BehaviorSubject<void>(null)
+  readonly #refresh$ = new BehaviorSubject<void>(null)
 
-  readonly builtinToolProviders$ = this.getProviders().pipe(
+  readonly builtinToolProviders$ = this.#refresh$.pipe(
+    switchMap(() => this.getProviders()),
     shareReplay(1),
   )
 
   constructor() {
     super(API_XPERT_TOOLSET)
+  }
+
+  /**
+   * Refresh cached provider data (e.g., after plugin install/uninstall)
+   */
+  refresh() {
+    this.#refresh$.next()
   }
 
   parserOpenAPISchema(schema: string) {

--- a/apps/cloud/src/app/features/setting/plugins/install/install.component.ts
+++ b/apps/cloud/src/app/features/setting/plugins/install/install.component.ts
@@ -19,7 +19,7 @@ import { TranslateModule } from '@ngx-translate/core'
 })
 export class PluginInstallComponent {
   readonly #dialogRef = inject(DialogRef)
-  readonly #data = inject<{plugin: TPlugin; reload: () => void}>(DIALOG_DATA)
+  readonly #data = inject<{plugin: TPlugin; reload: () => void; refreshStrategies?: () => void}>(DIALOG_DATA)
   readonly installHelpUrl = injectHelpWebsite('/docs/plugin/install')
   readonly pluginAPI = injectPluginAPI()
   readonly #toastr = injectToastr()
@@ -88,6 +88,7 @@ export class PluginInstallComponent {
         this.status.set('installed')
         this.#installedPlugin.reload()
         this.#data.reload()
+        this.#data.refreshStrategies?.()
       },
       error: (err) => {
         this.error.set(getErrorMessage(err))

--- a/apps/cloud/src/app/features/setting/plugins/plugin/plugin.component.ts
+++ b/apps/cloud/src/app/features/setting/plugins/plugin/plugin.component.ts
@@ -36,6 +36,7 @@ export class SettingsPluginComponent {
       data: {
         plugin: this.plugin(),
         reload: this.pluginsComponent.reload.bind(this.pluginsComponent),
+        refreshStrategies: this.pluginsComponent.refreshStrategyCaches.bind(this.pluginsComponent),
       },
       disableClose: true,
     }).closed.subscribe({

--- a/apps/cloud/src/app/features/setting/plugins/plugins.component.ts
+++ b/apps/cloud/src/app/features/setting/plugins/plugins.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, effect, inject, model, signal, TemplateRef, viewCh
 import { FormsModule } from '@angular/forms'
 import { Router } from '@angular/router'
 import { MatTooltipModule } from '@angular/material/tooltip'
-import { getErrorMessage, injectHelpWebsite, routeAnimations } from '@cloud/app/@core'
+import { getErrorMessage, injectHelpWebsite, routeAnimations, KnowledgebaseService, XpertAgentService, XpertToolsetService } from '@cloud/app/@core'
 import { IconComponent } from '@cloud/app/@shared/avatar'
 import { NgmSelectComponent } from '@cloud/app/@shared/common'
 import { injectPluginAPI } from '@metad/cloud/state'
@@ -44,6 +44,9 @@ export class PluginsComponent {
   readonly i18nService = inject(I18nService)
   readonly pluginAPI = injectPluginAPI()
   readonly confirmDelete = injectConfirmDelete()
+  readonly #agentService = inject(XpertAgentService)
+  readonly #knowledgebaseService = inject(KnowledgebaseService)
+  readonly #toolsetService = inject(XpertToolsetService)
   readonly npmInstallDialog = viewChild('npmInstallDialog', { read: TemplateRef })
 
   readonly category = linkedModel({
@@ -193,6 +196,7 @@ export class PluginsComponent {
       next: () => {
         this.removing.set('')
         this.plugins.update((plugins) => plugins.filter((item) => item.name !== plugin.name))
+        this.#refreshStrategyCaches()
       },
       error: () => {
         this.removing.set('')
@@ -236,11 +240,21 @@ export class PluginsComponent {
         this.npmInstalling.set(false)
         dialogRef.close()
         this.#plugins.reload()
+        this.#refreshStrategyCaches()
       },
       error: (err) => {
         this.npmInstallError.set(getErrorMessage(err))
         this.npmInstalling.set(false)
       }
     })
+  }
+
+  /**
+   * Refresh all strategy caches after plugin install/uninstall
+   */
+  refreshStrategyCaches() {
+    this.#agentService.refresh()
+    this.#knowledgebaseService.refresh()
+    this.#toolsetService.refresh()
   }
 }


### PR DESCRIPTION
Issue: After installing a plugin, newly available strategies (middlewares, document sources, tool providers, etc.) were not visible until page refresh.

Root Cause: Frontend services cached strategy lists using shareReplay(1) which caches indefinitely. After plugin installation, the caches were never invalidated.

Solution:
- Add refresh mechanism to XpertAgentService, KnowledgebaseService, and XpertToolsetService using BehaviorSubject + switchMap pattern
- Call refresh() on all services after plugin install/uninstall in PluginsComponent
- Pass refreshStrategies callback through plugin install dialog

Fixes #442

# PR

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Checklist

- [ ] Have you followed the [contributing guidelines](https://github.com/xpert-ai/xpert/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: ✅ we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
