### PR TITLE
feat: unify sandbox timeout handling

### DIFF
--- a/packages/plugin-sdk/src/lib/sandbox/execution.ts
+++ b/packages/plugin-sdk/src/lib/sandbox/execution.ts
@@ -1,0 +1,85 @@
+export interface SandboxExecutionOptions {
+  timeoutMs?: number
+  maxOutputBytes?: number
+}
+
+export interface ResolvedSandboxExecutionOptions {
+  timeoutMs: number
+  maxOutputBytes: number
+}
+
+export const SANDBOX_SHELL_TIMEOUT_LIMITS_SEC = {
+  min: 1,
+  max: 3600
+} as const
+
+export const DEFAULT_SANDBOX_SHELL_TIMEOUT_SEC = 600
+export const DEFAULT_SANDBOX_FILE_SEARCH_TIMEOUT_SEC = 120
+export const DEFAULT_SANDBOX_FILE_OPERATION_TIMEOUT_SEC = 120
+
+export const DEFAULT_SANDBOX_SHELL_TIMEOUT_MS = DEFAULT_SANDBOX_SHELL_TIMEOUT_SEC * 1000
+export const DEFAULT_SANDBOX_FILE_SEARCH_TIMEOUT_MS = DEFAULT_SANDBOX_FILE_SEARCH_TIMEOUT_SEC * 1000
+export const DEFAULT_SANDBOX_FILE_OPERATION_TIMEOUT_MS = DEFAULT_SANDBOX_FILE_OPERATION_TIMEOUT_SEC * 1000
+
+export const DEFAULT_SANDBOX_EXECUTION_MAX_OUTPUT_BYTES = 1024 * 1024
+
+export const DEFAULT_SANDBOX_SHELL_EXECUTION_OPTIONS: Readonly<SandboxExecutionOptions> = {
+  timeoutMs: DEFAULT_SANDBOX_SHELL_TIMEOUT_MS,
+  maxOutputBytes: DEFAULT_SANDBOX_EXECUTION_MAX_OUTPUT_BYTES
+}
+
+export const DEFAULT_SANDBOX_FILE_SEARCH_EXECUTION_OPTIONS: Readonly<SandboxExecutionOptions> = {
+  timeoutMs: DEFAULT_SANDBOX_FILE_SEARCH_TIMEOUT_MS,
+  maxOutputBytes: DEFAULT_SANDBOX_EXECUTION_MAX_OUTPUT_BYTES
+}
+
+export const DEFAULT_SANDBOX_FILE_OPERATION_EXECUTION_OPTIONS: Readonly<SandboxExecutionOptions> = {
+  timeoutMs: DEFAULT_SANDBOX_FILE_OPERATION_TIMEOUT_MS,
+  maxOutputBytes: DEFAULT_SANDBOX_EXECUTION_MAX_OUTPUT_BYTES
+}
+
+export function secondsToMilliseconds(seconds: number): number {
+  return Math.trunc(seconds * 1000)
+}
+
+export function formatSandboxTimeout(timeoutMs: number): string {
+  const timeoutSeconds = timeoutMs / 1000
+  const secondsLabel = Number.isInteger(timeoutSeconds)
+    ? String(timeoutSeconds)
+    : Number(timeoutSeconds.toFixed(3)).toString()
+  return `${secondsLabel}s (${timeoutMs}ms)`
+}
+
+export function buildSandboxTimeoutMessage(subject: string, timeoutMs: number): string {
+  return `${subject} timed out after ${formatSandboxTimeout(timeoutMs)}`
+}
+
+export function appendSandboxMessage(output: string, message: string): string {
+  return output ? `${output}\n${message}` : message
+}
+
+export function resolveSandboxExecutionOptions(
+  options?: SandboxExecutionOptions,
+  defaults: SandboxExecutionOptions = DEFAULT_SANDBOX_SHELL_EXECUTION_OPTIONS
+): ResolvedSandboxExecutionOptions {
+  const timeoutMs =
+    typeof options?.timeoutMs === 'number' && Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
+      ? Math.trunc(options.timeoutMs)
+      : typeof defaults.timeoutMs === 'number' && Number.isFinite(defaults.timeoutMs) && defaults.timeoutMs > 0
+        ? Math.trunc(defaults.timeoutMs)
+        : DEFAULT_SANDBOX_SHELL_TIMEOUT_MS
+
+  const maxOutputBytes =
+    typeof options?.maxOutputBytes === 'number' && Number.isFinite(options.maxOutputBytes) && options.maxOutputBytes > 0
+      ? Math.trunc(options.maxOutputBytes)
+      : typeof defaults.maxOutputBytes === 'number' &&
+          Number.isFinite(defaults.maxOutputBytes) &&
+          defaults.maxOutputBytes > 0
+        ? Math.trunc(defaults.maxOutputBytes)
+        : DEFAULT_SANDBOX_EXECUTION_MAX_OUTPUT_BYTES
+
+  return {
+    timeoutMs,
+    maxOutputBytes
+  }
+}

--- a/packages/plugin-sdk/src/lib/sandbox/index.ts
+++ b/packages/plugin-sdk/src/lib/sandbox/index.ts
@@ -1,3 +1,4 @@
+export * from './execution'
 export * from './protocol'
 export * from './sandbox'
 export * from './sandbox.decorator'

--- a/packages/plugin-sdk/src/lib/sandbox/protocol.ts
+++ b/packages/plugin-sdk/src/lib/sandbox/protocol.ts
@@ -1,3 +1,5 @@
+import type { SandboxExecutionOptions } from './execution'
+
 /**
  * Protocol definition for pluggable memory backends.
  *
@@ -6,7 +8,7 @@
  * database, etc.) and provide a uniform interface for file operations.
  */
 
-export type MaybePromise<T> = T | Promise<T>;
+export type MaybePromise<T> = T | Promise<T>
 
 /**
  * Structured file listing info.
@@ -16,13 +18,13 @@ export type MaybePromise<T> = T | Promise<T>;
  */
 export interface FileInfo {
   /** File path */
-  path: string;
+  path: string
   /** Whether this is a directory */
-  is_dir?: boolean;
+  is_dir?: boolean
   /** File size in bytes (approximate) */
-  size?: number;
+  size?: number
   /** ISO 8601 timestamp of last modification */
-  modified_at?: string;
+  modified_at?: string
 }
 
 /**
@@ -30,32 +32,32 @@ export interface FileInfo {
  */
 export interface GrepMatch {
   /** File path where match was found */
-  path: string;
+  path: string
   /** Line number (1-indexed) */
-  line: number;
+  line: number
   /** The matching line text */
-  text: string;
+  text: string
 }
 
 /**
  * Read mode for file reading operations.
  */
-export type ReadMode = 'slice' | 'indentation';
+export type ReadMode = 'slice' | 'indentation'
 
 /**
  * Configuration for indentation-aware file reading.
  */
 export interface IndentationOptions {
   /** Anchor line number (1-indexed), defaults to offset */
-  anchor_line?: number;
+  anchor_line?: number
   /** Maximum indentation depth to collect; 0 means unlimited */
-  max_levels?: number;
+  max_levels?: number
   /** Whether to include sibling blocks at the same indentation level */
-  include_siblings?: boolean;
+  include_siblings?: boolean
   /** Whether to include header lines (comments) above the anchor block */
-  include_header?: boolean;
+  include_header?: boolean
   /** Hard cap on returned lines */
-  max_lines?: number;
+  max_lines?: number
 }
 
 /**
@@ -65,11 +67,11 @@ export interface IndentationOptions {
  */
 export interface FileData {
   /** Lines of text content */
-  content: string[];
+  content: string[]
   /** ISO format timestamp of creation */
-  created_at: string;
+  created_at: string
   /** ISO format timestamp of last modification */
-  modified_at: string;
+  modified_at: string
 }
 
 /**
@@ -80,17 +82,17 @@ export interface FileData {
  */
 export interface WriteResult {
   /** Error message on failure, undefined on success */
-  error?: string;
+  error?: string
   /** File path of written file, undefined on failure */
-  path?: string;
+  path?: string
   /**
    * State update dict for checkpoint backends, null for external storage.
    * Checkpoint backends populate this with {file_path: file_data} for LangGraph state.
    * External backends set null (already persisted to disk/S3/database/etc).
    */
-  filesUpdate?: Record<string, FileData> | null;
+  filesUpdate?: Record<string, FileData> | null
   /** Metadata for the write operation, attached to the ToolMessage */
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown>
 }
 
 /**
@@ -101,19 +103,19 @@ export interface WriteResult {
  */
 export interface EditResult {
   /** Error message on failure, undefined on success */
-  error?: string;
+  error?: string
   /** File path of edited file, undefined on failure */
-  path?: string;
+  path?: string
   /**
    * State update dict for checkpoint backends, null for external storage.
    * Checkpoint backends populate this with {file_path: file_data} for LangGraph state.
    * External backends set null (already persisted to disk/S3/database/etc).
    */
-  filesUpdate?: Record<string, FileData> | null;
+  filesUpdate?: Record<string, FileData> | null
   /** Number of replacements made, undefined on failure */
-  occurrences?: number;
+  occurrences?: number
   /** Metadata for the edit operation, attached to the ToolMessage */
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown>
 }
 
 /**
@@ -121,11 +123,11 @@ export interface EditResult {
  */
 export interface EditOperation {
   /** String to find and replace */
-  oldString: string;
+  oldString: string
   /** Replacement string */
-  newString: string;
+  newString: string
   /** If true, replace all occurrences (default: false) */
-  replaceAll?: boolean;
+  replaceAll?: boolean
 }
 
 /**
@@ -136,19 +138,19 @@ export interface EditOperation {
  */
 export interface MultiEditResult {
   /** Error message on failure, undefined on success */
-  error?: string;
+  error?: string
   /** File path of edited file, undefined on failure */
-  path?: string;
+  path?: string
   /**
    * State update dict for checkpoint backends, null for external storage.
    * Checkpoint backends populate this with {file_path: file_data} for LangGraph state.
    * External backends set null (already persisted to disk/S3/database/etc).
    */
-  filesUpdate?: Record<string, FileData> | null;
+  filesUpdate?: Record<string, FileData> | null
   /** Results from each individual edit operation */
-  results?: EditResult[];
+  results?: EditResult[]
   /** Metadata for the multi-edit operation, attached to the ToolMessage */
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown>
 }
 
 /**
@@ -157,32 +159,30 @@ export interface MultiEditResult {
  */
 export interface ExecuteResponse {
   /** Combined stdout and stderr output of the executed command */
-  output: string;
+  output: string
   /** The process exit code. 0 indicates success, non-zero indicates failure */
-  exitCode: number | null;
+  exitCode: number | null
   /** Whether the output was truncated due to backend limitations */
-  truncated: boolean;
+  truncated: boolean
+  /** Whether the command exceeded its timeout and was terminated */
+  timedOut?: boolean
 }
 
 /**
  * Standardized error codes for file upload/download operations.
  */
-export type FileOperationError =
-  | "file_not_found"
-  | "permission_denied"
-  | "is_directory"
-  | "invalid_path";
+export type FileOperationError = 'file_not_found' | 'permission_denied' | 'is_directory' | 'invalid_path'
 
 /**
  * Result of a single file download operation.
  */
 export interface FileDownloadResponse {
   /** The file path that was requested */
-  path: string;
+  path: string
   /** File contents as Uint8Array on success, null on failure */
-  content: Uint8Array | null;
+  content: Uint8Array | null
   /** Standardized error code on failure, null on success */
-  error: FileOperationError | null;
+  error: FileOperationError | null
 }
 
 /**
@@ -190,9 +190,9 @@ export interface FileDownloadResponse {
  */
 export interface FileUploadResponse {
   /** The file path that was requested */
-  path: string;
+  path: string
   /** Standardized error code on failure, null on success */
-  error: FileOperationError | null;
+  error: FileOperationError | null
 }
 
 /**
@@ -216,7 +216,7 @@ export interface BackendProtocol {
    * @param path - Absolute path to directory
    * @returns List of FileInfo objects for files and directories directly in the directory
    */
