### PR TITLE
[codex] Port copilot provider hydration and model picker updates

### DIFF
--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.html
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.html
@@ -16,31 +16,30 @@
 }
 
 <div
+  #modelContainer
+  #mt="cdkMenuTriggerFor"
   class="container group/container flex items-center px-1 h-8 rounded-lg border border-divider-regular bg-components-input-bg-normal hover:border-divider-deep"
+  [cdkMenuTriggerFor]="readonly() ? null : modelsMenu"
+  [cdkMenuTriggerData]="{ mt: mt }"
+  (cdkMenuOpened)="syncActiveCopilotTab()"
+  [cdkMenuPosition]="[
+    {
+      originX: 'start',
+      originY: 'bottom',
+      overlayX: 'start',
+      overlayY: 'top',
+      offsetY: 8
+    },
+    {
+      originX: 'start',
+      originY: 'top',
+      overlayX: 'start',
+      overlayY: 'bottom',
+      offsetY: -8
+    }
+  ]"
 >
-  <div
-    class="flex-1 relative flex items-center rounded-md px-1 overflow-hidden"
-    #modelTrigger
-    #mt="cdkMenuTriggerFor"
-    [cdkMenuTriggerFor]="readonly() ? null : modelsMenu"
-    [cdkMenuTriggerData]="{ mt: mt }"
-    [cdkMenuPosition]="[
-      {
-        originX: 'start',
-        originY: 'bottom',
-        overlayX: 'start',
-        overlayY: 'top',
-        offsetY: 8
-      },
-      {
-        originX: 'start',
-        originY: 'top',
-        overlayX: 'start',
-        overlayY: 'bottom',
-        offsetY: -8
-      }
-    ]"
-  >
+  <div class="flex-1 relative flex items-center rounded-md px-1 overflow-hidden">
     @if (inheritModel()) {
       @if (isInherit()) {
         <i class="ri-skip-up-line mx-1" [zTooltip]="'PAC.Copilot.Inherited' | translate: { Default: 'Inherited' }"></i>
@@ -137,7 +136,9 @@
         }
       </div>
     } @else {
-      <div class="mr-1.5 flex items-center justify-center w-4 h-4 rounded-[5px] border border-dashed border-divider-regular">
+      <div
+        class="mr-1.5 flex items-center justify-center w-4 h-4 rounded-[5px] border border-dashed border-divider-regular"
+      >
         <svg
           width="16"
           height="17"
@@ -207,6 +208,7 @@
       #parametersTrigger="cdkMenuTriggerFor"
       [cdkMenuTriggerFor]="parametersMenu"
       [class.active]="parametersTrigger.isOpen()"
+      (click)="$event.stopPropagation()"
     >
       <svg
         width="24"
@@ -286,7 +288,15 @@
 </ng-template>
 
 <ng-template #modelsMenu let-mt="mt">
-  <div #menu="cdkMenu" cdkMenu class="ngm-cdk-menu pl-2" [style.width.px]="modelTrigger.offsetWidth">
+  @let menuWidth = getMenuWidth(modelContainer);
+  @let menuRailWidth = getMenuRailWidth(menuWidth);
+  <div
+    #menu="cdkMenu"
+    cdkMenu
+    class="ngm-cdk-menu flex max-h-[min(560px,75vh)] max-w-[calc(100vw-2rem)] flex-col overflow-hidden pl-2"
+    [style.width.px]="menuWidth"
+    [style.--copilot-picker-rail-width.px]="menuRailWidth"
+  >
     <div class="px-1 py-2 sticky top-0 w-full bg-components-card-bg border-b border-solid border-divider-regular z-10">
       <div class="w-full relative">
         <i class="ri-search-2-line absolute left-1.5 top-1"></i>
@@ -300,112 +310,207 @@
       </div>
     </div>
 
-    <div class="pr-2">
-      @for (copilot of searchedModels(); track copilot.id) {
-        <div class="text-base px-4 my-4 font-semibold flex justify-start items-center">
-          <span>{{ copilot.providerWithModels?.label | i18n }}</span>
-          <span class="mx-1">•</span>
-          <div>
-            @if (copilot.name) {
-              <span>{{ copilot.name }}</span>
-            } @else {
-              <span class="uppercase">{{
-                'PAC.Copilot.Role_' + copilot.role | translate: { Default: copilot.role }
-              }}</span>
-            }
-          </div>
+    <div class="min-h-0 flex-1 overflow-hidden">
+      @if ((searchedModels()?.length ?? 0) === 0) {
+        <div class="flex h-full items-center justify-center px-6 text-sm text-text-tertiary">
+          {{ 'PAC.Copilot.NoMatchingModels' | translate: { Default: 'No matching models' } }}
         </div>
-        @for (item of copilot.providerWithModels?.models; track item.model) {
+      } @else {
+        <div class="relative flex h-full min-h-0 flex-col overflow-hidden">
+          <div
+            class="grid border-b border-divider-regular bg-components-panel-bg text-xs font-medium text-text-tertiary"
+            [style.grid-template-columns]="getMenuGridTemplateColumns(menuWidth)"
+          >
+            <div class="border-r border-divider-regular px-3 py-1.5">
+              {{ 'PAC.Copilot.Provider' | translate: { Default: 'Provider' } }}
+            </div>
+            <div class="px-3 py-1.5">
+              {{ 'PAC.Copilot.Models' | translate: { Default: 'Models' } }}
+            </div>
+          </div>
+
           <button
             type="button"
-            class="w-full flex justify-start items-center gap-1 px-4 py-2 rounded-xl cursor-pointer enabled:hover:bg-hover-bg hover:text-primary-500 disabled:cursor-not-allowed"
-            [ngClass]="
-              copilot.id === copilotId() && model() === item.model && modelType() === item.model_type
-                ? 'bg-components-card-bg text-primary-600 font-semibold'
-                : ''
-            "
-            [class.opacity-60]="item.deprecated"
-            [zTooltip]="item.deprecated ? ('PAC.Copilot.Deprecated' | translate: { Default: 'Deprecated' }) : ''"
-            zPosition="left"
-            [disabled]="item.deprecated"
-            (click)="setModel(copilot, item); mt.close()"
+            role="separator"
+            aria-orientation="vertical"
+            class="group/divider absolute inset-y-0 z-20 flex w-5 -translate-x-1/2 cursor-col-resize touch-none select-none items-stretch justify-center outline-none"
+            [style.left.px]="menuRailWidth"
+            [attr.aria-label]="'PAC.Copilot.ResizeProviderPanel' | translate: { Default: 'Resize provider panel' }"
+            [attr.aria-valuemin]="getMenuRailMinWidth(menuWidth)"
+            [attr.aria-valuemax]="getMenuRailMaxWidth(menuWidth)"
+            [attr.aria-valuenow]="menuRailWidth"
+            [class.bg-hover-bg]="isRailResizing()"
+            (mousedown)="startRailResize($event, modelContainer)"
+            (click)="$event.preventDefault(); $event.stopPropagation()"
+            (keydown)="onRailResizeKeydown($event, modelContainer)"
           >
-            @if (copilot.providerWithModels.icon_small) {
-              <img [src]="copilot.providerWithModels.icon_small | i18n" class="w-4 h-4 inline-block" />
-            }
             <span
-              class="truncate"
-              [title]="item.model"
-              [ngmHighlight]="searchTerm()"
-              [content]="item.model"
-              customClasses="text-primary-600"
-              >{{ item.model }}</span
-            >
-            @switch (item.model_type) {
-              @case (eModelType.LLM) {
-                <div
-                  class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
-                >
-                  {{ 'PAC.Copilot.Chat' | translate: { Default: 'Chat' } }}
-                </div>
-              }
-              @case (eModelType.RERANK) {
-                <div
-                  class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
-                >
-                  <i class="ri-sort-number-asc"></i>
-                </div>
-              }
-              @case (eModelType.TEXT_EMBEDDING) {
-                <div
-                  class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
-                >
-                  <i class="ri-text-block"></i>
-                </div>
-              }
-              @case (eModelType.SPEECH2TEXT) {
-                <div
-                  class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
-                >
-                  <i class="ri-speech-to-text-line"></i>
-                </div>
-              }
-              @case (eModelType.TTS) {
-                <div
-                  class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
-                >
-                  <i class="ri-text-to-speech-line"></i>
-                </div>
-              }
-            }
-            @if (
-              item.features?.includes(eModelFeature.TOOL_CALL) || item.features?.includes(eModelFeature.MULTI_TOOL_CALL)
-            ) {
-              <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 w-[18px] justify-center opacity-60"
-              >
-                <i class="ri-hammer-fill"></i>
-              </div>
-            }
-            @if (item.features?.includes(eModelFeature.VISION)) {
-              <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 w-[18px] justify-center opacity-60"
-              >
-                <i class="ri-eye-fill"></i>
-              </div>
-            }
+              class="pointer-events-none h-full w-[4px] rounded-full bg-divider-deep transition-colors group-hover/divider:bg-primary-500 group-focus-visible/divider:bg-primary-500"
+            ></span>
           </button>
-        }
+
+          <z-tab-group
+            class="copilot-model-picker flex-1 min-h-0 overflow-hidden"
+            zTabsPosition="left"
+            zActivePosition="left"
+            zSize="sm"
+            [disablePagination]="true"
+            [selectedIndex]="activeCopilotTabIndex()"
+            (selectedIndexChange)="selectCopilotTabByIndex($event)"
+          >
+            @for (copilot of searchedModels(); track copilot.id) {
+              <z-tab bodyClass="h-full min-w-0 shrink-0 overflow-y-auto pr-1">
+                <ng-template zTabLabel>
+                  <span class="flex w-full min-w-0 items-start justify-between gap-3 py-0.5">
+                    <span class="flex min-w-0 flex-1 items-start gap-2 text-left">
+                      @if (copilot.providerWithModels.icon_small) {
+                        <img [src]="copilot.providerWithModels.icon_small | i18n" class="mt-0.5 h-4 w-4 shrink-0" />
+                      } @else {
+                        <span
+                          class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border border-dashed border-divider-regular text-[9px] font-semibold uppercase text-text-quaternary"
+                        >
+                          P
+                        </span>
+                      }
+
+                      <span class="min-w-0 flex-1">
+                        <span class="block truncate text-[13px] font-semibold">
+                          {{ copilot.providerWithModels?.label | i18n }}
+                        </span>
+                        <span
+                          class="mt-0.5 block truncate text-[11px] uppercase tracking-[0.04em] text-text-quaternary"
+                        >
+                          {{ copilot.providerWithModels?.provider }}
+                        </span>
+                        <span class="mt-0.5 block truncate text-[11px] opacity-75">
+                          @if (copilot.name) {
+                            {{ copilot.name }}
+                          } @else {
+                            {{ 'PAC.Copilot.Role_' + copilot.role | translate: { Default: copilot.role } }}
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span class="rounded-md border border-current/10 px-1.5 py-0.5 text-[10px] font-medium opacity-80">
+                      {{ getCopilotTabModelCount(copilot) }}
+                    </span>
+                  </span>
+                </ng-template>
+
+                <ng-container
+                  [ngTemplateOutlet]="copilotModels"
+                  [ngTemplateOutletContext]="{ $implicit: copilot, mt: mt }"
+                />
+              </z-tab>
+            }
+          </z-tab-group>
+        </div>
       }
     </div>
 
     <a
       href="/settings/copilot/basic"
       target="_blank"
-      class="sticky group bottom-0 flex cursor-pointer items-center rounded-b-lg border-t border-divider-subtle bg-components-panel-bg px-4 py-2 text-text-accent z-10"
+      class="group flex cursor-pointer items-center rounded-b-lg border-t border-divider-subtle bg-components-panel-bg px-4 py-2 text-text-accent"
     >
       <span class="system-xs-medium">{{ 'PAC.Copilot.ModelConfig' | translate: { Default: 'Model config' } }}</span>
       <i class="ri-external-link-line inline-block group-hover:translate-x-1 transition-transform"></i>
     </a>
   </div>
+</ng-template>
+
+<ng-template #copilotModels let-copilot let-mt="mt">
+  <div class="sticky top-0 z-10 flex items-center bg-components-card-bg px-4 pb-3 pt-4 text-base font-semibold">
+    <div class="min-w-0 text-left">
+      <span>{{ copilot.providerWithModels?.label | i18n }}</span>
+      <span class="mx-1">•</span>
+      <span>
+        @if (copilot.name) {
+          <span>{{ copilot.name }}</span>
+        } @else {
+          <span class="uppercase">{{ 'PAC.Copilot.Role_' + copilot.role | translate: { Default: copilot.role } }}</span>
+        }
+      </span>
+    </div>
+  </div>
+
+  @for (item of copilot.providerWithModels?.models; track item.model) {
+    <button
+      type="button"
+      class="flex w-full min-w-0 items-center justify-start gap-0.5 rounded-xl px-2.5 py-2 text-left cursor-pointer enabled:hover:bg-hover-bg hover:text-primary-500 disabled:cursor-not-allowed"
+      [ngClass]="
+        copilot.id === copilotId() && model() === item.model && modelType() === item.model_type
+          ? 'bg-components-card-bg text-primary-600 font-semibold'
+          : ''
+      "
+      [class.opacity-60]="item.deprecated"
+      [zTooltip]="item.deprecated ? ('PAC.Copilot.Deprecated' | translate: { Default: 'Deprecated' }) : ''"
+      zPosition="left"
+      [disabled]="item.deprecated"
+      (click)="setModel(copilot, item); mt.close()"
+    >
+      @if (copilot.providerWithModels.icon_small) {
+        <img [src]="copilot.providerWithModels.icon_small | i18n" class="h-4 w-4 shrink-0 inline-block" />
+      }
+      <span
+        class="min-w-0 flex-1 truncate"
+        [title]="item.model"
+        [ngmHighlight]="searchTerm()"
+        [content]="item.model"
+        customClasses="text-primary-600"
+        >{{ item.model }}</span
+      >
+      @switch (item.model_type) {
+        @case (eModelType.LLM) {
+          <div
+            class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
+          >
+            {{ 'PAC.Copilot.Chat' | translate: { Default: 'Chat' } }}
+          </div>
+        }
+        @case (eModelType.RERANK) {
+          <div
+            class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
+          >
+            <i class="ri-sort-number-asc"></i>
+          </div>
+        }
+        @case (eModelType.TEXT_EMBEDDING) {
+          <div
+            class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
+          >
+            <i class="ri-text-block"></i>
+          </div>
+        }
+        @case (eModelType.SPEECH2TEXT) {
+          <div
+            class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
+          >
+            <i class="ri-speech-to-text-line"></i>
+          </div>
+        }
+        @case (eModelType.TTS) {
+          <div
+            class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
+          >
+            <i class="ri-text-to-speech-line"></i>
+          </div>
+        }
+      }
+      @if (item.features?.includes(eModelFeature.TOOL_CALL) || item.features?.includes(eModelFeature.MULTI_TOOL_CALL)) {
+        <div
+          class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 w-[18px] justify-center opacity-60"
+        >
+          <i class="ri-hammer-fill"></i>
+        </div>
+      }
+      @if (item.features?.includes(eModelFeature.VISION)) {
+        <div
+          class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 w-[18px] justify-center opacity-60"
+        >
+          <i class="ri-eye-fill"></i>
+        </div>
+      }
+    </button>
+  }
 </ng-template>

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.scss
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.scss
@@ -23,4 +23,33 @@
     --mdc-slider-handle-width: 15px;
     --mdc-slider-handle-height: 15px;
   }
+
+  .copilot-model-picker {
+    > .grid {
+      width: var(--copilot-picker-rail-width, 88px);
+      min-width: var(--copilot-picker-rail-width, 88px);
+      flex-shrink: 0;
+    }
+
+    .z-tab-group__nav {
+      width: 100%;
+      min-width: 0;
+      overflow-x: hidden;
+      overflow-y: auto;
+      padding-right: 0.25rem;
+    }
+
+    .z-tab-group__content {
+      min-height: 0;
+      min-width: 0;
+      overflow: hidden;
+    }
+
+    .z-tab-group__trigger {
+      width: 100%;
+      min-width: 0;
+      justify-content: flex-start;
+      overflow: hidden;
+    }
+  }
 }

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
@@ -1,4 +1,3 @@
-import { CdkListboxModule } from '@angular/cdk/listbox'
 import { CdkMenuModule } from '@angular/cdk/menu'
 import { CommonModule } from '@angular/common'
 import {
@@ -7,10 +6,12 @@ import {
   ChangeDetectorRef,
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   input,
-  model
+  model,
+  signal
 } from '@angular/core'
 import { toObservable } from '@angular/core/rxjs-interop'
 import { ControlValueAccessor, FormsModule, ReactiveFormsModule } from '@angular/forms'
@@ -26,15 +27,15 @@ import {
   I18nObject,
   ICopilot,
   ICopilotModel,
+  ICopilotWithProvider,
   injectCopilotProviderService,
-  injectCopilots,
   ModelPropertyKey,
   ModelFeature,
   ParameterType,
   ProviderModel
 } from '../../../@core'
 import { ModelParameterInputComponent } from '../model-parameter-input/input.component'
-import { ZardTooltipImports } from '@xpert-ai/headless-ui'
+import { ZardTabsImports, ZardTooltipImports } from '@xpert-ai/headless-ui'
 import { ZardAlertComponent } from '@xpert-ai/headless-ui/components/alert'
 
 @Component({
@@ -45,7 +46,7 @@ import { ZardAlertComponent } from '@xpert-ai/headless-ui/components/alert'
     ReactiveFormsModule,
     TranslateModule,
     CdkMenuModule,
-    CdkListboxModule,
+    ...ZardTabsImports,
     ...ZardTooltipImports,
     NgmI18nPipe,
     NgmHighlightDirective,
@@ -69,9 +70,9 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
   protected cva = inject<NgxControlValueAccessor<Partial<ICopilotModel> | null>>(NgxControlValueAccessor)
   readonly copilotServer = inject(CopilotServerService)
   readonly copilotProviderService = injectCopilotProviderService()
-  readonly copilots = injectCopilots()
   readonly i18n = new NgmI18nPipe()
   readonly #cdr = inject(ChangeDetectorRef)
+  readonly #destroyRef = inject(DestroyRef)
 
   // Inputs
   readonly modelType = input<AiModelTypeEnum>()
@@ -114,9 +115,12 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
   readonly copilotWithModels$ = toObservable(this.copilotWithModels)
 
   readonly searchTerm = model('')
+  readonly activeCopilotTabId = model<string | null>(null)
+  readonly railWidth = model<number | null>(null)
+  readonly isRailResizing = signal(false)
   readonly #searchTerm = debouncedSignal(this.searchTerm, 300)
   readonly searchedModels = computed(() => {
-    const searchText = this.#searchTerm()
+    const searchText = this.#searchTerm().trim().toLowerCase()
     const copilots = this.features()?.length
       ? this.copilotWithModels()
           ?.map((_) => {
@@ -157,13 +161,42 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
           .filter(nonBlank)
       : copilots
   })
+  readonly activeCopilotTabIndex = computed(() => {
+    const copilots = this.searchedModels() ?? []
+    const activeCopilotTabId = this.resolvedActiveCopilotTabId()
+
+    if (!copilots.length || !activeCopilotTabId) {
+      return 0
+    }
+
+    const index = copilots.findIndex((copilot) => copilot.id === activeCopilotTabId)
+    return index > -1 ? index : 0
+  })
+  readonly resolvedActiveCopilotTabId = computed(() => {
+    const copilots = this.searchedModels() ?? []
+    if (!copilots.length) {
+      return null
+    }
+
+    const activeCopilotTabId = this.activeCopilotTabId()
+    if (activeCopilotTabId && copilots.some((copilot) => copilot.id === activeCopilotTabId)) {
+      return activeCopilotTabId
+    }
+
+    const currentCopilotId = this.copilotId()
+    if (currentCopilotId && copilots.some((copilot) => copilot.id === currentCopilotId)) {
+      return currentCopilotId
+    }
+
+    return copilots[0].id
+  })
 
   readonly copilotId = computed(() => this._copilotModel()?.copilotId)
   readonly selectedCopilotWithModels = computed(() => {
     return this.copilotWithModels()?.find((_) => _.id === this.copilotId())
   })
 
-  readonly providerId = computed(() => this.copilots()?.find((_) => _.id === this.copilotId())?.modelProvider?.id)
+  readonly providerId = computed(() => this.selectedCopilotWithModels()?.modelProvider?.id)
 
   readonly model = computed(() => this._copilotModel()?.model)
 
@@ -196,6 +229,7 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
 
   onChange: ((value: ICopilotModel | null) => void) | null = null
   onTouched: (() => void) | null = null
+  #railResizeAbortController: AbortController | null = null
   private valueChangeSub = this.cva.valueChange.pipe(distinctUntilChanged()).subscribe((value) => {
     this.onChange?.(value)
   })
@@ -208,32 +242,32 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
   })
 
   constructor() {
-    effect(
-      () => {
-        const value = this.cva.value$()
-        const rules = this.modelParameterRules()
-        if (value && rules?.length && this.shouldInitDefaultOptions(value.options)) {
-          const contextSize = this.parseContextSize(value.options?.[ModelPropertyKey.CONTEXT_SIZE])
-          this.cva.value$.update((current) => {
-            if (!current) {
-              return current
-            }
-            return {
-              ...current,
-              options: rules.reduce(
-                (acc, curr) => {
-                  acc[curr.name] = curr.default
-                  return acc
-                },
-                {
-                  ...(typeof contextSize === 'number' ? { [ModelPropertyKey.CONTEXT_SIZE]: contextSize } : {})
-                } as Record<string, any>
-              )
-            }
-          })
-        }
+    this.#destroyRef.onDestroy(() => this.stopRailResize())
+
+    effect(() => {
+      const value = this.cva.value$()
+      const rules = this.modelParameterRules()
+      if (value && rules?.length && this.shouldInitDefaultOptions(value.options)) {
+        const contextSize = this.parseContextSize(value.options?.[ModelPropertyKey.CONTEXT_SIZE])
+        this.cva.value$.update((current) => {
+          if (!current) {
+            return current
+          }
+          return {
+            ...current,
+            options: rules.reduce(
+              (acc, curr) => {
+                acc[curr.name] = curr.default
+                return acc
+              },
+              {
+                ...(typeof contextSize === 'number' ? { [ModelPropertyKey.CONTEXT_SIZE]: contextSize } : {})
+              } as Record<string, any>
+            )
+          }
+        })
       }
-    )
+    })
 
     afterNextRender(() => {
       setTimeout(() => {
@@ -309,6 +343,108 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
     this.updateValue(null)
   }
 
+  syncActiveCopilotTab() {
+    const copilots = this.searchedModels() ?? []
+    if (!copilots.length) {
+      this.activeCopilotTabId.set(null)
+      return
+    }
+
+    const currentCopilotId = this.copilotId()
+    this.activeCopilotTabId.set(
+      currentCopilotId && copilots.some((copilot) => copilot.id === currentCopilotId)
+        ? currentCopilotId
+        : copilots[0].id
+    )
+  }
+
+  selectCopilotTabByIndex(index: number) {
+    const copilot = this.searchedModels()?.[index]
+    if (copilot) {
+      this.activeCopilotTabId.set(copilot.id)
+    }
+  }
+
+  getCopilotTabModelCount(copilot: ICopilotWithProvider) {
+    return copilot.providerWithModels?.models?.length ?? 0
+  }
+
+  getMenuWidth(container: HTMLElement | null | undefined) {
+    return container?.getBoundingClientRect().width || 0
+  }
+
+  getMenuRailMinWidth(containerWidth: number | null | undefined) {
+    return this.getMenuRailBounds(containerWidth).min
+  }
+
+  getMenuRailMaxWidth(containerWidth: number | null | undefined) {
+    return this.getMenuRailBounds(containerWidth).max
+  }
+
+  getMenuRailWidth(containerWidth: number | null | undefined) {
+    const { defaultWidth } = this.getMenuRailBounds(containerWidth)
+    const railWidth = this.railWidth()
+    return this.clampRailWidth(typeof railWidth === 'number' ? railWidth : defaultWidth, containerWidth)
+  }
+
+  getMenuGridTemplateColumns(containerWidth: number | null | undefined) {
+    return `${this.getMenuRailWidth(containerWidth)}px minmax(0, 1fr)`
+  }
+
+  startRailResize(event: MouseEvent, container: HTMLElement | null | undefined) {
+    if (!container) {
+      return
+    }
+
+    if ('button' in event && event.button !== 0) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const rect = container.getBoundingClientRect()
+    this.stopRailResize()
+
+    const abortController = new AbortController()
+    this.#railResizeAbortController = abortController
+
+    const updateWidth = (clientX: number) => {
+      this.setRailWidth(clientX - rect.left, rect.width)
+    }
+
+    updateWidth(event.clientX)
+    this.isRailResizing.set(true)
+    document.body.classList.add('cursor-col-resize', 'select-none')
+
+    const stopResize = () => this.stopRailResize()
+
+    document.addEventListener('mousemove', (moveEvent) => updateWidth(moveEvent.clientX), {
+      signal: abortController.signal
+    })
+    document.addEventListener('mouseup', stopResize, {
+      once: true,
+      signal: abortController.signal
+    })
+    window.addEventListener('blur', stopResize, {
+      once: true,
+      signal: abortController.signal
+    })
+  }
+
+  onRailResizeKeydown(event: KeyboardEvent, container: HTMLElement | null | undefined) {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const containerWidth = this.getMenuWidth(container)
+    const delta = event.key === 'ArrowLeft' ? -12 : 12
+    this.setRailWidth(this.getMenuRailWidth(containerWidth) + delta, containerWidth)
+  }
+
   private withModelContextSize(value: Partial<ICopilotModel>, model?: ProviderModel | null): ICopilotModel {
     const contextSize = this.parseContextSize(model?.model_properties?.[ModelPropertyKey.CONTEXT_SIZE])
     const options = {
@@ -346,5 +482,44 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
     }
     const keys = Object.keys(options).filter((key) => options[key] !== undefined)
     return keys.length === 0 || (keys.length === 1 && keys[0] === ModelPropertyKey.CONTEXT_SIZE)
+  }
+
+  private getMenuRailBounds(containerWidth: number | null | undefined) {
+    const min = 72
+    const fallbackMax = 220
+    const fallbackDefault = 88
+
+    if (!containerWidth) {
+      return {
+        min,
+        max: fallbackMax,
+        defaultWidth: fallbackDefault
+      }
+    }
+
+    const max = Math.max(min + 32, Math.min(fallbackMax, Math.floor(containerWidth - 220)))
+    const defaultWidth = Math.min(max, Math.max(min, Math.floor(containerWidth * 0.13)))
+
+    return {
+      min,
+      max,
+      defaultWidth
+    }
+  }
+
+  private clampRailWidth(width: number, containerWidth: number | null | undefined) {
+    const { min, max } = this.getMenuRailBounds(containerWidth)
+    return Math.min(max, Math.max(min, Math.floor(width)))
+  }
+
+  private setRailWidth(width: number, containerWidth: number | null | undefined) {
+    this.railWidth.set(this.clampRailWidth(width, containerWidth))
+  }
+
+  private stopRailResize() {
+    this.#railResizeAbortController?.abort()
+    this.#railResizeAbortController = null
+    this.isRailResizing.set(false)
+    document.body.classList.remove('cursor-col-resize', 'select-none')
   }
 }

--- a/packages/server-ai/src/copilot-provider/copilot-provider.service.ts
+++ b/packages/server-ai/src/copilot-provider/copilot-provider.service.ts
@@ -1,15 +1,70 @@
-import { TenantOrganizationAwareCrudService } from '@xpert-ai/server-core'
+import { RequestContext, TenantOrganizationAwareCrudService } from '@xpert-ai/server-core'
 import { Injectable } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { Repository } from 'typeorm'
+import { FindManyOptions, In, IsNull, Repository } from 'typeorm'
 import { CopilotProvider } from './copilot-provider.entity'
 
 @Injectable()
 export class CopilotProviderService extends TenantOrganizationAwareCrudService<CopilotProvider> {
-	constructor(
-		@InjectRepository(CopilotProvider)
-		repository: Repository<CopilotProvider>
-	) {
-		super(repository)
-	}
+    constructor(
+        @InjectRepository(CopilotProvider)
+        repository: Repository<CopilotProvider>
+    ) {
+        super(repository)
+    }
+
+    async findVisibleByCopilotIds(
+        copilotIds: string[],
+        options?: {
+            tenantId?: string | null
+            organizationId?: string | null
+            findOptions?: Omit<FindManyOptions<CopilotProvider>, 'where'>
+        }
+    ): Promise<Map<string, CopilotProvider>> {
+        const tenantId = options?.tenantId !== undefined ? options.tenantId : RequestContext.currentTenantId()
+        const organizationId =
+            options?.organizationId !== undefined ? options.organizationId : RequestContext.getOrganizationId()
+
+        if (!tenantId || !copilotIds?.length) {
+            return new Map()
+        }
+
+        const items = await this.repository.find({
+            ...(options?.findOptions ?? {}),
+            where: organizationId
+                ? [
+                      {
+                          tenantId,
+                          organizationId,
+                          copilotId: In(copilotIds)
+                      },
+                      {
+                          tenantId,
+                          organizationId: IsNull(),
+                          copilotId: In(copilotIds)
+                      }
+                  ]
+                : [
+                      {
+                          tenantId,
+                          organizationId: IsNull(),
+                          copilotId: In(copilotIds)
+                      }
+                  ]
+        })
+
+        const providers = new Map<string, CopilotProvider>()
+        for (const item of items) {
+            if (!item?.copilotId) {
+                continue
+            }
+
+            const existing = providers.get(item.copilotId)
+            if (!existing || (!existing.organizationId && item.organizationId)) {
+                providers.set(item.copilotId, item)
+            }
+        }
+
+        return providers
+    }
 }

--- a/packages/server-ai/src/copilot-provider/index.ts
+++ b/packages/server-ai/src/copilot-provider/index.ts
@@ -1,2 +1,3 @@
 export * from './copilot-provider.module'
+export * from './copilot-provider.service'
 export * from './queries/index'

--- a/packages/server-ai/src/copilot/copilot.module.ts
+++ b/packages/server-ai/src/copilot/copilot.module.ts
@@ -10,18 +10,20 @@ import { QueryHandlers } from './queries/handlers/index'
 import { CopilotService } from './copilot.service'
 import { AIModelModule } from '../ai-model'
 import { CommandHandlers } from './commands/handlers'
+import { CopilotProviderModule } from '../copilot-provider'
 
 @Module({
-	imports: [
-		RouterModule.register([{ path: '/copilot', module: CopilotModule }]),
-		TypeOrmModule.forFeature([Copilot]),
-		TenantModule,
-		CqrsModule,
-		UserModule,
-		AIModelModule
-	],
-	controllers: [CopilotController],
-	providers: [CopilotService, ...QueryHandlers, ...CommandHandlers],
-	exports: [CopilotService]
+    imports: [
+        RouterModule.register([{ path: '/copilot', module: CopilotModule }]),
+        TypeOrmModule.forFeature([Copilot]),
+        TenantModule,
+        CqrsModule,
+        UserModule,
+        AIModelModule,
+        CopilotProviderModule
+    ],
+    controllers: [CopilotController],
+    providers: [CopilotService, ...QueryHandlers, ...CommandHandlers],
+    exports: [CopilotService]
 })
 export class CopilotModule {}

--- a/packages/server-ai/src/copilot/copilot.service.spec.ts
+++ b/packages/server-ai/src/copilot/copilot.service.spec.ts
@@ -1,0 +1,191 @@
+import { AiProviderRole } from '@xpert-ai/contracts'
+import { ConfigService } from '@xpert-ai/server-config'
+import { QueryBus } from '@nestjs/cqrs'
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { CopilotProvider } from '../copilot-provider/copilot-provider.entity'
+import { CopilotProviderService } from '../copilot-provider/copilot-provider.service'
+import { Copilot } from './copilot.entity'
+import { CopilotService } from './copilot.service'
+
+jest.mock('../ai-model', () => ({
+    AiProviderDto: class AiProviderDto {},
+    ListModelProvidersQuery: class ListModelProvidersQuery {
+        constructor(readonly providerNames?: string[]) {}
+    }
+}))
+
+describe('CopilotService', () => {
+    let moduleRef: TestingModule
+    let repository: jest.Mocked<Pick<Repository<Copilot>, 'find'>>
+    let queryBus: jest.Mocked<Pick<QueryBus, 'execute'>>
+    let copilotProviderService: jest.Mocked<Pick<CopilotProviderService, 'findVisibleByCopilotIds'>>
+    let configService: jest.Mocked<Pick<ConfigService, 'get'>>
+    let service: CopilotService
+
+    beforeEach(async () => {
+        repository = {
+            find: jest.fn()
+        }
+        queryBus = {
+            execute: jest.fn()
+        }
+        copilotProviderService = {
+            findVisibleByCopilotIds: jest.fn()
+        }
+        configService = {
+            get: jest.fn().mockReturnValue('http://localhost')
+        }
+
+        moduleRef = await Test.createTestingModule({
+            providers: [
+                CopilotService,
+                {
+                    provide: getRepositoryToken(Copilot),
+                    useValue: repository
+                },
+                {
+                    provide: QueryBus,
+                    useValue: queryBus
+                },
+                {
+                    provide: CopilotProviderService,
+                    useValue: copilotProviderService
+                },
+                {
+                    provide: ConfigService,
+                    useValue: configService
+                }
+            ]
+        }).compile()
+
+        service = moduleRef.get(CopilotService)
+    })
+
+    afterEach(async () => {
+        await moduleRef?.close()
+    })
+
+    it('replaces eager-loaded providers with scope-visible providers', async () => {
+        repository.find.mockResolvedValue([
+            createCopilot({
+                id: 'copilot-1',
+                role: AiProviderRole.Primary,
+                modelProvider: createProvider({
+                    id: 'stale-provider',
+                    providerName: 'openai'
+                })
+            })
+        ])
+        copilotProviderService.findVisibleByCopilotIds.mockResolvedValue(
+            new Map([
+                [
+                    'copilot-1',
+                    createProvider({
+                        id: 'visible-provider',
+                        copilotId: 'copilot-1',
+                        providerName: 'openai'
+                    })
+                ]
+            ])
+        )
+
+        const result = await service.findAllAvailablesCopilots('tenant-1', 'org-1')
+
+        expect(repository.find).toHaveBeenCalledWith({
+            where: {
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                enabled: true
+            },
+            relations: ['modelProvider']
+        })
+        expect(copilotProviderService.findVisibleByCopilotIds).toHaveBeenCalledWith(['copilot-1'], {
+            tenantId: 'tenant-1',
+            organizationId: 'org-1'
+        })
+        expect(result[0].modelProvider).toMatchObject({
+            id: 'visible-provider',
+            copilotId: 'copilot-1',
+            providerName: 'openai'
+        })
+    })
+
+    it('falls back to tenant-global copilots before hydrating visible providers', async () => {
+        repository.find.mockResolvedValueOnce([]).mockResolvedValueOnce([
+            createCopilot({
+                id: 'copilot-2',
+                role: AiProviderRole.Secondary,
+                modelProvider: createProvider({
+                    id: 'tenant-provider',
+                    providerName: 'anthropic'
+                })
+            })
+        ])
+        copilotProviderService.findVisibleByCopilotIds.mockResolvedValue(
+            new Map([
+                [
+                    'copilot-2',
+                    createProvider({
+                        id: 'tenant-provider',
+                        copilotId: 'copilot-2',
+                        providerName: 'anthropic'
+                    })
+                ]
+            ])
+        )
+
+        const result = await service.findAllAvailablesCopilots('tenant-1', 'org-1')
+
+        expect(repository.find).toHaveBeenNthCalledWith(1, {
+            where: {
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                enabled: true
+            },
+            relations: ['modelProvider']
+        })
+        expect(repository.find).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                relations: ['modelProvider']
+            })
+        )
+
+        const secondCall = repository.find.mock.calls[1][0]
+        expect(Array.isArray(secondCall.where)).toBe(false)
+        if (Array.isArray(secondCall.where)) {
+            throw new Error('Expected tenant fallback query to use a single where object')
+        }
+
+        expect(secondCall.where).toMatchObject({
+            tenantId: 'tenant-1',
+            enabled: true
+        })
+        expect(secondCall.where.organizationId).toBeDefined()
+        expect(result).toHaveLength(1)
+        expect(result[0].id).toBe('copilot-2')
+        expect(result[0].modelProvider?.id).toBe('tenant-provider')
+    })
+})
+
+function createCopilot(overrides: Partial<Copilot>): Copilot {
+    return Object.assign(new Copilot(), {
+        id: 'copilot-id',
+        tenantId: 'tenant-1',
+        organizationId: null,
+        enabled: true,
+        role: AiProviderRole.Primary,
+        ...overrides
+    })
+}
+
+function createProvider(overrides: Partial<CopilotProvider>): CopilotProvider {
+    return Object.assign(new CopilotProvider(), {
+        id: 'provider-id',
+        copilotId: 'copilot-id',
+        providerName: 'openai',
+        ...overrides
+    })
+}

--- a/packages/server-ai/src/copilot/copilot.service.ts
+++ b/packages/server-ai/src/copilot/copilot.service.ts
@@ -2,10 +2,10 @@ import { AiProviderRole, IAiProviderEntity, ICopilot } from '@xpert-ai/contracts
 import { DeepPartial } from '@xpert-ai/server-common'
 import { ConfigService } from '@xpert-ai/server-config'
 import {
-	FindOptionsWhere,
-	PaginationParams,
-	RequestContext,
-	TenantOrganizationAwareCrudService
+    FindOptionsWhere,
+    PaginationParams,
+    RequestContext,
+    TenantOrganizationAwareCrudService
 } from '@xpert-ai/server-core'
 import { Inject, Injectable } from '@nestjs/common'
 import { QueryBus } from '@nestjs/cqrs'
@@ -14,140 +14,170 @@ import { assign, compact, uniq } from 'lodash'
 import { IsNull, Repository } from 'typeorm'
 import { ListModelProvidersQuery } from '../ai-model'
 import { GetCopilotOrgUsageQuery } from '../copilot-organization/queries'
+import { CopilotProviderService } from '../copilot-provider/copilot-provider.service'
 import { Copilot } from './copilot.entity'
 import { CopilotDto } from './dto'
 
 export const ProviderRolePriority = [
-	AiProviderRole.Embedding,
-	AiProviderRole.Secondary,
-	AiProviderRole.Primary,
-	AiProviderRole.Reasoning
+    AiProviderRole.Embedding,
+    AiProviderRole.Secondary,
+    AiProviderRole.Primary,
+    AiProviderRole.Reasoning
 ]
 
 @Injectable()
 export class CopilotService extends TenantOrganizationAwareCrudService<Copilot> {
-	@Inject(ConfigService)
-	private readonly configService: ConfigService
+    @Inject(ConfigService)
+    private readonly configService: ConfigService
 
-	get baseUrl() {
-		return this.configService.get('baseUrl') as string
-	}
+    get baseUrl() {
+        return this.configService.get('baseUrl') as string
+    }
 
-	constructor(
-		@InjectRepository(Copilot)
-		repository: Repository<Copilot>,
+    constructor(
+        @InjectRepository(Copilot)
+        repository: Repository<Copilot>,
 
-		private readonly queryBus: QueryBus
-	) {
-		super(repository)
-	}
+        private readonly queryBus: QueryBus,
+        private readonly copilotProviderService: CopilotProviderService
+    ) {
+        super(repository)
+    }
 
-	/**
-	 * Get all available copilots in organization or tenant (if not enabled anyone in organization).
-	 * Fill the quota of tenant copilots for organization user
-	 *
-	 * @param filter
-	 */
-	async findAvailables(filter?: PaginationParams<Copilot>) {
-		const tenantId = RequestContext.currentTenantId()
-		const organizationId = RequestContext.getOrganizationId()
-		const copilots = await this.findAllAvailablesCopilots()
-		// Filter the tenant enabled copilots for organization user
-		// copilots = copilots.filter((copilot) => (organizationId && !copilot.organizationId) ? copilot.enabled : true)
-		for await (const copilot of copilots) {
-			if (!copilot.organizationId) {
-				const usage = await this.queryBus.execute(
-					new GetCopilotOrgUsageQuery(tenantId, organizationId, copilot.id)
-				)
-				copilot.usage = usage ?? {
-					tokenLimit: copilot.tokenBalance,
-					tokenUsed: 0
-				}
-			}
-		}
+    /**
+     * Get all available copilots in organization or tenant (if not enabled anyone in organization).
+     * Fill the quota of tenant copilots for organization user
+     *
+     * @param filter
+     */
+    async findAvailables(filter?: PaginationParams<Copilot>) {
+        const tenantId = RequestContext.currentTenantId()
+        const organizationId = RequestContext.getOrganizationId()
+        const copilots = await this.findAllAvailablesCopilots()
+        // Filter the tenant enabled copilots for organization user
+        // copilots = copilots.filter((copilot) => (organizationId && !copilot.organizationId) ? copilot.enabled : true)
+        for await (const copilot of copilots) {
+            if (!copilot.organizationId) {
+                const usage = await this.queryBus.execute(
+                    new GetCopilotOrgUsageQuery(tenantId, organizationId, copilot.id)
+                )
+                copilot.usage = usage ?? {
+                    tokenLimit: copilot.tokenBalance,
+                    tokenUsed: 0
+                }
+            }
+        }
 
-		return copilots
-	}
+        return copilots
+    }
 
-	/**
-	 *
-	 */
-	// async findOneByRole(role: AiProviderRole, tenantId: string, organizationId: string): Promise<Copilot> {
-	// 	const items = await this.findAllAvailablesCopilots(tenantId, organizationId, { role })
-	// 	return items.length ? items[0] : null
-	// }
+    /**
+     *
+     */
+    // async findOneByRole(role: AiProviderRole, tenantId: string, organizationId: string): Promise<Copilot> {
+    // 	const items = await this.findAllAvailablesCopilots(tenantId, organizationId, { role })
+    // 	return items.length ? items[0] : null
+    // }
 
-	/**
-	 * Find all copilots in organization or tenant globally
-	 *
-	 * @param tenantId
-	 * @param organizationId
-	 * @returns All copilots
-	 */
-	async findAllAvailablesCopilots(tenantId?: string, organizationId?: string, where?: FindOptionsWhere<Copilot>) {
-		tenantId = tenantId || RequestContext.currentTenantId()
-		organizationId = organizationId || RequestContext.getOrganizationId()
-		const items = await this.repository.find({
-			where: { ...(where ?? {}), tenantId, organizationId, enabled: true },
-			relations: ['modelProvider']
-		})
-		if (items.length) {
-			return items
-		}
+    /**
+     * Find all copilots in organization or tenant globally
+     *
+     * @param tenantId
+     * @param organizationId
+     * @returns All copilots
+     */
+    async findAllAvailablesCopilots(
+        tenantId?: string | null,
+        organizationId?: string | null,
+        where?: FindOptionsWhere<Copilot>
+    ) {
+        tenantId = tenantId ?? RequestContext.currentTenantId()
+        organizationId = organizationId ?? RequestContext.getOrganizationId()
+        const items = await this.repository.find({
+            where: { ...(where ?? {}), tenantId, organizationId, enabled: true },
+            relations: ['modelProvider']
+        })
+        if (items.length) {
+            return this.hydrateVisibleModelProviders(items, tenantId, organizationId)
+        }
 
-		return await this.repository.find({
-			where: { ...(where ?? {}), tenantId, organizationId: IsNull(), enabled: true },
-			relations: ['modelProvider']
-		})
-	}
+        const tenantItems = await this.repository.find({
+            where: { ...(where ?? {}), tenantId, organizationId: IsNull(), enabled: true },
+            relations: ['modelProvider']
+        })
 
-	/**
-	 * Insert or update by id
-	 *
-	 * @param entity
-	 * @returns
-	 */
-	async upsert(entity: DeepPartial<Copilot>) {
-		if (entity.id) {
-			await this.update(entity.id, entity)
-			return await this.findOne(entity.id)
-		} else {
-			return await this.create(entity)
-		}
-	}
+        return this.hydrateVisibleModelProviders(tenantItems, tenantId, organizationId)
+    }
 
-	async update(id: string, entity: DeepPartial<ICopilot>) {
-		const copilot = await this.findOne(id)
-		assign(copilot, entity)
-		return await this.repository.save(copilot)
-	}
+    /**
+     * Insert or update by id
+     *
+     * @param entity
+     * @returns
+     */
+    async upsert(entity: DeepPartial<Copilot>) {
+        if (entity.id) {
+            await this.update(entity.id, entity)
+            return await this.findOne(entity.id)
+        } else {
+            return await this.create(entity)
+        }
+    }
 
-	/**
-	 * Find all copilots
-	 */
-	async findAllCopilots(params: PaginationParams<Copilot>) {
-		const result = await this.findAll(params)
+    async update(id: string, entity: DeepPartial<ICopilot>) {
+        const copilot = await this.findOne(id)
+        assign(copilot, entity)
+        return await this.repository.save(copilot)
+    }
 
-		const providers = await this.queryBus.execute<ListModelProvidersQuery, IAiProviderEntity[]>(
-			new ListModelProvidersQuery(compact(uniq(result.items.map((item) => item.modelProvider?.providerName))))
-		)
+    /**
+     * Find all copilots
+     */
+    async findAllCopilots(params: PaginationParams<Copilot>) {
+        const result = await this.findAll(params)
+        const items = await this.hydrateVisibleModelProviders(result.items)
 
-		return {
-			...result,
-			items: result.items.map((item) =>
-					new CopilotDto(
-						{
-							...item,
-							modelProvider: item.modelProvider
-								? {
-										...item.modelProvider,
-										provider: providers.find((_) => _.provider === item.modelProvider.providerName)
-									}
-								: null
-						},
-						this.baseUrl
-					)
-			)
-		}
-	}
+        const providers = await this.queryBus.execute<ListModelProvidersQuery, IAiProviderEntity[]>(
+            new ListModelProvidersQuery(compact(uniq(items.map((item) => item.modelProvider?.providerName))))
+        )
+
+        return {
+            ...result,
+            items: items.map(
+                (item) =>
+                    new CopilotDto(
+                        {
+                            ...item,
+                            modelProvider: item.modelProvider
+                                ? {
+                                      ...item.modelProvider,
+                                      provider: providers.find((_) => _.provider === item.modelProvider.providerName)
+                                  }
+                                : null
+                        },
+                        this.baseUrl
+                    )
+            )
+        }
+    }
+
+    private async hydrateVisibleModelProviders(
+        copilots: Copilot[],
+        tenantId = RequestContext.currentTenantId(),
+        organizationId = RequestContext.getOrganizationId()
+    ) {
+        if (!copilots?.length || !tenantId) {
+            return copilots
+        }
+
+        const providerByCopilotId = await this.copilotProviderService.findVisibleByCopilotIds(
+            copilots.map((copilot) => copilot.id),
+            { tenantId, organizationId }
+        )
+
+        return copilots.map((copilot) => ({
+            ...copilot,
+            modelProvider: providerByCopilotId.get(copilot.id) ?? null
+        }))
+    }
 }


### PR DESCRIPTION
## Summary
- port the copilot provider hydration fix from `xpert-pro` so `copilot` responses resolve the visible `modelProvider` instead of trusting stale eager relations
- add a regression spec covering visible provider hydration and tenant fallback behavior
- port the two-column copilot model picker UI, including the provider rail, draggable divider, model-name-first layout, and outer control width alignment

## Why
The model parameter flow could fail with `Copilot provider ... is not found` when a copilot exposed a stale provider relation that was no longer visible in the current scope. On the frontend, the previous picker became hard to use when providers exposed many models and long model names were truncated too aggressively.

## Impact
- the backend now rehydrates `modelProvider` by `copilotId` before returning available copilots
- the cloud model picker keeps the provider list and model list side by side, gives more room to model names, and lets users resize the divider
- parameter configuration continues to use the current visible provider id from the selected copilot payload

## Validation
- `pnpm nx build server-ai`
- `pnpm nx build cloud`
- `pnpm exec jest --config packages/server-ai/jest.config.ts --runInBand packages/server-ai/src/copilot/copilot.service.spec.ts packages/server-ai/src/copilot-provider/queries/handlers/model-parameter-rules.handler.spec.ts`