### PR TITLE
fix(docs): correct OpenAPI source path in docs.json

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,7 +47,7 @@
               {
                 "group": "AI",
                 "openapi": {
-                  "source": "/api/openapi.ai.json",
+                  "source": "api/openapi.ai.json",
                   "directory": "en/api-reference"
                 }
               }
@@ -87,7 +87,7 @@
               {
                 "group": "AI",
                 "openapi": {
-                  "source": "/api/openapi.ai.json",
+                  "source": "api/openapi.ai.json",
                   "directory": "zh-hans/api-reference"
                 }
               }


### PR DESCRIPTION
- Remove leading slash from OpenAPI source path to use relative path
- Change from '/api/openapi.ai.json' to 'api/openapi.ai.json'
- Fixes #320: API reference for clicking was incorrect due to wrong path

# PR

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Checklist

- [ ] Have you followed the [contributing guidelines](https://github.com/xpert-ai/xpert/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: ✅ we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