-  lsInfo(path: string): MaybePromise<FileInfo[]>;
+  lsInfo(path: string): MaybePromise<FileInfo[]>
 
   /**
    * List directory contents recursively with depth control and pagination.
@@ -227,12 +227,7 @@ export interface BackendProtocol {
    * @param depth - Maximum depth to traverse (default: 2)
    * @returns Human-readable directory tree with indentation
    */
-  listDir(
-    dirPath: string,
-    offset?: number,
-    limit?: number,
-    depth?: number,
-  ): MaybePromise<string>;
+  listDir(dirPath: string, offset?: number, limit?: number, depth?: number): MaybePromise<string>
 
   /**
    * Read file content with line numbers or an error string.
@@ -250,7 +245,7 @@ export interface BackendProtocol {
     limit?: number,
     mode?: ReadMode,
     indentation?: IndentationOptions
-  ): MaybePromise<string>;
+  ): MaybePromise<string>
 
   /**
    * Structured search results or error string for invalid input.
@@ -262,11 +257,7 @@ export interface BackendProtocol {
    * @param include - Optional glob pattern to filter files (e.g., "*.py")
    * @returns List of GrepMatch objects or error string for invalid regex
    */
-  grepRaw(
-    pattern: string,
-    path?: string | null,
-    include?: string | null,
-  ): MaybePromise<GrepMatch[] | string>;
+  grepRaw(pattern: string, path?: string | null, include?: string | null): MaybePromise<GrepMatch[] | string>
 
   /**
    * Search file contents for a regex pattern, returning human-readable output.
@@ -276,11 +267,7 @@ export interface BackendProtocol {
    * @param include - Optional glob pattern to filter files (e.g., "*.js", "*.{ts,tsx}")
    * @returns Human-readable output with matches grouped by file
    */
-  grep(
-    pattern: string,
-    path?: string | null,
-    include?: string | null,
-  ): MaybePromise<string>;
+  grep(pattern: string, path?: string | null, include?: string | null): MaybePromise<string>
 
   /**
    * Structured glob matching returning FileInfo objects.
@@ -289,7 +276,7 @@ export interface BackendProtocol {
    * @param path - Base path to search from (default: "/")
    * @returns List of FileInfo objects matching the pattern
    */
-  globInfo(pattern: string, path?: string): MaybePromise<FileInfo[]>;
+  globInfo(pattern: string, path?: string): MaybePromise<FileInfo[]>
 
   /**
    * Find files matching a glob pattern, returning human-readable output.
@@ -298,7 +285,7 @@ export interface BackendProtocol {
    * @param path - Base path to search from (default: workspace root)
    * @returns Human-readable output with matching file paths
    */
-  glob(pattern: string, path?: string): MaybePromise<string>;
+  glob(pattern: string, path?: string): MaybePromise<string>
 
   /**
    * Create a new file.
@@ -307,7 +294,7 @@ export interface BackendProtocol {
    * @param content - File content as string
    * @returns WriteResult with error populated on failure
    */
-  write(filePath: string, content: string): MaybePromise<WriteResult>;
+  write(filePath: string, content: string): MaybePromise<WriteResult>
 
   /**
    * Append content to a file. Creates the file if it doesn't exist.
@@ -316,7 +303,7 @@ export interface BackendProtocol {
    * @param content - Content to append
    * @returns WriteResult with error populated on failure
    */
-  append(filePath: string, content: string): MaybePromise<WriteResult>;
+  append(filePath: string, content: string): MaybePromise<WriteResult>
 
   /**
    * Edit a file by replacing string occurrences.
@@ -327,12 +314,7 @@ export interface BackendProtocol {
    * @param replaceAll - If true, replace all occurrences (default: false)
    * @returns EditResult with error, path, filesUpdate, and occurrences
    */
-  edit(
-    filePath: string,
-    oldString: string,
-    newString: string,
-    replaceAll?: boolean,
-  ): MaybePromise<EditResult>;
+  edit(filePath: string, oldString: string, newString: string, replaceAll?: boolean): MaybePromise<EditResult>
 
   /**
    * Perform multiple sequential edits on a single file.
@@ -343,10 +325,7 @@ export interface BackendProtocol {
    * @param edits - Array of edit operations to perform sequentially
    * @returns MultiEditResult with error, path, filesUpdate, and individual results
    */
-  multiEdit(
-    filePath: string,
-    edits: EditOperation[],
-  ): MaybePromise<MultiEditResult>;
+  multiEdit(filePath: string, edits: EditOperation[]): MaybePromise<MultiEditResult>
 
   /**
    * Upload multiple files.
@@ -354,9 +333,7 @@ export interface BackendProtocol {
    * @param files - List of [path, content] tuples to upload
    * @returns List of FileUploadResponse objects, one per input file
    */
-  uploadFiles(
-    files: Array<[string, Uint8Array]>,
-  ): MaybePromise<FileUploadResponse[]>;
+  uploadFiles(files: Array<[string, Uint8Array]>): MaybePromise<FileUploadResponse[]>
 
   /**
    * Download multiple files.
@@ -364,7 +341,7 @@ export interface BackendProtocol {
    * @param paths - List of file paths to download
    * @returns List of FileDownloadResponse objects, one per input path
    */
-  downloadFiles(paths: string[]): MaybePromise<FileDownloadResponse[]>;
+  downloadFiles(paths: string[]): MaybePromise<FileDownloadResponse[]>
 }
 
 /**
@@ -379,7 +356,7 @@ export interface SandboxBackendProtocol extends BackendProtocol {
    * @param command - Full shell command string to execute
    * @returns ExecuteResponse with combined output, exit code, and truncation flag
    */
-  execute(command: string): MaybePromise<ExecuteResponse>;
+  execute(command: string, options?: SandboxExecutionOptions): MaybePromise<ExecuteResponse>
 
   /**
    * Execute a command with line-by-line streaming output.
@@ -399,10 +376,14 @@ export interface SandboxBackendProtocol extends BackendProtocol {
    * @param onLine  - Callback invoked once per complete output line
    * @returns ExecuteResponse with combined output, exit code, and truncation flag
    */
-  streamExecute?(command: string, onLine: (line: string) => void): MaybePromise<ExecuteResponse>;
+  streamExecute?(
+    command: string,
+    onLine: (line: string) => void,
+    options?: SandboxExecutionOptions
+  ): MaybePromise<ExecuteResponse>
 
   /** Unique identifier for the sandbox backend instance */
-  readonly id: string;
+  readonly id: string
 }
 
 /**
@@ -411,13 +392,11 @@ export interface SandboxBackendProtocol extends BackendProtocol {
  * @param backend - Backend instance to check
  * @returns True if the backend implements SandboxBackendProtocol
  */
-export function isSandboxBackend(
-  backend: BackendProtocol,
-): backend is SandboxBackendProtocol {
+export function isSandboxBackend(backend: BackendProtocol): backend is SandboxBackendProtocol {
   return (
-    typeof (backend as SandboxBackendProtocol).execute === "function" &&
-    typeof (backend as SandboxBackendProtocol).id === "string"
-  );
+    typeof (backend as SandboxBackendProtocol).execute === 'function' &&
+    typeof (backend as SandboxBackendProtocol).id === 'string'
+  )
 }
 
 /**
@@ -433,11 +412,11 @@ export function isSandboxBackend(
  */
 export interface StateAndStore {
   /** Current agent state with files, messages, etc. */
-  state: unknown;
+  state: unknown
   /** Optional BaseStore for persistent cross-conversation storage */
   // store?: BaseStore;
   /** Optional assistant ID for per-assistant isolation in store */
-  assistantId?: string;
+  assistantId?: string
 }
 
 /**
@@ -454,4 +433,4 @@ export interface StateAndStore {
  * });
  * ```
  */
-export type BackendFactory = (stateAndStore: StateAndStore) => BackendProtocol;
+export type BackendFactory = (stateAndStore: StateAndStore) => BackendProtocol

--- a/packages/plugin-sdk/src/lib/sandbox/sandbox.ts
+++ b/packages/plugin-sdk/src/lib/sandbox/sandbox.ts
@@ -21,83 +21,87 @@ import type {
   MultiEditResult,
   ReadMode,
   SandboxBackendProtocol,
-  WriteResult,
-} from "./protocol";
+  WriteResult
+} from './protocol'
+import {
+  DEFAULT_SANDBOX_FILE_OPERATION_EXECUTION_OPTIONS as FILE_OPERATION_EXECUTION_OPTIONS,
+  DEFAULT_SANDBOX_FILE_SEARCH_EXECUTION_OPTIONS as FILE_SEARCH_EXECUTION_OPTIONS,
+  SandboxExecutionOptions
+} from './execution'
 
-const MAX_LINE_LENGTH = 500;
-const MAX_GREP_LINE_LENGTH = 2000;
-const GREP_RESULT_LIMIT = 100;
-const GLOB_RESULT_LIMIT = 100;
-const WRITE_EXISTS_OUTPUT = "Error: File already exists";
+const MAX_LINE_LENGTH = 500
+const MAX_GREP_LINE_LENGTH = 2000
+const GREP_RESULT_LIMIT = 100
+const GLOB_RESULT_LIMIT = 100
+const WRITE_EXISTS_OUTPUT = 'Error: File already exists'
 
 /**
  * UTF-8 safe Base64 encoding function.
  * Replaces btoa() which only supports Latin1 characters.
  */
 function utf8ToBase64(str: string): string {
-  return Buffer.from(str, 'utf-8').toString('base64');
+  return Buffer.from(str, 'utf-8').toString('base64')
 }
 
 /**
  * Format glob results into human-readable output.
  */
 function formatGlobOutput(files: FileInfo[], pattern: string): string {
-  const limit = GLOB_RESULT_LIMIT;
-  const truncated = files.length > limit;
-  const finalFiles = truncated ? files.slice(0, limit) : files;
+  const limit = GLOB_RESULT_LIMIT
+  const truncated = files.length > limit
+  const finalFiles = truncated ? files.slice(0, limit) : files
 
   if (finalFiles.length === 0) {
-    return "No files found";
+    return 'No files found'
   }
 
-  const lines: string[] = [];
+  const lines: string[] = []
   for (const file of finalFiles) {
-    lines.push(file.path);
+    lines.push(file.path)
   }
 
   if (truncated) {
-    lines.push("");
-    lines.push("(Results truncated. Consider using a more specific path or pattern.)");
+    lines.push('')
+    lines.push('(Results truncated. Consider using a more specific path or pattern.)')
   }
 
-  return lines.join("\n");
+  return lines.join('\n')
 }
 
 /**
  * Format grep matches into human-readable output grouped by file.
  */
 function formatGrepOutput(matches: GrepMatch[]): string {
-  const limit = GREP_RESULT_LIMIT;
-  const truncated = matches.length > limit;
-  const finalMatches = truncated ? matches.slice(0, limit) : matches;
+  const limit = GREP_RESULT_LIMIT
+  const truncated = matches.length > limit
+  const finalMatches = truncated ? matches.slice(0, limit) : matches
 
   if (finalMatches.length === 0) {
-    return "No matches found";
+    return 'No matches found'
   }
 
-  const lines: string[] = [`Found ${finalMatches.length} matches`];
-  let currentFile = "";
+  const lines: string[] = [`Found ${finalMatches.length} matches`]
+  let currentFile = ''
 
   for (const match of finalMatches) {
     if (currentFile !== match.path) {
-      if (currentFile !== "") {
-        lines.push("");
+      if (currentFile !== '') {
+        lines.push('')
       }
-      currentFile = match.path;
-      lines.push(`${match.path}:`);
+      currentFile = match.path
+      lines.push(`${match.path}:`)
     }
-    const text = match.text.length > MAX_GREP_LINE_LENGTH
-      ? match.text.substring(0, MAX_GREP_LINE_LENGTH) + "..."
-      : match.text;
-    lines.push(`  Line ${match.line}: ${text}`);
+    const text =
+      match.text.length > MAX_GREP_LINE_LENGTH ? match.text.substring(0, MAX_GREP_LINE_LENGTH) + '...' : match.text
+    lines.push(`  Line ${match.line}: ${text}`)
   }
 
   if (truncated) {
-    lines.push("");
-    lines.push("(Results truncated. Consider using a more specific path or pattern.)");
+    lines.push('')
+    lines.push('(Results truncated. Consider using a more specific path or pattern.)')
   }
 
-  return lines.join("\n");
+  return lines.join('\n')
 }
 
 /**
@@ -105,8 +109,8 @@ function formatGrepOutput(matches: GrepMatch[]): string {
  * Uses web-standard atob() for base64 decoding.
  */
 function buildGlobCommand(searchPath: string, pattern: string): string {
-  const pathB64 = utf8ToBase64(searchPath);
-  const patternB64 = utf8ToBase64(pattern);
+  const pathB64 = utf8ToBase64(searchPath)
+  const patternB64 = utf8ToBase64(pattern)
 
   return `node -e "
 const fs = require('fs');
@@ -153,14 +157,14 @@ try {
 } catch (e) {
   // Silent failure for non-existent paths
 }
-"`;
+"`
 }
 
 /**
  * Node.js command template for listing directory contents.
  */
 function buildLsCommand(dirPath: string): string {
-  const pathB64 = utf8ToBase64(dirPath);
+  const pathB64 = utf8ToBase64(dirPath)
 
   return `node -e "
 const fs = require('fs');
@@ -184,25 +188,20 @@ try {
   console.error('Error: ' + e.message);
   process.exit(1);
 }
-"`;
+"`
 }
 
-const INDENTATION_SPACES = 2;
-const MAX_ENTRY_LENGTH = 500;
+const INDENTATION_SPACES = 2
+const MAX_ENTRY_LENGTH = 500
 
 /**
  * Node.js command template for recursive directory listing with depth control.
  */
-function buildListDirCommand(
-  dirPath: string,
-  offset: number,
-  limit: number,
-  depth: number,
-): string {
-  const pathB64 = utf8ToBase64(dirPath);
-  const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) : 1;
-  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 25;
-  const safeDepth = Number.isFinite(depth) && depth > 0 ? Math.floor(depth) : 2;
+function buildListDirCommand(dirPath: string, offset: number, limit: number, depth: number): string {
+  const pathB64 = utf8ToBase64(dirPath)
+  const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) : 1
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 25
+  const safeDepth = Number.isFinite(depth) && depth > 0 ? Math.floor(depth) : 2
 
   return `node -e "
 const fs = require('fs');
@@ -299,27 +298,19 @@ for (const entry of selectedEntries) {
 if (endIndex < allEntries.length) {
   console.log('More than ' + limit + ' entries found');
 }
-"`;
+"`
 }
 
