### PR TITLE
fix: skip unreachable hidden agent tools

### DIFF
--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts
@@ -1,16 +1,25 @@
 import { RunnableLambda } from '@langchain/core/runnables'
+import { tool } from '@langchain/core/tools'
 import {
     channelName,
     ChatMessageEventTypeEnum,
     ChatMessageTypeEnum,
+    IEnvironment,
+    IXpertAgentExecution,
     STATE_VARIABLE_HUMAN,
-    STATE_VARIABLE_SYS
+    STATE_VARIABLE_SYS,
+    WorkflowNodeTypeEnum
 } from '@xpert-ai/contracts'
+import type { CommandBus, QueryBus } from '@nestjs/cqrs'
+import { z } from 'zod'
+import type { AgentMiddlewareRuntimeService } from '../../../shared/agent/middleware-runtime.service'
 import { STATE_VARIABLE_PENDING_FOLLOW_UPS } from '../../../shared'
 import { CreateNodeConsumePendingSteerFollowUpsCommand } from '../create-node-consume-pending-steer-follow-ups.command'
 import { CreateNodeStagePendingSteerFollowUpsCommand } from '../create-node-stage-pending-steer-follow-ups.command'
+import { XpertAgentSubgraphCommand } from '../subgraph.command'
 import { CreateNodeConsumePendingSteerFollowUpsHandler } from './create-node-consume-pending-steer-follow-ups.handler'
 import { CreateNodeStagePendingSteerFollowUpsHandler } from './create-node-stage-pending-steer-follow-ups.handler'
