### PR TITLE
fix: use sandbox environment volume for conversation files

### DIFF
--- a/packages/server-ai/src/chat-conversation/conversation.service.spec.ts
+++ b/packages/server-ai/src/chat-conversation/conversation.service.spec.ts
@@ -54,12 +54,14 @@ import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import { Queue } from 'bull'
 import { Repository } from 'typeorm'
 import { ChatMessageService } from '../chat-message/chat-message.service'
+import { VolumeClient } from '../shared/volume'
 import { VolumeSubtreeClient } from '../shared/volume/volume-subtree'
 import { ChatConversation } from './conversation.entity'
 import { ChatConversationService } from './conversation.service'
 
 describe('ChatConversationService workspace files', () => {
     let repository: { findOne: jest.Mock }
+    let volumeClient: jest.Mocked<Pick<VolumeClient, 'resolve' | 'resolveRoot'>>
     let service: ChatConversationService
     const conversation = {
         id: 'conversation-1',
@@ -79,18 +81,21 @@ describe('ChatConversationService workspace files', () => {
             findOne: jest.fn()
         }
 
+        volumeClient = {
+            resolve: jest.fn().mockReturnValue({
+                path: jest.fn().mockReturnValue('/workspace/root'),
+                publicUrl: jest.fn().mockReturnValue('/workspace/public')
+            }),
+            resolveRoot: jest.fn()
+        }
+
         service = new ChatConversationService(
             repository as unknown as Repository<ChatConversation>,
             {} as ChatMessageService,
             {} as CommandBus,
             {} as QueryBus,
             {} as Queue,
-            {
-                resolve: jest.fn().mockReturnValue({
-                    path: jest.fn().mockReturnValue('/workspace/root'),
-                    publicUrl: jest.fn().mockReturnValue('/workspace/public')
-                })
-            } as any
+            volumeClient
         )
     })
 
@@ -99,9 +104,7 @@ describe('ChatConversationService workspace files', () => {
     })
 
     it('lists files inside the current conversation workspace', async () => {
-        const findConversation = jest
-            .spyOn(service, 'findOne')
-            .mockResolvedValue(conversation as ChatConversation)
+        const findConversation = jest.spyOn(service, 'findOne').mockResolvedValue(conversation as ChatConversation)
         const listWorkspace = jest.spyOn(VolumeSubtreeClient.prototype, 'list').mockResolvedValue([])
 
         await service.getWorkspaceFiles('conversation-1', 'docs', 2)
@@ -113,10 +116,28 @@ describe('ChatConversationService workspace files', () => {
         })
     })
 
+    it('uses the sandbox environment workspace when the conversation has a sandbox environment id', async () => {
+        jest.spyOn(service, 'findOne').mockResolvedValue({
+            ...conversation,
+            projectId: 'project-1',
+            options: {
+                sandboxEnvironmentId: 'sandbox-env-1'
+            }
+        } as ChatConversation)
+        jest.spyOn(VolumeSubtreeClient.prototype, 'list').mockResolvedValue([])
+
+        await service.getWorkspaceFiles('conversation-1', '/4567', 1)
+
+        expect(volumeClient.resolve).toHaveBeenCalledWith({
+            tenantId: 'tenant-1',
+            catalog: 'environment',
+            environmentId: 'sandbox-env-1',
+            userId: 'user-1'
+        })
+    })
+
     it('reads files inside the current conversation workspace', async () => {
-        const findConversation = jest
-            .spyOn(service, 'findOne')
-            .mockResolvedValue(conversation as ChatConversation)
+        const findConversation = jest.spyOn(service, 'findOne').mockResolvedValue(conversation as ChatConversation)
         const readWorkspaceFile = jest.spyOn(VolumeSubtreeClient.prototype, 'readFile').mockResolvedValue({
             filePath: 'README.md'
         } as TFile)
@@ -128,9 +149,7 @@ describe('ChatConversationService workspace files', () => {
     })
 
     it('saves files inside the current conversation workspace', async () => {
-        const findConversation = jest
-            .spyOn(service, 'findOne')
-            .mockResolvedValue(conversation as ChatConversation)
+        const findConversation = jest.spyOn(service, 'findOne').mockResolvedValue(conversation as ChatConversation)
         const saveWorkspaceFile = jest.spyOn(VolumeSubtreeClient.prototype, 'saveFile').mockResolvedValue({
             filePath: 'README.md',
             contents: '# Updated\n'
@@ -152,7 +171,9 @@ describe('ChatConversationService workspace files', () => {
     })
 
     it('finds the conversation by thread id inside the current scope', async () => {
-        const findOneByOptions = jest.spyOn(service, 'findOneByOptions').mockResolvedValue(conversation as ChatConversation)
+        const findOneByOptions = jest
+            .spyOn(service, 'findOneByOptions')
+            .mockResolvedValue(conversation as ChatConversation)
 
         await service.findOneByThreadId('thread-1')
 

--- a/packages/server-ai/src/chat-conversation/conversation.service.ts
+++ b/packages/server-ai/src/chat-conversation/conversation.service.ts
@@ -199,6 +199,19 @@ export class ChatConversationService extends TenantOrganizationAwareCrudService<
     }
 
     private createWorkspaceVolumeClient(conversation: ChatConversation) {
+        const sandboxEnvironmentId = conversation.options?.sandboxEnvironmentId?.trim()
+        if (sandboxEnvironmentId) {
+            return {
+                client: new VolumeSubtreeClient(
+                    this.createEnvironmentVolumeHandle(conversation, sandboxEnvironmentId),
+                    {
+                        allowRootWorkspace: true
+                    }
+                ),
+                scopePath: ''
+            }
+        }
+
         if (conversation.projectId) {
             return {
                 client: new VolumeSubtreeClient(this.createProjectVolumeHandle(conversation), {
@@ -218,6 +231,15 @@ export class ChatConversationService extends TenantOrganizationAwareCrudService<
         }
 
         throw new BadRequestException('Non-project conversations require xpertId to access workspace files')
+    }
+
+    private createEnvironmentVolumeHandle(conversation: ChatConversation, sandboxEnvironmentId: string) {
+        return this.volumeClient.resolve({
+            tenantId: conversation.tenantId,
+            catalog: 'environment',
+            environmentId: sandboxEnvironmentId,
+            userId: conversation.createdById
+        })
     }
 
     private createProjectVolumeHandle(conversation: ChatConversation) {


### PR DESCRIPTION
## Summary

Fixes Docker sandbox conversation file uploads so the file tree workspace APIs use the same sandbox environment volume as the Docker `/workspace` mount when a conversation has `options.sandboxEnvironmentId`.

## Root cause

The sandbox terminal context already resolves the work area with `sandboxEnvironmentId`, which maps Docker `/workspace` to the environment volume. The conversation file APIs, however, only selected project or xpert volumes. Uploads could therefore succeed while writing into a different volume than the Docker sandbox was using.

## Changes

- Prefer the conversation sandbox environment volume for workspace file APIs when `conversation.options.sandboxEnvironmentId` is present.
- Preserve the existing project and xpert volume fallback behavior for conversations without a sandbox environment id.
- Add a regression test covering the environment-volume selection path.

## Validation

- Passed in the main workspace before creating the clean branch: `pnpm nx test server-ai --testFile=packages/server-ai/src/chat-conversation/conversation.service.spec.ts --runInBand`
- The same check could not run from the temporary clean worktree because that worktree has no installed `node_modules`/`nx`.