### PR TITLE
fix: include scope fields in pipeline document query

### DIFF
--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/pipeline.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/pipeline.component.ts
@@ -68,7 +68,7 @@ export class KnowledgeDocumentPipelineComponent {
   readonly #pipeline = toSignal(
     this.knowledgebaseAPI.getOneById(this.knowledgebaseComponent.paramId(), {
       relations: ['pipeline'],
-      select: ['id', 'name']
+      select: ['id', 'name', 'tenantId', 'organizationId', 'workspaceId']
     })
   )
 


### PR DESCRIPTION
## Summary

- Include tenant, organization, and workspace scope fields when loading the knowledgebase pipeline for the create-from-pipeline document flow.
- Fixes the pipeline document source page failing to render source cards when the backend read check rejects a narrow `select: ['id', 'name']` response.

## Root cause

The page requested only `id` and `name` while also loading the `pipeline` relation. Current backend workspace/tenant readability checks need scope fields on the selected knowledgebase record, so the narrowed query could return 404 and leave `pipeline.graph` unavailable.

## Validation

- Confirmed the branch diff is one file with one line changed.
- Ran `git diff --check` successfully.
- Targeted lint was attempted in the isolated worktree, but `nx` was unavailable there because the worktree had no local dependency install.