### PR TITLE
Support folder zip downloads

### DIFF
--- a/apps/cloud/src/app/@core/services/chat-conversation.service.ts
+++ b/apps/cloud/src/app/@core/services/chat-conversation.service.ts
@@ -100,6 +100,16 @@ export class ChatConversationService extends OrganizationBaseCrudService<IChatCo
     })
   }
 
+  downloadFile(id: string, path: string, organizationId?: string) {
+    return this.httpClient.get(this.apiBaseUrl + `/${id}/file/download`, {
+      params: createOptionalQueryParams({
+        path,
+        organizationId
+      }),
+      responseType: 'blob'
+    })
+  }
+
   saveFile(id: string, path: string, content: string, organizationId?: string) {
     return this.httpClient.put<TFile>(
       this.apiBaseUrl + `/${id}/file`,

--- a/apps/cloud/src/app/@shared/files/tree/tree.component.html
+++ b/apps/cloud/src/app/@shared/files/tree/tree.component.html
@@ -115,7 +115,7 @@
                 <div
                   class="absolute right-1 ml-auto flex shrink-0 items-center gap-1 p-0.5 rounded-lg opacity-100 transition-opacity bg-components-panel-bg md:pointer-events-none md:opacity-0 md:group-hover:pointer-events-auto md:group-hover:opacity-100 md:group-focus-within:pointer-events-auto "
                 >
-                  @if (!item.hasChildren && canDownload()) {
+                  @if (canDownloadItem(item)) {
                     <button
                       type="button"
                       [class]="itemActionClasses()"

--- a/apps/cloud/src/app/@shared/files/tree/tree.component.spec.ts
+++ b/apps/cloud/src/app/@shared/files/tree/tree.component.spec.ts
@@ -79,4 +79,59 @@ describe('FileTreeComponent', () => {
 
     expect(rows.map((row) => row.getAttribute('title'))).toEqual(['workspace/docs', 'workspace/README.md'])
   })
+
+  it('hides download actions for folders unless directory downloads are enabled', () => {
+    const fixture = TestBed.createComponent(FileTreeComponent)
+    fixture.componentRef.setInput('hasContext', true)
+    fixture.componentRef.setInput('canDownload', true)
+    fixture.componentRef.setInput('items', [
+      {
+        filePath: 'docs',
+        fullPath: 'workspace/docs',
+        fileType: 'directory',
+        hasChildren: true,
+        expanded: false,
+        children: null
+      }
+    ])
+    fixture.detectChanges()
+
+    expect(
+      fixture.nativeElement.querySelector<HTMLButtonElement>('button[aria-label="PAC.Files.Download"]')
+    ).toBeNull()
+  })
+
+  it('shows download actions for folders when directory downloads are enabled', () => {
+    const fixture = TestBed.createComponent(FileTreeComponent)
+    const downloadSpy = jest.fn()
+    fixture.componentRef.setInput('hasContext', true)
+    fixture.componentRef.setInput('canDownload', true)
+    fixture.componentRef.setInput('canDownloadDirectory', true)
+    fixture.componentRef.setInput('items', [
+      {
+        filePath: 'docs',
+        fullPath: 'workspace/docs',
+        fileType: 'directory',
+        hasChildren: true,
+        expanded: false,
+        children: null
+      }
+    ])
+    fixture.componentInstance.fileDownload.subscribe(downloadSpy)
+    fixture.detectChanges()
+
+    const downloadButton = fixture.nativeElement.querySelector<HTMLButtonElement>(
+      'button[aria-label="PAC.Files.Download"]'
+    )
+    downloadButton?.click()
+
+    expect(downloadButton).not.toBeNull()
+    expect(downloadSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: 'docs',
+        fullPath: 'workspace/docs',
+        hasChildren: true
+      })
+    )
+  })
 })

