### PR TITLE
fix: keep local shell skill sync inside sandbox root

### DIFF
--- a/packages/plugins/agent-middlewares/src/lib/localShellSandbox.provider.spec.ts
+++ b/packages/plugins/agent-middlewares/src/lib/localShellSandbox.provider.spec.ts
@@ -65,6 +65,55 @@ describe('LocalShellSandbox', () => {
     mockSpawnPty.mockReset()
   })
 
+  it('uploads and downloads absolute file paths without nesting them under the working directory', async () => {
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'local-shell-sandbox-'))
+    const absoluteFilePath = path.join(workingDirectory, '.xpert', 'skills', 'skill-a', 'SKILL.md')
+    const wronglyNestedPath = path.join(workingDirectory, absoluteFilePath)
+    const sandbox = new LocalShellSandbox({ workingDirectory })
+
+    try {
+      const uploadResult = await sandbox.uploadFiles([[absoluteFilePath, Buffer.from('skill body', 'utf8')]])
+
+      expect(uploadResult).toEqual([{ path: absoluteFilePath, error: null }])
+      expect(fs.readFileSync(absoluteFilePath, 'utf8')).toBe('skill body')
+      expect(fs.existsSync(wronglyNestedPath)).toBe(false)
+
+      const downloadResult = await sandbox.downloadFiles([absoluteFilePath])
+      expect(Buffer.from(downloadResult[0].content ?? []).toString('utf8')).toBe('skill body')
+      expect(downloadResult[0].error).toBeNull()
+    } finally {
+      fs.rmSync(workingDirectory, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects upload and download paths outside the working directory', async () => {
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'local-shell-sandbox-'))
+    const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'local-shell-outside-'))
+    const outsidePath = path.join(outsideRoot, 'SKILL.md')
+    const sandbox = new LocalShellSandbox({ workingDirectory })
+
+    try {
+      const uploadResult = await sandbox.uploadFiles([
+        [outsidePath, Buffer.from('outside', 'utf8')],
+        ['../outside-relative.txt', Buffer.from('outside', 'utf8')]
+      ])
+      expect(uploadResult).toEqual([
+        { path: outsidePath, error: 'invalid_path' },
+        { path: '../outside-relative.txt', error: 'invalid_path' }
+      ])
+      expect(fs.existsSync(outsidePath)).toBe(false)
+
+      const downloadResult = await sandbox.downloadFiles([outsidePath, '../outside-relative.txt'])
+      expect(downloadResult).toEqual([
+        { path: outsidePath, content: null, error: 'invalid_path' },
+        { path: '../outside-relative.txt', content: null, error: 'invalid_path' }
+      ])
+    } finally {
+      fs.rmSync(workingDirectory, { recursive: true, force: true })
+      fs.rmSync(outsideRoot, { recursive: true, force: true })
+    }
+  })
+
   it('terminates timed out commands and prevents detached children from continuing', async () => {
     const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'local-shell-sandbox-'))
     const markerPath = path.join(workingDirectory, 'still-running.txt')
