### PR TITLE
[closed] Clarify sandbox shell Playwright CLI usage

### DIFF
--- a/packages/server-ai/src/sandbox/middlewares/sandbox-shell.middleware.spec.ts
+++ b/packages/server-ai/src/sandbox/middlewares/sandbox-shell.middleware.spec.ts
@@ -159,6 +159,14 @@ describe('SandboxShellMiddleware', () => {
     expect(agentMiddleware.tools.map((tool) => tool.name)).toEqual(['sandbox_shell'])
   })
 
+  it('documents one playwright-cli command per sandbox_shell call', async () => {
+    const tool = await createTool('sandbox_shell')
+
+    expect(tool.description).toContain('playwright-cli')
+    expect(tool.description).toContain('one CLI command per sandbox_shell call')
+    expect(tool.description).toContain('Do not chain multiple playwright-cli commands')
+  })
+
   it('passes the 600 second default timeout to the backend', async () => {
     const tool = await createTool('sandbox_shell')
     const backend = createBackend({

--- a/packages/server-ai/src/sandbox/middlewares/sandbox-shell.middleware.ts
+++ b/packages/server-ai/src/sandbox/middlewares/sandbox-shell.middleware.ts
@@ -237,6 +237,8 @@ Default timeout: ${DEFAULT_SANDBOX_SHELL_TIMEOUT_SEC} seconds.
 
 Use timeout_sec for long-running commands such as npm install, pnpm install, cargo build, pytest, or large test/build jobs. When the timeout is reached, the sandbox terminates the command and returns explicit timeout information.
 
+When using sandbox-provided CLIs that are prepared by middleware, such as playwright-cli, run one CLI command per sandbox_shell call. Do not chain multiple playwright-cli commands with &&, ;, or | in a single command; use separate sandbox_shell calls so each command can be prepared and rewritten correctly.
+
 Do not use this tool to background a long-running server with &, nohup, or disown. Use the SandboxService middleware's sandbox_service_start tool for managed background services so the agent can list, inspect logs, restart, stop, and preview them later.`,
         schema: shellToolSchema
       }


### PR DESCRIPTION
Closed by Codex because the guidance belongs in the `@xpert-ai/plugin-playwright-cli` plugin, not in the generic `sandbox_shell` tool description. A replacement PR will be opened in `xpert-ai/xpert-plugins`.