--- a/apps/cloud/src/app/@shared/files/tree/tree.component.ts
+++ b/apps/cloud/src/app/@shared/files/tree/tree.component.ts
@@ -29,6 +29,7 @@ export class FileTreeComponent {
   readonly loading = input(false)
   readonly loadingPaths = input<Set<string>>(new Set())
   readonly canDownload = input(false)
+  readonly canDownloadDirectory = input(false)
   readonly canDelete = input(false)
   readonly canUpload = input(false)
   readonly uploadDisabled = input(false)
@@ -125,8 +126,12 @@ export class FileTreeComponent {
     return !!filePath && this.deletingPaths().has(filePath)
   }
 
+  canDownloadItem(item: FileTreeNode) {
+    return this.canDownload() && (!item.hasChildren || this.canDownloadDirectory())
+  }
+
   showActions(item: FileTreeNode) {
-    return this.canDelete() || (!item.hasChildren && this.canDownload())
+    return this.canDownloadItem(item) || this.canDelete()
   }
 
   onItemClick(item: FileTreeNode) {

--- a/apps/cloud/src/app/@shared/files/workbench/workbench.component.html
+++ b/apps/cloud/src/app/@shared/files/workbench/workbench.component.html
@@ -20,6 +20,7 @@
   [uploading]="uploading()"
   [uploadTargetHint]="uploadTargetHint()"
   [canDownload]="canDownloadFiles()"
+  [canDownloadDirectory]="canDownloadDirectories()"
   [canDelete]="canDeleteFiles()"
   [downloadingPaths]="downloadingPaths()"
   [deletingPaths]="deletingPaths()"

--- a/apps/cloud/src/app/@shared/files/workbench/workbench.component.spec.ts
+++ b/apps/cloud/src/app/@shared/files/workbench/workbench.component.spec.ts
@@ -68,6 +68,7 @@ jest.mock('../tree/tree.component', () => {
     @Input() uploading?: boolean
     @Input() uploadTargetHint?: string | null
     @Input() canDownload?: boolean
+    @Input() canDownloadDirectory?: boolean
     @Input() canDelete?: boolean
     @Input() downloadingPaths?: Set<string>
     @Input() deletingPaths?: Set<string>
@@ -137,6 +138,7 @@ async function setup(options?: {
   rootFiles?: TFileDirectory[]
   nestedFiles?: Record<string, TFileDirectory[]>
   fileContents?: Record<string, TFile>
+  fileDownloader?: jest.Mock
   referenceable?: boolean
 }) {
   const rootFiles =
@@ -207,6 +209,7 @@ async function setup(options?: {
     } as TFile)
   )
   const fileDeleter = jest.fn(() => of(undefined))
+  const fileDownloader = options?.fileDownloader
 
   TestBed.resetTestingModule()
   await TestBed.configureTestingModule({
@@ -227,6 +230,9 @@ async function setup(options?: {
   fixture.componentRef.setInput('fileSaver', fileSaver)
   fixture.componentRef.setInput('fileUploader', fileUploader)
   fixture.componentRef.setInput('fileDeleter', fileDeleter)
+  if (fileDownloader) {
+    fixture.componentRef.setInput('fileDownloader', fileDownloader)
+  }
   fixture.componentRef.setInput('referenceable', options?.referenceable ?? false)
   fixture.detectChanges()
   await fixture.whenStable()
@@ -276,6 +282,34 @@ describe('FileWorkbenchComponent', () => {
     expect((component.fileTree().find((item) => item.fullPath === 'docs')?.children as FileTreeNode[])?.[0]?.fullPath).toBe(
       'docs/guide.md'
     )
+  })
+
+  it('downloads folder nodes through the configured downloader', async () => {
+    const fileDownloader = jest.fn(() =>
+      of({
+        kind: 'url',
+        url: '/download/docs',
+        fileName: 'docs.zip'
+      })
+    )
+    const { component } = await setup({ fileDownloader })
+    const docsNode = component.fileTree().find((item) => item.fullPath === 'docs')
+    expect(docsNode).toBeDefined()
+    if (!docsNode) {
+      throw new Error('Expected docs node to be present')
+    }
+
+    await component.downloadTreeFile(docsNode)
+
+    expect(fileDownloader).toHaveBeenCalledWith('docs', expect.objectContaining({ hasChildren: true }))
+  })
+
+  it('does not enable folder downloads without a configured downloader', async () => {
+    const { fixture } = await setup()
+    const tree = fixture.debugElement.query(By.directive(MockFileTreeComponent)).componentInstance as any
+
+    expect(tree.canDownload).toBe(true)
+    expect(tree.canDownloadDirectory).toBe(false)
   })
 
   it('supports markdown edit and save', async () => {

--- a/apps/cloud/src/app/@shared/files/workbench/workbench.component.ts
+++ b/apps/cloud/src/app/@shared/files/workbench/workbench.component.ts
@@ -55,7 +55,10 @@ export type FileWorkbenchFileUploader = (file: File, path: string) => AsyncValue
 export type FileWorkbenchDownloadPayload =
   | { kind: 'url'; url: string; fileName?: string }
   | { kind: 'blob'; blob: Blob; fileName?: string }
-export type FileWorkbenchFileDownloader = (path: string) => AsyncValue<FileWorkbenchDownloadPayload | null | undefined>
+export type FileWorkbenchFileDownloader = (
+  path: string,
+  item?: FileTreeNode
+) => AsyncValue<FileWorkbenchDownloadPayload | null | undefined>
 export type FileWorkbenchCodeReferenceRequest = {
   path: string
   text: string
@@ -182,6 +185,7 @@ export class FileWorkbenchComponent {
   readonly canDeleteFiles = computed(() => !!this.fileDeleter())
   readonly canUploadFiles = computed(() => !!this.fileUploader() && !!this.rootId())
   readonly canDownloadFiles = computed(() => !!this.fileDownloader() || !!this.fileLoader())
+  readonly canDownloadDirectories = computed(() => !!this.fileDownloader())
   readonly canDownloadActiveFile = computed(() => {
     const activeFile = this.activeFile()
     return (
@@ -386,7 +390,7 @@ export class FileWorkbenchComponent {
 
   async downloadTreeFile(item: FileTreeNode) {
     const filePath = item.fullPath || item.filePath
-    if (!filePath || item.hasChildren) {
+    if (!filePath) {
       return
     }
 
@@ -831,7 +835,7 @@ export class FileWorkbenchComponent {
   ): Promise<FileWorkbenchDownloadPayload | null | undefined> {
     const fileDownloader = this.fileDownloader()
     if (fileDownloader) {
-      const payload = await resolveAsyncValue(fileDownloader(filePath))
+      const payload = await resolveAsyncValue(fileDownloader(filePath, item))
       if (payload) {
         return payload
       }

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-files.component.spec.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-files.component.spec.ts
@@ -32,6 +32,7 @@ jest.mock('../../../@shared/files', () => {
     @Input() fileSaver?: unknown
     @Input() fileDeleter?: unknown
     @Input() fileUploader?: unknown
+    @Input() fileDownloader?: unknown
     @Input() referenceable?: boolean
     @Input() reloadKey?: number
     @Input() treeSize?: 'sm' | 'default' | 'lg'
@@ -48,7 +49,8 @@ describe('ClawXpertConversationFilesComponent', () => {
   const conversationService = {
     getFiles: jest.fn(),
     getFile: jest.fn(),
-    saveFile: jest.fn()
+    saveFile: jest.fn(),
+    downloadFile: jest.fn()
   }
 
   beforeEach(async () => {
@@ -97,6 +99,7 @@ describe('ClawXpertConversationFilesComponent', () => {
     expect(typeof workbench.filesLoader).toBe('function')
     expect(typeof workbench.fileLoader).toBe('function')
     expect(typeof workbench.fileSaver).toBe('function')
+    expect(typeof workbench.fileDownloader).toBe('function')
     expect(workbench.reloadKey).toBe(3)
   })
 

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-files.component.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-files.component.ts
@@ -5,12 +5,14 @@ import {
   FileWorkbenchComponent,
   FileWorkbenchReferenceRequest,
   FileWorkbenchFileDeleter,
+  FileWorkbenchFileDownloader,
   FileWorkbenchFileLoader,
   FileWorkbenchFileSaver,
   FileWorkbenchFileUploader,
   FileWorkbenchFilesLoader
 } from '../../../@shared/files'
 import { TranslateModule } from '@ngx-translate/core'
+import { firstValueFrom } from 'rxjs'
 
 export type ClawXpertConversationFilesMode = 'readonly' | 'editable'
 
@@ -27,6 +29,7 @@ export type ClawXpertConversationFilesMode = 'readonly' | 'editable'
       [fileSaver]="mode() === 'editable' ? saveConversationFile : null"
       [fileDeleter]="mode() === 'editable' ? deleteConversationFile : null"
       [fileUploader]="mode() === 'editable' ? uploadConversationFile : null"
+      [fileDownloader]="downloadConversationFile"
       [reloadKey]="reloadKey()"
       [referenceable]="true"
       [treeSize]="'sm'"
@@ -63,6 +66,20 @@ export class ClawXpertConversationFilesComponent {
     }
 
     return this.#conversationService.getFile(conversationId, path)
+  }
+
+  readonly downloadConversationFile: FileWorkbenchFileDownloader = async (path, item) => {
+    const conversationId = this.conversationId()
+    if (!conversationId) {
+      throw new Error('Conversation context is required')
+    }
+
+    const blob = await firstValueFrom(this.#conversationService.downloadFile(conversationId, path))
+    return {
+      kind: 'blob',
+      blob,
+      fileName: item?.hasChildren ? `${path.split('/').pop() || path}.zip` : path.split('/').pop() || path
+    }
   }
 
   readonly saveConversationFile: FileWorkbenchFileSaver = (path: string, content: string) => {

--- a/apps/cloud/src/app/features/xpert/workspace/skills/skills.component.ts
+++ b/apps/cloud/src/app/features/xpert/workspace/skills/skills.component.ts
@@ -233,7 +233,7 @@ export class XpertWorkspaceSkillsComponent {
     return this.skillPackageAPI.deleteFile(workspaceId, skillId, path)
   }
 
-  readonly downloadActiveSkillFile: FileWorkbenchFileDownloader = async (path: string) => {
+  readonly downloadActiveSkillFile: FileWorkbenchFileDownloader = async (path, item) => {
     const workspaceId = this.workspace()?.id
     const skillId = this.activeSkillId()
     if (!workspaceId || !skillId) {
@@ -244,7 +244,7 @@ export class XpertWorkspaceSkillsComponent {
     return {
       kind: 'blob',
       blob,
-      fileName: path.split('/').pop() || path
+      fileName: item?.hasChildren ? `${path.split('/').pop() || path}.zip` : path.split('/').pop() || path
     } satisfies FileWorkbenchDownloadPayload
   }
 

--- a/packages/server-ai/src/chat-conversation/conversation.controller.ts
+++ b/packages/server-ai/src/chat-conversation/conversation.controller.ts
@@ -9,11 +9,14 @@ import {
 	transformWhere,
 	UUIDValidationPipe
 } from '@xpert-ai/server-core'
-import { Body, Controller, Delete, Get, HttpStatus, Param, Post, Put, Query, UploadedFile, UseInterceptors } from '@nestjs/common'
+import { Body, Controller, Delete, Get, HttpStatus, Param, Post, Put, Query, Res, UploadedFile, UseInterceptors } from '@nestjs/common'
 import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
 import { FileInterceptor } from '@nestjs/platform-express'
 import { Like } from 'typeorm'
+import { createReadStream } from 'fs'
+import type { Response } from 'express'
+import archiver from 'archiver'
 import { SuperAdminOrganizationScopeService } from '../shared/super-admin-organization-scope.service'
 import { ChatConversation } from './conversation.entity'
 import { ChatConversationService } from './conversation.service'
@@ -156,6 +159,37 @@ export class ChatConversationController extends CrudController<ChatConversation>
 		@Query('organizationId') organizationId?: string
 	) {
 		return this.organizationScopeService.run(organizationId, () => this.service.readWorkspaceFile(id, path))
+	}
+
+	@Get(':id/file/download')
+	async downloadFile(
+		@Param('id', UUIDValidationPipe) id: string,
+		@Query('path') path: string,
+		@Query('organizationId') organizationId: string,
+		@Res() res: Response
+	) {
+		const file = await this.organizationScopeService.run(organizationId, () =>
+			this.service.getWorkspaceFileDownload(id, path)
+		)
+		const encodedFilename = encodeURIComponent(file.fileName)
+		res.setHeader('Content-Type', file.mimeType)
+		res.setHeader(
+			'Content-Disposition',
+			`attachment; filename="${encodedFilename}"; filename*=UTF-8''${encodedFilename}`
+		)
+
+		if (file.type === 'directory') {
+			const archive = archiver('zip', { zlib: { level: 9 } })
+			archive.on('error', (error) => {
+				res.destroy(error)
+			})
+			archive.pipe(res)
+			archive.directory(file.absolutePath, false)
+			await archive.finalize()
+			return
+		}
+
+		createReadStream(file.absolutePath).pipe(res)
 	}
 
 	@Put(':id/file')

--- a/packages/server-ai/src/chat-conversation/conversation.service.spec.ts
+++ b/packages/server-ai/src/chat-conversation/conversation.service.spec.ts
@@ -127,6 +127,23 @@ describe('ChatConversationService workspace files', () => {
         expect(readWorkspaceFile).toHaveBeenCalledWith('', 'README.md')
     })
 
+    it('returns download targets inside the current conversation workspace', async () => {
+        const findConversation = jest
+            .spyOn(service, 'findOne')
+            .mockResolvedValue(conversation as ChatConversation)
+        const getDownloadTarget = jest.spyOn(VolumeSubtreeClient.prototype, 'getDownloadTarget').mockResolvedValue({
+            absolutePath: '/workspace/root/docs',
+            fileName: 'docs.zip',
+            mimeType: 'application/zip',
+            type: 'directory'
+        })
+
+        await service.getWorkspaceFileDownload('conversation-1', 'docs')
+
+        expect(findConversation).toHaveBeenCalledWith('conversation-1')
+        expect(getDownloadTarget).toHaveBeenCalledWith('', 'docs')
+    })
+
     it('saves files inside the current conversation workspace', async () => {
         const findConversation = jest
             .spyOn(service, 'findOne')

--- a/packages/server-ai/src/chat-conversation/conversation.service.ts
+++ b/packages/server-ai/src/chat-conversation/conversation.service.ts
@@ -176,6 +176,12 @@ export class ChatConversationService extends TenantOrganizationAwareCrudService<
         return client.readFile(scopePath, filePath)
     }
 
+    async getWorkspaceFileDownload(id: string, filePath: string) {
+        const conversation = await this.findOne(id)
+        const { client, scopePath } = this.createWorkspaceVolumeClient(conversation)
+        return client.getDownloadTarget(scopePath, filePath)
+    }
+
     async saveWorkspaceFile(id: string, filePath: string, content: string): Promise<TFile> {
         const conversation = await this.findOne(id)
         const { client, scopePath } = this.createWorkspaceVolumeClient(conversation)

--- a/packages/server-ai/src/shared/volume/volume-subtree.spec.ts
+++ b/packages/server-ai/src/shared/volume/volume-subtree.spec.ts
@@ -39,4 +39,29 @@ describe('VolumeSubtreeClient', () => {
         })
         await expect(readFile(join(tempRoot, 'README.md'), 'utf8')).resolves.toBe('# Root\n')
     })
+
+    it('returns zip download metadata for folders inside a subtree', async () => {
+        tempRoot = await mkdtemp(join(tmpdir(), 'volume-subtree-download-folder-'))
+        await mkdir(join(tempRoot, 'docs', 'nested'), { recursive: true })
+        await writeFile(join(tempRoot, 'docs', 'nested', 'readme.md'), 'hello', 'utf8')
+
+        const volume = new VolumeHandle(
+            {
+                tenantId: 'tenant-1',
+                catalog: 'projects',
+                projectId: 'project-1'
+            },
+            tempRoot,
+            tempRoot,
+            'http://localhost/volume'
+        )
+        const client = new VolumeSubtreeClient(volume, { allowRootWorkspace: true })
+
+        await expect(client.getDownloadTarget('', 'docs')).resolves.toEqual({
+            absolutePath: join(tempRoot, 'docs'),
+            fileName: 'docs.zip',
+            mimeType: 'application/zip',
+            type: 'directory'
+        })
+    })
 })

--- a/packages/server-ai/src/shared/volume/volume-subtree.ts
+++ b/packages/server-ai/src/shared/volume/volume-subtree.ts
@@ -29,6 +29,13 @@ type TVolumeSubtreeOptions = {
     allowRootWorkspace?: boolean
 }
 
+export type TVolumeSubtreeDownloadTarget = {
+    absolutePath: string
+    fileName: string
+    mimeType: string
+    type: 'file' | 'directory'
+}
+
 export class VolumeSubtreeClient {
     constructor(
         private readonly volume: VolumeHandle,
@@ -75,6 +82,40 @@ export class VolumeSubtreeClient {
             updatedAt: stat.mtime,
             fileUrl: this.volume.publicUrl(publicPath),
             url: this.volume.publicUrl(publicPath)
+        }
+    }
+
+    async getDownloadTarget(scopePath: string, filePath: string): Promise<TVolumeSubtreeDownloadTarget> {
+        const subtreeRoot = this.resolveSubtreeRoot(scopePath)
+        const relativePath = this.resolveSubtreeRelativePath(subtreeRoot, filePath)
+        if (!relativePath) {
+            throw new BadRequestException('File path is required')
+        }
+
+        const absolutePath = resolve(subtreeRoot, relativePath)
+        const stat = await fsPromises.stat(absolutePath).catch(() => null)
+        if (!stat) {
+            throw new BadRequestException('Conversation file not found')
+        }
+
+        if (stat.isDirectory()) {
+            return {
+                absolutePath,
+                fileName: `${basename(relativePath)}.zip`,
+                mimeType: 'application/zip',
+                type: 'directory'
+            }
+        }
+
+        if (!stat.isFile()) {
+            throw new BadRequestException('Conversation file not found')
+        }
+
+        return {
+            absolutePath,
+            fileName: basename(relativePath),
+            mimeType: getMediaTypeWithCharset(relativePath),
+            type: 'file'
         }
     }
 

--- a/packages/server-ai/src/skill-package/skill-package.controller.ts
+++ b/packages/server-ai/src/skill-package/skill-package.controller.ts
@@ -21,6 +21,7 @@ import { RequestContext } from '@xpert-ai/plugin-sdk'
 import { FileInterceptor } from '@nestjs/platform-express'
 import { createReadStream } from 'fs'
 import type { Response } from 'express'
+import archiver from 'archiver'
 import { SkillPackage } from './skill-package.entity'
 import { InstallGithubSkillPackagesInput, SkillPackageService } from './skill-package.service'
 import { WorkspaceGuard } from '../xpert-workspace'
@@ -171,6 +172,18 @@ export class SkillPackageController {
 			'Content-Disposition',
 			`attachment; filename="${encodedFilename}"; filename*=UTF-8''${encodedFilename}`
 		)
+
+		if (file.type === 'directory') {
+			const archive = archiver('zip', { zlib: { level: 9 } })
+			archive.on('error', (error) => {
+				res.destroy(error)
+			})
+			archive.pipe(res)
+			archive.directory(file.absolutePath, false)
+			await archive.finalize()
+			return
+		}
+
 		createReadStream(file.absolutePath).pipe(res)
 	}
 

--- a/packages/server-ai/src/skill-package/skill-package.service.spec.ts
+++ b/packages/server-ai/src/skill-package/skill-package.service.spec.ts
@@ -1290,6 +1290,30 @@ describe('SkillPackageService', () => {
 		await expect(readFile(join(skillRoot, 'SKILL.md'), 'utf8')).resolves.toBe('# Weather\n')
 	})
 
+	it('returns zip download metadata for workspace skill folders', async () => {
+		tempRoot = await mkdtemp(join(tmpdir(), 'skill-package-download-folder-'))
+		const skillRoot = join(tempRoot, 'weather')
+		await mkdir(join(skillRoot, 'docs', 'nested'), { recursive: true })
+		await writeFile(join(skillRoot, 'docs', 'nested', 'readme.md'), 'hello', 'utf8')
+
+		;(getWorkspaceSkillsRoot as jest.Mock).mockReturnValue(tempRoot)
+		;(service as any).findOne = jest.fn().mockResolvedValue({
+			id: 'skill-1',
+			tenantId: 'tenant-1',
+			workspaceId: 'workspace-1',
+			packagePath: 'weather'
+		})
+
+		const result = await service.getSkillPackageFileDownload('workspace-1', 'skill-1', 'docs')
+
+		expect(result).toEqual({
+			absolutePath: join(skillRoot, 'docs'),
+			fileName: 'docs.zip',
+			mimeType: 'application/zip',
+			type: 'directory'
+		})
+	})
+
 	it('allows editing .env files from the supported text whitelist', async () => {
 		tempRoot = await mkdtemp(join(tmpdir(), 'skill-package-env-'))
 		const skillRoot = join(tempRoot, 'weather')

--- a/packages/server-ai/src/skill-package/skill-package.service.ts
+++ b/packages/server-ai/src/skill-package/skill-package.service.ts
@@ -82,6 +82,13 @@ type SkillPackageInstallMetadata = Partial<SkillMetadata> & {
 	resources?: IUploadedSkill['resources']
 }
 
+type SkillPackageDownloadTarget = {
+	absolutePath: string
+	fileName: string
+	mimeType: string
+	type: 'file' | 'directory'
+}
+
 type SharedSkillMetadataInput = {
 	displayName: string
 	description: string
@@ -1109,17 +1116,31 @@ export class SkillPackageService extends XpertWorkspaceBaseService<SkillPackage>
 		await fs.unlink(absolutePath)
 	}
 
-	async getSkillPackageFileDownload(workspaceId: string, id: string, filePath: string) {
+	async getSkillPackageFileDownload(workspaceId: string, id: string, filePath: string): Promise<SkillPackageDownloadTarget> {
 		const { absolutePath, relativePath } = await this.resolveSkillPackageFilePath(workspaceId, id, filePath)
 		const stat = await fs.stat(absolutePath).catch(() => null)
-		if (!stat?.isFile()) {
+		if (!stat) {
+			throw new BadRequestException('Skill file not found')
+		}
+
+		if (stat.isDirectory()) {
+			return {
+				absolutePath,
+				fileName: `${basename(relativePath)}.zip`,
+				mimeType: 'application/zip',
+				type: 'directory'
+			}
+		}
+
+		if (!stat.isFile()) {
 			throw new BadRequestException('Skill file not found')
 		}
 
 		return {
 			absolutePath,
 			fileName: basename(relativePath),
-			mimeType: getMediaTypeWithCharset(relativePath)
+			mimeType: getMediaTypeWithCharset(relativePath),
+			type: 'file'
 		}
 	}
 


### PR DESCRIPTION
## Summary

- enable folder download actions only when a file downloader is configured
- stream workspace skill and conversation folders as zip files from the backend
- preserve existing single-file download behavior and path boundary checks

## Validation

- `git diff --check`
- `pnpm nx test cloud --testFile=apps/cloud/src/app/@shared/files/tree/tree.component.spec.ts --runInBand`
- `pnpm nx test cloud --testFile=apps/cloud/src/app/@shared/files/workbench/workbench.component.spec.ts --runInBand`
- `pnpm nx test cloud --testFile=apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-files.component.spec.ts --runInBand`
- `pnpm nx test server-ai --testFile=packages/server-ai/src/shared/volume/volume-subtree.spec.ts --runInBand`
- `pnpm nx test server-ai --testFile=packages/server-ai/src/chat-conversation/conversation.service.spec.ts --runInBand`
- `pnpm nx test server-ai --testFile=packages/server-ai/src/skill-package/skill-package.service.spec.ts --runInBand`

Note: `pnpm nx build server-ai` was attempted in the temporary worktree, but that worktree used a symlink to the main checkout's `node_modules` after `pnpm install --frozen-lockfile` was blocked by `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`. The build then failed with TS2742 portable type errors pointing at the symlinked dependency path, which appears to be an environment/dependency layout issue rather than this diff.