+import { XpertAgentSubgraphHandler } from './subgraph.handler'
 
 describe('subgraph steer follow-up pre-turn node handlers', () => {
     it('stage handler returns a runnable lambda that loads pending steer follow-ups into the staging channel', async () => {
@@ -227,6 +236,138 @@ describe('subgraph steer follow-up pre-turn node handlers', () => {
                         clientMessageIds: ['client-message-1', 'client-message-2']
                     })
                 })
+            })
+        )
+    })
+})
+
+describe('XpertAgentSubgraphHandler hidden agent graph', () => {
+    it('does not register unreachable model tool nodes for hidden agents', async () => {
+        const graph = {
+            nodes: [
+                {
+                    type: 'agent',
+                    key: 'agent-1',
+                    entity: {
+                        key: 'agent-1',
+                        name: 'Hidden Agent',
+                        title: 'Hidden Agent',
+                        toolsetIds: [],
+                        knowledgebaseIds: [],
+                        options: {
+                            hidden: true
+                        },
+                        team: {
+                            id: 'xpert-1',
+                            workspaceId: 'workspace-1',
+                            agentConfig: {}
+                        }
+                    }
+                },
+                {
+                    type: 'workflow',
+                    key: 'trigger-1',
+                    entity: {
+                        key: 'trigger-1',
+                        type: WorkflowNodeTypeEnum.TRIGGER,
+                        from: 'chat'
+                    }
+                }
+            ],
+            connections: []
+        }
+        const commandBus = {
+            execute: jest.fn(async (command) => {
+                if (command.constructor.name === 'ToolsetGetToolsCommand') {
+                    return []
+                }
+
+                if (command.constructor.name === 'CreateWorkflowNodeCommand') {
+                    return {
+                        workflowNode: {
+                            graph: RunnableLambda.from(() => ({})),
+                            ends: []
+                        },
+                        nextNodes: []
+                    }
+                }
+
+                throw new Error(`Unexpected command: ${command.constructor.name}`)
+            })
+        }
+        const queryBus = {
+            execute: jest.fn(async (command) => {
+                if (command.constructor.name === 'GetXpertWorkflowQuery') {
+                    return {
+                        agent: graph.nodes[0].entity,
+                        graph,
+                        next: [],
+                        fail: []
+                    }
+                }
+
+                throw new Error(`Unexpected query: ${command.constructor.name}`)
+            })
+        }
+        const handler = new XpertAgentSubgraphHandler(
+            null,
+            commandBus as unknown as CommandBus,
+            queryBus as unknown as QueryBus,
+            null,
+            null,
+            {
+                api: {}
+            } as unknown as AgentMiddlewareRuntimeService
+        )
+        Object.defineProperty(handler, 'agentMiddlewareRegistry', {
+            value: {
+                get: jest.fn().mockReturnValue({
+                    createMiddleware: jest.fn().mockReturnValue({
+                        name: 'ClientToolMiddleware',
+                        tools: [
+                            tool(async () => '', {
+                                name: 'file_search',
+                                description: 'Search files.',
+                                schema: z.object({
+                                    query: z.string()
+                                })
+                            })
+                        ]
+                    })
+                })
+            }
+        })
+
+        await expect(
+            handler.execute(
+                new XpertAgentSubgraphCommand(
+                    'agent-1',
+                    {
+                        id: 'xpert-1',
+                        workspaceId: 'workspace-1'
+                    },
+                    {
+                        isStart: true,
+                        isDraft: true,
+                        mute: [],
+                        store: null,
+                        subscriber: null,
+                        execution: {
+                            id: 'execution-1'
+                        } as IXpertAgentExecution,
+                        rootController: new AbortController(),
+                        signal: new AbortController().signal,
+                        channel: channelName('agent-1'),
+                        thread_id: 'thread-1',
+                        environment: {
+                            variables: []
+                        } as IEnvironment
+                    }
+                )
+            )
+        ).resolves.toEqual(
+            expect.objectContaining({
+                graph: expect.any(Object)
             })
         )
     })

--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
@@ -1405,44 +1405,46 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
         }
 
         // Add nodes for tools
-        tools
-            ?.filter((_) => !_.graph)
-            .forEach(({ caller, tool, variables, toolset }) => {
-                const name = tool.name
-                const ends = []
-                if (endNodes?.includes(tool.name)) {
-                    // If it is end of the agent, connect the subsequent nodes of the agent
-                    if (nextNodeKey?.length) {
-                        ends.push(...nextNodeKey)
-                        subgraphBuilder.addConditionalEdges(name, (state, config) => {
-                            return nextNodeKey.filter((_) => !!_).map((n) => new Send(n, state))
-                        })
+        if (!hiddenAgent) {
+            tools
+                ?.filter((_) => !_.graph)
+                .forEach(({ caller, tool, variables, toolset }) => {
+                    const name = tool.name
+                    const ends = []
+                    if (endNodes?.includes(tool.name)) {
+                        // If it is end of the agent, connect the subsequent nodes of the agent
+                        if (nextNodeKey?.length) {
+                            ends.push(...nextNodeKey)
+                            subgraphBuilder.addConditionalEdges(name, (state, config) => {
+                                return nextNodeKey.filter((_) => !!_).map((n) => new Send(n, state))
+                            })
+                        } else {
+                            // No subsequent node, go to the end
+                            subgraphBuilder.addEdge(name, END)
+                            ends.push(END)
+                        }
                     } else {
-                        // No subsequent node, go to the end
-                        subgraphBuilder.addEdge(name, END)
-                        ends.push(END)
+                        // Not the end of the agent, return to the agent node
+                        subgraphBuilder.addEdge(name, agentLoopEntryNode)
+                        // ends.push(agentKey)
                     }
-                } else {
-                    // Not the end of the agent, return to the agent node
-                    subgraphBuilder.addEdge(name, agentLoopEntryNode)
-                    // ends.push(agentKey)
-                }
-                subgraphBuilder.addNode(
-                    name,
-                    new ToolNode([tool], { caller, variables, toolName: toolset.title, wrapToolCall }),
-                    {
-                        ends,
-                        metadata: omitBy({ toolset: toolset.provider, toolsetId: toolset.id }, isNil)
-                    }
-                )
-            })
+                    subgraphBuilder.addNode(
+                        name,
+                        new ToolNode([tool], { caller, variables, toolName: toolset.title, wrapToolCall }),
+                        {
+                            ends,
+                            metadata: omitBy({ toolset: toolset.provider, toolsetId: toolset.id }, isNil)
+                        }
+                    )
+                })
 
-        handoffTools?.forEach((tool) => {
-            const name = tool.name
-            subgraphBuilder.addNode(name, new ToolNode([tool], { caller: '', toolName: tool.description }), {
-                metadata: { toolset: 'transfer_to' }
+            handoffTools?.forEach((tool) => {
+                const name = tool.name
+                subgraphBuilder.addNode(name, new ToolNode([tool], { caller: '', toolName: tool.description }), {
+                    metadata: { toolset: 'transfer_to' }
+                })
             })
-        })
+        }
 
         // Sub Agents
         if (subAgents) {


### PR DESCRIPTION
## Summary

- avoid registering model-callable `ToolNode` and handoff tool nodes when the hidden agent graph is workflow-only
- add a regression test for hidden agent preview graphs with injected `file_search`

## Root cause

Hidden knowledge pipeline agents are workflow-only and start from workflow triggers. They do not have the model node and decision router that make model-callable tool nodes reachable. After file-understanding tools introduced `file_search`, the hidden preview graph could register that tool node without a route to it, causing LangGraph `UNREACHABLE_NODE` during compile.

## Validation

- `pnpm prettier --check packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts`
- `git diff --check origin/develop..HEAD -- packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts`
- `NX_SKIP_NX_CACHE=true pnpm nx test server-ai --testFile=packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts --testNamePattern='does not register unreachable model tool nodes for hidden agents' --runInBand`