### PR TITLE
fix: initialize knowledge name input

### DIFF
--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.spec.ts
@@ -1,0 +1,53 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog'
+import { TestBed } from '@angular/core/testing'
+import { KnowledgebaseService, ToastrService, XpertAPIService } from '../../../../@core'
+import { XpertNewKnowledgeComponent } from './new.component'
+
+describe('XpertNewKnowledgeComponent', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule()
+  })
+
+  it('keeps an empty initial name invalid after selecting an embedding model', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            workspaceId: 'workspace-1'
+          }
+        },
+        {
+          provide: DialogRef,
+          useValue: {
+            close: jest.fn()
+          }
+        },
+        {
+          provide: XpertAPIService,
+          useValue: {}
+        },
+        {
+          provide: ToastrService,
+          useValue: {
+            success: jest.fn(),
+            error: jest.fn()
+          }
+        },
+        {
+          provide: KnowledgebaseService,
+          useValue: {
+            create: jest.fn()
+          }
+        }
+      ]
+    })
+
+    const component = TestBed.runInInjectionContext(() => new XpertNewKnowledgeComponent())
+
+    component.copilotModel.set({} as never)
+
+    expect(() => component.invalid()).not.toThrow()
+    expect(component.invalid()).toBe(true)
+  })
+})

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
@@ -33,7 +33,7 @@ export class XpertNewKnowledgeComponent {
   readonly knowledgebaseService = inject(KnowledgebaseService)
 
   readonly workspaceId = signal(this.#dialogData?.workspaceId)
-  readonly name = model<string>()
+  readonly name = model<string>('')
   readonly copilotModel = model<ICopilotModel>()
   readonly chatModel = model<ICopilotModel>()
   readonly rerankModel = model<ICopilotModel>()


### PR DESCRIPTION
## Summary

Fix the create knowledgebase dialog crash that happened when the embedding model was selected while the knowledgebase name was still empty.

## Root cause

`name` was declared as `model<string>()`, so its initial runtime value was `undefined`. Once the required embedding model had a value, the `invalid` computed was no longer short-circuited by `!this.copilotModel()` and evaluated `this.name().trim()`, causing `Cannot read properties of undefined (reading 'trim')`.

That exception interrupted the dialog/menu render flow, which made the model dropdown appear at the top-left. The previous overlay timing change was a symptom workaround, so it has been removed from this PR.

## Changes

- Initialize the knowledgebase name model with an empty string.
- Add a focused regression test for the initial empty-name invalid state after selecting an embedding model.
- Remove the earlier `copilot-model-select` overlay positioning workaround from the PR diff.

## Validation

- Red test before the fix: `pnpm nx test cloud --testFile=apps/cloud/src/app/features/xpert/knowledge/new/new.component.spec.ts --runInBand` failed with `Cannot read properties of undefined (reading 'trim')` at `new.component.ts:43`.
- Green test after the fix: `pnpm nx test cloud --testFile=apps/cloud/src/app/features/xpert/knowledge/new/new.component.spec.ts --runInBand`
- `pnpm exec prettier --check apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts apps/cloud/src/app/features/xpert/knowledge/new/new.component.spec.ts`
- `git diff --check origin/develop..HEAD`
