### PR TITLE
[codex] align user workspace and memory paths

### DIFF
--- a/apps/cloud/src/app/features/xpert/xpert/memory/files/files.component.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/memory/files/files.component.ts
@@ -21,7 +21,7 @@ export class XpertMemoryFilesComponent {
   readonly xpertId = this.xpertComponent.paramId
   readonly xpert = computed(() => this.xpertComponent.xpert() ?? this.xpertComponent.latestXpert())
   readonly workspaceId = computed(() => this.xpert()?.workspaceId ?? null)
-  readonly rootLabel = computed(() => this.xpert()?.title || this.xpert()?.name || 'Memory files')
+  readonly rootLabel = computed(() => '.xpert/memory')
   readonly reloadKey = computed(() => this.workspaceId() ?? '__hosted__')
 
   readonly loadMemoryFiles: FileWorkbenchFilesLoader = (path?: string) => {

--- a/packages/plugins/agent-middlewares/src/lib/sandboxFile.spec.ts
+++ b/packages/plugins/agent-middlewares/src/lib/sandboxFile.spec.ts
@@ -1,6 +1,10 @@
 import { WorkflowNodeTypeEnum } from '@xpert-ai/contracts'
 import { SandboxFileMiddleware } from './sandboxFile'
 
+const mockWithToolMessage = jest.fn(
+  async (_toolCallId: string, _toolName: string, _title: string, _input: unknown, fn: () => Promise<unknown>) => fn()
+)
+
 jest.mock('@xpert-ai/contracts', () => ({
   WorkflowNodeTypeEnum: {
     MIDDLEWARE: 'middleware'
@@ -18,6 +22,12 @@ jest.mock('@xpert-ai/plugin-sdk', () => {
     AgentMiddlewareStrategy: () => (target: unknown) => target
   }
 })
+
+jest.mock('./toolMessageUtils', () => ({
+  __esModule: true,
+  getToolCallId: () => 'tool-call-1',
+  withToolMessage: (...args: Parameters<typeof mockWithToolMessage>) => mockWithToolMessage(...args)
+}))
 
 describe('SandboxFileMiddleware', () => {
   const createXpertFeatures = () => ({
@@ -41,30 +51,9 @@ describe('SandboxFileMiddleware', () => {
     }
   })
 
-  it('requires the sandbox xpert feature before creating middleware', async () => {
-    const middleware = new SandboxFileMiddleware()
-
-    expect(() =>
-        middleware.createMiddleware({}, {
-          tenantId: 'tenant-1',
-          userId: 'user-1',
-          xpertFeatures: null,
-          node: {
-            id: 'middleware-1',
-            key: 'middleware-1',
-            type: WorkflowNodeTypeEnum.MIDDLEWARE,
-            provider: 'sandbox-file'
-          },
-          tools: new Map()
-        })
-    ).toThrow('SandboxFile requires the xpert sandbox feature to be enabled.')
-  })
-
-  it('creates middleware tools when the sandbox xpert feature is enabled', async () => {
-    const middleware = new SandboxFileMiddleware()
-
-    const agentMiddleware = await Promise.resolve(
-      middleware.createMiddleware({}, {
+  const createMiddleware = async () =>
+    Promise.resolve(
+      new SandboxFileMiddleware().createMiddleware({}, {
         tenantId: 'tenant-1',
         userId: 'user-1',
         xpertFeatures: createXpertFeatures(),
@@ -78,6 +67,53 @@ describe('SandboxFileMiddleware', () => {
       })
     )
 
+  const createTool = async (name: string) => {
+    const middleware = await createMiddleware()
+    const tool = middleware.tools.find((item) => item.name === name)
+    if (!tool) {
+      throw new Error(`Tool ${name} not found`)
+    }
+    return tool
+  }
+
+  const createBackend = (workingDirectory = '/workspace/user') => ({
+    workingDirectory,
+    read: jest.fn().mockResolvedValue('file contents'),
+    glob: jest.fn().mockResolvedValue('glob results'),
+    grep: jest.fn().mockResolvedValue('grep results'),
+    write: jest.fn().mockImplementation(async (filePath: string) => ({ path: filePath, filesUpdate: null })),
+    append: jest.fn().mockImplementation(async (filePath: string) => ({ path: filePath, filesUpdate: null })),
+    edit: jest.fn().mockImplementation(async (filePath: string) => ({ path: filePath, filesUpdate: null })),
+    multiEdit: jest.fn().mockImplementation(async (filePath: string) => ({ path: filePath, filesUpdate: null })),
+    listDir: jest.fn().mockResolvedValue('list results')
+  })
+
+  beforeEach(() => {
+    mockWithToolMessage.mockClear()
+  })
+
+  it('requires the sandbox xpert feature before creating middleware', async () => {
+    const middleware = new SandboxFileMiddleware()
+
+    expect(() =>
+      middleware.createMiddleware({}, {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        xpertFeatures: null,
+        node: {
+          id: 'middleware-1',
+          key: 'middleware-1',
+          type: WorkflowNodeTypeEnum.MIDDLEWARE,
+          provider: 'sandbox-file'
+        },
+        tools: new Map()
+      })
+    ).toThrow('SandboxFile requires the xpert sandbox feature to be enabled.')
+  })
+
+  it('creates middleware tools when the sandbox xpert feature is enabled', async () => {
+    const agentMiddleware = await createMiddleware()
+
     expect(agentMiddleware.tools.map((tool) => tool.name)).toEqual([
       'sandbox_read_file',
       'sandbox_glob',
@@ -88,5 +124,97 @@ describe('SandboxFileMiddleware', () => {
       'sandbox_multi_edit_file',
       'sandbox_list_dir'
     ])
+  })
+
+  it('resolves root absolute write paths into the current workspace root and reports relative paths', async () => {
+    const tool = await createTool('sandbox_write_file')
+    const backend = createBackend('/workspace/user')
+
+    const result = await tool.invoke(
+      {
+        file_path: '/root/report.txt',
+        content: 'hello'
+      },
+      {
+        configurable: {
+          sandbox: {
+            backend,
+            provider: 'local-shell-sandbox'
+          }
+        }
+      }
+    )
+
+    expect(backend.write).toHaveBeenCalledWith('/workspace/user/report.txt', 'hello')
+    expect(JSON.parse(result)).toEqual({
+      path: 'report.txt',
+      filesUpdate: null
+    })
+    expect(mockWithToolMessage).toHaveBeenCalledWith(
+      'tool-call-1',
+      'sandbox_write_file',
+      'report.txt',
+      { file_path: 'report.txt' },
+      expect.any(Function)
+    )
+  })
+
+  it('keeps absolute paths that are already inside the current workspace and reports them relative to that root', async () => {
+    const tool = await createTool('sandbox_write_file')
+    const backend = createBackend('/mnt/sandbox/session/user')
+
+    const result = await tool.invoke(
+      {
+        file_path: '/mnt/sandbox/session/user/docs/report.txt',
+        content: 'hello'
+      },
+      {
+        configurable: {
+          sandbox: {
+            backend,
+            provider: 'local-shell-sandbox'
+          }
+        }
+      }
+    )
+
+    expect(backend.write).toHaveBeenCalledWith('/mnt/sandbox/session/user/docs/report.txt', 'hello')
+    expect(JSON.parse(result)).toEqual({
+      path: 'docs/report.txt',
+      filesUpdate: null
+    })
+  })
+
+  it('preserves absolute paths for non-local sandbox providers', async () => {
+    const tool = await createTool('sandbox_write_file')
+    const backend = createBackend('/mnt/sandbox/session/user')
+
+    const result = await tool.invoke(
+      {
+        file_path: '/root/report.txt',
+        content: 'hello'
+      },
+      {
+        configurable: {
+          sandbox: {
+            backend,
+            provider: 'docker-sandbox'
+          }
+        }
+      }
+    )
+
+    expect(backend.write).toHaveBeenCalledWith('/root/report.txt', 'hello')
+    expect(JSON.parse(result)).toEqual({
+      path: '/root/report.txt',
+      filesUpdate: null
+    })
+    expect(mockWithToolMessage).toHaveBeenCalledWith(
+      'tool-call-1',
+      'sandbox_write_file',
+      '/root/report.txt',
+      { file_path: '/root/report.txt' },
+      expect.any(Function)
+    )
   })
 })

--- a/packages/plugins/agent-middlewares/src/lib/sandboxFile.ts
+++ b/packages/plugins/agent-middlewares/src/lib/sandboxFile.ts
@@ -13,12 +13,14 @@ import {
   IAgentMiddlewareStrategy,
   PromiseOrValue
 } from '@xpert-ai/plugin-sdk'
-import { isAbsolute, resolve } from 'node:path'
+import { basename, isAbsolute, relative, resolve } from 'node:path'
 import { z } from 'zod/v3'
 import { getToolCallId, withToolMessage } from './toolMessageUtils'
 import { assertSandboxFeatureEnabled } from './xpertFeatureGate'
 
 const SANDBOX_FILE_MIDDLEWARE_NAME = 'SandboxFile'
+const LOCAL_SHELL_SANDBOX_PROVIDER = 'local-shell-sandbox'
+const SANDBOX_ROOT_MARKERS = ['user', 'workspace', 'sandbox', 'root'] as const
 
 const indentationSchema = z.object({
   anchor_line: z.number().optional().describe('Anchor line to center the indentation lookup on (defaults to offset)'),
@@ -29,7 +31,7 @@ const indentationSchema = z.object({
 }).optional()
 
 const readToolSchema = z.object({
-  file_path: z.string().min(1, 'File path is required.').describe('Absolute path to the file'),
+  file_path: z.string().min(1, 'File path is required.').describe('File path relative to the current working directory. Absolute paths inside the current workspace are also accepted.'),
   offset: z.number().optional().describe('The 1-indexed line number to start reading from (defaults to 1)'),
   limit: z.number().optional().describe('Maximum number of lines to return (defaults to 2000)'),
   mode: z.enum(['slice', 'indentation']).optional().describe('Mode: "slice" for simple ranges (default), "indentation" to expand around anchor line'),
@@ -38,24 +40,24 @@ const readToolSchema = z.object({
 
 const globToolSchema = z.object({
   pattern: z.string().min(1, 'Pattern is required.').describe('The glob pattern to match files against (e.g., "**/*.ts", "src/*.py")'),
-  path: z.string().optional().describe('Subdirectory to search in (relative to workspace root). Defaults to "." (current directory) if not specified. Always provide this parameter for best results.')
+  path: z.string().optional().describe('Subdirectory to search in, relative to the current working directory. Defaults to "." if not specified. Always provide this parameter for best results.')
 })
 
 const grepToolSchema = z.object({
   pattern: z.string().min(1, 'Pattern is required.').describe('The regex pattern to search for in file contents'),
-  path: z.string().optional().describe('Subdirectory to search in (relative to workspace root). Defaults to "." (current directory) if not specified. Always provide this parameter for best results.'),
+  path: z.string().optional().describe('Subdirectory to search in, relative to the current working directory. Defaults to "." if not specified. Always provide this parameter for best results.'),
   include: z.string().optional().describe('File pattern to include in the search (e.g. "*.js", "*.{ts,tsx}")')
 })
 
 const editToolSchema = z.object({
-  file_path: z.string().min(1, 'File path is required.').describe('Absolute path to the file to edit'),
+  file_path: z.string().min(1, 'File path is required.').describe('File path relative to the current working directory. Absolute paths inside the current workspace are also accepted.'),
   old_string: z.string().describe('Exact text to replace (must match file content)'),
   new_string: z.string().describe('Replacement text'),
   replace_all: z.boolean().optional().describe('Replace all occurrences (default false)')
 })
 
 const multiEditToolSchema = z.object({
-  file_path: z.string().min(1, 'File path is required.').describe('Absolute path to the file to edit'),
+  file_path: z.string().min(1, 'File path is required.').describe('File path relative to the current working directory. Absolute paths inside the current workspace are also accepted.'),
   edits: z.array(z.object({
     oldString: z.string().min(1, 'Old string is required.').describe('Exact text to replace (must match file content)'),
     newString: z.string().describe('Replacement text'),
@@ -64,17 +66,17 @@ const multiEditToolSchema = z.object({
 })
 
 const writeToolSchema = z.object({
-  file_path: z.string().min(1, 'File path is required.').describe('Absolute path to the file to create'),
+  file_path: z.string().min(1, 'File path is required.').describe('File path relative to the current working directory. Absolute paths inside the current workspace are also accepted.'),
   content: z.any().describe('Complete file content as a single string. Special characters (quotes, newlines, etc.) must be properly escaped in JSON.')
 })
 
 const appendToolSchema = z.object({
-  file_path: z.string().min(1, 'File path is required.').describe('Absolute path to the file to append to'),
+  file_path: z.string().min(1, 'File path is required.').describe('File path relative to the current working directory. Absolute paths inside the current workspace are also accepted.'),
   content: z.any().describe('Content to append to the file. Special characters (quotes, newlines, etc.) must be properly escaped in JSON.')
 })
 
 const listDirToolSchema = z.object({
-  dir_path: z.string().min(1, 'Directory path is required.').describe('Absolute path to the directory'),
+  dir_path: z.string().min(1, 'Directory path is required.').describe('Directory path relative to the current working directory. Absolute paths inside the current workspace are also accepted.'),
   offset: z.number().optional().describe('1-indexed entry number to start from (defaults to 1)'),
   limit: z.number().optional().describe('Maximum number of entries to return (defaults to 25)'),
   depth: z.number().optional().describe('Maximum depth to traverse (defaults to 2)')
@@ -95,12 +97,75 @@ function getWorkingDirectory(config: any): string {
   return backend.workingDirectory || configurable?.sandbox?.workingDirectory
 }
 
+function getSandboxProvider(config: any): string | undefined {
+  const configurable = config?.configurable as TAgentRunnableConfigurable | undefined
+  return configurable?.sandbox?.provider
+}
+
+function isLocalShellSandbox(config: any): boolean {
+  return getSandboxProvider(config) === LOCAL_SHELL_SANDBOX_PROVIDER
+}
+
+function isPathInsideWorkingDirectory(workingDirectory: string, candidatePath: string): boolean {
+  const relativePath = relative(workingDirectory, candidatePath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
+function deriveWorkspaceRelativePath(absolutePath: string): string {
+  const segments = absolutePath.replace(/\\/g, '/').split('/').filter(Boolean)
+  for (const marker of SANDBOX_ROOT_MARKERS) {
+    const markerIndex = segments.lastIndexOf(marker)
+    if (markerIndex !== -1 && markerIndex < segments.length - 1) {
+      return segments.slice(markerIndex + 1).join('/')
+    }
+  }
+  return segments.at(-1) ?? ''
+}
+
 function resolveSandboxPath(config: any, fileOrDirPath?: string): string {
   const workingDirectory = getWorkingDirectory(config)
   if (!fileOrDirPath) {
     return workingDirectory
   }
-  return isAbsolute(fileOrDirPath) ? fileOrDirPath : resolve(workingDirectory, fileOrDirPath)
+
+  if (!isAbsolute(fileOrDirPath)) {
+    return resolve(workingDirectory, fileOrDirPath)
+  }
+
+  const normalizedAbsolutePath = resolve(fileOrDirPath)
+  if (!isLocalShellSandbox(config)) {
+    return normalizedAbsolutePath
+  }
+
+  if (isPathInsideWorkingDirectory(workingDirectory, normalizedAbsolutePath)) {
+    return normalizedAbsolutePath
+  }
+
+  return resolve(workingDirectory, deriveWorkspaceRelativePath(normalizedAbsolutePath))
+}
+
+function getSandboxDisplayPath(config: any, resolvedPath: string, requestedPath?: string): string {
+  if (!isLocalShellSandbox(config)) {
+    return requestedPath ?? resolvedPath
+  }
+
+  const workingDirectory = getWorkingDirectory(config)
+  const relativePath = relative(workingDirectory, resolvedPath).replace(/\\/g, '/')
+  if (!relativePath || relativePath === '') {
+    return '.'
+  }
+  if (!relativePath.startsWith('..') && !isAbsolute(relativePath)) {
+    return relativePath
+  }
+  return basename(resolvedPath)
+}
+
+function normalizeWriteResultPath<T extends { path?: string }>(config: any, result: T, displayPath: string): T {
+  if (!isLocalShellSandbox(config) || !result.path) {
+    return result
+  }
+
+  return { ...result, path: displayPath }
 }
 
 
@@ -138,7 +203,8 @@ export class SandboxFileMiddleware implements IAgentMiddlewareStrategy {
       async ({ file_path, offset, limit, mode, indentation }, config) => {
         const backend = getBackend(config)
         const resolvedFilePath = resolveSandboxPath(config, file_path)
-        return withToolMessage(getToolCallId(config), 'sandbox_read_file', file_path, { file_path, offset, limit }, () =>
+        const displayFilePath = getSandboxDisplayPath(config, resolvedFilePath, file_path)
+        return withToolMessage(getToolCallId(config), 'sandbox_read_file', displayFilePath, { file_path: displayFilePath, offset, limit }, () =>
           backend.read(resolvedFilePath, offset, limit, mode, indentation)
         )
       },
@@ -153,7 +219,8 @@ export class SandboxFileMiddleware implements IAgentMiddlewareStrategy {
       async ({ pattern, path }, config) => {
         const backend = getBackend(config)
         const resolvedPath = resolveSandboxPath(config, path)
-        return withToolMessage(getToolCallId(config), 'sandbox_glob', pattern, { pattern, path }, () =>
+        const displayPath = getSandboxDisplayPath(config, resolvedPath, path)
+        return withToolMessage(getToolCallId(config), 'sandbox_glob', pattern, { pattern, path: displayPath }, () =>
           backend.glob(pattern, resolvedPath)
         )
       },
@@ -168,7 +235,8 @@ export class SandboxFileMiddleware implements IAgentMiddlewareStrategy {
       async ({ pattern, path, include }, config) => {
         const backend = getBackend(config)
         const resolvedPath = resolveSandboxPath(config, path)
-        return withToolMessage(getToolCallId(config), 'sandbox_grep', pattern, { pattern, path, include }, () =>
+        const displayPath = getSandboxDisplayPath(config, resolvedPath, path)
+        return withToolMessage(getToolCallId(config), 'sandbox_grep', pattern, { pattern, path: displayPath, include }, () =>
           backend.grep(pattern, resolvedPath, include)
         )
       },
@@ -183,8 +251,13 @@ export class SandboxFileMiddleware implements IAgentMiddlewareStrategy {
       async ({ file_path, old_string, new_string, replace_all }, config) => {
         const backend = getBackend(config)
         const resolvedFilePath = resolveSandboxPath(config, file_path)
-        return withToolMessage(getToolCallId(config), 'sandbox_edit_file', file_path, { file_path }, async () => {
-          const result = await backend.edit(resolvedFilePath, old_string, new_string, replace_all)
+        const displayFilePath = getSandboxDisplayPath(config, resolvedFilePath, file_path)
+        return withToolMessage(getToolCallId(config), 'sandbox_edit_file', displayFilePath, { file_path: displayFilePath }, async () => {
+          const result = normalizeWriteResultPath(
+            config,
+            await backend.edit(resolvedFilePath, old_string, new_string, replace_all),
+            displayFilePath
+          )
           return JSON.stringify(result, null, 2)
         })
       },
@@ -199,9 +272,10 @@ export class SandboxFileMiddleware implements IAgentMiddlewareStrategy {
       async ({ file_path, content }, config) => {
         const backend = getBackend(config)
         const resolvedFilePath = resolveSandboxPath(config, file_path)
-        return withToolMessage(getToolCallId(config), 'sandbox_write_file', file_path, { file_path }, async () => {
+        const displayFilePath = getSandboxDisplayPath(config, resolvedFilePath, file_path)
+        return withToolMessage(getToolCallId(config), 'sandbox_write_file', displayFilePath, { file_path: displayFilePath }, async () => {
           const normalizedContent = Array.isArray(content) ? content.join('') : content
-          const result = await backend.write(resolvedFilePath, normalizedContent)
+          const result = normalizeWriteResultPath(config, await backend.write(resolvedFilePath, normalizedContent), displayFilePath)
           return JSON.stringify(result, null, 2)
         })
       },
@@ -221,13 +295,13 @@ CRITICAL FORMAT REQUIREMENTS:
 
 CORRECT format:
 {
-  "file_path": "/path/to/file.js",
+  "file_path": "docs/file.js",
   "content": "const x = 1;\\nconst y = 2;\\nconsole.log(x + y);"
 }
 
 INCORRECT format (DO NOT USE):
 [
-  {"file_path": "/path/to/file.js", "content": "const x = 1;"},
+  {"file_path": "docs/file.js", "content": "const x = 1;"},
   {"content": "const y = 2;"}
 ]`,
         schema: writeToolSchema
@@ -238,9 +312,10 @@ INCORRECT format (DO NOT USE):
       async ({ file_path, content }, config) => {
         const backend = getBackend(config)
         const resolvedFilePath = resolveSandboxPath(config, file_path)
-        return withToolMessage(getToolCallId(config), 'sandbox_append_file', file_path, { file_path }, async () => {
+        const displayFilePath = getSandboxDisplayPath(config, resolvedFilePath, file_path)
+        return withToolMessage(getToolCallId(config), 'sandbox_append_file', displayFilePath, { file_path: displayFilePath }, async () => {
           const normalizedContent = Array.isArray(content) ? content.join('') : content
-          const result = await backend.append(resolvedFilePath, normalizedContent)
+          const result = normalizeWriteResultPath(config, await backend.append(resolvedFilePath, normalizedContent), displayFilePath)
           return JSON.stringify(result, null, 2)
         })
       },
@@ -267,8 +342,13 @@ CRITICAL FORMAT REQUIREMENTS:
       async ({ file_path, edits }, config) => {
         const backend = getBackend(config)
         const resolvedFilePath = resolveSandboxPath(config, file_path)
-        return withToolMessage(getToolCallId(config), 'sandbox_multi_edit_file', file_path, { file_path }, async () => {
-          const result = await backend.multiEdit(resolvedFilePath, edits as EditOperation[])
+        const displayFilePath = getSandboxDisplayPath(config, resolvedFilePath, file_path)
+        return withToolMessage(getToolCallId(config), 'sandbox_multi_edit_file', displayFilePath, { file_path: displayFilePath }, async () => {
+          const result = normalizeWriteResultPath(
+            config,
+            await backend.multiEdit(resolvedFilePath, edits as EditOperation[]),
+            displayFilePath
+          )
           return JSON.stringify(result, null, 2)
         })
       },
@@ -283,7 +363,8 @@ CRITICAL FORMAT REQUIREMENTS:
       async ({ dir_path, offset, limit, depth }, config) => {
         const backend = getBackend(config)
         const resolvedDirPath = resolveSandboxPath(config, dir_path)
-        return withToolMessage(getToolCallId(config), 'sandbox_list_dir', dir_path, { dir_path, offset, limit, depth }, () =>
+        const displayDirPath = getSandboxDisplayPath(config, resolvedDirPath, dir_path)
+        return withToolMessage(getToolCallId(config), 'sandbox_list_dir', displayDirPath, { dir_path: displayDirPath, offset, limit, depth }, () =>
           backend.listDir(resolvedDirPath, offset, limit, depth)
         )
       },

--- a/packages/server-ai/src/chat-conversation/conversation.service.spec.ts
+++ b/packages/server-ai/src/chat-conversation/conversation.service.spec.ts
@@ -81,7 +81,7 @@ describe('ChatConversationService workspace files', () => {
         await service.getWorkspaceFiles('conversation-1', 'docs', 2)
 
         expect(service.findOne).toHaveBeenCalledWith('conversation-1')
-        expect(listWorkspace).toHaveBeenCalledWith('thread-1', {
+        expect(listWorkspace).toHaveBeenCalledWith('', {
             path: 'docs',
             deepth: 2
         })
@@ -95,7 +95,7 @@ describe('ChatConversationService workspace files', () => {
         await service.readWorkspaceFile('conversation-1', 'README.md')
 
         expect(service.findOne).toHaveBeenCalledWith('conversation-1')
-        expect(readWorkspaceFile).toHaveBeenCalledWith('thread-1', 'README.md')
+        expect(readWorkspaceFile).toHaveBeenCalledWith('', 'README.md')
     })
 
     it('saves files inside the current conversation workspace', async () => {
@@ -107,7 +107,7 @@ describe('ChatConversationService workspace files', () => {
         await service.saveWorkspaceFile('conversation-1', 'README.md', '# Updated\n')
 
         expect(service.findOne).toHaveBeenCalledWith('conversation-1')
-        expect(saveWorkspaceFile).toHaveBeenCalledWith('thread-1', 'README.md', '# Updated\n')
+        expect(saveWorkspaceFile).toHaveBeenCalledWith('', 'README.md', '# Updated\n')
     })
 
     it('finds the conversation by thread id inside the current scope', async () => {

--- a/packages/server-ai/src/chat-conversation/conversation.service.ts
+++ b/packages/server-ai/src/chat-conversation/conversation.service.ts
@@ -161,7 +161,7 @@ export class ChatConversationService extends TenantOrganizationAwareCrudService<
 
     async getWorkspaceFiles(id: string, path?: string, deepth?: number): Promise<TFileDirectory[]> {
         const conversation = await this.findOne(id)
-        return this.createWorkspaceVolumeClient(conversation).list(conversation.threadId, {
+        return this.createWorkspaceVolumeClient(conversation).list('', {
             path,
             deepth
         })
@@ -169,12 +169,12 @@ export class ChatConversationService extends TenantOrganizationAwareCrudService<
 
     async readWorkspaceFile(id: string, filePath: string): Promise<TFile> {
         const conversation = await this.findOne(id)
-        return this.createWorkspaceVolumeClient(conversation).readFile(conversation.threadId, filePath)
+        return this.createWorkspaceVolumeClient(conversation).readFile('', filePath)
     }
 
     async saveWorkspaceFile(id: string, filePath: string, content: string): Promise<TFile> {
         const conversation = await this.findOne(id)
-        return this.createWorkspaceVolumeClient(conversation).saveFile(conversation.threadId, filePath, content)
+        return this.createWorkspaceVolumeClient(conversation).saveFile('', filePath, content)
     }
 
     private createWorkspaceVolumeClient(conversation: ChatConversation) {

--- a/packages/server-ai/src/chat/commands/handlers/chat-common.handler.ts
+++ b/packages/server-ai/src/chat/commands/handlers/chat-common.handler.ts
@@ -216,8 +216,8 @@ export class ChatCommonHandler implements ICommandHandler<ChatCommonCommand> {
                 if (retry) {
                     throw new Error('Conversation ID is required for retry operation')
                 }
-                const workspacePath = await VolumeClient.getSharedWorkspacePath(tenantId, projectId, userId)
-                const workspaceUrl = VolumeClient.getSharedWorkspaceUrl(projectId, userId)
+                const workspacePath = await VolumeClient.getCurrentUserWorkspacePath(tenantId, userId)
+                const workspaceUrl = VolumeClient.getCurrentUserWorkspaceUrl(userId)
                 conversation = await this.commandBus.execute(
                     new ChatConversationUpsertCommand({
                         tenantId,

--- a/packages/server-ai/src/sandbox/client-local.spec.ts
+++ b/packages/server-ai/src/sandbox/client-local.spec.ts
@@ -1,0 +1,130 @@
+const mockMkdir = jest.fn()
+const mockWriteFile = jest.fn()
+const mockList = jest.fn()
+const mockReadFile = jest.fn()
+const mockDeleteFile = jest.fn()
+const mockGetVolumePath = jest.fn((filePath?: string) => (filePath ? `/volume/${filePath}` : '/volume'))
+const mockGetCurrentUserWorkspacePath = jest.fn()
+
+jest.mock('node:fs/promises', () => ({
+    mkdir: mockMkdir,
+    writeFile: mockWriteFile
+}))
+
+jest.mock('../shared', () => ({
+    VolumeClient: jest.fn().mockImplementation(() => ({
+        list: mockList,
+        readFile: mockReadFile,
+        deleteFile: mockDeleteFile,
+        getVolumePath: mockGetVolumePath
+    }))
+}))
+
+import path from 'node:path'
+import fsPromises from 'node:fs/promises'
+import { VolumeClient } from '../shared'
+import { FileLocalSystem, GitLocalClient } from './client-local'
+
+describe('FileLocalSystem', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockGetCurrentUserWorkspacePath.mockResolvedValue('/tmp/user-workspace')
+        ;(VolumeClient as unknown as { getCurrentUserWorkspacePath: jest.Mock }).getCurrentUserWorkspacePath =
+            mockGetCurrentUserWorkspacePath
+    })
+
+    it('stores created files in the current user volume root', async () => {
+        const fileSystem = new FileLocalSystem({
+            tenantId: 'tenant-1',
+            userId: 'user-1',
+            projectId: 'project-1'
+        } as any)
+
+        await fileSystem.createFile(
+            {
+                workspace_id: '',
+                file_path: 'docs/notes.md',
+                file_contents: '# Notes\n',
+                file_description: null
+            },
+            { signal: {} as AbortSignal }
+        )
+
+        expect(VolumeClient).toHaveBeenCalledWith({
+            tenantId: 'tenant-1',
+            catalog: 'users',
+            userId: 'user-1'
+        })
+        expect(mockGetVolumePath).toHaveBeenCalledWith(path.join('', 'docs/notes.md'))
+        expect(fsPromises.mkdir).toHaveBeenCalledWith('/volume/docs', { recursive: true })
+        expect(fsPromises.writeFile).toHaveBeenCalledWith('/volume/docs/notes.md', '# Notes\n')
+    })
+
+    it('lists files from the current user volume root', async () => {
+        const createdAt = new Date('2026-04-16T00:00:00.000Z')
+        mockList.mockResolvedValue([
+            {
+                filePath: 'README.md',
+                fileType: 'md',
+                size: 42,
+                createdAt
+            }
+        ])
+
+        const fileSystem = new FileLocalSystem({
+            tenantId: 'tenant-1',
+            userId: 'user-1',
+            projectId: 'project-1'
+        } as any)
+
+        const result = await fileSystem.listFiles(
+            {
+                workspace_id: '',
+                path: 'docs',
+                depth: 2,
+                limit: 1000
+            },
+            { signal: {} as AbortSignal }
+        )
+
+        expect(VolumeClient).toHaveBeenCalledWith({
+            tenantId: 'tenant-1',
+            catalog: 'users',
+            userId: 'user-1'
+        })
+        expect(mockList).toHaveBeenCalledWith({
+            path: path.join('', 'docs'),
+            deepth: 2
+        })
+        expect(result).toEqual({
+            files: [
+                {
+                    name: 'README.md',
+                    extension: 'md',
+                    size: 42,
+                    created_date: createdAt.toISOString()
+                }
+            ]
+        })
+    })
+})
+
+describe('GitLocalClient', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockGetCurrentUserWorkspacePath.mockResolvedValue('/tmp/user-workspace')
+        ;(VolumeClient as unknown as { getCurrentUserWorkspacePath: jest.Mock }).getCurrentUserWorkspacePath =
+            mockGetCurrentUserWorkspacePath
+    })
+
+    it('resolves git workspace paths from the current user root', async () => {
+        const client = new GitLocalClient({
+            tenantId: 'tenant-1',
+            userId: 'user-1',
+            projectId: 'project-1'
+        } as any)
+
+        await expect(client.getWorkspacePath()).resolves.toBe('/tmp/user-workspace')
+        expect(mockGetCurrentUserWorkspacePath).toHaveBeenCalledWith('tenant-1', 'user-1')
+    })
+})

--- a/packages/server-ai/src/sandbox/client-local.ts
+++ b/packages/server-ai/src/sandbox/client-local.ts
@@ -21,10 +21,18 @@ const execPromise = util.promisify(exec)
 export class FileLocalSystem implements FilesSystem {
 	constructor(protected params: TSandboxParams) {}
 
+	private createUserVolumeClient() {
+		return new VolumeClient({
+			tenantId: this.params.tenantId,
+			catalog: 'users',
+			userId: this.params.userId
+		})
+	}
+
 	async createFile(body: TCreateFileReq, options: { signal: AbortSignal }): Promise<TCreateFileResp> {
 		const { workspace_id, file_path, file_contents, file_description } = body
-		const root = VolumeClient.getWorkspaceRoot(this.params.tenantId, this.params.projectId, this.params.userId)
-		const filePath = path.join(root, workspace_id, file_path)
+		const client = this.createUserVolumeClient()
+		const filePath = client.getVolumePath(path.join(workspace_id, file_path))
 		await fsPromises.mkdir(path.dirname(filePath), { recursive: true })
 		await fsPromises.writeFile(filePath, file_contents)
 
@@ -42,12 +50,7 @@ export class FileLocalSystem implements FilesSystem {
 	async listFiles(body: TListFilesReq, options: { signal: AbortSignal }): Promise<TListFilesResponse> {
 		const { workspace_id, path: dirPath = '', depth = 2, limit = 1000 } = body
 
-		const client = new VolumeClient({
-			tenantId: this.params.tenantId,
-			catalog: 'projects',
-			projectId: this.params.projectId,
-			userId: this.params.userId
-		})
+		const client = this.createUserVolumeClient()
 
 		const files = await client.list({
 			path: path.join(workspace_id, dirPath),
@@ -68,12 +71,7 @@ export class FileLocalSystem implements FilesSystem {
 
 	async readFile(req: TReadFileReq, options?: { signal: AbortSignal }): Promise<string> {
 		const { workspace_id, file_path, line_from, line_to } = req
-		const client = new VolumeClient({
-			tenantId: this.params.tenantId,
-			catalog: 'projects',
-			projectId: this.params.projectId,
-			userId: this.params.userId
-		})
+		const client = this.createUserVolumeClient()
 
 		const content = await client.readFile(path.join(workspace_id, file_path))
 		if (line_from !== undefined && line_to !== undefined) {
@@ -85,12 +83,7 @@ export class FileLocalSystem implements FilesSystem {
 
 	deleteFile(body: TFileBaseReq, options?: { signal: AbortSignal }): Promise<void> {
 		const { workspace_id, file_path } = body
-		const client = new VolumeClient({
-			tenantId: this.params.tenantId,
-			catalog: 'projects',
-			projectId: this.params.projectId,
-			userId: this.params.userId
-		})
+		const client = this.createUserVolumeClient()
 
 		return client.deleteFile(path.join(workspace_id, file_path))
 	}
@@ -125,7 +118,7 @@ export class SandboxLocal extends Sandbox {
 
 export class GitLocalClient extends GitClient {
 	async getWorkspacePath() {
-		return await VolumeClient.getSharedWorkspacePath(this.params.tenantId, this.params.projectId, this.params.userId)
+		return await VolumeClient.getCurrentUserWorkspacePath(this.params.tenantId, this.params.userId)
 	}
 
 	async execGit(command: string, repoPath: string) {

--- a/packages/server-ai/src/sandbox/sandbox.controller.spec.ts
+++ b/packages/server-ai/src/sandbox/sandbox.controller.spec.ts
@@ -27,7 +27,7 @@ jest.mock('../chat-conversation', () => ({
 
 jest.mock('../shared', () => ({
     VolumeClient: {
-        getSharedWorkspacePath: jest.fn().mockResolvedValue('/workspace/user-1')
+        getCurrentUserWorkspacePath: jest.fn().mockResolvedValue('/workspace/user-1')
     },
     getMediaTypeWithCharset: jest.fn()
 }))

--- a/packages/server-ai/src/sandbox/sandbox.controller.ts
+++ b/packages/server-ai/src/sandbox/sandbox.controller.ts
@@ -117,17 +117,15 @@ export class SandboxController {
     @Post('file')
     @UseInterceptors(FileInterceptor('file'))
     async uploadFile(
-        @Body('workspace') workspace: string,
-        @Body('conversationId') conversationId: string,
+        @Body('workspace') _workspace: string,
+        @Body('conversationId') _conversationId: string,
         @Body('path') path: string,
         @UploadedFile() file: Express.Multer.File
     ) {
-        const conversation = await this.conversationService.findOne({ where: { id: conversationId } })
         const client = new VolumeClient({
             tenantId: RequestContext.currentTenantId(),
             userId: RequestContext.currentUserId(),
-            catalog: 'projects',
-            projectId: conversation.projectId
+            catalog: 'users'
         })
 
         const asset = await this.commandBus.execute(
@@ -140,8 +138,8 @@ export class SandboxController {
                     {
                         kind: 'sandbox',
                         mode: 'mounted_workspace',
-                        workspacePath: client.getVolumePath(workspace),
-                        workspaceUrl: client.getPublicUrl(workspace),
+                        workspacePath: client.getVolumePath(),
+                        workspaceUrl: client.getPublicUrl(''),
                         folder: path || ''
                     }
                 ]
@@ -183,7 +181,7 @@ export class SandboxController {
         }
 
         const effectiveProjectId = projectId ?? conversation?.projectId ?? null
-        const workspacePath = await VolumeClient.getSharedWorkspacePath(tenantId, effectiveProjectId, userId)
+        const workspacePath = await VolumeClient.getCurrentUserWorkspacePath(tenantId, userId)
         const sandboxContext = await this.commandBus.execute(
             new SandboxAcquireBackendCommand({
                 tenantId,

--- a/packages/server-ai/src/shared/volume/volume.spec.ts
+++ b/packages/server-ai/src/shared/volume/volume.spec.ts
@@ -41,4 +41,16 @@ describe('VolumeClient shared workspace helpers', () => {
         )
         expect(mkdirSpy).toHaveBeenCalledWith('/sandbox/tenant-1/user/user-1', { recursive: true })
     })
+
+    it('returns the explicit current user workspace root helpers', async () => {
+        const mkdirSpy = jest.spyOn(fsPromises, 'mkdir').mockResolvedValue(undefined)
+
+        await expect(VolumeClient.getCurrentUserWorkspacePath('tenant-1', 'user-1')).resolves.toBe(
+            '/sandbox/tenant-1/user/user-1'
+        )
+        expect(VolumeClient.getCurrentUserWorkspaceUrl('user-1')).toBe(
+            'http://localhost:3000/api/sandbox/volume/user/user-1'
+        )
+        expect(mkdirSpy).toHaveBeenCalledWith('/sandbox/tenant-1/user/user-1', { recursive: true })
+    })
 })

--- a/packages/server-ai/src/shared/volume/volume.ts
+++ b/packages/server-ai/src/shared/volume/volume.ts
@@ -77,12 +77,22 @@ export class VolumeClient {
         return dist
     }
 
+    static async getCurrentUserWorkspacePath(tenantId: string, userId: string): Promise<string> {
+        const dist = VolumeClient._getWorkspaceRoot(tenantId, 'user', userId)
+        await fsPromises.mkdir(dist, { recursive: true })
+        return dist
+    }
+
     static getWorkspaceUrl(projectId: string, userId: string, conversationId?: string) {
         return sandboxVolumeUrl(sandboxVolume(projectId, userId), getWorkspace(projectId, conversationId) + '/')
     }
 
     static getSharedWorkspaceUrl(projectId: string, userId: string) {
         return sandboxVolumeUrl(sandboxVolume(projectId, userId))
+    }
+
+    static getCurrentUserWorkspaceUrl(userId: string) {
+        return sandboxVolumeUrl(`/user/${userId}`)
     }
 
     constructor(params: {

--- a/packages/server-ai/src/shared/volume/workspace-volume.spec.ts
+++ b/packages/server-ai/src/shared/volume/workspace-volume.spec.ts
@@ -15,6 +15,9 @@ describe('WorkspaceVolumeClient', () => {
             getPublicUrl: (filePath: string) => (filePath ? `${baseUrl}/${filePath.replace(/^\/+/, '')}` : baseUrl)
         })
 
+        await fsPromises.mkdir(path.join(tempRoot, 'docs'), { recursive: true })
+        await fsPromises.writeFile(path.join(tempRoot, 'README.md'), '# User Root\n', 'utf8')
+        await fsPromises.writeFile(path.join(tempRoot, 'docs', 'root-guide.md'), '# Root Guide\n', 'utf8')
         await fsPromises.mkdir(path.join(tempRoot, 'thread-1', 'docs'), { recursive: true })
         await fsPromises.writeFile(path.join(tempRoot, 'thread-1', 'README.md'), '# Workspace\n', 'utf8')
         await fsPromises.writeFile(path.join(tempRoot, 'thread-1', 'docs', 'guide.md'), '# Guide\n', 'utf8')
@@ -31,6 +34,16 @@ describe('WorkspaceVolumeClient', () => {
 
         expect(files.map((file) => file.fullPath)).toEqual(expect.arrayContaining(['/README.md', '/docs', '/binary.bin']))
         expect(files.find((file) => file.filePath === 'README.md')?.url).toContain('/thread-1/README.md')
+    })
+
+    it('supports using the volume root as the workspace root', async () => {
+        const files = await workspaceVolume.list('')
+
+        expect(files.map((file) => file.fullPath)).toEqual(expect.arrayContaining(['/README.md', '/docs', '/thread-1']))
+        await expect(workspaceVolume.readFile('', 'README.md')).resolves.toMatchObject({
+            filePath: 'README.md',
+            contents: '# User Root\n'
+        })
     })
 
     it('reads text files and keeps binary files read-only', async () => {

--- a/packages/server-ai/src/shared/volume/workspace-volume.ts
+++ b/packages/server-ai/src/shared/volume/workspace-volume.ts
@@ -100,11 +100,11 @@ export class WorkspaceVolumeClient {
 
     private resolveWorkspaceRoot(workspacePath: string) {
         const normalizedWorkspacePath = normalizeWorkspacePath(workspacePath)
+        const volumePath = this.access.getVolumePath()
         if (!normalizedWorkspacePath) {
-            throw new BadRequestException('Workspace path is required')
+            return volumePath
         }
 
-        const volumePath = this.access.getVolumePath()
         const workspaceRoot = resolve(volumePath, normalizedWorkspacePath)
         const relativeToVolume = relative(volumePath, workspaceRoot)
         if (relativeToVolume.startsWith('..') || isAbsolute(relativeToVolume)) {

--- a/packages/server-ai/src/xpert-agent/commands/handlers/invoke.handler.spec.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/invoke.handler.spec.ts
@@ -46,6 +46,8 @@ jest.mock('../../../shared', () => ({
         static getWorkspaceUrl = jest.fn()
         static getSharedWorkspacePath = jest.fn()
         static getSharedWorkspaceUrl = jest.fn()
+        static getCurrentUserWorkspacePath = jest.fn()
+        static getCurrentUserWorkspaceUrl = jest.fn()
 
         getVolumePath(workspace?: string) {
             return workspace ? `/volume/${workspace}` : '/volume'
@@ -127,8 +129,8 @@ describe('XpertAgentInvokeHandler', () => {
             timeZone: 'Asia/Shanghai',
             preferredLanguage: 'en-US'
         } as any)
-        jest.spyOn(VolumeClient, 'getSharedWorkspacePath').mockResolvedValue('/tmp/workspace')
-        jest.spyOn(VolumeClient, 'getSharedWorkspaceUrl').mockReturnValue('/workspace')
+        jest.spyOn(VolumeClient, 'getCurrentUserWorkspacePath').mockResolvedValue('/tmp/workspace')
+        jest.spyOn(VolumeClient, 'getCurrentUserWorkspaceUrl').mockReturnValue('/workspace')
     })
 
     afterEach(() => {
@@ -193,8 +195,8 @@ describe('XpertAgentInvokeHandler', () => {
                 volume: '/tmp/workspace'
             })
         })
-        expect(VolumeClient.getSharedWorkspacePath).toHaveBeenCalledWith('tenant-1', undefined, 'user-1')
-        expect(VolumeClient.getSharedWorkspaceUrl).toHaveBeenCalledWith(undefined, 'user-1')
+        expect(VolumeClient.getCurrentUserWorkspacePath).toHaveBeenCalledWith('tenant-1', 'user-1')
+        expect(VolumeClient.getCurrentUserWorkspaceUrl).toHaveBeenCalledWith('user-1')
     })
 
     it('merges soul and profile into resume command updates', async () => {
@@ -410,6 +412,73 @@ describe('XpertAgentInvokeHandler', () => {
                     workFor: {
                         type: 'user',
                         id: 'user-1'
+                    }
+                })
+            })
+        )
+    })
+
+    it('uses the shared workspace root as sandbox working directory even for sandbox environments', async () => {
+        const graph = createGraph()
+
+        commandBus.execute.mockImplementation(async (command) => {
+            if (command instanceof SandboxAcquireBackendCommand) {
+                return {
+                    provider: 'local-shell-sandbox',
+                    workingDirectory: '/tmp/workspace'
+                }
+            }
+            if (command instanceof CompileGraphCommand) {
+                return createCompiledGraph(graph)
+            }
+            return null
+        })
+
+        const stream = await handler.execute(
+            new XpertAgentInvokeCommand(
+                {
+                    human: {
+                        input: 'Original prompt'
+                    }
+                } as any,
+                'agent-1',
+                {
+                    id: 'xpert-1',
+                    features: {
+                        sandbox: {
+                            enabled: true,
+                            provider: 'local-shell-sandbox'
+                        }
+                    }
+                } as any,
+                {
+                    isDraft: true,
+                    thread_id: 'thread-1',
+                    sandboxEnvironmentId: 'sandbox-env-1',
+                    execution: {
+                        id: 'execution-1',
+                        threadId: 'thread-1'
+                    },
+                    rootExecutionId: 'execution-1',
+                    subscriber: {
+                        next: jest.fn()
+                    },
+                    store: null
+                } as any
+            )
+        )
+
+        await consumeStream(stream)
+
+        expect(commandBus.execute).toHaveBeenCalledWith(
+            expect.objectContaining({
+                params: expect.objectContaining({
+                    provider: 'local-shell-sandbox',
+                    tenantId: 'tenant-1',
+                    workingDirectory: '/tmp/workspace',
+                    workFor: {
+                        type: 'environment',
+                        id: 'sandbox-env-1'
                     }
                 })
             })

--- a/packages/server-ai/src/xpert-agent/commands/handlers/invoke.handler.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/invoke.handler.ts
@@ -102,8 +102,8 @@ export class XpertAgentInvokeHandler implements ICommandHandler<XpertAgentInvoke
         const mute = [] as TXpertAgentConfig['mute']
         let unmutes = [] as TXpertAgentConfig['mute']
         const threadId = options.thread_id
-        const workspacePath = await VolumeClient.getSharedWorkspacePath(tenantId, options.projectId, userId)
-        const workspaceUrl = VolumeClient.getSharedWorkspaceUrl(options.projectId, userId)
+        const workspacePath = await VolumeClient.getCurrentUserWorkspacePath(tenantId, userId)
+        const workspaceUrl = VolumeClient.getCurrentUserWorkspaceUrl(userId)
         const latestXpert = figureOutXpert(xpert as IXpert, options?.isDraft)
         const sandboxFeature = latestXpert.features?.sandbox
         const sandboxEnvironmentId = options?.sandboxEnvironmentId
@@ -120,7 +120,7 @@ export class XpertAgentInvokeHandler implements ICommandHandler<XpertAgentInvoke
                 sandboxContext = await this.commandBus.execute(
                     new SandboxAcquireBackendCommand({
                         provider: sandboxFeature?.provider,
-                        workingDirectory: sandboxEnvironmentId ? null : workspacePath,
+                        workingDirectory: workspacePath,
                         tenantId,
                         workFor: sandboxWorkFor
                     })

--- a/packages/server-ai/src/xpert/xpert.memory-files.spec.ts
+++ b/packages/server-ai/src/xpert/xpert.memory-files.spec.ts
@@ -105,6 +105,8 @@ import { VolumeClient, WorkspaceVolumeClient } from '../shared/volume'
 import { XpertService } from './xpert.service'
 
 describe('XpertService memory files', () => {
+    const memoryWorkspacePath = '.xpert/memory'
+
     let service: XpertService
 
     beforeEach(() => {
@@ -123,7 +125,7 @@ describe('XpertService memory files', () => {
         )
     })
 
-    it('lists files inside the current user memory workspace for the xpert', async () => {
+    it('lists files inside the memory workspace root for the xpert', async () => {
         jest.spyOn(service, 'findOne').mockResolvedValue({
             id: 'xpert-1',
             tenantId: 'tenant-1'
@@ -144,13 +146,13 @@ describe('XpertService memory files', () => {
                 userId: 'user-1'
             })
         )
-        expect(mockList).toHaveBeenCalledWith('xpert-1', {
+        expect(mockList).toHaveBeenCalledWith(memoryWorkspacePath, {
             path: 'docs',
             deepth: 2
         })
     })
 
-    it('reads files inside the current user memory workspace for the xpert', async () => {
+    it('reads files inside the memory workspace root for the xpert', async () => {
         jest.spyOn(service, 'findOne').mockResolvedValue({
             id: 'xpert-1',
             tenantId: 'tenant-1'
@@ -167,10 +169,10 @@ describe('XpertService memory files', () => {
             catalog: 'users',
             userId: 'user-1'
         })
-        expect(mockReadFile).toHaveBeenCalledWith('xpert-1', 'README.md')
+        expect(mockReadFile).toHaveBeenCalledWith(memoryWorkspacePath, 'README.md')
     })
 
-    it('saves files inside the current user memory workspace for the xpert', async () => {
+    it('saves files inside the memory workspace root for the xpert', async () => {
         jest.spyOn(service, 'findOne').mockResolvedValue({
             id: 'xpert-1',
             tenantId: 'tenant-1'
@@ -188,6 +190,6 @@ describe('XpertService memory files', () => {
             catalog: 'users',
             userId: 'user-1'
         })
-        expect(mockSaveFile).toHaveBeenCalledWith('xpert-1', 'README.md', '# Updated\n')
+        expect(mockSaveFile).toHaveBeenCalledWith(memoryWorkspacePath, 'README.md', '# Updated\n')
     })
 })

--- a/packages/server-ai/src/xpert/xpert.service.ts
+++ b/packages/server-ai/src/xpert/xpert.service.ts
@@ -446,16 +446,19 @@ export class XpertService extends TenantOrganizationAwareCrudService<Xpert> {
 
     async getMemoryFiles(id: string, path?: string, deepth?: number): Promise<TFileDirectory[]> {
         const xpert = await this.findOne(id)
-        return this.createWorkspaceVolumeClient(xpert.tenantId, RequestContext.currentUserId()).list(xpert.id, {
-            path,
-            deepth
-        })
+        return this.createWorkspaceVolumeClient(xpert.tenantId, RequestContext.currentUserId()).list(
+            getXpertMemoryWorkspacePath(),
+            {
+                path,
+                deepth
+            }
+        )
     }
 
     async getMemoryFile(id: string, filePath: string): Promise<TFile> {
         const xpert = await this.findOne(id)
         return this.createWorkspaceVolumeClient(xpert.tenantId, RequestContext.currentUserId()).readFile(
-            xpert.id,
+            getXpertMemoryWorkspacePath(),
             filePath
         )
     }
@@ -463,7 +466,7 @@ export class XpertService extends TenantOrganizationAwareCrudService<Xpert> {
     async saveMemoryFile(id: string, filePath: string, content: string): Promise<TFile> {
         const xpert = await this.findOne(id)
         return this.createWorkspaceVolumeClient(xpert.tenantId, RequestContext.currentUserId()).saveFile(
-            xpert.id,
+            getXpertMemoryWorkspacePath(),
             filePath,
             content
         )
@@ -490,4 +493,8 @@ export class XpertService extends TenantOrganizationAwareCrudService<Xpert> {
             userId
         })
     }
+}
+
+function getXpertMemoryWorkspacePath() {
+    return ['.xpert', 'memory'].join('/')
 }


### PR DESCRIPTION
## Summary
This PR aligns local workspace-related flows around the current user root and fixes memory file browsing so the UI reflects the actual `.xpert/memory` tree.

On the workspace side, ClawXpert conversation files, terminal default cwd, local sandbox file operations, and agent sandbox working directories now resolve from the current user volume root instead of thread- or project-scoped subdirectories.

On the memory side, the memory files page now reads from `.xpert/memory` itself instead of a deeper `private/user` leaf, so the file tree can show the broader directory structure that actually exists on disk.

## Root Cause
There were two separate path mismatches:

1. Several workspace entry points still defaulted to thread/project-oriented paths, while the intended behavior was to operate from the current user's shared root.
2. The memory files page only changed its display label to `.xpert/memory`, but the backend was still reading from a much deeper xpert-specific subdirectory, so the UI tree showed only a small subset of files.

There was also a local-only sandbox path issue where `sandbox_write_file` could still surface `/root/...` style paths. That path normalization is now limited to the local shell sandbox provider so online/docker providers keep their existing absolute-path behavior.

## What Changed
Server-side workspace helpers now expose explicit current-user workspace path/url helpers, and consumers that should default to the user root use those helpers.

Workspace volume access now supports using the volume root itself as the effective workspace root. Conversation file browsing uses that root directly, and sandbox terminal/upload/local file flows now point to the user volume.

Agent sandbox acquisition now always passes the resolved user workspace as the working directory, including sandbox-environment runs.

The sandbox file middleware now normalizes `/root/...`-style paths only for the local shell sandbox provider and reports relative paths for local tool output, while leaving non-local providers unchanged.

Memory file APIs now list/read/save against `.xpert/memory`, and the memory files UI labels the tree accordingly.

## Validation
Validated on this branch with:

- `pnpm nx test server-ai packages/server-ai/src/shared/volume/volume.spec.ts --runInBand`
- `pnpm nx test server-ai packages/server-ai/src/shared/volume/workspace-volume.spec.ts --runInBand`
- `pnpm nx test server-ai packages/server-ai/src/chat-conversation/conversation.service.spec.ts --runInBand`
- `pnpm nx test server-ai packages/server-ai/src/sandbox/sandbox.controller.spec.ts --runInBand`
- `pnpm nx test server-ai packages/server-ai/src/sandbox/client-local.spec.ts --runInBand`
- `pnpm nx test server-ai packages/server-ai/src/xpert/xpert.memory-files.spec.ts --runInBand`
- `pnpm exec tsc -p packages/server-ai/tsconfig.lib.json --noEmit`
- `pnpm exec tsc -p packages/plugins/agent-middlewares/tsconfig.lib.json --noEmit`
- `pnpm exec tsc -p packages/plugins/agent-middlewares/tsconfig.spec.json --noEmit`

## Notes
`packages/server-ai/src/xpert-agent/commands/handlers/invoke.handler.spec.ts` still has a pre-existing test harness issue in isolated execution (`TenantOrganizationBaseEntity` mock wiring), so that spec was not used as the final source of confidence for this PR.