### PR TITLE
fix: sync copilot model parameters and middleware defaults

### DIFF
--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
@@ -1,0 +1,194 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing'
+import { TranslateService } from '@ngx-translate/core'
+import { of, Subject } from 'rxjs'
+import {
+  AiModelTypeEnum,
+  CopilotProviderService,
+  CopilotServerService,
+  ModelPropertyKey,
+  ParameterType
+} from '../../../@core'
+import { CopilotModelSelectComponent } from './select.component'
+
+describe('CopilotModelSelectComponent', () => {
+  const copilot = {
+    id: 'copilot-1',
+    role: 'primary',
+    name: 'Primary Copilot',
+    modelProvider: {
+      id: 'provider-1'
+    },
+    providerWithModels: {
+      label: {
+        en_US: 'Provider'
+      },
+      models: [
+        {
+          model: 'deepseek-chat',
+          model_type: AiModelTypeEnum.LLM,
+          model_properties: {
+            [ModelPropertyKey.CONTEXT_SIZE]: 64000
+          }
+        },
+        {
+          model: 'glm-5',
+          model_type: AiModelTypeEnum.LLM,
+          model_properties: {
+            [ModelPropertyKey.CONTEXT_SIZE]: 200000
+          }
+        }
+      ]
+    }
+  } as any
+  const deepseekModel = copilot.providerWithModels.models[0]
+  const glmModel = copilot.providerWithModels.models[1]
+  let deepseekRules$: Subject<any[]>
+  let glmRules$: Subject<any[]>
+  let component: CopilotModelSelectComponent
+  let fixture: ComponentFixture<CopilotModelSelectComponent>
+
+  beforeEach(async () => {
+    deepseekRules$ = new Subject<any[]>()
+    glmRules$ = new Subject<any[]>()
+    const copilotServer = {
+      getCopilotModels: jest.fn(() => of([copilot]))
+    }
+    const copilotProviderService = {
+      getModelParameterRules: jest.fn((_providerId: string, _modelType: AiModelTypeEnum, model: string) => {
+        switch (model) {
+          case 'deepseek-chat':
+            return deepseekRules$.asObservable()
+          case 'glm-5':
+            return glmRules$.asObservable()
+          default:
+            return of([])
+        }
+      })
+    }
+
+    await TestBed.configureTestingModule({
+      imports: [CopilotModelSelectComponent],
+      providers: [
+        { provide: CopilotServerService, useValue: copilotServer },
+        { provide: CopilotProviderService, useValue: copilotProviderService },
+        {
+          provide: TranslateService,
+          useValue: {
+            currentLang: 'en_US'
+          }
+        }
+      ]
+    })
+      .overrideComponent(CopilotModelSelectComponent, {
+        set: {
+          template: ''
+        }
+      })
+      .compileComponents()
+
+    fixture = TestBed.createComponent(CopilotModelSelectComponent)
+    component = fixture.componentInstance
+    fixture.componentRef.setInput('modelType', AiModelTypeEnum.LLM)
+    fixture.detectChanges()
+  })
+
+  afterEach(() => {
+    deepseekRules$.complete()
+    glmRules$.complete()
+  })
+
+  it('resets model options and applies the new model defaults after switching models', fakeAsync(() => {
+    tick(600)
+    fixture.detectChanges()
+
+    component.setModel(copilot, deepseekModel)
+    fixture.detectChanges()
+
+    deepseekRules$.next([
+      {
+        name: 'temperature',
+        type: ParameterType.FLOAT,
+        default: 0.2
+      },
+      {
+        name: 'max_tokens',
+        type: ParameterType.INT,
+        default: 64
+      }
+    ])
+    tick()
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()?.options).toEqual({
+      [ModelPropertyKey.CONTEXT_SIZE]: 64000,
+      temperature: 0.2,
+      max_tokens: 64
+    })
+
+    component.setModel(copilot, glmModel)
+    fixture.detectChanges()
+    tick()
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()?.options).toEqual({
+      [ModelPropertyKey.CONTEXT_SIZE]: 200000
+    })
+
+    glmRules$.next([
+      {
+        name: 'temperature',
+        type: ParameterType.FLOAT,
+        default: 1
+      },
+      {
+        name: 'max_tokens',
+        type: ParameterType.INT,
+        default: 8192
+      }
+    ])
+    tick()
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()?.options).toEqual({
+      [ModelPropertyKey.CONTEXT_SIZE]: 200000,
+      temperature: 1,
+      max_tokens: 8192
+    })
+  }))
+
+  it('keeps existing options when re-selecting the same model', fakeAsync(() => {
+    tick(600)
+    fixture.detectChanges()
+
+    component.setModel(copilot, deepseekModel)
+    fixture.detectChanges()
+
+    deepseekRules$.next([
+      {
+        name: 'temperature',
+        type: ParameterType.FLOAT,
+        default: 0.2
+      },
+      {
+        name: 'max_tokens',
+        type: ParameterType.INT,
+        default: 64
+      }
+    ])
+    tick()
+    fixture.detectChanges()
+
+    component.updateParameter('max_tokens', 256)
+    fixture.detectChanges()
+
+    component.setModel(copilot, deepseekModel)
+    tick()
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()?.options).toEqual({
+      [ModelPropertyKey.CONTEXT_SIZE]: 64000,
+      temperature: 0.2,
+      max_tokens: 256
+    })
+  }))
+})

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
@@ -31,12 +31,20 @@ import {
   injectCopilotProviderService,
   ModelPropertyKey,
   ModelFeature,
+  ParameterRule,
   ParameterType,
   ProviderModel
 } from '../../../@core'
 import { ModelParameterInputComponent } from '../model-parameter-input/input.component'
 import { ZardTabsImports, ZardTooltipImports } from '@xpert-ai/headless-ui'
 import { ZardAlertComponent } from '@xpert-ai/headless-ui/components/alert'
