### PR TITLE
Fix #471: The concurrent agent streaming output is wrongly segmented:...

### DIFF
--- a/packages/contracts/src/ai/message-content.utils.spec.ts
+++ b/packages/contracts/src/ai/message-content.utils.spec.ts
@@ -44,7 +44,9 @@ describe('message-content.utils', () => {
     expect(chunks[0].text).toBe('hello world')
   })
 
-  it('keeps append order when multiple text streams interleave', () => {
+  it('merges interleaved chunks from the same stream into one segment', () => {
+    // Concurrent streams: A → B → A (interleaved). A2 must merge back into the A1
+    // chunk rather than being appended as a third fragment (issue #471).
     const message = { id: 'm1', role: 'ai', content: '' } as CopilotChatMessage
 
     appendMessageContent(message, 'A1', { source: 'chat_stream', streamId: 'stream-a' })
@@ -52,13 +54,11 @@ describe('message-content.utils', () => {
     appendMessageContent(message, 'A2', { source: 'chat_stream', streamId: 'stream-a' })
 
     const chunks = message.content as any[]
-    expect(chunks).toHaveLength(3)
+    expect(chunks).toHaveLength(2)
     expect(chunks[0].id).toBe('stream-a')
-    expect(chunks[0].text).toBe('A1')
+    expect(chunks[0].text).toBe('A1A2')
     expect(chunks[1].id).toBe('stream-b')
     expect(chunks[1].text).toBe('\nB1')
-    expect(chunks[2].id).toBe('stream-a')
-    expect(chunks[2].text).toBe('\nA2')
   })
 
   it('adds a line break when next text follows a closed code fence from another stream', () => {

--- a/packages/contracts/src/ai/message-content.utils.ts
+++ b/packages/contracts/src/ai/message-content.utils.ts
@@ -308,14 +308,26 @@ export function appendMessageContent(
     const joinHint =
       resolvedContext.joinHint ?? (shouldJoinWithoutSeparator(previous, resolvedContext) ? 'none' : undefined)
     const lastContent = chunks[chunks.length - 1]
-    if (
-      isTextContent(lastContent) &&
-      (joinHint === 'none' || (!!content.id && !!lastContent.id && lastContent.id === content.id))
-    ) {
+
+    // When the incoming chunk has an id (streamId), search backward for an existing
+    // chunk with the same id so that interleaved concurrent streams (A→B→A) are
+    // merged into the correct segment rather than appended as new fragments.
+    if (!!content.id) {
+      const existingIndex = chunks.findLastIndex(
+        (c) => isTextContent(c) && (c as TMessageContentText).id === content.id
+      )
+      if (existingIndex > -1) {
+        const existing = chunks[existingIndex] as TMessageContentText
+        const merged = { ...existing, text: `${existing.text}${content.text}` } as TMessageContentText
+        const nextChunks = [...chunks]
+        nextChunks[existingIndex] = merged
+        aiMessage.content = nextChunks
+        return
+      }
+    } else if (isTextContent(lastContent) && joinHint === 'none') {
       const mergedLastContent = {
         ...lastContent,
-        text: `${lastContent.text}${content.text}`,
-        ...(!lastContent.id && content.id ? { id: content.id } : {})
+        text: `${lastContent.text}${content.text}`
       } as TMessageContentText
       aiMessage.content = [...chunks.slice(0, chunks.length - 1), mergedLastContent]
       return


### PR DESCRIPTION
Closes #471

# PR

## Summary

Fixes the fragmented display of concurrent agent streaming output (issue #471). When multiple agents stream simultaneously with `maxConcurrency > 1`, interleaved chunk delivery (e.g., A→B→A) caused stream A's second chunk to be appended as a new segment rather than merged into stream A's existing chunk, producing alternating fragments in the message area.

**Root cause:** `appendMessageContent` in `packages/contracts/src/ai/message-content.utils.ts` only merged a new chunk into the *last* chunk in the array. With interleaved streams, the last chunk belongs to a different stream (B), so stream A's continuation was wrongly appended as a third independent fragment.

## Changes

**`packages/contracts/src/ai/message-content.utils.ts`**

The merge logic in `appendMessageContent` is split into two distinct paths:

1. **Chunks with a `streamId`/`id`:** Instead of comparing against only `chunks[chunks.length - 1]`, the function now calls `findLastIndex` to search backward through the array for an existing chunk with a matching `id`. When found, the new text is merged in-place at that index (`existing.text + content.text`), leaving all other chunks untouched. This correctly handles the A→B→A interleaving pattern.

2. **Chunks without an `id`:** The previous `joinHint === 'none'` merge path is preserved for anonymous/non-streamed chunks. The `!lastContent.id && content.id` id-promotion branch is removed as it is superseded by the new id-based lookup.

**`packages/contracts/src/ai/message-content.utils.spec.ts`**

The existing test `'keeps append order when multiple text streams interleave'` is updated to assert the corrected behavior: after A1→B1→A2 delivery, `message.content` has **2** chunks (not 3), with `chunks[0].text === 'A1A2'` and `chunks[1].text === '\nB1'`. The test description is updated to reflect the intent.

## Testing

- The updated unit test in `message-content.utils.spec.ts` directly covers the interleaved A→B→A scenario and passes with the fix applied.
- The fix is contained to the merge strategy inside `appendMessageContent` and does not affect chunks that lack an `id`, preserving existing behavior for non-concurrent streams.

## Checklist

- [x] Have you followed the [contributing guidelines](https://github.com/xpert-ai/xpert/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*