### PR TITLE
fix(plugin-sdk): widen integration test result type

### DIFF
--- a/packages/plugin-sdk/src/lib/integration/strategy.interface.ts
+++ b/packages/plugin-sdk/src/lib/integration/strategy.interface.ts
@@ -4,12 +4,24 @@ export type TIntegrationStrategyParams = {
   query: string
 }
 
+export type IntegrationTestProbe = {
+  connected?: boolean
+  state?: string
+  lastError?: string | null
+  checkedAt?: number | null
+}
+
+export type IntegrationTestResult = {
+  webhookUrl?: string
+  mode?: string
+  warnings?: string[]
+  probe?: IntegrationTestProbe
+} & Record<string, unknown>
+
 export interface IntegrationStrategy<T = unknown> {
   meta: TIntegrationProvider
   execute(integration: IIntegration<T>, payload: TIntegrationStrategyParams): Promise<any>
   onUpdate?(previous: IIntegration<T>, current: IIntegration<any>): Promise<void> | void
   onDelete?(integration: IIntegration<T>): Promise<void> | void
-  validateConfig?(config: T, integration?: IIntegration<T>): Promise<void | {
-    webhookUrl: string
-  }>
+  validateConfig?(config: T, integration?: IIntegration<T>): Promise<void | IntegrationTestResult>
 }


### PR DESCRIPTION
## Summary
- widen the shared `IntegrationStrategy.validateConfig()` result type in `@xpert-ai/plugin-sdk`
- align the SDK contract with the host integration test UI, which already supports `webhookUrl`, `mode`, `warnings`, and `probe`
- unblock external Lark plugin builds that return richer integration test results

## Validation
- `nx build plugin-sdk`
- `nx build server`
- `nx test plugin-sdk`

## Notes
- this PR only updates the shared plugin-sdk integration test result contract
- no built-in host Lark code was changed in this PR