+
+type ModelParameterRulesResourceValue = {
+  model: string | undefined
+  modelType: AiModelTypeEnum | undefined
+  providerId: string | undefined
+  rules: ParameterRule[]
+}
 
 @Component({
   standalone: true,
@@ -214,15 +222,37 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
     }),
     loader: ({ request }) =>
       request.providerId && request.modelType && request.model
-        ? this.copilotProviderService.getModelParameterRules(request.providerId, request.modelType, request.model)
-        : of([])
+        ? this.copilotProviderService.getModelParameterRules(request.providerId, request.modelType, request.model).pipe(
+            map(
+              (rules): ModelParameterRulesResourceValue => ({
+                ...request,
+                rules
+              })
+            )
+          )
+        : of({
+            ...request,
+            rules: []
+          } satisfies ModelParameterRulesResourceValue)
   })
   readonly modelParameterRulesError = computed(() =>
     this.#modelParameterRules.status() === 'error' ? this.#modelParameterRules.error() : null
   )
   readonly modelParameterRules = computed(() =>
-    this.modelParameterRulesError() ? [] : (this.#modelParameterRules.value() ?? [])
+    this.modelParameterRulesError() ? [] : (this.#modelParameterRules.value()?.rules ?? [])
   )
+  readonly hasResolvedCurrentModelParameterRules = computed(() => {
+    if (this.#modelParameterRules.status() !== 'success') {
+      return false
+    }
+
+    const resource = this.#modelParameterRules.value()
+    return (
+      resource?.providerId === this.providerId() &&
+      resource?.modelType === this.modelType() &&
+      resource?.model === this.model()
+    )
+  })
 
   readonly isInherit = computed(() => !this.__copilotModel())
   readonly statusChoose = computed(() => !this.selectedCopilotWithModels() && !!this.__copilotModel())
@@ -247,7 +277,7 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
     effect(() => {
       const value = this.cva.value$()
       const rules = this.modelParameterRules()
-      if (value && rules?.length && this.shouldInitDefaultOptions(value.options)) {
+      if (value && rules?.length && this.hasResolvedCurrentModelParameterRules() && this.shouldInitDefaultOptions(value.options)) {
         const contextSize = this.parseContextSize(value.options?.[ModelPropertyKey.CONTEXT_SIZE])
         this.cva.value$.update((current) => {
           if (!current) {
@@ -309,12 +339,19 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
   }
 
   setModel(copilot: ICopilot, model: ProviderModel) {
+    const currentValue = this.cva.value$()
+    const nextModelType = this.modelType()
+    const shouldResetOptions =
+      currentValue?.copilotId !== copilot.id ||
+      currentValue?.modelType !== nextModelType ||
+      currentValue?.model !== model.model
     const nValue = this.withModelContextSize(
       {
-        ...(this.cva.value$() ?? {}),
+        ...(currentValue ?? {}),
+        ...(shouldResetOptions ? { options: undefined } : {}),
         model: model.model,
         copilotId: copilot.id,
-        modelType: this.modelType()
+        modelType: nextModelType
       },
       model
     )

--- a/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.html
+++ b/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.html
@@ -18,7 +18,8 @@
         [min]="parameter.min"
         [step]="0.1"
         type="number"
-        [(ngModel)]="value$"
+        [ngModel]="value$()"
+        (ngModelChange)="updateNumericValue($event, eParameterType.FLOAT)"
         [ngModelOptions]="{ standalone: true }"
       />
     }
@@ -39,7 +40,8 @@
         [min]="parameter.min"
         [step]="1"
         type="number"
-        [(ngModel)]="value$"
+        [ngModel]="value$()"
+        (ngModelChange)="updateNumericValue($event, eParameterType.INT)"
         [ngModelOptions]="{ standalone: true }"
       />
     }

--- a/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ParameterType } from '../../../@core'
+import { ModelParameterInputComponent } from './input.component'
+
+describe('ModelParameterInputComponent', () => {
+  let component: ModelParameterInputComponent
+  let fixture: ComponentFixture<ModelParameterInputComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ModelParameterInputComponent]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(ModelParameterInputComponent)
+    component = fixture.componentInstance
+  })
+
+  it('coerces float input values to numbers', () => {
+    fixture.componentRef.setInput('parameter', {
+      name: 'temperature',
+      label: { en_US: 'Temperature' },
+      type: ParameterType.FLOAT
+    })
+    component['cva'].value$.set(0.2)
+    fixture.detectChanges()
+
+    const input = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement
+    input.value = '0.7'
+    input.dispatchEvent(new Event('input'))
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()).toBe(0.7)
+    expect(typeof component['cva'].value$()).toBe('number')
+  })
+
+  it('coerces int input values to numbers', () => {
+    fixture.componentRef.setInput('parameter', {
+      name: 'max_tokens',
+      label: { en_US: 'Max Tokens' },
+      type: ParameterType.INT
+    })
+    component['cva'].value$.set(64)
+    fixture.detectChanges()
+
+    const input = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement
+    input.value = '256'
+    input.dispatchEvent(new Event('input'))
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()).toBe(256)
+    expect(typeof component['cva'].value$()).toBe('number')
+  })
+})

--- a/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.ts
@@ -25,7 +25,28 @@ export class ModelParameterInputComponent {
 
   readonly value$ = this.cva.value$
 
-  updateValue(value) {
+  updateValue(value: unknown) {
     this.value$.set(value)
+  }
+
+  updateNumericValue(value: unknown, type: ParameterType.FLOAT | ParameterType.INT) {
+    this.updateValue(this.normalizeNumericValue(value, type))
+  }
+
+  private normalizeNumericValue(value: unknown, type: ParameterType.FLOAT | ParameterType.INT): number | undefined {
+    if (value === '' || value === null || value === undefined) {
+      return undefined
+    }
+
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : undefined
+    }
+
+    if (typeof value === 'string') {
+      const parsed = type === ParameterType.INT ? Number.parseInt(value, 10) : Number.parseFloat(value)
+      return Number.isFinite(parsed) ? parsed : undefined
+    }
+
+    return undefined
   }
 }

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank-template.util.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank-template.util.spec.ts
@@ -1,4 +1,4 @@
-import { TXpertTeamDraft, WorkflowNodeTypeEnum, XpertTypeEnum } from '@xpert-ai/contracts'
+import { AiModelTypeEnum, TXpertTeamDraft, WorkflowNodeTypeEnum, XpertTypeEnum } from '@xpert-ai/contracts'
 import { BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER } from './blank-draft.util'
 import {
   applyAgentTemplateWizardState,
@@ -362,6 +362,24 @@ describe('blank template util', () => {
     expect(state.selections.skills).toEqual(['writer'])
     expect(state.selections.repositoryDefault).toBeNull()
     expect(state.selections.middlewares).toEqual(['guard', BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER, 'audit'])
+  })
+
+  it('falls back to the primary agent model when the template team model is missing', () => {
+    const draft = createAgentTemplateDraft()
+    draft.team.copilotModel = undefined
+    ;(draft.nodes.find((node) => node.key === 'Agent_primary')!.entity as any).copilotModel = {
+      copilotId: 'copilot-glm',
+      modelType: AiModelTypeEnum.LLM,
+      model: 'glm-5'
+    }
+
+    const state = extractAgentTemplateWizardState(draft)
+
+    expect(state.basic.copilotModel).toEqual({
+      copilotId: 'copilot-glm',
+      modelType: AiModelTypeEnum.LLM,
+      model: 'glm-5'
+    })
   })
 
   it('ignores legacy skill nodes when extracting agent template wizard state', () => {

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank-template.util.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank-template.util.ts
@@ -16,6 +16,7 @@ import {
   BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER,
   BlankRepositoryDefaultSelection,
   BlankTriggerSelection,
+  BlankXpertDraftBuildOptions,
   buildBlankKnowledgeSelectionGraph,
   buildBlankXpertSelectionGraph,
   KnowledgeBlankWizardSelections,
@@ -38,6 +39,8 @@ export type BlankKnowledgeTemplateWizardState = {
   selections: Required<KnowledgeBlankWizardSelections>
 }
 
+type BlankAgentTemplateApplyOptions = Pick<BlankXpertDraftBuildOptions, 'defaultCopilotModel' | 'middlewareDefinitions'>
+
 const KNOWLEDGE_MANAGED_NODE_TYPES = new Set<WorkflowNodeTypeEnum>([
   WorkflowNodeTypeEnum.TRIGGER,
   WorkflowNodeTypeEnum.SOURCE,
@@ -52,7 +55,9 @@ export function extractTemplateBasicInfo(draft: TXpertTeamDraft): BlankTemplateB
     title: draft.team?.title ?? undefined,
     description: draft.team?.description ?? undefined,
     avatar: cloneMaybe(draft.team?.avatar),
-    copilotModel: cloneMaybe(draft.team?.copilotModel)
+    copilotModel: cloneMaybe(
+      draft.team?.copilotModel ?? getPrimaryAgentNodeMaybe(draft)?.entity?.copilotModel ?? draft.team?.agent?.copilotModel
+    )
   }
 }
 
@@ -128,7 +133,8 @@ export function extractKnowledgeTemplateWizardState(draft: TXpertTeamDraft): Bla
 
 export function applyAgentTemplateWizardState(
   draft: TXpertTeamDraft,
-  selections?: XpertBlankWizardSelections
+  selections?: XpertBlankWizardSelections,
+  options?: BlankAgentTemplateApplyOptions
 ): TXpertTeamDraft {
   const nextDraft = cloneDeep(draft)
   const primaryAgentNode = getPrimaryAgentNode(nextDraft)
@@ -151,7 +157,7 @@ export function applyAgentTemplateWizardState(
     nodes: managedNodes,
     connections: managedConnections,
     middlewareNodes
-  } = buildBlankXpertSelectionGraph(primaryAgentNode, selections)
+  } = buildBlankXpertSelectionGraph(primaryAgentNode, selections, options)
 
   nextDraft.nodes = [...nextDraft.nodes.filter((node) => !managedNodeKeys.has(node.key)), ...managedNodes]
   nextDraft.connections = [
@@ -203,16 +209,25 @@ export function applyKnowledgeTemplateWizardState(
 }
 
 function getPrimaryAgentNode(draft: TXpertTeamDraft): TXpertTeamNode<'agent'> {
-  const primaryAgentKey = draft.team?.agent?.key
-  const primaryAgentNode = draft.nodes.find(
-    (node): node is TXpertTeamNode<'agent'> => node.type === 'agent' && node.key === primaryAgentKey
-  )
+  const primaryAgentNode = getPrimaryAgentNodeMaybe(draft)
 
-  if (!primaryAgentKey || !primaryAgentNode) {
+  if (!primaryAgentNode) {
     throw new Error('Primary agent node not found in template draft')
   }
 
   return primaryAgentNode
+}
+
+function getPrimaryAgentNodeMaybe(draft: TXpertTeamDraft): TXpertTeamNode<'agent'> | null {
+  const primaryAgentKey = draft.team?.agent?.key
+  if (!primaryAgentKey) {
+    return null
+  }
+
+  return (
+    draft.nodes.find((node): node is TXpertTeamNode<'agent'> => node.type === 'agent' && node.key === primaryAgentKey) ??
+    null
+  )
 }
 
 function getInboundNodeKeys(draft: TXpertTeamDraft, targetKey: string): string[] {

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.spec.ts
@@ -259,6 +259,49 @@ connections:
 `
 }
 
+function createAgentTemplateYamlWithPrimaryAgentModelOnly() {
+  return `
+team:
+  name: template-agent
+  type: agent
+  title: Template Agent
+  description: Template agent description
+  agent:
+    key: Agent_primary
+    options:
+      middlewares:
+        order:
+          - Middleware_summary
+nodes:
+  - type: agent
+    key: Agent_primary
+    position:
+      x: 360
+      y: 220
+    entity:
+      key: Agent_primary
+      copilotModel:
+        copilotId: copilot-glm
+        modelType: llm
+        model: glm-5
+  - type: workflow
+    key: Middleware_summary
+    position:
+      x: 360
+      y: 460
+    entity:
+      key: Middleware_summary
+      type: middleware
+      provider: SummarizationMiddleware
+      title: SummarizationMiddleware
+connections:
+  - key: Agent_primary/Middleware_summary
+    type: workflow
+    from: Agent_primary
+    to: Middleware_summary
+`
+}
+
 async function createComponent(
   data: BlankXpertDialogData,
   options?: {
@@ -1243,6 +1286,86 @@ describe('XpertNewBlankComponent', () => {
       copilotId: 'copilot-qwen',
       modelType: AiModelTypeEnum.LLM,
       model: 'qwen3.6-plus'
+    })
+  })
+
+  it('seeds template middleware model options from the primary agent model before importing', async () => {
+    const { component, fixture, xpertService } = await createComponent(
+      {
+        completionMode: 'create',
+        type: XpertTypeEnum.Agent
+      },
+      {
+        agentTemplateDetail: {
+          export_data: createAgentTemplateYamlWithPrimaryAgentModelOnly()
+        },
+        agentTemplates: [
+          {
+            id: 'template-agent',
+            name: 'template-agent',
+            title: 'Template Agent',
+            description: 'Template agent description',
+            category: 'Agent',
+            type: XpertTypeEnum.Agent
+          }
+        ],
+        middlewareProviders: [
+          {
+            meta: {
+              name: 'SummarizationMiddleware',
+              label: {
+                en_US: 'Summarization Middleware'
+              },
+              configSchema: {
+                type: 'object',
+                properties: {
+                  model: {
+                    type: 'object',
+                    'x-ui': {
+                      component: 'ai-model-select',
+                      inputs: {
+                        modelType: AiModelTypeEnum.LLM
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    )
+
+    component.setStartMode('template')
+    component.selectedTemplateId.set('template-agent')
+    fixture.detectChanges()
+    await fixture.whenStable()
+    await flushPromises()
+
+    expect(component.copilotModel()).toEqual({
+      copilotId: 'copilot-glm',
+      modelType: AiModelTypeEnum.LLM,
+      model: 'glm-5'
+    })
+
+    await component.create()
+    await fixture.whenStable()
+    await flushPromises()
+
+    const importedDraft = xpertService.importDSL.mock.calls[0][0]
+    const middlewareNode = importedDraft.nodes.find(
+      (node: any) => node.type === 'workflow' && node.entity?.provider === 'SummarizationMiddleware'
+    )
+
+    expect(importedDraft.team.copilotModel).toEqual({
+      copilotId: 'copilot-glm',
+      modelType: AiModelTypeEnum.LLM,
+      model: 'glm-5'
+    })
+    expect(middlewareNode.entity.options.model).toEqual({
+      copilotId: 'copilot-glm',
+      modelType: AiModelTypeEnum.LLM,
+      model: 'glm-5'
     })
   })
 

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.ts
@@ -1041,8 +1041,12 @@ export class XpertNewBlankComponent {
   }
 
   private buildTemplateImportDraft(draft: TXpertTeamDraft) {
+    const selectedCopilotModel = this.copilotModel() ?? draft.team.agent?.copilotModel ?? draft.team.copilotModel ?? null
     const finalDraft = this.isAgentType()
-      ? applyAgentTemplateWizardState(draft, this.getSelections())
+      ? applyAgentTemplateWizardState(draft, this.getSelections(), {
+          defaultCopilotModel: selectedCopilotModel,
+          middlewareDefinitions: this.getSelectedMiddlewareDefinitions()
+        })
       : this.isKnowledgeType()
         ? applyKnowledgeTemplateWizardState(draft, this.getKnowledgeSelections())
         : draft
@@ -1065,7 +1069,7 @@ export class XpertNewBlankComponent {
         title: this.title(),
         description: this.description(),
         avatar: this.avatar(),
-        copilotModel: this.copilotModel(),
+        copilotModel: selectedCopilotModel,
         ...(features ? { features } : {})
       }
     }


### PR DESCRIPTION
## Summary
- fix numeric parameter input typing for copilot model parameters
- reset stale model options when switching copilot models
- seed template middleware models from the selected primary agent model
- keep the PR clean by isolating these three commits from the merge commit on the original branch

## Root cause
The original branch mixed three clean fixes with a later merge-from-develop commit. On top of that, the affected copilot flows had a few state consistency issues: numeric inputs were not handled consistently during typing, stale parameter options could survive model switches, and blank template middleware models were not initialized from the current primary agent model.

## Validation
- cherry-picked only the three clean commits onto a fresh branch from `develop`
- included the existing unit tests added by those commits
- no additional local test run was performed during the branch split