### PR TITLE
[codex] Refine ClawXpert workspace UI

### DIFF
--- a/apps/cloud/src/app/@shared/files/viewer/viewer.component.css
+++ b/apps/cloud/src/app/@shared/files/viewer/viewer.component.css
@@ -10,6 +10,7 @@
 
 .xp-pane-header {
   @apply flex items-start justify-between gap-3;
+  container-type: inline-size;
 }
 
 .xp-pane-body {
@@ -30,4 +31,14 @@
 
 .xp-file-preview-reference-button {
   transform: translate(-50%, -100%);
+}
+
+.xp-file-heading {
+  display: none;
+}
+
+@container (min-width: 52rem) {
+  .xp-file-heading {
+    display: flex;
+  }
 }

--- a/apps/cloud/src/app/@shared/files/viewer/viewer.component.html
+++ b/apps/cloud/src/app/@shared/files/viewer/viewer.component.html
@@ -52,7 +52,7 @@
       >
         {{ filePath() || ('PAC.Files.NoFileSelected' | translate: { Default: 'No file selected' }) }}
       </div>
-      <div class="mt-1 flex flex-wrap items-center gap-2">
+      <div class="xp-file-heading mt-1 flex flex-wrap items-center gap-2" data-file-content-heading="viewer">
         <div class="text-sm font-semibold text-text-primary">
           {{ 'PAC.Files.FileContent' | translate: { Default: 'File Content' } }}
         </div>
@@ -126,15 +126,33 @@
         </z-segmented>
       }
 
-      <button z-button zType="secondary" zSize="sm" type="button" [disabled]="!dirty()" (click)="discard.emit()">
-        {{ 'PAC.Files.Discard' | translate: { Default: 'Discard' } }}
-      </button>
-      <button z-button zType="default" zSize="sm" type="button" [disabled]="!dirty() || saving()" (click)="save.emit()">
-        @if (saving()) {
-          <i class="ri-loader-4-line mr-1 animate-spin"></i>
-        }
-        {{ 'PAC.ACTIONS.Save' | translate: { Default: 'Save' } }}
-      </button>
+      @if (mode() === 'edit') {
+        <button
+          z-button
+          zType="secondary"
+          zSize="sm"
+          type="button"
+          data-discard-button="viewer"
+          [disabled]="!dirty()"
+          (click)="discard.emit()"
+        >
+          {{ 'PAC.Files.Discard' | translate: { Default: 'Discard' } }}
+        </button>
+        <button
+          z-button
+          zType="default"
+          zSize="sm"
+          type="button"
+          data-save-button="viewer"
+          [disabled]="!dirty() || saving()"
+          (click)="save.emit()"
+        >
+          @if (saving()) {
+            <i class="ri-loader-4-line mr-1 animate-spin"></i>
+          }
+          {{ 'PAC.ACTIONS.Save' | translate: { Default: 'Save' } }}
+        </button>
+      }
     </div>
   </div>
 

--- a/apps/cloud/src/app/@shared/files/viewer/viewer.component.spec.ts
+++ b/apps/cloud/src/app/@shared/files/viewer/viewer.component.spec.ts
@@ -277,6 +277,34 @@ describe('FileViewerComponent', () => {
     expect((pathLabel.nativeElement as HTMLElement).getAttribute('title')).toBe('docs/architecture/long-file-name.md')
   })
 
+  it('shows save and discard actions only in edit mode', () => {
+    const fixture = TestBed.createComponent(FileViewerComponent)
+    fixture.componentRef.setInput('filePath', 'README.md')
+    fixture.componentRef.setInput('dirty', true)
+    fixture.componentRef.setInput('mode', 'view')
+    fixture.detectChanges()
+
+    expect(fixture.debugElement.query(By.css('[data-discard-button="viewer"]'))).toBeNull()
+    expect(fixture.debugElement.query(By.css('[data-save-button="viewer"]'))).toBeNull()
+
+    fixture.componentRef.setInput('mode', 'edit')
+    fixture.detectChanges()
+
+    expect(fixture.debugElement.query(By.css('[data-discard-button="viewer"]'))).not.toBeNull()
+    expect(fixture.debugElement.query(By.css('[data-save-button="viewer"]'))).not.toBeNull()
+  })
+
+  it('marks the file content heading as a responsive header detail', () => {
+    const fixture = TestBed.createComponent(FileViewerComponent)
+    fixture.componentRef.setInput('filePath', 'README.md')
+    fixture.detectChanges()
+
+    const heading = fixture.debugElement.query(By.css('[data-file-content-heading="viewer"]'))
+
+    expect(heading).not.toBeNull()
+    expect((heading.nativeElement as HTMLElement).classList.contains('xp-file-heading')).toBe(true)
+  })
+
   it('disables the inline selection action in markdown preview while keeping full-file references', () => {
     const fixture = TestBed.createComponent(FileViewerComponent)
     fixture.componentRef.setInput('filePath', 'README.md')

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.spec.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.spec.ts
@@ -394,19 +394,43 @@ describe('ClawXpertConversationDetailComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-panel-button="terminal"]')).toBeNull()
   })
 
