### PR TITLE
fix(redis): add refresh support to lock service

### DIFF
--- a/packages/server/src/core/redis/redis-lock.service.ts
+++ b/packages/server/src/core/redis/redis-lock.service.ts
@@ -3,6 +3,24 @@ import { randomUUID } from 'crypto'
 import { Redis } from 'ioredis'
 import { REDIS_CLIENT } from './types'
 
+const RELEASE_LOCK_SCRIPT = `
+  if redis.call("get", KEYS[1]) == ARGV[1]
+  then
+    return redis.call("del", KEYS[1])
+  else
+    return 0
+  end
+`
+
+const REFRESH_LOCK_SCRIPT = `
+  if redis.call("get", KEYS[1]) == ARGV[1]
+  then
+    return redis.call("pexpire", KEYS[1], ARGV[2])
+  else
+    return 0
+  end
+`
+
 @Injectable()
 export class RedisLockService {
 	@Inject(REDIS_CLIENT)
@@ -17,15 +35,13 @@ export class RedisLockService {
 
 	// Release lock (only if lockId matches)
 	async releaseLock(key: string, lockId: string): Promise<boolean> {
-		const script = `
-      if redis.call("get", KEYS[1]) == ARGV[1] 
-      then 
-        return redis.call("del", KEYS[1]) 
-      else 
-        return 0 
-      end
-    `
-		const result = await this.redis.eval(script, 1, key, lockId)
+		const result = await this.redis.eval(RELEASE_LOCK_SCRIPT, 1, key, lockId)
+		return result === 1
+	}
+
+	// Refresh lock TTL (only if lockId matches)
+	async refreshLock(key: string, lockId: string, ttl: number): Promise<boolean> {
+		const result = await this.redis.eval(REFRESH_LOCK_SCRIPT, 1, key, lockId, `${ttl}`)
 		return result === 1
 	}
 }


### PR DESCRIPTION
## Summary
- extract the Redis Lua release script into a shared constant
- add `refreshLock()` so callers can safely extend lock TTL while retaining lock ownership checks
- keep the existing `acquireLock()` and `releaseLock()` behavior unchanged

## Verification
- reviewed the diff to confirm the PR only changes `packages/server/src/core/redis/redis-lock.service.ts`
- attempted `./node_modules/.bin/tsc -p packages/server/tsconfig.lib.json --noEmit`, but the local workspace currently fails with unrelated missing `nestjs-pino` module errors

## Context
This mirrors the lock-service improvement already applied in `xpert-pro`, where long-running repo-sync work now needs lock refresh support.