@@ -362,7 +411,7 @@ describe('LocalShellSandbox', () => {
         this.headers.set(name.toLowerCase(), value)
       },
       end(chunk?: string | Buffer) {
-        this.body = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk ?? ''
+        this.body = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : (chunk ?? '')
         this.headersSent = true
       },
       statusCode: 200

--- a/packages/plugins/agent-middlewares/src/lib/localShellSandbox.provider.ts
+++ b/packages/plugins/agent-middlewares/src/lib/localShellSandbox.provider.ts
@@ -228,7 +228,7 @@ function isFiniteNumber(value: unknown): value is number {
 }
 
 function normalizeHeaderValue(value: number | string | string[] | undefined): string {
-  return Array.isArray(value) ? value.join(', ') : value?.toString() ?? ''
+  return Array.isArray(value) ? value.join(', ') : (value?.toString() ?? '')
 }
 
 function shouldRewritePreviewResponse(headers: http.IncomingHttpHeaders, method: string | undefined): boolean {
@@ -294,11 +294,10 @@ function rewritePreviewTextResponse(content: string, proxyBasePath: string): str
     .replace(/(["'`])\/(?!\/)([^"'`\s<>)]*)/g, (_match, quote: string, pathname: string) => {
       return `${quote}${rewritePreviewRootPath(`/${pathname}`, proxyBasePath)}`
     })
-    .replace(/(\b(?:src|href|action|poster|data|xlink:href)\s*=\s*)(\/(?!\/)[^\s"'<>]*)/gi, (
-      _match,
-      prefix: string,
-      pathname: string
-    ) => `${prefix}${rewritePreviewRootPath(pathname, proxyBasePath)}`)
+    .replace(
+      /(\b(?:src|href|action|poster|data|xlink:href)\s*=\s*)(\/(?!\/)[^\s"'<>]*)/gi,
+      (_match, prefix: string, pathname: string) => `${prefix}${rewritePreviewRootPath(pathname, proxyBasePath)}`
+    )
     .replace(/(url\(\s*)(\/(?!\/)[^"')\s]+)(\s*\))/gi, (_match, prefix: string, pathname: string, suffix: string) => {
       return `${prefix}${rewritePreviewRootPath(pathname, proxyBasePath)}${suffix}`
     })
@@ -375,7 +374,10 @@ function readLogTail(filePath: string, maxLines: number): string {
 
   const content = fs.readFileSync(filePath, 'utf8')
   const lines = content.split(/\r?\n/)
-  return lines.slice(Math.max(0, lines.length - maxLines)).join('\n').trim()
+  return lines
+    .slice(Math.max(0, lines.length - maxLines))
+    .join('\n')
+    .trim()
 }
 
 function doesServiceLogMatch(logPaths: ManagedServiceLogPaths, readyPattern: RegExp): boolean {
@@ -1097,7 +1099,7 @@ export class LocalShellSandbox
 
     for (const [filePath, content] of files) {
       try {
-        const fullPath = path.join(this.workingDirectory, filePath)
+        const fullPath = this.resolveSandboxFilePath(filePath)
         const parentDir = path.dirname(fullPath)
 
         // Ensure parent directory exists
@@ -1132,7 +1134,7 @@ export class LocalShellSandbox
 
     for (const filePath of paths) {
       try {
-        const fullPath = path.join(this.workingDirectory, filePath)
+        const fullPath = this.resolveSandboxFilePath(filePath)
 
         if (!fs.existsSync(fullPath)) {
           results.push({
@@ -1167,6 +1169,12 @@ export class LocalShellSandbox
             content: null,
             error: 'permission_denied'
           })
+        } else if (error.code === 'EINVAL') {
+          results.push({
+            path: filePath,
+            content: null,
+            error: 'invalid_path'
+          })
         } else {
           results.push({
             path: filePath,
@@ -1178,6 +1186,17 @@ export class LocalShellSandbox
     }
 
     return results
+  }
+
+  private resolveSandboxFilePath(filePath: string): string {
+    const resolvedPath = path.resolve(this.workingDirectory, filePath)
+    const relativePath = path.relative(this.workingDirectory, resolvedPath)
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+      const error = new Error(`Path is outside of the sandbox working directory: ${filePath}`) as NodeJS.ErrnoException
+      error.code = 'EINVAL'
+      throw error
+    }
+    return resolvedPath
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix local shell sandbox file upload/download path resolution for absolute runtime paths
- Keep absolute paths constrained to the sandbox working directory and reject path escapes
- Add coverage for absolute in-sandbox paths and outside-root rejection

## Verification
- pnpm nx build agent-middlewares
- git diff --cached --check before commit

## Note
- The targeted Jest command is currently blocked by the existing agent-middlewares Jest config using __dirname in ESM scope before tests execute.