### PR TITLE
[codex] Optimize current user bootstrap loading

### DIFF
--- a/apps/cloud/src/app/@core/services/app-init-service.ts
+++ b/apps/cloud/src/app/@core/services/app-init-service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core'
 import { Router } from '@angular/router'
 import { Ability, AbilityBuilder } from '@casl/ability'
 import { IUser } from '@xpert-ai/contracts'
-import { CurrentUserHydrationService, CURRENT_USER_BOOTSTRAP_RELATIONS, UsersService } from '@xpert-ai/cloud/state'
+import { CurrentUserHydrationService, CURRENT_USER_BOOTSTRAP_RELATIONS, CURRENT_USER_BOOTSTRAP_SELECT, UsersService } from '@xpert-ai/cloud/state'
 import * as Sentry from "@sentry/angular";
 import { NgxPermissionsService } from 'ngx-permissions'
 import { firstValueFrom } from 'rxjs'
@@ -32,7 +32,7 @@ export class AppInitService {
     try {
       const id = this.store.userId
       if (id) {
-        this.user = await this.usersService.getMe([...CURRENT_USER_BOOTSTRAP_RELATIONS])
+        this.user = await this.usersService.getMe([...CURRENT_USER_BOOTSTRAP_RELATIONS], CURRENT_USER_BOOTSTRAP_SELECT)
 
         //When a new user registers & logs in for the first time, he/she does not have tenantId.
         //In this case, we have to redirect the user to the onboarding page to create their first organization, tenant, role.

--- a/apps/cloud/src/app/features/features.component.ts
+++ b/apps/cloud/src/app/features/features.component.ts
@@ -21,7 +21,7 @@ import {
   RouterOutlet
 } from '@angular/router'
 import { PacMenuItem } from '@xpert-ai/cloud/auth'
-import { CurrentUserHydrationService, CURRENT_USER_BOOTSTRAP_RELATIONS, injectUserPreferences, UsersService } from '@xpert-ai/cloud/state'
+import { CurrentUserHydrationService, CURRENT_USER_BOOTSTRAP_RELATIONS, CURRENT_USER_BOOTSTRAP_SELECT, injectUserPreferences, UsersService } from '@xpert-ai/cloud/state'
 import { isNotEmpty, nonNullable } from '@xpert-ai/core'
 import { TranslateService } from '@ngx-translate/core'
 import { NGXLogger } from 'ngx-logger'
@@ -212,7 +212,7 @@ export class FeaturesComponent implements OnInit {
     this.user =
       hasHydratedUser
         ? cachedUser
-        : await this.#usersService.getMe([...CURRENT_USER_BOOTSTRAP_RELATIONS])
+        : await this.#usersService.getMe([...CURRENT_USER_BOOTSTRAP_RELATIONS], CURRENT_USER_BOOTSTRAP_SELECT)
 
     //When a new user registers & logs in for the first time, he/she does not have tenantId.
     //In this case, we have to redirect the user to the onboarding page to create their first organization, tenant, role.

--- a/libs/apps/state/src/lib/current-user-hydration.service.spec.ts
+++ b/libs/apps/state/src/lib/current-user-hydration.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing'
 import { IFeatureOrganization, IOrganization, IUser } from '@xpert-ai/contracts'
 import { Store } from './store.service'
-import { CURRENT_USER_FEATURE_RELATIONS, UsersService } from './users.service'
+import { CURRENT_USER_FEATURE_RELATIONS, UserMeSelect, UsersService } from './users.service'
 import {
   buildCurrentUserFeatureHydrationKey,
   CurrentUserHydrationService,
@@ -10,7 +10,7 @@ import {
 
 describe('CurrentUserHydrationService', () => {
   let service: CurrentUserHydrationService
-  let usersService: { getMe: jest.Mock<Promise<IUser>, [string[]]> }
+  let usersService: { getMe: jest.Mock<Promise<IUser>, [string[], UserMeSelect?]> }
   let storeState: {
     userId: string | null
     user: IUser | null

--- a/libs/apps/state/src/lib/users.service.ts
+++ b/libs/apps/state/src/lib/users.service.ts
@@ -22,6 +22,51 @@ export const CURRENT_USER_FULL_RELATIONS = [
   ...CURRENT_USER_FEATURE_RELATIONS
 ] as const
 
+export type UserMeSelect = {
+  [field: string]: true | UserMeSelect
+}
+
+export const CURRENT_USER_BOOTSTRAP_SELECT: UserMeSelect = {
+  id: true,
+  email: true,
+  username: true,
+  tenantId: true,
+  preferredLanguage: true,
+  role: {
+    id: true,
+    name: true,
+    rolePermissions: {
+      id: true,
+      permission: true,
+      enabled: true
+    }
+  },
+  tenant: {
+    id: true,
+    name: true
+  },
+  employee: {
+    id: true,
+    userId: true,
+    organizationId: true,
+    isActive: true
+  },
+  organizations: {
+    id: true,
+    userId: true,
+    tenantId: true,
+    organizationId: true,
+    isDefault: true,
+    isActive: true,
+    organization: {
+      id: true,
+      name: true,
+      isDefault: true,
+      isActive: true
+    }
+  }
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -30,12 +75,15 @@ export class UsersService {
 
   API_URL = `${API_PREFIX}/user`
 
-  getMe(relations?: string[]): Promise<IUser> {
-    if (!relations?.length) {
+  getMe(relations?: string[], select?: UserMeSelect): Promise<IUser> {
+    if (!relations?.length && !select) {
       return firstValueFrom(this.http.get<IUser>(`${this.API_URL}/me`))
     }
 
-    const data = JSON.stringify({ relations })
+    const data = JSON.stringify({
+      ...(relations?.length ? { relations } : {}),
+      ...(select ? { select } : {})
+    })
     return firstValueFrom(
       this.http.get<IUser>(`${this.API_URL}/me`, {
         params: { data }

--- a/packages/server/src/user/user.controller.ts
+++ b/packages/server/src/user/user.controller.ts
@@ -34,7 +34,7 @@ import { UUIDValidationPipe, ParseJsonPipe } from './../shared/pipes'
 import { PermissionGuard, RoleGuard, TenantPermissionGuard } from './../shared/guards'
 import { Permissions, Roles } from './../shared/decorators'
 import { User, UserPreferredLanguageDTO } from './user.entity'
-import { UserService } from './user.service'
+import { CurrentUserRelationSelect, UserService } from './user.service'
 import { UserBulkCreateCommand, UserCreateCommand } from './commands'
 import { FactoryResetService } from './factory-reset/factory-reset.service'
 import { UserDeleteCommand } from './commands/user.delete.command'
@@ -72,9 +72,11 @@ export class UserController extends CrudController<User> {
 		description: 'Record not found'
 	})
 	@Get('/me')
-	async findMe(@Query('data', ParseJsonPipe) data: { relations?: string[] } | null): Promise<User> {
+	async findMe(
+		@Query('data', ParseJsonPipe) data: { relations?: string[]; select?: CurrentUserRelationSelect } | null
+	): Promise<User> {
 		const id = RequestContext.currentUserId()
-		return await this.userService.findCurrentUser(id, data?.relations)
+		return await this.userService.findCurrentUser(id, data?.relations, data?.select)
 	}
 
 	/**

--- a/packages/server/src/user/user.service.spec.ts
+++ b/packages/server/src/user/user.service.spec.ts
@@ -136,6 +136,32 @@ describe('UserService', () => {
 		expect(result).toBe(user)
 	})
 
+	it('passes requested select fields to the original current-user query', async () => {
+		const user = { id: 'user-1' }
+		const select = {
+			id: true,
+			email: true,
+			organizations: {
+				id: true,
+				organizationId: true,
+				organization: {
+					id: true,
+					name: true
+				}
+			}
+		}
+
+		service.findOne = jest.fn().mockResolvedValue(user)
+
+		const result = await service.findCurrentUser('user-1', ['organizations', 'organizations.organization'], select)
+
+		expect(service.findOne).toHaveBeenCalledWith('user-1', {
+			relations: ['employee', 'role', 'role.rolePermissions', 'tenant', 'organizations', 'organizations.organization'],
+			select
+		})
+		expect(result).toBe(user)
+	})
+
 	it('keeps unknown current-user relations on the original findOne path', async () => {
 		const user = { id: 'user-1' }
 

--- a/packages/server/src/user/user.service.ts
+++ b/packages/server/src/user/user.service.ts
@@ -44,6 +44,8 @@ type CurrentUserFeatureContext = {
 	organizationFeatureOrganizations: IFeatureOrganization[]
 }
 
+export type CurrentUserRelationSelect = FindOneOptions<User>['select']
+
 function resolveCurrentUserRelations(relations?: string[]) {
 	return Array.from(new Set([...CURRENT_USER_CORE_RELATIONS, ...(relations ?? [])]))
 }
@@ -87,13 +89,14 @@ export class UserService extends TenantAwareCrudService<User> {
 		super(userRepository)
 	}
 
-	async findCurrentUser(id: string, relations?: string[]): Promise<User> {
+	async findCurrentUser(id: string, relations?: string[], select?: CurrentUserRelationSelect): Promise<User> {
 		if (isKnownCurrentUserFeatureHydrationRelations(relations) && this.featureOrganizationRepository) {
 			return this.findCurrentUserFeatureContext(id, relations ?? [])
 		}
 
 		return this.findOne(id, {
-			relations: resolveCurrentUserRelations(relations)
+			relations: resolveCurrentUserRelations(relations),
+			...(select ? { select } : {})
 		})
 	}
 


### PR DESCRIPTION
## Summary
- Add `data.select` support to `GET /user/me` and pass it through to the existing current-user `findOne` query.
- Keep dynamic `relations` behavior unchanged; no special handling or split query for `organizations` / `organizations.organization`.
- Update the frontend bootstrap `/user/me` calls to send a shared minimal select shape for the fields needed at startup.

## Root Cause
The `/user/me` bootstrap request loaded more columns than the initial shell needs. Supporting a normal TypeORM-style `select` parameter and using it from the frontend reduces the selected column set without changing relation semantics.

## Validation
- `pnpm jest --config packages/server/jest.config.ts packages/server/src/user/user.service.spec.ts --runInBand`
- `pnpm nx build server --skip-nx-cache`
- `NODE_TLS_REJECT_UNAUTHORIZED=0 pnpm nx build cloud --skip-nx-cache`

Notes:
- `pnpm nx lint @xpert-ai/cloud-state --skip-nx-cache` still fails on existing lint issues across the package, including constructor-injection rules in pre-existing services.
- Direct Jest for `libs/apps/state/src/lib/current-user-hydration.service.spec.ts` is blocked by the root Jest config referencing a missing `packages/plugins/integration-slack/jest.config.ts` in this worktree.