-const TAB_WIDTH = 4;
-const COMMENT_PREFIXES = ['#', '//', '--'];
+const TAB_WIDTH = 4
+const COMMENT_PREFIXES = ['#', '//', '--']
 
 /**
  * Node.js command template for slice mode reading.
  */
-function buildSliceReadCommand(
-  filePath: string,
-  offset: number,
-  limit: number,
-): string {
-  const pathB64 = utf8ToBase64(filePath);
-  const safeOffset =
-    Number.isFinite(offset) && offset > 0 ? Math.floor(offset) - 1 : 0;
-  const safeLimit =
-    Number.isFinite(limit) && limit > 0 && limit < Number.MAX_SAFE_INTEGER
-      ? Math.floor(limit)
-      : 2000;
+function buildSliceReadCommand(filePath: string, offset: number, limit: number): string {
+  const pathB64 = utf8ToBase64(filePath)
+  const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) - 1 : 0
+  const safeLimit = Number.isFinite(limit) && limit > 0 && limit < Number.MAX_SAFE_INTEGER ? Math.floor(limit) : 2000
 
   return `node -e "
 const fs = require('fs');
@@ -358,7 +349,7 @@ for (let i = 0; i < selected.length; i++) {
   }
   console.log('L' + lineNum + ': ' + line);
 }
-"`;
+"`
 }
 
 /**
@@ -368,20 +359,16 @@ function buildIndentationReadCommand(
   filePath: string,
   offset: number,
   limit: number,
-  options: IndentationOptions,
+  options: IndentationOptions
 ): string {
-  const pathB64 = utf8ToBase64(filePath);
-  const safeOffset =
-    Number.isFinite(offset) && offset > 0 ? Math.floor(offset) : 1;
-  const safeLimit =
-    Number.isFinite(limit) && limit > 0 && limit < Number.MAX_SAFE_INTEGER
-      ? Math.floor(limit)
-      : 2000;
-  const anchorLine = options.anchor_line ?? safeOffset;
-  const maxLevels = options.max_levels ?? 0;
-  const includeSiblings = options.include_siblings ?? false;
-  const includeHeader = options.include_header ?? true;
-  const maxLines = options.max_lines ?? safeLimit;
+  const pathB64 = utf8ToBase64(filePath)
+  const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) : 1
+  const safeLimit = Number.isFinite(limit) && limit > 0 && limit < Number.MAX_SAFE_INTEGER ? Math.floor(limit) : 2000
+  const anchorLine = options.anchor_line ?? safeOffset
+  const maxLevels = options.max_levels ?? 0
+  const includeSiblings = options.include_siblings ?? false
+  const includeHeader = options.include_header ?? true
+  const maxLines = options.max_lines ?? safeLimit
 
   return `node -e "
 const fs = require('fs');
@@ -515,15 +502,15 @@ while (out.length > 0 && isBlank(out[out.length - 1].raw)) out.pop();
 for (const r of out) {
   console.log('L' + r.number + ': ' + r.display);
 }
-"`;
+"`
 }
 
 /**
  * Node.js command template for writing files.
  */
 function buildWriteCommand(filePath: string, content: string): string {
-  const pathB64 = utf8ToBase64(filePath);
-  const contentB64 = utf8ToBase64(content);
+  const pathB64 = utf8ToBase64(filePath)
+  const contentB64 = utf8ToBase64(content)
 
   return `node -e "
 const fs = require('fs');
@@ -542,24 +529,24 @@ fs.mkdirSync(parentDir, { recursive: true });
 
 fs.writeFileSync(filePath, content, 'utf-8');
 console.log('OK');
-"`;
+"`
 }
 
 function buildExistsCommand(filePath: string): string {
-  const pathB64 = utf8ToBase64(filePath);
+  const pathB64 = utf8ToBase64(filePath)
   return `node -e "
 const fs = require('fs');
 const filePath = Buffer.from('${pathB64}', 'base64').toString('utf-8');
 process.exit(fs.existsSync(filePath) ? 0 : 1);
-"`;
+"`
 }
 
 /**
  * Node.js command template for appending to files.
  */
 function buildAppendCommand(filePath: string, content: string): string {
-  const pathB64 = utf8ToBase64(filePath);
-  const contentB64 = utf8ToBase64(content);
+  const pathB64 = utf8ToBase64(filePath)
+  const contentB64 = utf8ToBase64(content)
 
   return `node -e "
 const fs = require('fs');
@@ -573,21 +560,16 @@ fs.mkdirSync(parentDir, { recursive: true });
 
 fs.appendFileSync(filePath, content, 'utf-8');
 console.log('OK');
-"`;
+"`
 }
 
 /**
  * Node.js command template for editing files.
  */