-  it('does not allow closing the last remaining workspace tab', async () => {
+  it('allows closing the last remaining workspace tab and shows the empty workspace placeholder', async () => {
     const fixture = TestBed.createComponent(ClawXpertConversationDetailComponent)
     await settle(fixture)
 
     const onlyTabId = fixture.componentInstance.activeTabId()
-    expect(fixture.nativeElement.querySelector(`[data-close-tab="${onlyTabId}"]`)).toBeNull()
+    expect(fixture.nativeElement.querySelector(`[data-close-tab="${onlyTabId}"]`)).not.toBeNull()
 
     fixture.componentInstance.closeWorkspaceTab(new MouseEvent('click'), onlyTabId)
     await settle(fixture)
 
-    expect(fixture.componentInstance.workspaceTabs()).toHaveLength(1)
-    expect(fixture.componentInstance.activeTabId()).toBe(onlyTabId)
-    expect(fixture.debugElement.query(By.directive(ClawXpertConversationFilesComponent))).not.toBeNull()
+    expect(fixture.componentInstance.workspaceTabs()).toHaveLength(0)
+    expect(fixture.componentInstance.activeTabId()).toBe('')
+    expect(fixture.componentInstance.showDetailPanel()).toBe(true)
+    expect(fixture.nativeElement.querySelector('[data-empty-workspace-placeholder]')).not.toBeNull()
+    expect(fixture.nativeElement.querySelector('[data-empty-workspace-card-grid]')?.className).toContain(
+      'grid-cols-[repeat(auto-fit,minmax(min(100%,14rem),1fr))]'
+    )
+    expect(fixture.nativeElement.querySelector('[data-empty-workspace-card="files"]')).not.toBeNull()
+    expect(fixture.nativeElement.querySelector('[data-empty-workspace-card="browser"]')).not.toBeNull()
+    expect(fixture.nativeElement.querySelector('[data-empty-workspace-card="review"]')).toBeNull()
+    expect(fixture.nativeElement.querySelector('[data-empty-workspace-card="terminal"]')).not.toBeNull()
+    expect(fixture.debugElement.query(By.directive(ClawXpertConversationFilesComponent))).toBeNull()
+    expect(fixture.debugElement.query(By.directive(ClawXpertConversationPreviewComponent))).toBeNull()
+    expect(fixture.debugElement.query(By.directive(ChatSharedTerminalComponent))).toBeNull()
+  })
+
+  it('opens workspace tabs from the empty workspace placeholder', async () => {
+    const fixture = TestBed.createComponent(ClawXpertConversationDetailComponent)
+    await settle(fixture)
+
+    fixture.componentInstance.closeWorkspaceTab(new MouseEvent('click'), fixture.componentInstance.activeTabId())
+    await settle(fixture)
+    ;(fixture.nativeElement.querySelector('[data-empty-workspace-card="browser"]') as HTMLElement).click()
+    await settle(fixture)
+
+    expect(fixture.componentInstance.activeTab()?.kind).toBe('browser')
+    expect(fixture.debugElement.query(By.directive(ClawXpertConversationPreviewComponent))).not.toBeNull()
   })
 
   it('adds and closes file and terminal tabs on demand', async () => {

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.ts
@@ -139,19 +139,17 @@ type ChatKitReferenceComposerControl = {
                           <i class="ri-global-line shrink-0 text-base"></i>
                         }
                       }
-                      @if (workspaceTabs().length > 1) {
-                        <span
-                          role="button"
-                          tabindex="0"
-                          [attr.data-close-tab]="tab.id"
-                          class="absolute inset-0 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-text-tertiary text-components-card-bg opacity-0 transition-[background-color,color,opacity] hover:bg-text-secondary group-hover/tab:opacity-100 group-focus-within/tab:opacity-100"
-                          (click)="closeWorkspaceTab($event, tab.id)"
-                          (keydown.enter)="closeWorkspaceTab($event, tab.id)"
-                          (keydown.space)="closeWorkspaceTab($event, tab.id)"
-                        >
-                          <i class="ri-close-line text-sm"></i>
-                        </span>
-                      }
+                      <span
+                        role="button"
+                        tabindex="0"
+                        [attr.data-close-tab]="tab.id"
+                        class="absolute inset-0 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-text-tertiary text-components-card-bg opacity-0 transition-[background-color,color,opacity] hover:bg-text-secondary group-hover/tab:opacity-100 group-focus-within/tab:opacity-100"
+                        (click)="closeWorkspaceTab($event, tab.id)"
+                        (keydown.enter)="closeWorkspaceTab($event, tab.id)"
+                        (keydown.space)="closeWorkspaceTab($event, tab.id)"
+                      >
+                        <i class="ri-close-line text-sm"></i>
+                      </span>
                     </span>
                     @switch (tab.kind) {
                       @case ('files') {
@@ -210,7 +208,63 @@ type ChatKitReferenceComposerControl = {
 
             <z-tab-nav-panel #tabPanel class="flex min-h-0 flex-1 flex-col overflow-hidden">
               <div class="min-h-0 flex-1 p-2 pr-0">
-                @if (contextLoading() && !resolvedConversationId()) {
+                @if (!activeTab()) {
+                  <div
+                    data-empty-workspace-placeholder
+                    class="flex h-full min-h-[24rem] items-center justify-center px-4 py-8 sm:px-6"
+                  >
+                    <div
+                      data-empty-workspace-card-grid
+                      class="grid w-full max-w-5xl grid-cols-[repeat(auto-fit,minmax(min(100%,14rem),1fr))] gap-3 sm:gap-4"
+                    >
+                      <button
+                        type="button"
+                        data-empty-workspace-card="files"
+                        class="flex min-h-44 flex-col items-center justify-center rounded-2xl bg-background-default-subtle p-6 text-center transition-colors hover:bg-hover-bg"
+                        (click)="addWorkspaceTab('files')"
+                      >
+                        <i class="ri-folder-3-line text-3xl text-text-tertiary"></i>
+                        <div class="mt-4 text-xl font-semibold text-text-primary">
+                          {{ 'PAC.Chat.ClawXpert.Files' | translate: { Default: 'Files' } }}
+                        </div>
+                        <div class="mt-2 text-lg text-text-secondary">
+                          {{ 'PAC.Chat.ClawXpert.FilesLauncherDesc' | translate: { Default: 'Browse project files' } }}
+                        </div>
+                      </button>
+                      <button
+                        type="button"
+                        data-empty-workspace-card="browser"
+                        class="flex min-h-44 flex-col items-center justify-center rounded-2xl bg-background-default-subtle p-6 text-center transition-colors hover:bg-hover-bg"
+                        (click)="addWorkspaceTab('browser')"
+                      >
+                        <i class="ri-global-line text-3xl text-text-tertiary"></i>
+                        <div class="mt-4 text-xl font-semibold text-text-primary">
+                          {{ 'PAC.Chat.ClawXpert.Browser' | translate: { Default: 'Browser' } }}
+                        </div>
+                        <div class="mt-2 text-lg text-text-secondary">
+                          {{ 'PAC.Chat.ClawXpert.BrowserLauncherDesc' | translate: { Default: 'Open website' } }}
+                        </div>
+                      </button>
+                      <button
+                        type="button"
+                        data-empty-workspace-card="terminal"
+                        class="flex min-h-44 flex-col items-center justify-center rounded-2xl bg-background-default-subtle p-6 text-center transition-colors hover:bg-hover-bg"
+                        (click)="addWorkspaceTab('terminal')"
+                      >
+                        <i class="ri-terminal-window-line text-3xl text-text-tertiary"></i>
+                        <div class="mt-4 text-xl font-semibold text-text-primary">
+                          {{ 'PAC.Chat.ClawXpert.Terminal' | translate: { Default: 'Terminal' } }}
+                        </div>
+                        <div class="mt-2 text-lg text-text-secondary">
+                          {{
+                            'PAC.Chat.ClawXpert.TerminalLauncherDesc'
+                              | translate: { Default: 'Launch interactive shell' }
+                          }}
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                } @else if (contextLoading() && !resolvedConversationId()) {
                   <div
                     class="flex h-full min-h-[24rem] items-center justify-center rounded-2xl bg-background-default-subtle px-6 text-sm text-text-secondary"
                   >
@@ -466,7 +520,7 @@ export class ClawXpertConversationDetailComponent implements OnDestroy {
   readonly contextError = signal<string | null>(null)
   readonly isChatMinimizedToPet = signal(false)
   readonly chatkitHost = viewChild('chatkitHost', { read: ElementRef<HTMLElement> })
-  readonly showDetailPanel = computed(() => !!this.activePanel())
+  readonly showDetailPanel = computed(() => this.workspaceTabs().length === 0 || !!this.activePanel())
   readonly workspaceLayoutClasses = computed(() => {
     if (this.isChatMinimizedToPet()) {
       return this.showDetailPanel()
@@ -702,10 +756,6 @@ export class ClawXpertConversationDetailComponent implements OnDestroy {
     event.stopPropagation()
 
     const tabs = this.workspaceTabs()
-    if (tabs.length <= 1) {
-      return
-    }
-
     const closedIndex = tabs.findIndex((tab) => tab.id === tabId)
     if (closedIndex < 0) {
       return
@@ -713,7 +763,7 @@ export class ClawXpertConversationDetailComponent implements OnDestroy {
 
     const nextTabs = tabs.filter((tab) => tab.id !== tabId)
     this.workspaceTabs.set(nextTabs)
-    if (this.activeTabId() !== tabId) {
+    if (this.activeTabId() !== tabId && nextTabs.length > 0) {
       return
     }
 

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-preview.component.spec.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-preview.component.spec.ts
@@ -175,6 +175,22 @@ describe('ClawXpertConversationPreviewComponent', () => {
     expect(component.reloadNonce()).toBeGreaterThan(reloadBefore)
   })
 
+  it('renders a compact browser toolbar', async () => {
+    const fixture = TestBed.createComponent(ClawXpertConversationPreviewComponent)
+    fixture.componentRef.setInput('conversationId', 'conversation-1')
+    await settle(fixture)
+
+    const backButton = fixture.nativeElement.querySelector('[data-browser-back]') as HTMLButtonElement | null
+    const addressInput = fixture.nativeElement.querySelector('[data-browser-address]') as HTMLInputElement | null
+    const menuButton = fixture.nativeElement.querySelector('[data-browser-menu]') as HTMLButtonElement | null
+
+    expect(backButton?.className).toContain('h-8')
+    expect(backButton?.className).toContain('w-8')
+    expect(addressInput?.className).toContain('h-8')
+    expect(menuButton?.className).toContain('h-8')
+    expect(menuButton?.className).toContain('w-8')
+  })
+
   it('renders a responsive device toolbar with viewport controls', async () => {
     const fixture = TestBed.createComponent(ClawXpertConversationPreviewComponent)
     fixture.componentRef.setInput('conversationId', 'conversation-1')

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-preview.component.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-preview.component.ts
@@ -459,33 +459,33 @@ function buildElementReference(service: ISandboxManagedService, element: Element
     <div
       class="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-divider-regular bg-components-card-bg"
     >
-      <div class="border-b border-divider-regular px-3 py-2">
-        <div class="flex min-w-0 items-center gap-2">
+      <div class="border-b border-divider-regular px-2 py-1.5">
+        <div class="flex min-w-0 items-center gap-1.5">
           <button
             type="button"
             data-browser-back
-            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors enabled:hover:bg-hover-bg enabled:hover:text-text-primary disabled:text-text-quaternary"
+            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors enabled:hover:bg-hover-bg enabled:hover:text-text-primary disabled:text-text-quaternary"
             [disabled]="!canGoBack()"
             (click)="goBack()"
           >
-            <i class="ri-arrow-left-line text-xl"></i>
+            <i class="ri-arrow-left-line text-lg"></i>
           </button>
           <button
             type="button"
             data-browser-forward
-            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors enabled:hover:bg-hover-bg enabled:hover:text-text-primary disabled:text-text-quaternary"
+            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors enabled:hover:bg-hover-bg enabled:hover:text-text-primary disabled:text-text-quaternary"
             [disabled]="!canGoForward()"
             (click)="goForward()"
           >
-            <i class="ri-arrow-right-line text-xl"></i>
+            <i class="ri-arrow-right-line text-lg"></i>
           </button>
           <button
             type="button"
             data-browser-refresh
-            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary"
+            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary"
             (click)="reloadFrame()"
           >
-            <i class="ri-refresh-line text-xl"></i>
+            <i class="ri-refresh-line text-lg"></i>
           </button>
 
           <form class="flex min-w-0 flex-1 items-center" (submit)="navigateFromAddressEvent($event)">
@@ -494,16 +494,16 @@ function buildElementReference(service: ISandboxManagedService, element: Element
                 z-input
                 data-browser-address
                 name="browserAddress"
-                class="h-10 w-full rounded-xl border-divider-regular bg-components-card-bg pl-4 pr-10 text-center text-sm text-text-primary"
+                class="h-8 w-full rounded-xl border-divider-regular bg-components-card-bg pl-3 pr-8 text-center text-sm text-text-primary"
                 [ngModel]="addressValue()"
                 (ngModelChange)="addressValue.set($event)"
                 [placeholder]="'PAC.Chat.ClawXpert.EnterUrl' | translate: { Default: 'Enter URL' }"
               />
               <button
                 type="submit"
-                class="absolute right-1.5 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary"
+                class="absolute right-1 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary"
               >
-                <i class="ri-arrow-right-up-line text-lg"></i>
+                <i class="ri-arrow-right-up-line text-base"></i>
               </button>
             </label>
           </form>
@@ -513,22 +513,22 @@ function buildElementReference(service: ISandboxManagedService, element: Element
             data-browser-inspect
             [class]="
               mode() === 'inspect'
-                ? 'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-accent transition-colors hover:bg-hover-bg'
-                : 'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary'
+                ? 'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-accent transition-colors hover:bg-hover-bg'
+                : 'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary'
             "
             (click)="toggleInspectMode()"
           >
-            <i class="ri-focus-3-line text-xl"></i>
+            <i class="ri-focus-3-line text-lg"></i>
           </button>
 
           <button
             type="button"
             data-open-external
-            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors enabled:hover:bg-hover-bg enabled:hover:text-text-primary disabled:text-text-quaternary"
+            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors enabled:hover:bg-hover-bg enabled:hover:text-text-primary disabled:text-text-quaternary"
             [disabled]="!openableUrl()"
             (click)="openExternal()"
           >
-            <i class="ri-external-link-line text-xl"></i>
+            <i class="ri-external-link-line text-lg"></i>
           </button>
 
           <button
@@ -537,11 +537,11 @@ function buildElementReference(service: ISandboxManagedService, element: Element
             zType="ghost"
             zSize="icon"
             data-browser-menu
-            class="rounded-lg text-text-secondary hover:text-text-primary"
+            class="h-8 w-8 rounded-lg text-text-secondary hover:text-text-primary"
             z-menu
             [zMenuTriggerFor]="browserMenu"
           >
-            <i class="ri-more-2-fill text-xl"></i>
+            <i class="ri-more-2-fill text-lg"></i>
           </button>
         </div>
 


### PR DESCRIPTION
## Summary

This PR refines the ClawXpert workspace UI around workspace tabs, the empty workspace state, the embedded browser toolbar, and shared file viewer header controls.

The previous workspace tab behavior prevented closing the final tab, so users could not intentionally return to an empty workspace surface. The empty workspace state also needed to avoid invented tools and adapt to narrow containers rather than viewport width alone. This change allows the last workspace tab to close, keeps the workspace area visible with real entry points for files, browser, and terminal, and uses container-driven auto-fit columns so cramped layouts can collapse cleanly.

The browser preview toolbar was visually too tall for the split ClawXpert layout, so its padding, control size, address bar height, and icon size are tightened. The shared file viewer header now only shows Save and Discard while actually editing, and hides the secondary File Content heading when the header container is too narrow.

## Validation

- `nx test cloud --testFile=apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.spec.ts --skip-nx-cache`
- `nx test cloud --testFile=apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-preview.component.spec.ts --skip-nx-cache`
- `nx test cloud --testFile=apps/cloud/src/app/@shared/files/viewer/viewer.component.spec.ts --skip-nx-cache`

Note: this branch was created from `origin/develop` in an isolated worktree. The current local checkout still has unrelated `packages/server/src/user/*` edits that are not included here.