### PR TITLE
feat(integration): support plugin lifecycle hooks and test probes

### DIFF
--- a/apps/cloud/src/app/@core/services/integration.service.ts
+++ b/apps/cloud/src/app/@core/services/integration.service.ts
@@ -2,21 +2,103 @@ import { inject, Injectable } from '@angular/core'
 import { API_PREFIX, OrganizationBaseCrudService } from '@metad/cloud/state'
 import { IIntegration, IntegrationFeatureEnum, TIntegrationProvider } from '@metad/contracts'
 import { TSelectOption } from '@metad/ocap-angular/core'
-import { NGXLogger } from 'ngx-logger'
+import { Observable } from 'rxjs'
 
 const API_INTEGRATION = API_PREFIX + '/integration'
 
+export interface IntegrationTestProbe {
+  connected?: boolean
+  state?: string
+  lastError?: string | null
+  checkedAt?: number | null
+}
+
+export interface IntegrationTestResult {
+  webhookUrl?: string
+  mode?: string
+  warnings?: string[]
+  probe?: IntegrationTestProbe
+}
+
+export type IntegrationTestFormPatch = Partial<
+  Pick<IIntegration, 'name' | 'avatar' | 'description' | 'slug' | 'provider' | 'options' | 'features'>
+>
+
+export type IntegrationTestResponse = IntegrationTestResult & IntegrationTestFormPatch
+
+export function normalizeIntegrationTestResult(
+  result?: Partial<IntegrationTestResponse> | null
+): IntegrationTestResult | null {
+  if (!result) {
+    return null
+  }
+
+  const normalized: IntegrationTestResult = {}
+
+  if (result.webhookUrl !== undefined) {
+    normalized.webhookUrl = result.webhookUrl
+  }
+  if (result.mode !== undefined) {
+    normalized.mode = result.mode
+  }
+  if (Array.isArray(result.warnings)) {
+    normalized.warnings = [...result.warnings]
+  }
+  if (result.probe) {
+    normalized.probe = {
+      connected: result.probe.connected,
+      state: result.probe.state,
+      lastError: result.probe.lastError ?? null,
+      checkedAt: result.probe.checkedAt ?? null
+    }
+  }
+
+  return Object.keys(normalized).length ? normalized : null
+}
+
+export function pickIntegrationTestFormPatch(
+  result?: Partial<IntegrationTestResponse> | null
+): IntegrationTestFormPatch {
+  if (!result) {
+    return {}
+  }
+
+  const patch: IntegrationTestFormPatch = {}
+
+  if (result.name !== undefined) {
+    patch.name = result.name
+  }
+  if (result.avatar !== undefined) {
+    patch.avatar = result.avatar
+  }
+  if (result.description !== undefined) {
+    patch.description = result.description
+  }
+  if (result.slug !== undefined) {
+    patch.slug = result.slug
+  }
+  if (result.provider !== undefined) {
+    patch.provider = result.provider
+  }
+  if (result.options !== undefined) {
+    patch.options = result.options
+  }
+  if (result.features !== undefined) {
+    patch.features = result.features
+  }
+
+  return patch
+}
+
 @Injectable({ providedIn: 'root' })
 export class IntegrationService extends OrganizationBaseCrudService<IIntegration> {
-  readonly #logger = inject(NGXLogger)
-
   constructor() {
     super(API_INTEGRATION)
   }
 
-  test(integration: Partial<IIntegration>) {
+  test(integration: Partial<IIntegration>): Observable<IntegrationTestResponse> {
     // return this.httpClient.post(API_PREFIX + `/${integration.provider}/test`, integration)
-    return this.httpClient.post<Record<string, string>>(API_INTEGRATION + '/test', integration)
+    return this.httpClient.post<IntegrationTestResponse>(API_INTEGRATION + '/test', integration)
   }
 
   selectOptions(options: {provider?: string; features?: IntegrationFeatureEnum[]}) {

--- a/apps/cloud/src/app/features/setting/integration/integration/integration.component.html
+++ b/apps/cloud/src/app/features/setting/integration/integration/integration.component.html
@@ -89,6 +89,43 @@
       </div>
     }
 
+    @if (longConnectionProbe(); as probe) {
+      <div class="flex flex-col gap-2">
+        <p>{{ 'PAC.Integration.LongConnectionStatus' | translate: { Default: 'Long connection status' } }}:</p>
+        <div class="px-3 py-2 rounded-md text-sm bg-gray-50 dark:bg-white/10 flex flex-col gap-1">
+          <div>
+            <span class="font-medium">{{ 'PAC.KEY_WORDS.Connected' | translate: { Default: 'Connected' } }}:</span>
+            {{ probe.connected === true ? 'Yes' : probe.connected === false ? 'No' : '-' }}
+          </div>
+          <div>
+            <span class="font-medium">{{ 'PAC.KEY_WORDS.State' | translate: { Default: 'State' } }}:</span>
+            {{ probe.state || '-' }}
+          </div>
+          <div>
+            <span class="font-medium">{{ 'PAC.KEY_WORDS.Error' | translate: { Default: 'Last error' } }}:</span>
+            <span class="whitespace-break-spaces">{{ probe.lastError || '-' }}</span>
+          </div>
+          <div>
+            <span class="font-medium">{{ 'PAC.KEY_WORDS.CheckedAt' | translate: { Default: 'Checked at' } }}:</span>
+            {{ formatCheckedAt(probe.checkedAt) || '-' }}
+          </div>
+        </div>
+      </div>
+    }
+
+    @if (testWarnings().length) {
+      <div class="flex flex-col gap-2">
+        <p>{{ 'PAC.KEY_WORDS.Warnings' | translate: { Default: 'Warnings' } }}:</p>
+        <div class="px-3 py-2 rounded-md text-sm bg-amber-50 dark:bg-amber-500/10">
+          <ul class="list-disc pl-5 flex flex-col gap-1">
+            @for (warning of testWarnings(); track warning) {
+              <li class="whitespace-break-spaces">{{ warning }}</li>
+            }
+          </ul>
+        </div>
+      </div>
+    }
+
     <div class="w-full filter-bar p-2 flex justify-between items-center gap-4">
       <button mat-flat-button type="button" [disabled]="!integrationProvider() || optionsInvalid" (click)="test()">
         {{ 'PAC.KEY_WORDS.Test' | translate: {Default: 'Test'} }}

--- a/apps/cloud/src/app/features/setting/integration/integration/integration.component.ts
+++ b/apps/cloud/src/app/features/setting/integration/integration/integration.component.ts
@@ -23,14 +23,18 @@ import omit from 'lodash-es/omit'
 import { derivedFrom } from 'ngxtension/derived-from'
 import { injectParams } from 'ngxtension/inject-params'
 import { injectQueryParams } from 'ngxtension/inject-query-params'
-import { BehaviorSubject, distinctUntilChanged, EMPTY, pipe, startWith, switchMap } from 'rxjs'
+import { BehaviorSubject, distinctUntilChanged, EMPTY, map, pipe, startWith, switchMap } from 'rxjs'
 import {
   getErrorMessage,
   injectApiBaseUrl,
   injectTranslate,
   IntegrationService,
+  normalizeIntegrationTestResult,
+  pickIntegrationTestFormPatch,
   routeAnimations,
   Store,
+  type IntegrationTestProbe,
+  type IntegrationTestResult,
   ToastrService
 } from '../../../../@core'
 
@@ -144,8 +148,20 @@ export class IntegrationComponent implements IsDirty {
   )
 
   readonly loading = signal(true)
-
-  readonly webhookUrl = signal('')
+  readonly testResult = signal<IntegrationTestResult | null>(null)
+  readonly webhookUrl = computed(() => this.testResult()?.webhookUrl ?? '')
+  readonly longConnectionProbe = computed<IntegrationTestProbe | null>(() => this.testResult()?.probe ?? null)
+  readonly testWarnings = computed(() => this.testResult()?.warnings ?? [])
+  readonly connectionMode = toSignal(
+    this.optionsControl.valueChanges.pipe(
+      startWith(this.optionsControl.value),
+      map((value) => value?.connectionMode ?? null),
+      distinctUntilChanged()
+    ),
+    {
+      initialValue: this.optionsControl.value?.connectionMode ?? null
+    }
+  )
 
   constructor() {
     effect(
@@ -179,6 +195,15 @@ export class IntegrationComponent implements IsDirty {
       },
       { allowSignalWrites: true }
     )
+
+    effect(
+      () => {
+        this.provider()
+        this.connectionMode()
+        this.testResult.set(null)
+      },
+      { allowSignalWrites: true }
+    )
   }
 
   isDirty(): boolean {
@@ -191,13 +216,18 @@ export class IntegrationComponent implements IsDirty {
 
   test() {
     this.loading.set(true)
+    this.testResult.set(null)
     this.integrationAPI.test(this.formGroup.value).subscribe({
       next: (result) => {
-        if (result?.webhookUrl) {
-          this.webhookUrl.set(result.webhookUrl)
-        } else if (result) {
-          this.formGroup.patchValue(result)
+        const testResult = normalizeIntegrationTestResult(result)
+        const formPatch = pickIntegrationTestFormPatch(result)
+
+        this.testResult.set(testResult)
+
+        if (Object.keys(formPatch).length) {
+          this.formGroup.patchValue(formPatch)
         }
+
         this.formGroup.markAsDirty()
         this.loading.set(false)
         this.#toastr.success('PAC.Messages.TestSuccessfully', { Default: 'Test successfully!' })
@@ -205,6 +235,7 @@ export class IntegrationComponent implements IsDirty {
       error: (error) => {
         this.#toastr.danger(getErrorMessage(error))
         this.loading.set(false)
+        this.testResult.set(null)
       }
     })
   }
@@ -233,5 +264,13 @@ export class IntegrationComponent implements IsDirty {
 
   close(refresh = false) {
     this.#router.navigate(['../'], { relativeTo: this.#route })
+  }
+
+  formatCheckedAt(checkedAt?: number | null) {
+    if (!checkedAt) {
+      return ''
+    }
+
+    return new Date(checkedAt).toLocaleString()
   }
 }

--- a/packages/plugin-sdk/src/lib/core/permissions/general.ts
+++ b/packages/plugin-sdk/src/lib/core/permissions/general.ts
@@ -1,4 +1,4 @@
-import type { IIntegration } from '@metad/contracts'
+import type { IIntegration, IPagination } from '@metad/contracts'
 
 /**
  * Base Permission type
@@ -75,4 +75,5 @@ export const INTEGRATION_PERMISSION_SERVICE_TOKEN = 'XPERT_PLUGIN_INTEGRATION_PE
  */
 export interface IntegrationPermissionService {
   read<TIntegration = IIntegration>(id: string, options?: Record<string, any>): Promise<TIntegration | null>
+  findAll<TIntegration = IIntegration>(options?: Record<string, any>): Promise<IPagination<TIntegration>>
 }

--- a/packages/plugin-sdk/src/lib/integration/strategy.interface.ts
+++ b/packages/plugin-sdk/src/lib/integration/strategy.interface.ts
@@ -7,6 +7,8 @@ export type TIntegrationStrategyParams = {
 export interface IntegrationStrategy<T = unknown> {
   meta: TIntegrationProvider
   execute(integration: IIntegration<T>, payload: TIntegrationStrategyParams): Promise<any>
+  onUpdate?(previous: IIntegration<T>, current: IIntegration<any>): Promise<void> | void
+  onDelete?(integration: IIntegration<T>): Promise<void> | void
   validateConfig?(config: T, integration?: IIntegration<T>): Promise<void | {
     webhookUrl: string
   }>

--- a/packages/server/src/integration/commands/handlers/delete.handler.ts
+++ b/packages/server/src/integration/commands/handlers/delete.handler.ts
@@ -11,6 +11,8 @@ export class IntegrationDelHandler implements ICommandHandler<IntegrationDelComm
 
 	public async execute(command: IntegrationDelCommand): Promise<void> {
 		const { id } = command
+		const previous = await this.service.findOne(id)
+		await this.service.runStrategyDeleteHook(previous)
 		await this.service.delete(id)
 	}
 }

--- a/packages/server/src/integration/commands/handlers/upsert.handler.ts
+++ b/packages/server/src/integration/commands/handlers/upsert.handler.ts
@@ -14,7 +14,14 @@ export class IntegrationUpsertHandler implements ICommandHandler<IntegrationUpse
 	public async execute(command: IntegrationUpsertCommand): Promise<IIntegration> {
 		const { input } = command
 		if (input.id) {
-			await this.service.update(input.id, omit(input, 'id'))
+			const previous = await this.service.findOne(input.id)
+			const patch = omit(input, 'id')
+			const current = {
+				...previous,
+				...patch
+			} as IIntegration
+			await this.service.runStrategyUpdateHook(previous, current)
+			await this.service.update(input.id, patch)
 			return await this.service.findOne(input.id)
 		} else {
 			return await this.service.create(omit(input, 'id'))

--- a/packages/server/src/integration/integration.controller.ts
+++ b/packages/server/src/integration/integration.controller.ts
@@ -1,11 +1,26 @@
 import { IIntegration, INTEGRATION_PROVIDERS, IntegrationEnum, IntegrationFeatureEnum } from '@metad/contracts'
-import { Body, Controller, Get, InternalServerErrorException, Post, Query, UseInterceptors } from '@nestjs/common'
+import {
+	Body,
+	Controller,
+	Delete,
+	Get,
+	HttpCode,
+	HttpStatus,
+	InternalServerErrorException,
+	Param,
+	Post,
+	Put,
+	Query,
+	UseInterceptors
+} from '@nestjs/common'
 import { CommandBus } from '@nestjs/cqrs'
 import { ApiTags } from '@nestjs/swagger'
 import { FindOptionsWhere } from 'typeorm'
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity'
 import { TransformInterceptor } from '../core/interceptors'
-import { ParseJsonPipe } from '../shared/pipes'
+import { ParseJsonPipe, UUIDValidationPipe } from '../shared/pipes'
 import { CrudController, PaginationParams, transformWhere } from './../core/crud'
+import { IntegrationDelCommand, IntegrationUpsertCommand } from './commands'
 import { IntegrationPublicDTO } from './dto'
 import { Integration } from './integration.entity'
 import { IntegrationService } from './integration.service'
@@ -59,5 +74,31 @@ export class IntegrationController extends CrudController<Integration> {
 	@Get('providers')
 	async getProviders() {
 		return this.service.getProviders()
+	}
+
+	@Post()
+	@HttpCode(HttpStatus.CREATED)
+	async create(@Body() entity: Partial<Integration>) {
+		return this.commandBus.execute(new IntegrationUpsertCommand(entity))
+	}
+
+	@Put(':id')
+	@HttpCode(HttpStatus.ACCEPTED)
+	async update(
+		@Param('id', UUIDValidationPipe) id: string,
+		@Body() entity: QueryDeepPartialEntity<Integration>
+	) {
+		return this.commandBus.execute(
+			new IntegrationUpsertCommand({
+				...(entity as Record<string, unknown>),
+				id
+			})
+		)
+	}
+
+	@Delete(':id')
+	@HttpCode(HttpStatus.ACCEPTED)
+	async delete(@Param('id', UUIDValidationPipe) id: string) {
+		return this.commandBus.execute(new IntegrationDelCommand(id))
 	}
 }

--- a/packages/server/src/integration/integration.service.ts
+++ b/packages/server/src/integration/integration.service.ts
@@ -1,5 +1,5 @@
 import { IIntegration, INTEGRATION_PROVIDERS } from '@metad/contracts'
-import { Injectable } from '@nestjs/common'
+import { BadRequestException, Injectable } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { IntegrationStrategyRegistry, RequestContext } from '@xpert-ai/plugin-sdk'
 import { FindOneOptions, Repository } from 'typeorm'
@@ -31,6 +31,31 @@ export class IntegrationService extends TenantOrganizationAwareCrudService<Integ
 	async test(integration: IIntegration) {
 		const strategy = this.getIntegrationStrategy(integration.provider)
 		return strategy.validateConfig(integration.options, integration)
+	}
+
+	async runStrategyUpdateHook(previous: IIntegration, current: IIntegration) {
+		const strategy = previous?.provider ? this.getIntegrationStrategy(previous.provider) : null
+
+		try {
+			if (previous?.provider !== current?.provider) {
+				await strategy?.onDelete?.(previous)
+				return
+			}
+
+			await strategy?.onUpdate?.(previous, current)
+		} catch (error) {
+			throw new BadRequestException(error instanceof Error ? error.message : String(error))
+		}
+	}
+
+	async runStrategyDeleteHook(integration: IIntegration) {
+		const strategy = integration?.provider ? this.getIntegrationStrategy(integration.provider) : null
+
+		try {
+			await strategy?.onDelete?.(integration)
+		} catch (error) {
+			throw new BadRequestException(error instanceof Error ? error.message : String(error))
+		}
 	}
 
 	readOneById(id: string, options?: FindOneOptions<Integration>) {

--- a/packages/server/src/plugin/permissions/integration-permission.ts
+++ b/packages/server/src/plugin/permissions/integration-permission.ts
@@ -1,8 +1,8 @@
-import { IIntegration } from "@metad/contracts"
+import { IIntegration, IPagination } from "@metad/contracts"
 import { Injectable } from "@nestjs/common"
 import { ModuleRef } from "@nestjs/core"
 import { IntegrationPermissionService } from "@xpert-ai/plugin-sdk"
-import { FindOneOptions } from "typeorm"
+import { FindManyOptions, FindOneOptions } from "typeorm"
 import { IntegrationService } from "../../integration/integration.service"
 import { Integration } from "../../core/entities/internal"
 
@@ -31,6 +31,32 @@ export class PluginIntegrationPermissionService implements IntegrationPermission
       return (await integrationService.readOneById(id, options)) as TIntegration
     } catch {
       return null
+    }
+  }
+
+  async findAll<TIntegration = IIntegration>(
+    options?: FindManyOptions<Integration>
+  ): Promise<IPagination<TIntegration>> {
+    let integrationService: IntegrationService
+    try {
+      integrationService = this.moduleRef.get<IntegrationService>(IntegrationService, {
+        strict: false,
+      })
+    } catch {
+      return { items: [], total: 0 }
+    }
+    if (!integrationService) {
+      return { items: [], total: 0 }
+    }
+
+    try {
+      const result = await integrationService.findAll(options)
+      return {
+        items: (result?.items ?? []) as TIntegration[],
+        total: result?.total ?? 0
+      }
+    } catch {
+      return { items: [], total: 0 }
     }
   }
 }


### PR DESCRIPTION
# Summary

This PR adds the minimal host-side support needed for generic plugin integrations to manage integration lifecycles and expose richer test results in the shared integration settings page.

Fixes #<issue number>

Changes included in this PR:

- add `findAll()` to the generic `IntegrationPermissionService` contract and host implementation so plugin strategies can enumerate integrations through the existing permission layer
- add generic integration strategy lifecycle hooks for update and delete:
  - `onUpdate(previous, current)`
  - `onDelete(integration)`
- run those lifecycle hooks from the real integration update/delete flow before persistence changes are applied
- extend the shared integration test result model so the generic integration page can display:
  - webhook URL
  - long connection probe state
  - warnings
- keep the implementation generic and minimal:
  - no migration
  - no Feishu-specific page
  - no hardcoded provider logic
  - no runtime-status reconnect/disconnect UI
  - no changes to the built-in host `packages/plugins/integration-lark`

# Motivation And Context

We already have plugin-side integration logic that needs a few generic host capabilities in order to fully manage long-connection style integrations.

Before this change:

- plugins could read a single integration through permissions, but could not generically list integrations
- integration update/delete flows did not expose a generic strategy lifecycle for cleanup or reconfiguration
- the shared integration settings page could show webhook-related data after `test`, but could not also show long-connection probe status in a generic way

This PR fills those host-side gaps with the smallest practical change set, so provider-specific behavior can stay inside plugin strategies instead of being baked into the host.

In particular, this makes the host ready for plugin-side follow-up work such as:

- bootstrapping integrations by listing them through the permission service
- reacting to integration updates/deletes through generic lifecycle hooks
- showing webhook and long-connection status together in the shared integration configuration page

# What Changed

Backend:
- extended `IntegrationPermissionService` with `findAll()`
- implemented `PluginIntegrationPermissionService.findAll()` with safe empty pagination fallback
- extended `IntegrationStrategy` with optional `onUpdate` and `onDelete`
- added `runStrategyUpdateHook()` and `runStrategyDeleteHook()` in `IntegrationService`
- updated integration upsert/delete handlers to load the previous integration, run the lifecycle hook, then persist
- routed the real integration controller create/update/delete paths through the command handlers so lifecycle hooks are actually applied in the host API flow

Frontend:
- expanded integration test result typing to include `webhookUrl`, `mode`, `warnings`, and `probe`
- updated the shared integration settings component to store a normalized `testResult`
- cleared stale test result state when `provider` or `options.connectionMode` changes
- limited form patching after `test()` to explicit form-owned fields only
- added generic UI blocks for long-connection probe data and warnings while preserving webhook URL display

# Dependencies

No migration or schema change is required.

No additional host built-in plugin change is required.

This PR is host-side groundwork for plugin-side integration behavior to consume the new generic capabilities. In other words:
- merge dependency for this PR: none
- follow-up dependency for full provider behavior: plugin-side implementation can adopt the new `findAll()` and lifecycle hooks

# Checklist

- [x] Have you followed the [contributing guidelines](https://github.com/xpert-ai/xpert/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?