-function buildEditCommand(
-  filePath: string,
-  oldStr: string,
-  newStr: string,
-  replaceAll: boolean,
-): string {
-  const pathB64 = utf8ToBase64(filePath);
-  const oldB64 = utf8ToBase64(oldStr);
-  const newB64 = utf8ToBase64(newStr);
+function buildEditCommand(filePath: string, oldStr: string, newStr: string, replaceAll: boolean): string {
+  const pathB64 = utf8ToBase64(filePath)
+  const oldB64 = utf8ToBase64(oldStr)
+  const newB64 = utf8ToBase64(newStr)
 
   return `node -e "
 const fs = require('fs');
@@ -616,20 +598,16 @@ if (count > 1 && !replaceAll) {
 const result = text.split(oldStr).join(newStr);
 fs.writeFileSync(filePath, result, 'utf-8');
 console.log(count);
-"`;
+"`
 }
 
 /**
  * Node.js command template for grep operations.
  */
-function buildGrepCommand(
-  pattern: string,
-  searchPath: string,
-  globPattern: string | null,
-): string {
-  const patternB64 = utf8ToBase64(pattern);
-  const pathB64 = utf8ToBase64(searchPath);
-  const globB64 = globPattern ? utf8ToBase64(globPattern) : "";
+function buildGrepCommand(pattern: string, searchPath: string, globPattern: string | null): string {
+  const patternB64 = utf8ToBase64(pattern)
+  const pathB64 = utf8ToBase64(searchPath)
+  const globB64 = globPattern ? utf8ToBase64(globPattern) : ''
 
   return `node -e "
 const fs = require('fs');
@@ -637,7 +615,7 @@ const path = require('path');
 
 const pattern = Buffer.from('${patternB64}', 'base64').toString('utf-8');
 const searchPath = Buffer.from('${pathB64}', 'base64').toString('utf-8');
-const globPattern = ${globPattern ? `Buffer.from('${globB64}', 'base64').toString('utf-8')` : "null"};
+const globPattern = ${globPattern ? `Buffer.from('${globB64}', 'base64').toString('utf-8')` : 'null'};
 
 let regex;
 try {
@@ -695,7 +673,7 @@ try {
 } catch (e) {
   // Silent failure
 }
-"`;
+"`
 }
 
 /**
@@ -711,35 +689,37 @@ export abstract class BaseSandbox implements SandboxBackendProtocol {
   public workingDirectory: string
 
   /** Unique identifier for the sandbox backend */
-  abstract readonly id: string;
+  abstract readonly id: string
 
   /**
    * Execute a command in the sandbox.
    * This is the only method concrete implementations must provide.
    */
-  abstract execute(command: string): MaybePromise<ExecuteResponse>;
+  abstract execute(command: string, options?: SandboxExecutionOptions): MaybePromise<ExecuteResponse>
 
-  async streamExecute(command: string, onLine: (line: string) => void): Promise<ExecuteResponse> {
-    const result = await this.execute(command);
+  async streamExecute(
+    command: string,
+    onLine: (line: string) => void,
+    options?: SandboxExecutionOptions
+  ): Promise<ExecuteResponse> {
+    const result = await this.execute(command, options)
     if (result.output) {
-      onLine(result.output);
+      onLine(result.output)
     }
-    return result;
+    return result
   }
 
   /**
    * Upload multiple files to the sandbox.
    * Implementations must support partial success.
    */
-  abstract uploadFiles(
-    files: Array<[string, Uint8Array]>,
-  ): MaybePromise<FileUploadResponse[]>;
+  abstract uploadFiles(files: Array<[string, Uint8Array]>): MaybePromise<FileUploadResponse[]>
 
   /**
    * Download multiple files from the sandbox.
    * Implementations must support partial success.
    */
-  abstract downloadFiles(paths: string[]): MaybePromise<FileDownloadResponse[]>;
+  abstract downloadFiles(paths: string[]): MaybePromise<FileDownloadResponse[]>
 
   /**
    * List files and directories in the specified directory (non-recursive).
@@ -748,33 +728,31 @@ export abstract class BaseSandbox implements SandboxBackendProtocol {
    * @returns List of FileInfo objects for files and directories directly in the directory.
    */
   async lsInfo(path: string): Promise<FileInfo[]> {
-    const command = buildLsCommand(path);
-    const result = await this.execute(command);
+    const command = buildLsCommand(path)
+    const result = await this.execute(command, FILE_OPERATION_EXECUTION_OPTIONS)
 
     if (result.exitCode !== 0) {
-      return [];
+      return []
     }
 
-    const infos: FileInfo[] = [];
-    const lines = result.output.trim().split("\n").filter(Boolean);
+    const infos: FileInfo[] = []
+    const lines = result.output.trim().split('\n').filter(Boolean)
 
     for (const line of lines) {
       try {
-        const parsed = JSON.parse(line);
+        const parsed = JSON.parse(line)
         infos.push({
           path: parsed.path,
           is_dir: parsed.isDir,
           size: parsed.size,
-          modified_at: parsed.mtime
-            ? new Date(parsed.mtime).toISOString()
-            : undefined,
-        });
+          modified_at: parsed.mtime ? new Date(parsed.mtime).toISOString() : undefined
+        })
       } catch {
         // Skip invalid JSON lines
       }
     }
 
-    return infos;
+    return infos
   }
 
   /**
@@ -786,32 +764,27 @@ export abstract class BaseSandbox implements SandboxBackendProtocol {
    * @param depth - Maximum depth to traverse (default: 2)
    * @returns Human-readable directory tree with indentation
    */
-  async listDir(
-    dirPath: string,
-    offset: number = 1,
-    limit: number = 25,
-    depth: number = 2,
-  ): Promise<string> {
+  async listDir(dirPath: string, offset: number = 1, limit: number = 25, depth: number = 2): Promise<string> {
     if (offset < 1) {
-      return "Error: offset must be a 1-indexed entry number";
+      return 'Error: offset must be a 1-indexed entry number'
     }
 
     if (limit < 1) {
-      return "Error: limit must be greater than zero";
+      return 'Error: limit must be greater than zero'
     }
 
     if (depth < 1) {
-      return "Error: depth must be greater than zero";
+      return 'Error: depth must be greater than zero'
     }
 
-    const command = buildListDirCommand(dirPath, offset, limit, depth);
-    const result = await this.execute(command);
+    const command = buildListDirCommand(dirPath, offset, limit, depth)
+    const result = await this.execute(command, FILE_OPERATION_EXECUTION_OPTIONS)
 
     if (result.exitCode !== 0) {
-      return result.output || `Error: Failed to list directory '${dirPath}'`;
+      return result.output || `Error: Failed to list directory '${dirPath}'`
     }
 
-    return result.output;
+    return result.output
   }
 
   /**
@@ -829,225 +802,197 @@ export abstract class BaseSandbox implements SandboxBackendProtocol {
     offset: number = 1,
     limit: number = 2000,
     mode: ReadMode = 'slice',
-    indentation?: IndentationOptions,
+    indentation?: IndentationOptions
   ): Promise<string> {
-    const command = mode === 'indentation'
-      ? buildIndentationReadCommand(filePath, offset, limit, indentation ?? {})
-      : buildSliceReadCommand(filePath, offset, limit);
-    const result = await this.execute(command);
+    const command =
+      mode === 'indentation'
+        ? buildIndentationReadCommand(filePath, offset, limit, indentation ?? {})
+        : buildSliceReadCommand(filePath, offset, limit)
+    const result = await this.execute(command, FILE_OPERATION_EXECUTION_OPTIONS)
 
     if (result.exitCode !== 0) {
-      return result.output || `Error: File '${filePath}' not found`;
+      return result.output || `Error: File '${filePath}' not found`
     }
 
-    return result.output;
+    return result.output
   }
 
   /**
    * Structured search results or error string for invalid input.
    */
-  async grepRaw(
-    pattern: string,
-    path: string = "/",
-    include: string | null = null,
-  ): Promise<GrepMatch[] | string> {
-    const command = buildGrepCommand(pattern, path, include);
-    const result = await this.execute(command);
+  async grepRaw(pattern: string, path: string = '/', include: string | null = null): Promise<GrepMatch[] | string> {
+    const command = buildGrepCommand(pattern, path, include)
+    const result = await this.execute(command, FILE_SEARCH_EXECUTION_OPTIONS)
 
     if (result.exitCode === 1) {
       // Check if it's a regex error
-      if (result.output.includes("Invalid regex:")) {
-        return result.output.trim();
+      if (result.output.includes('Invalid regex:')) {
+        return result.output.trim()
       }
     }
 
-    const matches: GrepMatch[] = [];
-    const lines = result.output.trim().split("\n").filter(Boolean);
+    const matches: GrepMatch[] = []
+    const lines = result.output.trim().split('\n').filter(Boolean)
 
     for (const line of lines) {
       try {
-        const parsed = JSON.parse(line);
+        const parsed = JSON.parse(line)
         matches.push({
           path: parsed.path,
           line: parsed.line,
-          text: parsed.text,
-        });
+          text: parsed.text
+        })
       } catch {
         // Skip invalid JSON lines
       }
     }
 
-    return matches;
+    return matches
   }
 
   /**
    * Search file contents for a regex pattern, returning human-readable output.
    */
-  async grep(
-    pattern: string,
-    path: string = "/",
-    include: string | null = null,
-  ): Promise<string> {
-    const result = await this.grepRaw(pattern, path, include);
+  async grep(pattern: string, path: string = '/', include: string | null = null): Promise<string> {
+    const result = await this.grepRaw(pattern, path, include)
 
-    if (typeof result === "string") {
-      return result;
+    if (typeof result === 'string') {
+      return result
     }
 
     if (result.length === 0) {
-      return "No matches found";
+      return 'No matches found'
     }
 
-    return formatGrepOutput(result);
+    return formatGrepOutput(result)
   }
 
   /**
    * Structured glob matching returning FileInfo objects.
    */
-  async globInfo(pattern: string, path: string = "/"): Promise<FileInfo[]> {
-    const command = buildGlobCommand(path, pattern);
-    const result = await this.execute(command);
+  async globInfo(pattern: string, path: string = '/'): Promise<FileInfo[]> {
+    const command = buildGlobCommand(path, pattern)
+    const result = await this.execute(command, FILE_SEARCH_EXECUTION_OPTIONS)
 
-    const infos: FileInfo[] = [];
-    const lines = result.output.trim().split("\n").filter(Boolean);
+    const infos: FileInfo[] = []
+    const lines = result.output.trim().split('\n').filter(Boolean)
 
     for (const line of lines) {
       try {
-        const parsed = JSON.parse(line);
+        const parsed = JSON.parse(line)
         infos.push({
           path: parsed.path,
           is_dir: parsed.isDir,
           size: parsed.size,
-          modified_at: parsed.mtime
-            ? new Date(parsed.mtime).toISOString()
-            : undefined,
-        });
+          modified_at: parsed.mtime ? new Date(parsed.mtime).toISOString() : undefined
+        })
       } catch {
         // Skip invalid JSON lines
       }
     }
 
-    return infos;
+    return infos
   }
 
   /**
    * Find files matching a glob pattern, returning human-readable output.
    */
-  async glob(pattern: string, path: string = "/"): Promise<string> {
-    const files = await this.globInfo(pattern, path);
+  async glob(pattern: string, path: string = '/'): Promise<string> {
+    const files = await this.globInfo(pattern, path)
 
     if (files.length === 0) {
-      return "No files found";
+      return 'No files found'
     }
 
-    return formatGlobOutput(files, pattern);
+    return formatGlobOutput(files, pattern)
   }
 
   /**
    * Create a new file with content.
    */
   async write(filePath: string, content: string): Promise<WriteResult> {
-    const command = buildWriteCommand(filePath, content);
-    const result = await this.execute(command);
+    const command = buildWriteCommand(filePath, content)
+    const result = await this.execute(command, FILE_OPERATION_EXECUTION_OPTIONS)
 
     if (result.exitCode !== 0) {
-      const output = (result.output || "").trim();
+      const output = (result.output || '').trim()
       if (output.includes(WRITE_EXISTS_OUTPUT)) {
         return {
-          error: `Cannot write to ${filePath} because it already exists. Read and then make an edit, or write to a new path.`,
-        };
+          error: `Cannot write to ${filePath} because it already exists. Read and then make an edit, or write to a new path.`
+        }
       }
-      const fallback = await this.writeViaUpload(filePath, content);
+      const fallback = await this.writeViaUpload(filePath, content)
       if (!fallback.error) {
-        return fallback;
+        return fallback
       }
       return {
-        error: output
-          ? `Failed to write file '${filePath}': ${output}`
-          : `Failed to write file '${filePath}'.`,
-      };
+        error: output ? `Failed to write file '${filePath}': ${output}` : `Failed to write file '${filePath}'.`
+      }
     }
 
-    return { path: filePath, filesUpdate: null };
+    return { path: filePath, filesUpdate: null }
   }
 
-  private async writeViaUpload(
-    filePath: string,
-    content: string,
-  ): Promise<WriteResult> {
-    const existsCheck = await this.execute(buildExistsCommand(filePath));
+  private async writeViaUpload(filePath: string, content: string): Promise<WriteResult> {
+    const existsCheck = await this.execute(buildExistsCommand(filePath), FILE_OPERATION_EXECUTION_OPTIONS)
     if (existsCheck.exitCode === 0) {
       return {
-        error: `Cannot write to ${filePath} because it already exists. Read and then make an edit, or write to a new path.`,
-      };
+        error: `Cannot write to ${filePath} because it already exists. Read and then make an edit, or write to a new path.`
+      }
     }
 
-    const uploads = await this.uploadFiles([
-      [filePath, Buffer.from(content, "utf-8")],
-    ]);
-    const first = uploads[0];
+    const uploads = await this.uploadFiles([[filePath, Buffer.from(content, 'utf-8')]])
+    const first = uploads[0]
 
     if (!first) {
-      return { error: `Failed to write file '${filePath}': upload returned no result.` };
+      return { error: `Failed to write file '${filePath}': upload returned no result.` }
     }
     if (first.error) {
-      return { error: `Failed to write file '${filePath}': ${first.error}` };
+      return { error: `Failed to write file '${filePath}': ${first.error}` }
     }
 
-    return { path: filePath, filesUpdate: null };
+    return { path: filePath, filesUpdate: null }
   }
 
   /**
    * Append content to a file. Creates the file if it doesn't exist.
    */
   async append(filePath: string, content: string): Promise<WriteResult> {
-    const command = buildAppendCommand(filePath, content);
-    const result = await this.execute(command);
+    const command = buildAppendCommand(filePath, content)
+    const result = await this.execute(command, FILE_OPERATION_EXECUTION_OPTIONS)
 
     if (result.exitCode !== 0) {
-      const output = (result.output || "").trim();
+      const output = (result.output || '').trim()
       return {
-        error: output
-          ? `Failed to append to file '${filePath}': ${output}`
-          : `Failed to append to file '${filePath}'.`,
-      };
+        error: output ? `Failed to append to file '${filePath}': ${output}` : `Failed to append to file '${filePath}'.`
+      }
     }
 
-    return { path: filePath, filesUpdate: null };
+    return { path: filePath, filesUpdate: null }
   }
 
   /**
    * Edit a file by replacing string occurrences.
    */
-  async edit(
-    filePath: string,
-    oldString: string,
-    newString: string,
-    replaceAll: boolean = false,
-  ): Promise<EditResult> {
-    const command = buildEditCommand(
-      filePath,
-      oldString,
-      newString,
-      replaceAll,
-    );
-    const result = await this.execute(command);
+  async edit(filePath: string, oldString: string, newString: string, replaceAll: boolean = false): Promise<EditResult> {
+    const command = buildEditCommand(filePath, oldString, newString, replaceAll)
+    const result = await this.execute(command, FILE_OPERATION_EXECUTION_OPTIONS)
 
     switch (result.exitCode) {
       case 0: {
-        const occurrences = parseInt(result.output.trim(), 10) || 1;
-        return { path: filePath, filesUpdate: null, occurrences };
+        const occurrences = parseInt(result.output.trim(), 10) || 1
+        return { path: filePath, filesUpdate: null, occurrences }
       }
       case 1:
-        return { error: `String not found in file '${filePath}'` };
+        return { error: `String not found in file '${filePath}'` }
       case 2:
         return {
-          error: `Multiple occurrences found in '${filePath}'. Use replaceAll=true to replace all.`,
-        };
+          error: `Multiple occurrences found in '${filePath}'. Use replaceAll=true to replace all.`
+        }
       case 3:
-        return { error: `Error: File '${filePath}' not found` };
+        return { error: `Error: File '${filePath}' not found` }
       default:
-        return { error: `Unknown error editing file '${filePath}'` };
+        return { error: `Unknown error editing file '${filePath}'` }
     }
   }
 
@@ -1056,27 +1001,19 @@ export abstract class BaseSandbox implements SandboxBackendProtocol {
    * All edits are applied sequentially, with each edit operating on the result of the previous edit.
    * All edits must succeed for the operation to succeed (atomic).
    */
-  async multiEdit(
-    filePath: string,
-    edits: EditOperation[],
-  ): Promise<MultiEditResult> {
+  async multiEdit(filePath: string, edits: EditOperation[]): Promise<MultiEditResult> {
     if (!edits || edits.length === 0) {
       return {
-        error: "No edits provided",
-      };
+        error: 'No edits provided'
+      }
     }
 
-    const results: EditResult[] = [];
+    const results: EditResult[] = []
 
     for (const edit of edits) {
-      const result = await this.edit(
-        filePath,
-        edit.oldString,
-        edit.newString,
-        edit.replaceAll ?? false,
-      );
+      const result = await this.edit(filePath, edit.oldString, edit.newString, edit.replaceAll ?? false)
 
-      results.push(result);
+      results.push(result)
 
       // If any edit fails, return immediately with error
       if (result.error) {
@@ -1084,8 +1021,8 @@ export abstract class BaseSandbox implements SandboxBackendProtocol {
           error: `Multi-edit failed at edit ${results.length}: ${result.error}`,
           path: filePath,
           filesUpdate: null,
-          results,
-        };
+          results
+        }
       }
     }
 
@@ -1093,7 +1030,7 @@ export abstract class BaseSandbox implements SandboxBackendProtocol {
     return {
       path: filePath,
       filesUpdate: null,
-      results,
-    };
+      results
+    }
   }
 }

--- a/packages/plugins/agent-middlewares/src/lib/localShellSandbox.provider.spec.ts
+++ b/packages/plugins/agent-middlewares/src/lib/localShellSandbox.provider.spec.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { LocalShellSandbox } from './localShellSandbox.provider'
+
+jest.mock('@xpert-ai/plugin-sdk', () => {
+  class BaseSandbox {
+    workingDirectory = ''
+  }
+
+  return {
+    __esModule: true,
+    BaseSandbox,
+    DEFAULT_SANDBOX_SHELL_EXECUTION_OPTIONS: {
+      timeoutMs: 600000,
+      maxOutputBytes: 1024 * 1024
+    },
+    appendSandboxMessage: (output: string, message: string) => (output ? `${output}\n${message}` : message),
+    buildSandboxTimeoutMessage: (subject: string, timeoutMs: number) =>
+      `${subject} timed out after ${timeoutMs / 1000}s (${timeoutMs}ms)`,
+    resolveSandboxExecutionOptions: (
+      options: { timeoutMs?: number; maxOutputBytes?: number } | undefined,
+      defaults: { timeoutMs: number; maxOutputBytes: number }
+    ) => ({
+      timeoutMs: options?.timeoutMs ?? defaults.timeoutMs,
+      maxOutputBytes: options?.maxOutputBytes ?? defaults.maxOutputBytes
+    }),
+    SandboxProviderStrategy: () => (target: unknown) => target
+  }
+})
+
+describe('LocalShellSandbox', () => {
+  it('terminates timed out commands and prevents detached children from continuing', async () => {
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'local-shell-sandbox-'))
+    const markerPath = path.join(workingDirectory, 'still-running.txt')
+    const sandbox = new LocalShellSandbox({ workingDirectory })
+
+    try {
+      const startTime = Date.now()
+      const command = `node -e "setTimeout(() => require('fs').writeFileSync('${markerPath}', 'alive'), 1500); setTimeout(() => {}, 5000)"`
+      const result = await sandbox.execute(command, { timeoutMs: 200 })
+      const elapsedMs = Date.now() - startTime
+
+      await new Promise((resolve) => setTimeout(resolve, 2200))
+
+      expect(result.timedOut).toBe(true)
+      expect(result.exitCode).toBeNull()
+      expect(result.output).toContain('Command timed out after 0.2s (200ms)')
+      expect(elapsedMs).toBeLessThan(4000)
+      expect(fs.existsSync(markerPath)).toBe(false)
+    } finally {
+      fs.rmSync(workingDirectory, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/plugins/agent-middlewares/src/lib/localShellSandbox.provider.ts
+++ b/packages/plugins/agent-middlewares/src/lib/localShellSandbox.provider.ts
@@ -3,11 +3,16 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { Injectable } from '@nestjs/common'
 import {
+  appendSandboxMessage,
   BaseSandbox,
+  buildSandboxTimeoutMessage,
+  DEFAULT_SANDBOX_SHELL_EXECUTION_OPTIONS,
   ExecuteResponse,
   FileDownloadResponse,
   FileUploadResponse,
   ISandboxProvider,
+  resolveSandboxExecutionOptions,
+  SandboxExecutionOptions,
   SandboxProviderCreateOptions,
   SandboxProviderStrategy
 } from '@xpert-ai/plugin-sdk'
@@ -106,25 +111,22 @@ const LOCAL_SHELL_SANDBOX_ICON = `<?xml version="1.0" encoding="utf-8"?>
  * - downloadFiles(): Read files from the sandbox
  */
 export class LocalShellSandbox extends BaseSandbox {
-  readonly id: string;
-  private readonly timeout: number;
+  readonly id: string
 
   /**
    * Create a new LocalShellSandbox.
    *
    * @param options - Configuration options
    * @param options.workingDirectory - Directory where commands will be executed
-   * @param options.timeout - Command timeout in milliseconds (default: 30000)
    */
-  constructor(options: { workingDirectory: string; timeout?: number }) {
-    super();
-    this.workingDirectory = path.resolve(options.workingDirectory);
-    this.timeout = options.timeout ?? 30000;
-    this.id = `local-shell-${this.workingDirectory.replace(/[^a-zA-Z0-9]/g, "-")}`;
+  constructor(options: { workingDirectory: string }) {
+    super()
+    this.workingDirectory = path.resolve(options.workingDirectory)
+    this.id = `local-shell-${this.workingDirectory.replace(/[^a-zA-Z0-9]/g, '-')}`
 
     // Ensure working directory exists
     if (!fs.existsSync(this.workingDirectory)) {
-      fs.mkdirSync(this.workingDirectory, { recursive: true });
+      fs.mkdirSync(this.workingDirectory, { recursive: true })
     }
   }
 
@@ -134,90 +136,148 @@ export class LocalShellSandbox extends BaseSandbox {
    * Uses /bin/bash to run commands with proper shell interpretation.
    * Captures both stdout and stderr, respects timeout.
    */
-  async execute(command: string): Promise<ExecuteResponse> {
-    return this.runCommand(command);
+  async execute(command: string, options?: SandboxExecutionOptions): Promise<ExecuteResponse> {
+    return this.runCommand(command, undefined, options)
   }
 
-  override async streamExecute(command: string, onLine: (line: string) => void): Promise<ExecuteResponse> {
-    return this.runCommand(command, onLine);
+  override async streamExecute(
+    command: string,
+    onLine: (line: string) => void,
+    options?: SandboxExecutionOptions
+  ): Promise<ExecuteResponse> {
+    return this.runCommand(command, onLine, options)
   }
 
-  private runCommand(command: string, onChunk?: (line: string) => void): Promise<ExecuteResponse> {
+  private runCommand(
+    command: string,
+    onChunk?: (line: string) => void,
+    executionOptions?: SandboxExecutionOptions
+  ): Promise<ExecuteResponse> {
     return new Promise((resolve) => {
-      const chunks: string[] = [];
-      let truncated = false;
-      const maxOutputBytes = 1024 * 1024; // 1MB output limit
-      let totalBytes = 0;
-      let lineBuffer = "";
-      let settled = false;
+      const resolvedOptions = resolveSandboxExecutionOptions(executionOptions, DEFAULT_SANDBOX_SHELL_EXECUTION_OPTIONS)
+      const chunks: string[] = []
+      let truncated = false
+      let totalBytes = 0
+      let lineBuffer = ''
+      let settled = false
+      let timedOut = false
+      let forceKillTimer: NodeJS.Timeout | null = null
 
-      const child = cp.spawn("/bin/bash", ["-c", command], {
+      const child = cp.spawn('/bin/bash', ['-c', command], {
         cwd: this.workingDirectory,
         env: { ...process.env, HOME: process.env['HOME'] },
-      });
+        detached: process.platform !== 'win32'
+      })
+
+      const timeoutMessage = buildSandboxTimeoutMessage('Command', resolvedOptions.timeoutMs)
+
+      const buildTimeoutResponse = (): ExecuteResponse => ({
+        output: appendSandboxMessage(chunks.join(''), timeoutMessage),
+        exitCode: null,
+        truncated,
+        timedOut: true
+      })
 
       const collectOutput = (data: Buffer) => {
-        const str = data.toString();
-        totalBytes += data.byteLength;
+        const str = data.toString()
+        totalBytes += data.byteLength
 
-        if (totalBytes <= maxOutputBytes) {
-          chunks.push(str);
+        if (totalBytes <= resolvedOptions.maxOutputBytes) {
+          chunks.push(str)
         } else {
-          truncated = true;
+          truncated = true
         }
 
         if (onChunk) {
-          lineBuffer += str.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-          const lines = lineBuffer.split("\n");
-          lineBuffer = lines.pop() ?? "";
+          lineBuffer += str.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+          const lines = lineBuffer.split('\n')
+          lineBuffer = lines.pop() ?? ''
           for (const line of lines) {
-            onChunk(line);
+            onChunk(line)
           }
         }
-      };
+      }
 
       const finalize = (response: ExecuteResponse) => {
         if (settled) {
-          return;
+          return
         }
-        settled = true;
-        clearTimeout(timer);
+        settled = true
+        clearTimeout(timer)
+        if (forceKillTimer) {
+          clearTimeout(forceKillTimer)
+        }
         if (onChunk && lineBuffer) {
-          onChunk(lineBuffer);
-          lineBuffer = "";
+          onChunk(lineBuffer)
+          lineBuffer = ''
         }
-        resolve(response);
-      };
+        resolve(response)
+      }
 
-      child.stdout.on("data", collectOutput);
-      child.stderr.on("data", collectOutput);
+      const killChild = (signal: NodeJS.Signals) => {
+        if (!child.pid) {
+          return
+        }
 
-      // Handle timeout
+        try {
+          if (process.platform !== 'win32') {
+            process.kill(-child.pid, signal)
+          } else {
+            child.kill(signal)
+          }
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+            finalize({
+              output: `Error terminating process: ${(error as Error).message}`,
+              exitCode: 1,
+              truncated: false
+            })
+          }
+        }
+      }
+
+      child.stdout.on('data', collectOutput)
+      child.stderr.on('data', collectOutput)
+
       const timer = setTimeout(() => {
-        child.kill("SIGTERM");
-        finalize({
-          output: chunks.join("") + "\n[Command timed out]",
-          exitCode: null,
-          truncated,
-        });
-      }, this.timeout);
+        timedOut = true
+        killChild('SIGTERM')
+        forceKillTimer = setTimeout(() => {
+          killChild('SIGKILL')
+        }, 5000)
+      }, resolvedOptions.timeoutMs)
 
-      child.on("close", (exitCode) => {
-        finalize({
-          output: chunks.join(""),
-          exitCode,
-          truncated,
-        });
-      });
+      child.on('close', (exitCode) => {
+        if (forceKillTimer) {
+          clearTimeout(forceKillTimer)
+        }
+        finalize(
+          timedOut
+            ? buildTimeoutResponse()
+            : {
+                output: chunks.join(''),
+                exitCode,
+                truncated,
+                timedOut: false
+              }
+        )
+      })
 
-      child.on("error", (err) => {
-        finalize({
-          output: `Error spawning process: ${err.message}`,
-          exitCode: 1,
-          truncated: false,
-        });
-      });
-    });
+      child.on('error', (err) => {
+        if (forceKillTimer) {
+          clearTimeout(forceKillTimer)
+        }
+        finalize(
+          timedOut
+            ? buildTimeoutResponse()
+            : {
+                output: `Error spawning process: ${err.message}`,
+                exitCode: 1,
+                truncated: false
+              }
+        )
+      })
+    })
   }
 
   /**
@@ -225,36 +285,34 @@ export class LocalShellSandbox extends BaseSandbox {
    *
    * Writes files to the working directory, creating parent directories as needed.
    */
-  async uploadFiles(
-    files: Array<[string, Uint8Array]>,
-  ): Promise<FileUploadResponse[]> {
-    const results: FileUploadResponse[] = [];
+  async uploadFiles(files: Array<[string, Uint8Array]>): Promise<FileUploadResponse[]> {
+    const results: FileUploadResponse[] = []
 
     for (const [filePath, content] of files) {
       try {
-        const fullPath = path.join(this.workingDirectory, filePath);
-        const parentDir = path.dirname(fullPath);
+        const fullPath = path.join(this.workingDirectory, filePath)
+        const parentDir = path.dirname(fullPath)
 
         // Ensure parent directory exists
         if (!fs.existsSync(parentDir)) {
-          fs.mkdirSync(parentDir, { recursive: true });
+          fs.mkdirSync(parentDir, { recursive: true })
         }
 
-        fs.writeFileSync(fullPath, content);
-        results.push({ path: filePath, error: null });
+        fs.writeFileSync(fullPath, content)
+        results.push({ path: filePath, error: null })
       } catch (err) {
-        const error = err as NodeJS.ErrnoException;
-        if (error.code === "EACCES") {
-          results.push({ path: filePath, error: "permission_denied" });
-        } else if (error.code === "EISDIR") {
-          results.push({ path: filePath, error: "is_directory" });
+        const error = err as NodeJS.ErrnoException
+        if (error.code === 'EACCES') {
+          results.push({ path: filePath, error: 'permission_denied' })
+        } else if (error.code === 'EISDIR') {
+          results.push({ path: filePath, error: 'is_directory' })
         } else {
-          results.push({ path: filePath, error: "invalid_path" });
+          results.push({ path: filePath, error: 'invalid_path' })
         }
       }
     }
 
-    return results;
+    return results
   }
 
   /**
@@ -263,56 +321,56 @@ export class LocalShellSandbox extends BaseSandbox {
    * Reads files from the working directory.
    */
   async downloadFiles(paths: string[]): Promise<FileDownloadResponse[]> {
-    const results: FileDownloadResponse[] = [];
+    const results: FileDownloadResponse[] = []
 
     for (const filePath of paths) {
       try {
-        const fullPath = path.join(this.workingDirectory, filePath);
+        const fullPath = path.join(this.workingDirectory, filePath)
 
         if (!fs.existsSync(fullPath)) {
           results.push({
             path: filePath,
             content: null,
-            error: "file_not_found",
-          });
-          continue;
+            error: 'file_not_found'
+          })
+          continue
         }
 
-        const stat = fs.statSync(fullPath);
+        const stat = fs.statSync(fullPath)
         if (stat.isDirectory()) {
           results.push({
             path: filePath,
             content: null,
-            error: "is_directory",
-          });
-          continue;
+            error: 'is_directory'
+          })
+          continue
         }
 
-        const content = fs.readFileSync(fullPath);
+        const content = fs.readFileSync(fullPath)
         results.push({
           path: filePath,
           content: new Uint8Array(content),
-          error: null,
-        });
+          error: null
+        })
       } catch (err) {
-        const error = err as NodeJS.ErrnoException;
-        if (error.code === "EACCES") {
+        const error = err as NodeJS.ErrnoException
+        if (error.code === 'EACCES') {
           results.push({
             path: filePath,
             content: null,
-            error: "permission_denied",
-          });
+            error: 'permission_denied'
+          })
         } else {
           results.push({
             path: filePath,
             content: null,
-            error: "file_not_found",
-          });
+            error: 'file_not_found'
+          })
         }
       }
     }
 
-    return results;
+    return results
   }
 }
 

--- a/packages/plugins/agent-middlewares/src/lib/sandboxShell.spec.ts
+++ b/packages/plugins/agent-middlewares/src/lib/sandboxShell.spec.ts
@@ -1,0 +1,133 @@
+import { DEFAULT_SANDBOX_SHELL_TIMEOUT_MS, ExecuteResponse } from '@xpert-ai/plugin-sdk'
+import { SandboxShellMiddleware } from './sandboxShell'
+
+jest.mock('@xpert-ai/plugin-sdk', () => {
+  class BaseSandbox {
+    workingDirectory = ''
+  }
+
+  return {
+    __esModule: true,
+    BaseSandbox,
+    DEFAULT_SANDBOX_SHELL_TIMEOUT_SEC: 600,
+    DEFAULT_SANDBOX_SHELL_TIMEOUT_MS: 600000,
+    SANDBOX_SHELL_TIMEOUT_LIMITS_SEC: {
+      min: 1,
+      max: 3600
+    },
+    secondsToMilliseconds: (seconds: number) => Math.trunc(seconds * 1000),
+    AgentMiddlewareStrategy: () => (target: unknown) => target
+  }
+})
+
+jest.mock('./toolMessageUtils', () => ({
+  __esModule: true,
+  getToolCallId: () => 'tool-call-1',
+  withStreamingToolMessage: async (
+    _toolCallId: string,
+    _toolName: string,
+    command: string,
+    backend: { streamExecute?: Function; execute: Function },
+    executionOptions?: { timeoutMs?: number }
+  ) =>
+    backend.streamExecute
+      ? backend.streamExecute(command, () => undefined, executionOptions)
+      : backend.execute(command, executionOptions)
+}))
+
+describe('SandboxShellMiddleware', () => {
+  const createTool = async () => {
+    const middleware = new SandboxShellMiddleware()
+    const agentMiddleware = await Promise.resolve(middleware.createMiddleware({}, {} as any))
+    return agentMiddleware.tools[0]
+  }
+
+  const createBackend = (response: ExecuteResponse) => ({
+    execute: jest.fn().mockResolvedValue(response),
+    streamExecute: jest.fn().mockResolvedValue(response)
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('passes the 600 second default timeout to the backend', async () => {
+    const tool = await createTool()
+    const backend = createBackend({
+      output: 'install complete',
+      exitCode: 0,
+      truncated: false,
+      timedOut: false
+    })
+
+    const result = await tool.invoke(
+      { command: 'npm install' },
+      {
+        configurable: {
+          sandbox: {
+            backend
+          }
+        },
+        metadata: {
+          tool_call_id: 'tool-call-1'
+        }
+      }
+    )
+
+    expect(result).toBe('install complete')
+    expect(backend.streamExecute).toHaveBeenCalledWith('npm install', expect.any(Function), {
+      timeoutMs: DEFAULT_SANDBOX_SHELL_TIMEOUT_MS
+    })
+  })
+
+  it('passes timeout_sec overrides through to the backend', async () => {
+    const tool = await createTool()
+    const backend = createBackend({
+      output: 'done',
+      exitCode: 0,
+      truncated: false,
+      timedOut: false
+    })
+
+    await tool.invoke(
+      {
+        command: 'cargo build',
+        timeout_sec: 42
+      },
+      {
+        configurable: {
+          sandbox: {
+            backend
+          }
+        }
+      }
+    )
+
+    expect(backend.streamExecute).toHaveBeenCalledWith('cargo build', expect.any(Function), {
+      timeoutMs: 42000
+    })
+  })
+
+  it('returns explicit timeout output without an exitCode null wrapper', async () => {
+    const tool = await createTool()
+    const backend = createBackend({
+      output: 'Command timed out after 2s (2000ms)',
+      exitCode: null,
+      truncated: false,
+      timedOut: true
+    })
+
+    const result = await tool.invoke(
+      { command: 'pytest', timeout_sec: 2 },
+      {
+        configurable: {
+          sandbox: {
+            backend
+          }
+        }
+      }
+    )
+
+    expect(result).toBe('Command timed out after 2s (2000ms)')
+  })
+})

--- a/packages/plugins/agent-middlewares/src/lib/sandboxShell.ts
+++ b/packages/plugins/agent-middlewares/src/lib/sandboxShell.ts
@@ -1,13 +1,13 @@
 import { tool } from '@langchain/core/tools'
-import {
-  TAgentMiddlewareMeta,
-  TAgentRunnableConfigurable
-} from '@metad/contracts'
+import { TAgentMiddlewareMeta, TAgentRunnableConfigurable } from '@metad/contracts'
 import { Injectable } from '@nestjs/common'
 import {
   AgentMiddleware,
   AgentMiddlewareStrategy,
   BaseSandbox,
+  DEFAULT_SANDBOX_SHELL_TIMEOUT_SEC,
+  SANDBOX_SHELL_TIMEOUT_LIMITS_SEC,
+  secondsToMilliseconds,
   IAgentMiddlewareContext,
   IAgentMiddlewareStrategy,
   PromiseOrValue
@@ -19,7 +19,22 @@ const SANDBOX_SHELL_MIDDLEWARE_NAME = 'SandboxShell'
 const SANDBOX_SHELL_TOOL_NAME = 'sandbox_shell'
 
 const shellToolSchema = z.object({
-  command: z.string().min(1, 'Command is required.')
+  command: z.string().min(1, 'Command is required.'),
+  timeout_sec: z
+    .number()
+    .int()
+    .min(
+      SANDBOX_SHELL_TIMEOUT_LIMITS_SEC.min,
+      `Timeout must be at least ${SANDBOX_SHELL_TIMEOUT_LIMITS_SEC.min} second.`
+    )
+    .max(
+      SANDBOX_SHELL_TIMEOUT_LIMITS_SEC.max,
+      `Timeout must be at most ${SANDBOX_SHELL_TIMEOUT_LIMITS_SEC.max} seconds.`
+    )
+    .optional()
+    .describe(
+      `Optional command timeout in seconds. Defaults to ${DEFAULT_SANDBOX_SHELL_TIMEOUT_SEC} seconds. Increase this for long-running commands like npm install, pnpm install, cargo build, or test suites. The sandbox terminates the command when the timeout is reached and returns an explicit timeout message.`
+    )
 })
 
 @Injectable()
@@ -45,12 +60,9 @@ export class SandboxShellMiddleware implements IAgentMiddlewareStrategy {
     }
   }
 
-  createMiddleware(
-    _options: unknown,
-    _context: IAgentMiddlewareContext
-  ): PromiseOrValue<AgentMiddleware> {
+  createMiddleware(_options: unknown, _context: IAgentMiddlewareContext): PromiseOrValue<AgentMiddleware> {
     const shellTool = tool(
-      async ({ command }, config) => {
+      async ({ command, timeout_sec }, config) => {
         const configurable = config?.configurable as TAgentRunnableConfigurable | undefined
         const backend = configurable?.sandbox?.backend as BaseSandbox | undefined
 
@@ -58,13 +70,20 @@ export class SandboxShellMiddleware implements IAgentMiddlewareStrategy {
           throw new Error('Sandbox backend is not available for SandboxShell.')
         }
 
+        const timeoutSec = timeout_sec ?? DEFAULT_SANDBOX_SHELL_TIMEOUT_SEC
         const result = await withStreamingToolMessage(
           getToolCallId(config),
           SANDBOX_SHELL_TOOL_NAME,
           command,
-          backend
+          backend,
+          {
+            timeoutMs: secondsToMilliseconds(timeoutSec)
+          }
         )
 
+        if (result.timedOut) {
+          return result.output
+        }
         if (result.exitCode !== 0) {
           return `Exit code ${result.exitCode}\n${result.output}`
         }
@@ -72,7 +91,11 @@ export class SandboxShellMiddleware implements IAgentMiddlewareStrategy {
       },
       {
         name: SANDBOX_SHELL_TOOL_NAME,
-        description: 'Execute a shell command in the configured sandbox backend.',
+        description: `Execute a shell command in the configured sandbox backend.
+
+Default timeout: ${DEFAULT_SANDBOX_SHELL_TIMEOUT_SEC} seconds.
+
+Use timeout_sec for long-running commands such as npm install, pnpm install, cargo build, pytest, or large test/build jobs. When the timeout is reached, the sandbox terminates the command and returns explicit timeout information.`,
         schema: shellToolSchema
       }
     )

--- a/packages/plugins/agent-middlewares/src/lib/toolMessageUtils.ts
+++ b/packages/plugins/agent-middlewares/src/lib/toolMessageUtils.ts
@@ -5,7 +5,7 @@ import {
   TChatMessageStep,
   TProgramToolMessage
 } from '@metad/contracts'
-import { BaseSandbox, ExecuteResponse } from '@xpert-ai/plugin-sdk'
+import { BaseSandbox, ExecuteResponse, SandboxExecutionOptions } from '@xpert-ai/plugin-sdk'
 import ShortUniqueId from 'short-unique-id'
 
 const uid = new ShortUniqueId({ length: 10 })
@@ -38,7 +38,9 @@ export async function withToolMessage<T>(
     status: 'running',
     created_date: new Date(),
     input
-  } as TChatMessageStep).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
+  } as TChatMessageStep).catch((e) => {
+    console.warn('[ToolMessage] dispatch failed:', e?.message)
+  })
 
   try {
     const result = await fn()
@@ -51,7 +53,9 @@ export async function withToolMessage<T>(
       status: 'success',
       end_date: new Date(),
       output: typeof result === 'string' ? result : JSON.stringify(result)
-    } as TChatMessageStep).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
+    } as TChatMessageStep).catch((e) => {
+      console.warn('[ToolMessage] dispatch failed:', e?.message)
+    })
     return result
   } catch (err: any) {
     await dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE, {
@@ -63,7 +67,9 @@ export async function withToolMessage<T>(
       status: 'fail',
       end_date: new Date(),
       error: err.message
-    } as TChatMessageStep).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
+    } as TChatMessageStep).catch((e) => {
+      console.warn('[ToolMessage] dispatch failed:', e?.message)
+    })
     throw err
   }
 }
@@ -86,18 +92,26 @@ export async function withStreamingToolMessage(
   toolCallId: string,
   toolName: string,
   command: string,
-  backend: BaseSandbox
+  backend: BaseSandbox,
+  executionOptions?: SandboxExecutionOptions
 ): Promise<ExecuteResponse> {
-  const makeStep = (
-    overrides: Partial<TChatMessageStep<TProgramToolMessage>>
-  ): TChatMessageStep<TProgramToolMessage> =>
+  const input = {
+    command,
+    ...(executionOptions?.timeoutMs
+      ? {
+          timeout_sec: Number((executionOptions.timeoutMs / 1000).toFixed(3))
+        }
+      : {})
+  }
+
+  const makeStep = (overrides: Partial<TChatMessageStep<TProgramToolMessage>>): TChatMessageStep<TProgramToolMessage> =>
     ({
       id: toolCallId,
       category: 'Tool',
       type: ChatMessageStepCategory.Program,
       tool: toolName,
       title: toolName,
-      input: { command },
+      input,
       ...overrides
     }) as TChatMessageStep<TProgramToolMessage>
 
@@ -110,7 +124,9 @@ export async function withStreamingToolMessage(
       output: '',
       data: { code: command, output: '' }
     })
-  ).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
+  ).catch((e) => {
+    console.warn('[ToolMessage] dispatch failed:', e?.message)
+  })
 
   // Phase 2: streaming execution
   let result: ExecuteResponse
@@ -118,23 +134,29 @@ export async function withStreamingToolMessage(
     let accumulatedOutput = ''
     let lastDispatchTime = 0
 
-    result = await backend.streamExecute(command, (line) => {
-      accumulatedOutput += (accumulatedOutput ? '\n' : '') + line
-      const now = Date.now()
-      if (now - lastDispatchTime >= STREAM_THROTTLE_MS) {
-        lastDispatchTime = now
-        dispatchCustomEvent(
-          ChatMessageEventTypeEnum.ON_TOOL_MESSAGE,
-          makeStep({
-            status: 'running',
-            output: accumulatedOutput,
-            data: { code: command, output: accumulatedOutput }
+    result = await backend.streamExecute(
+      command,
+      (line) => {
+        accumulatedOutput += (accumulatedOutput ? '\n' : '') + line
+        const now = Date.now()
+        if (now - lastDispatchTime >= STREAM_THROTTLE_MS) {
+          lastDispatchTime = now
+          dispatchCustomEvent(
+            ChatMessageEventTypeEnum.ON_TOOL_MESSAGE,
+            makeStep({
+              status: 'running',
+              output: accumulatedOutput,
+              data: { code: command, output: accumulatedOutput }
+            })
+          ).catch((e) => {
+            console.warn('[ToolMessage] dispatch failed:', e?.message)
           })
-        ).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
-      }
-    })
+        }
+      },
+      executionOptions
+    )
   } else {
-    result = await backend.execute(command)
+    result = await backend.execute(command, executionOptions)
   }
 
   // Phase 3: completion
@@ -148,7 +170,9 @@ export async function withStreamingToolMessage(
       data: { code: command, output: finalOutput },
       error: result.exitCode !== 0 ? finalOutput : undefined
     })
-  ).catch((e) => { console.warn('[ToolMessage] dispatch failed:', e?.message) })
+  ).catch((e) => {
+    console.warn('[ToolMessage] dispatch failed:', e?.message)
+  })
 
   return result
 }

--- a/packages/server-ai/src/sandbox/client.shell.spec.ts
+++ b/packages/server-ai/src/sandbox/client.shell.spec.ts
@@ -1,0 +1,147 @@
+const mockEventSourceInstances: MockEventSource[] = []
+
+class MockEventSource {
+	url: string
+	options: any
+	listeners = new Map<string, Array<(event: any) => void>>()
+	close = jest.fn()
+
+	constructor(url: string, options: any) {
+		this.url = url
+		this.options = options
+		mockEventSourceInstances.push(this)
+	}
+
+	addEventListener(type: string, listener: (event: any) => void) {
+		const listeners = this.listeners.get(type) ?? []
+		listeners.push(listener)
+		this.listeners.set(type, listeners)
+	}
+
+	emit(type: string, event: any) {
+		for (const listener of this.listeners.get(type) ?? []) {
+			listener(event)
+		}
+	}
+}
+
+jest.mock('@langchain/core/callbacks/dispatch', () => ({
+	dispatchCustomEvent: jest.fn().mockResolvedValue(undefined)
+}))
+
+jest.mock('@metad/contracts', () => ({
+	ChatMessageEventTypeEnum: {
+		ON_TOOL_MESSAGE: 'ON_TOOL_MESSAGE'
+	},
+	ChatMessageStepCategory: {
+		Program: 'Program'
+	}
+}))
+
+jest.mock('@metad/server-common', () => ({
+	getPythonErrorMessage: (error: any) => error?.message ?? String(error),
+	shortuuid: () => 'shortuuid',
+	urlJoin: (...parts: string[]) => parts.join('/')
+}))
+
+jest.mock('@metad/server-config', () => ({
+	environment: {
+		pro: true
+	}
+}))
+
+jest.mock('@metad/server-core', () => ({
+	DeployWebappCommand: class DeployWebappCommand {},
+	RequestContext: {
+		currentTenantId: () => 'tenant-id'
+	}
+}))
+
+jest.mock('@nestjs/cqrs', () => ({
+	CommandBus: class CommandBus {}
+}))
+
+jest.mock('axios', () => ({
+	__esModule: true,
+	default: {
+		post: jest.fn(),
+		get: jest.fn()
+	}
+}))
+
+jest.mock('eventsource', () => ({
+	EventSource: jest.fn().mockImplementation((url: string, options: any) => new MockEventSource(url, options))
+}))
+
+jest.mock('i18next', () => ({
+	t: (key: string) => key
+}))
+
+jest.mock('../shared', () => ({
+	sandboxVolume: jest.fn(),
+	sandboxVolumeUrl: jest.fn()
+}))
+
+import { ShellClient } from './client'
+
+describe('ShellClient', () => {
+	beforeEach(() => {
+		mockEventSourceInstances.length = 0
+		jest.clearAllMocks()
+	})
+
+	it('includes the timeout termination message in exec() rejections', async () => {
+		const client = new ShellClient({
+			commandBus: {} as any,
+			sandboxUrl: 'http://sandbox'
+		})
+
+		const promise = client.exec(
+			{
+				workspace_id: 'workspace',
+				command: 'npm install'
+			},
+			{
+				signal: new AbortController().signal,
+				toolCall: { id: 'tool-call-1' } as any
+			}
+		)
+
+		const eventSource = mockEventSourceInstances[0]
+		eventSource.emit('message', { data: 'line 1' })
+		eventSource.emit('message', {
+			data: '<timeout> <error> Command timed out after 1s (1000ms)'
+		})
+
+		await expect(promise).rejects.toBe('line 1\n<timeout> <error> Command timed out after 1s (1000ms)')
+	})
+
+	it('emits and propagates the timeout termination message in stream()', async () => {
+		const client = new ShellClient({
+			commandBus: {} as any,
+			sandboxUrl: 'http://sandbox'
+		})
+		const nextValues: string[] = []
+
+		const completion = new Promise<string>((resolve) => {
+			client
+				.stream({
+					workspace_id: 'workspace',
+					command: 'npm install'
+				})
+				.subscribe({
+					next: (value) => nextValues.push(String(value)),
+					error: (error) => resolve(String(error))
+				})
+
+			const eventSource = mockEventSourceInstances[0]
+			eventSource.emit('message', { data: 'line 1' })
+			eventSource.emit('message', {
+				data: '<timeout> <error> Command timed out after 1s (1000ms)'
+			})
+		})
+
+		await expect(completion).resolves.toBe('line 1\n<timeout> <error> Command timed out after 1s (1000ms)')
+		expect(nextValues).toEqual(['line 1', '<timeout> <error> Command timed out after 1s (1000ms)'])
+	})
+})

--- a/packages/server-ai/src/sandbox/client.ts
+++ b/packages/server-ai/src/sandbox/client.ts
@@ -16,7 +16,16 @@ import { ServerResponse } from 'http'
 import { t } from 'i18next'
 import { Observable } from 'rxjs'
 import { sandboxVolume, sandboxVolumeUrl } from '../shared'
-import { FilesSystem, TCreateFileReq, TCreateFileResp, TFileBaseReq, TListFilesReq, TListFilesResponse, TReadFileReq, TSandboxParams } from './types'
+import {
+	FilesSystem,
+	TCreateFileReq,
+	TCreateFileResp,
+	TFileBaseReq,
+	TListFilesReq,
+	TListFilesResponse,
+	TReadFileReq,
+	TSandboxParams
+} from './types'
 
 /**
  * Base parameters for sandbox operations.
@@ -34,9 +43,7 @@ export class SandboxFileSystem implements FilesSystem {
 		return this.params.sandboxUrl
 	}
 
-	constructor(
-		protected params: TSandboxParams
-	) {}
+	constructor(protected params: TSandboxParams) {}
 
 	async doRequest(path: string, requestData: any, options: { signal: AbortSignal }) {
 		if (environment.pro) {
@@ -118,12 +125,18 @@ export type TProjectCodeParams = TProjectBaseParams & {
 	content: string
 }
 
-const completionCondition = (data) => {
-			return data.includes('<done>')
-		}
-	const errorCondition = (data) => {
-			return data.includes('<error>')
-		}
+const completionCondition = (data = '') => {
+	return data.includes('<done>')
+}
+const errorCondition = (data = '') => {
+	return data.includes('<error>')
+}
+const appendShellEventOutput = (result: string, data?: string) => {
+	if (data == null || data === '') {
+		return result
+	}
+	return result ? `${result}\n${data}` : data
+}
 export class ProjectClient {
 	get sandboxUrl() {
 		return this.params.sandboxUrl
@@ -166,97 +179,97 @@ export class ProjectClient {
 	async build(body: TProjectDeployParams, options: { signal: AbortSignal }): Promise<string> {
 		const command = `npm install && npm run build`
 		return new Promise((resolve, reject) => {
-				const stepId = shortuuid()
-				const createdDate = new Date()
-				let result = ''
-				const es = new EventSource(this.sandboxUrl + '/project/build/', {
-					fetch: (input, init) =>
-						fetch(input, {
-							...init,
-							method: 'POST',
-							headers: {
-								...init.headers,
-								'Content-Type': 'application/json'
-							},
-							body: JSON.stringify(body),
-							signal: options.signal
-						})
-				})
-
-				es.addEventListener('message', (event) => {
-					if (errorCondition(event.data)) {
-						dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE, {
-							id: stepId,
-							category: 'Computer',
-							type: ChatMessageStepCategory.Program,
-							end_date: new Date(),
-							status: 'fail',
-							error: event.data,
-							data: {
-								code: command,
-								output: result
-							},
-						} as TChatMessageStep<TProgramToolMessage>).catch((err) => {
-							console.error(err)
-						})
-						reject(`Build failed:\n${result}`)
-					} else if (completionCondition(event.data)) {
-						dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE, {
-							id: stepId,
-							category: 'Computer',
-							type: ChatMessageStepCategory.Program,
-							end_date: new Date(),
-							status: 'success',
-							data: {
-								code: command,
-								output: result
-							},
-						} as TChatMessageStep<TProgramToolMessage>).catch((err) => {
-							console.error(err)
-						})
-						resolve(result) // Resolve with the complete message
-						es.close() // Close the connection
-						return
-					} else if (event.data != null) {
-						try {
-							if (result) {
-								result += '\n'
-							}
-							result += event.data ?? ''
-
-							// Update tool message
-							dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE, {
-								id: stepId,
-								category: 'Computer',
-								type: ChatMessageStepCategory.Program,
-								toolset: 'code-project',
-								tool: 'build-deploy',
-								title: t('server-ai:Tools.CodeProject.Building'),
-								message: `npm run build`,
-								data: {
-									code: command,
-									output: result
-								},
-								created_date: createdDate,
-								status: 'running'
-							} as TChatMessageStep<TProgramToolMessage>).catch((err) => {
-								console.error(err)
-							})
-						} catch (err) {
-							throw new Error(`Convert build call result error`)
-						}
-					}
-				})
-
-				es.addEventListener('error', (err) => {
-					console.error(err)
-					if (err.code === 401 || err.code === 403) {
-						console.log('not authorized')
-					}
-					es.close()
-					reject(err)
-				})
+			const stepId = shortuuid()
+			const createdDate = new Date()
+			let result = ''
+			const es = new EventSource(this.sandboxUrl + '/project/build/', {
+				fetch: (input, init) =>
+					fetch(input, {
+						...init,
+						method: 'POST',
+						headers: {
+							...init.headers,
+							'Content-Type': 'application/json'
+						},
+						body: JSON.stringify(body),
+						signal: options.signal
+					})
 			})
+
+			es.addEventListener('message', (event) => {
+				if (errorCondition(event.data)) {
+					dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE, {
+						id: stepId,
+						category: 'Computer',
+						type: ChatMessageStepCategory.Program,
+						end_date: new Date(),
+						status: 'fail',
+						error: event.data,
+						data: {
+							code: command,
+							output: result
+						}
+					} as TChatMessageStep<TProgramToolMessage>).catch((err) => {
+						console.error(err)
+					})
+					reject(`Build failed:\n${result}`)
+				} else if (completionCondition(event.data)) {
+					dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE, {
+						id: stepId,
+						category: 'Computer',
+						type: ChatMessageStepCategory.Program,
+						end_date: new Date(),
+						status: 'success',
+						data: {
+							code: command,
+							output: result
+						}
+					} as TChatMessageStep<TProgramToolMessage>).catch((err) => {
+						console.error(err)
+					})
+					resolve(result) // Resolve with the complete message
+					es.close() // Close the connection
+					return
+				} else if (event.data != null) {
+					try {
+						if (result) {
+							result += '\n'
+						}
+						result += event.data ?? ''
+
+						// Update tool message
+						dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE, {
+							id: stepId,
+							category: 'Computer',
+							type: ChatMessageStepCategory.Program,
+							toolset: 'code-project',
+							tool: 'build-deploy',
+							title: t('server-ai:Tools.CodeProject.Building'),
+							message: `npm run build`,
+							data: {
+								code: command,
+								output: result
+							},
+							created_date: createdDate,
+							status: 'running'
+						} as TChatMessageStep<TProgramToolMessage>).catch((err) => {
+							console.error(err)
+						})
+					} catch (err) {
+						throw new Error(`Convert build call result error`)
+					}
+				}
+			})
+
+			es.addEventListener('error', (err) => {
+				console.error(err)
+				if (err.code === 401 || err.code === 403) {
+					console.log('not authorized')
+				}
+				es.close()
+				reject(err)
+			})
+		})
 	}
 
 	async deploy(body: TProjectDeployParams, options: { signal: AbortSignal }): Promise<string> {
@@ -269,15 +282,15 @@ export class PythonClient {
 	get sandboxUrl() {
 		return this.params.sandboxUrl
 	}
-	constructor(
-		protected params: TSandboxParams
-	) {}
+	constructor(protected params: TSandboxParams) {}
 
 	async exec(body: { code: string }, options: { signal: AbortSignal }): Promise<string> {
 		if (environment.pro) {
 			const sandboxUrl = this.sandboxUrl
 			try {
-				const { data: result } = await axios.post(`${sandboxUrl}/python/exec/`, body, { signal: options.signal })
+				const { data: result } = await axios.post(`${sandboxUrl}/python/exec/`, body, {
+					signal: options.signal
+				})
 				return JSON.stringify(result.observation, null, 2)
 			} catch (error) {
 				throw new Error(getPythonErrorMessage(error))
@@ -317,10 +330,10 @@ export class BaseToolClient {
 export type TShellExecReq = TSandboxBaseParams & {
 	dir?: string
 	command: string
+	timeout_sec?: number
 }
 
 export class ShellClient extends BaseToolClient {
-
 	stream(body: TShellExecReq, options?: { signal?: AbortSignal }) {
 		return new Observable((subscriber) => {
 			const abortController = new AbortController()
@@ -341,6 +354,8 @@ export class ShellClient extends BaseToolClient {
 
 			es.addEventListener('message', (event) => {
 				if (errorCondition(event.data)) {
+					result = appendShellEventOutput(result, event.data)
+					subscriber.next(event.data)
 					subscriber.error(result)
 					es.close()
 					return
@@ -401,6 +416,7 @@ export class ShellClient extends BaseToolClient {
 
 				es.addEventListener('message', (event) => {
 					if (errorCondition(event.data)) {
+						result = appendShellEventOutput(result, event.data)
 						this.dispatchStepEvent(body.command, result, stepId, event.data)
 						reject(result)
 						es.close()
@@ -440,24 +456,22 @@ export class ShellClient extends BaseToolClient {
 	}
 
 	async dispatchStepEvent(command: string, output: string, stepId: string, error?: string) {
-		dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE,
-			{
-				id: stepId,
-				category: 'Computer',
-				type: ChatMessageStepCategory.Program,
-				toolset: 'Bash',
-				tool: 'execute',
-				title: t('server-ai:Tools.Bash.ExecuteBashCommand'),
-				message: command,
-				data: {
-					code: command,
-					output: output
-				},
-				error
-			} as TChatMessageStep<TProgramToolMessage>
-		).catch((err) => {
-					console.error(err)
-				})
+		dispatchCustomEvent(ChatMessageEventTypeEnum.ON_TOOL_MESSAGE, {
+			id: stepId,
+			category: 'Computer',
+			type: ChatMessageStepCategory.Program,
+			toolset: 'Bash',
+			tool: 'execute',
+			title: t('server-ai:Tools.Bash.ExecuteBashCommand'),
+			message: command,
+			data: {
+				code: command,
+				output: output
+			},
+			error
+		} as TChatMessageStep<TProgramToolMessage>).catch((err) => {
+			console.error(err)
+		})
 	}
 }
 
@@ -468,14 +482,14 @@ export class Sandbox {
 	python = new PythonClient(this.params)
 	shell = new ShellClient(this.params)
 	browser = new BrowserClient(this.params)
-	git  = new GitClient(this.params)
+	git = new GitClient(this.params)
 
 	static sandboxVolume(projectId: string, userId: string) {
 		return sandboxVolume(projectId, userId)
 	}
 
 	static sandboxFileUrl(volume: string, workspaceId: string, file: string) {
-    	return urlJoin(sandboxVolumeUrl(volume, workspaceId), file) + `?tenant=${RequestContext.currentTenantId()}`;
+		return urlJoin(sandboxVolumeUrl(volume, workspaceId), file) + `?tenant=${RequestContext.currentTenantId()}`
 	}
 
 	get sandboxUrl() {
@@ -503,7 +517,6 @@ export class Sandbox {
 		return requestData
 	}
 }
-
 
 export type TBrowserActionResult = {
 	success?: boolean
@@ -540,12 +553,16 @@ export class BrowserClient {
 
 	/**
 	 * Execute a browser automation action through the API
-	 * 
+	 *
 	 * @param endpoint The API endpoint to call
 	 * @param params Parameters to send. Defaults to null.
 	 * @param method HTTP method to use. Defaults to "POST".
 	 */
-	async executeAction(endpoint: string, params: Record<string, any> | string = null, options: { method?: 'POST'; signal: AbortSignal; responseType?: 'blob' | 'stream' }): Promise<TBrowserActionResult> {
+	async executeAction(
+		endpoint: string,
+		params: Record<string, any> | string = null,
+		options: { method?: 'POST'; signal: AbortSignal; responseType?: 'blob' | 'stream' }
+	): Promise<TBrowserActionResult> {
 		if (environment.pro) {
 			const sandboxUrl = this.sandboxUrl
 			try {
@@ -569,13 +586,11 @@ export class GitClient {
 	get sandboxUrl() {
 		return this.params.sandboxUrl
 	}
-	constructor(
-		protected params: TSandboxParams
-	) {}
+	constructor(protected params: TSandboxParams) {}
 
 	async clone(url: string, path?: string, branch?: string) {
-        return ''
-    }
+		return ''
+	}
 	async status(repoPath: string) {
 		return ''
 	}
@@ -597,7 +612,7 @@ export class GitClient {
 	async commit(repoPath: string, message: string) {
 		return ''
 	}
-	async push(repoPath: string, params?: {username?: string; password?: string; createBranch?: string}) {
+	async push(repoPath: string, params?: { username?: string; password?: string; createBranch?: string }) {
 		return ''
 	}
 	async pull(repoPath: string) {


### PR DESCRIPTION
## Summary
- add shared sandbox execution options and make sandbox_shell timeout explicit per call
- update the local shell sandbox to use centralized timeout defaults, process-group termination, and explicit timeout output
- preserve timeout termination SSE messages in the Node shell client and add targeted regression tests

## Testing
- yarn nx test agent-middlewares --runInBand --testPathPattern="sandboxShell.spec.ts|localShellSandbox.provider.spec.ts"
- yarn nx test server-ai --runInBand --testPathPattern="client.shell.spec.ts"

## Notes
- this open-source repo does not contain the pro-only Docker sandbox backend or Python sandbox server, so this PR only ports the timeout changes that exist in both repos
- yarn nx run-many -t build -p plugin-sdk,agent-middlewares,server-ai --parallel=1 is still blocked by the existing server build dependency issue for nestjs-pino in packages/server