### PR TITLE
perf: optimize current user organization loading

### DIFF
--- a/apps/cloud/src/app/@core/services/app-init-service.ts
+++ b/apps/cloud/src/app/@core/services/app-init-service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core'
 import { Router } from '@angular/router'
 import { Ability, AbilityBuilder } from '@casl/ability'
 import { IUser } from '@xpert-ai/contracts'
-import { CurrentUserHydrationService, CURRENT_USER_BOOTSTRAP_RELATIONS, UsersService } from '@xpert-ai/cloud/state'
+import { CurrentUserHydrationService, CURRENT_USER_BOOTSTRAP_RELATIONS, CURRENT_USER_BOOTSTRAP_SELECT, UsersService } from '@xpert-ai/cloud/state'
 import * as Sentry from "@sentry/angular";
 import { NgxPermissionsService } from 'ngx-permissions'
 import { firstValueFrom } from 'rxjs'
@@ -32,7 +32,14 @@ export class AppInitService {
     try {
       const id = this.store.userId
       if (id) {
-        this.user = await this.usersService.getMe([...CURRENT_USER_BOOTSTRAP_RELATIONS])
+        this.user = await this.usersService.getMe(
+          [...CURRENT_USER_BOOTSTRAP_RELATIONS],
+          CURRENT_USER_BOOTSTRAP_SELECT,
+          {
+            currentOrganizationId: this.store.organizationId ?? this.store.lastOrganizationId,
+            limitOrganizations: true
+          }
+        )
 
         //When a new user registers & logs in for the first time, he/she does not have tenantId.
         //In this case, we have to redirect the user to the onboarding page to create their first organization, tenant, role.

--- a/apps/cloud/src/app/@theme/header/organization-selector/organization-selector.component.html
+++ b/apps/cloud/src/app/@theme/header/organization-selector/organization-selector.component.html
@@ -11,6 +11,7 @@
   zPosition="right"
   [zDisabled]="!isCollapsed()"
   [cdkMenuTriggerFor]="canOpenMenu() ? menu : null"
+  (cdkMenuOpened)="loadOrganizations()"
   (closed)="resetSearch()"
 >
   <div class="flex items-center gap-2">

--- a/apps/cloud/src/app/@theme/header/organization-selector/organization-selector.component.ts
+++ b/apps/cloud/src/app/@theme/header/organization-selector/organization-selector.component.ts
@@ -1,9 +1,17 @@
 import { CdkMenuModule } from '@angular/cdk/menu'
 
-import { Component, computed, effect, inject, input, model } from '@angular/core'
+import { Component, computed, effect, inject, input, model, signal } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
 import { FormsModule } from '@angular/forms'
 import { injectI18nService } from '@cloud/app/@shared/i18n'
+import {
+  CurrentUserHydrationService,
+  CURRENT_USER_BOOTSTRAP_RELATIONS,
+  CURRENT_USER_ORGANIZATIONS_SELECT,
+  type IUser,
+  type IUserOrganization,
+  UsersService
+} from '@xpert-ai/cloud/state'
 import { nonNullable, OverlayAnimation1 } from '@xpert-ai/core'
 import { NgmSearchComponent, NgmHighlightDirective } from '@xpert-ai/ocap-angular/common'
 import { debouncedSignal } from '@xpert-ai/ocap-angular/core'
@@ -34,12 +42,16 @@ import { ZardTooltipImports } from '@xpert-ai/headless-ui'
 export class OrganizationSelectorComponent {
   private readonly store = inject(Store)
   private readonly scopeService = inject(ScopeService)
+  private readonly usersService = inject(UsersService)
+  private readonly currentUserHydrationService = inject(CurrentUserHydrationService)
   readonly i18nService = injectI18nService()
 
   readonly isCollapsed = input<boolean>(false)
 
   readonly searchTerm = model<string>('')
   readonly search = debouncedSignal(this.searchTerm, 300)
+  readonly organizationsLoadedKey = signal<string | null>(null)
+  readonly organizationsLoading = signal(false)
   readonly activeScope = this.scopeService.activeScope
   readonly canUseTenantScope = this.scopeService.canUseTenantScope
   readonly currentUser = toSignal(this.store.user$, {
@@ -155,5 +167,83 @@ export class OrganizationSelectorComponent {
     }
 
     this.searchTerm.set('')
+  }
+
+  async loadOrganizations() {
+    const user = this.currentUser()
+    const loadKey = getCurrentUserOrganizationsLoadKey(user)
+    if (!loadKey || this.organizationsLoadedKey() === loadKey || this.organizationsLoading()) {
+      return
+    }
+
+    this.organizationsLoading.set(true)
+    try {
+      const loadedUser = await this.usersService.getMe(
+        [...CURRENT_USER_BOOTSTRAP_RELATIONS],
+        CURRENT_USER_ORGANIZATIONS_SELECT
+      )
+      const currentUser = this.store.user
+      if (!currentUser || getCurrentUserOrganizationsLoadKey(currentUser) !== loadKey) {
+        return
+      }
+
+      this.store.user = mergeLoadedCurrentUserOrganizations(currentUser, loadedUser)
+      this.organizationsLoadedKey.set(loadKey)
+
+      if (this.store.featureContextHydrated) {
+        try {
+          await this.currentUserHydrationService.getFeatureHydration({ force: true })
+        } catch (error) {
+          console.warn('Refresh current-user feature hydration after loading organizations failed', error)
+        }
+      }
+    } catch (error) {
+      console.warn('Load current-user organizations failed', error)
+    } finally {
+      this.organizationsLoading.set(false)
+    }
+  }
+}
+
+function getCurrentUserOrganizationsLoadKey(user: { id?: string | null; tenantId?: string | null } | null | undefined) {
+  return user?.id ? `${user.tenantId ?? 'tenant'}:${user.id}` : null
+}
+
+function getMembershipOrganizationId(membership: IUserOrganization) {
+  return membership.organizationId ?? membership.organization?.id ?? null
+}
+
+function mergeLoadedCurrentUserOrganizations(currentUser: IUser, loadedUser: IUser): IUser {
+  const featureOrganizationsByOrganization = new Map(
+    (currentUser.organizations ?? [])
+      .map((membership) => {
+        const organizationId = getMembershipOrganizationId(membership)
+        const featureOrganizations = membership.organization?.featureOrganizations
+        return organizationId && Array.isArray(featureOrganizations)
+          ? ([organizationId, featureOrganizations] as const)
+          : null
+      })
+      .filter(nonNullable)
+  )
+  const organizations = (loadedUser.organizations ?? []).map((membership) => {
+    const organizationId = getMembershipOrganizationId(membership)
+    const featureOrganizations = organizationId ? featureOrganizationsByOrganization.get(organizationId) : undefined
+
+    if (!membership.organization || !featureOrganizations) {
+      return membership
+    }
+
+    return {
+      ...membership,
+      organization: {
+        ...membership.organization,
+        featureOrganizations
+      }
+    }
+  })
+
+  return {
+    ...currentUser,
+    organizations
   }
 }

--- a/apps/cloud/src/app/features/features.component.ts
+++ b/apps/cloud/src/app/features/features.component.ts
@@ -21,7 +21,7 @@ import {
   RouterOutlet
 } from '@angular/router'
 import { PacMenuItem } from '@xpert-ai/cloud/auth'
-import { CurrentUserHydrationService, CURRENT_USER_BOOTSTRAP_RELATIONS, injectUserPreferences, UsersService } from '@xpert-ai/cloud/state'
+import { CurrentUserHydrationService, CURRENT_USER_BOOTSTRAP_RELATIONS, CURRENT_USER_BOOTSTRAP_SELECT, injectUserPreferences, UsersService } from '@xpert-ai/cloud/state'
 import { isNotEmpty, nonNullable } from '@xpert-ai/core'
 import { TranslateService } from '@ngx-translate/core'
 import { NGXLogger } from 'ngx-logger'
@@ -212,7 +212,10 @@ export class FeaturesComponent implements OnInit {
     this.user =
       hasHydratedUser
         ? cachedUser
-        : await this.#usersService.getMe([...CURRENT_USER_BOOTSTRAP_RELATIONS])
+        : await this.#usersService.getMe([...CURRENT_USER_BOOTSTRAP_RELATIONS], CURRENT_USER_BOOTSTRAP_SELECT, {
+          currentOrganizationId: this.#store.organizationId ?? this.#store.lastOrganizationId,
+          limitOrganizations: true
+        })
 
     //When a new user registers & logs in for the first time, he/she does not have tenantId.
     //In this case, we have to redirect the user to the onboarding page to create their first organization, tenant, role.

--- a/libs/apps/state/src/lib/users.service.ts
+++ b/libs/apps/state/src/lib/users.service.ts
@@ -22,6 +22,92 @@ export const CURRENT_USER_FULL_RELATIONS = [
   ...CURRENT_USER_FEATURE_RELATIONS
 ] as const
 
+export type UserMeSelect = {
+  [field: string]: true | UserMeSelect
+}
+
+export type UserMeOptions = {
+  currentOrganizationId?: string | null
+  limitOrganizations?: boolean
+}
+
+export const CURRENT_USER_BOOTSTRAP_SELECT: UserMeSelect = {
+  id: true,
+  email: true,
+  username: true,
+  firstName: true,
+  lastName: true,
+  mobile: true,
+  imageUrl: true,
+  timeZone: true,
+  tenantId: true,
+  preferredLanguage: true,
+  role: {
+    id: true,
+    name: true,
+    rolePermissions: {
+      id: true,
+      permission: true,
+      enabled: true
+    }
+  },
+  tenant: {
+    id: true,
+    name: true
+  },
+  employee: {
+    id: true,
+    userId: true,
+    organizationId: true,
+    isActive: true
+  },
+  organizations: {
+    id: true,
+    userId: true,
+    tenantId: true,
+    organizationId: true,
+    isDefault: true,
+    isActive: true,
+    organization: {
+      id: true,
+      name: true,
+      imageUrl: true,
+      isDefault: true,
+      isActive: true,
+      defaultValueDateType: true,
+      allowManualTime: true,
+      allowModifyTime: true,
+      allowDeleteTime: true,
+      futureDateAllowed: true
+    }
+  }
+}
+
+export const CURRENT_USER_ORGANIZATIONS_SELECT: UserMeSelect = {
+  id: true,
+  tenantId: true,
+  organizations: {
+    id: true,
+    userId: true,
+    tenantId: true,
+    organizationId: true,
+    isDefault: true,
+    isActive: true,
+    organization: {
+      id: true,
+      name: true,
+      imageUrl: true,
+      isDefault: true,
+      isActive: true,
+      defaultValueDateType: true,
+      allowManualTime: true,
+      allowModifyTime: true,
+      allowDeleteTime: true,
+      futureDateAllowed: true
+    }
+  }
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -30,12 +116,16 @@ export class UsersService {
 
   API_URL = `${API_PREFIX}/user`
 
-  getMe(relations?: string[]): Promise<IUser> {
-    if (!relations?.length) {
+  getMe(relations?: string[], select?: UserMeSelect, options?: UserMeOptions): Promise<IUser> {
+    if (!relations?.length && !select && !options) {
       return firstValueFrom(this.http.get<IUser>(`${this.API_URL}/me`))
     }
 
-    const data = JSON.stringify({ relations })
+    const data = JSON.stringify({
+      ...(relations?.length ? { relations } : {}),
+      ...(select ? { select } : {}),
+      ...(options ?? {})
+    })
     return firstValueFrom(
       this.http.get<IUser>(`${this.API_URL}/me`, {
         params: { data }

--- a/packages/server/src/user/user.controller.ts
+++ b/packages/server/src/user/user.controller.ts
@@ -34,7 +34,7 @@ import { UUIDValidationPipe, ParseJsonPipe } from './../shared/pipes'
 import { PermissionGuard, RoleGuard, TenantPermissionGuard } from './../shared/guards'
 import { Permissions, Roles } from './../shared/decorators'
 import { User, UserPreferredLanguageDTO } from './user.entity'
-import { UserService } from './user.service'
+import { CurrentUserFindOptions, UserService } from './user.service'
 import { UserBulkCreateCommand, UserCreateCommand } from './commands'
 import { FactoryResetService } from './factory-reset/factory-reset.service'
 import { UserDeleteCommand } from './commands/user.delete.command'
@@ -72,9 +72,9 @@ export class UserController extends CrudController<User> {
 		description: 'Record not found'
 	})
 	@Get('/me')
-	async findMe(@Query('data', ParseJsonPipe) data: { relations?: string[] } | null): Promise<User> {
+	async findMe(@Query('data', ParseJsonPipe) data: ({ relations?: string[] } & CurrentUserFindOptions) | null): Promise<User> {
 		const id = RequestContext.currentUserId()
-		return await this.userService.findCurrentUser(id, data?.relations)
+		return await this.userService.findCurrentUser(id, data?.relations, data ?? undefined)
 	}
 
 	/**

--- a/packages/server/src/user/user.service.spec.ts
+++ b/packages/server/src/user/user.service.spec.ts
@@ -136,15 +136,26 @@ describe('UserService', () => {
 		expect(result).toBe(user)
 	})
 
-	it('keeps unknown current-user relations on the original findOne path', async () => {
+	it('passes requested select fields to the original current-user query', async () => {
 		const user = { id: 'user-1' }
+		const select = {
+			id: true,
+			email: true,
+			organizations: {
+				id: true,
+				organizationId: true,
+				organization: {
+					id: true,
+					name: true
+				}
+			}
+		}
 
 		service.findOne = jest.fn().mockResolvedValue(user)
 
-		const result = await service.findCurrentUser('user-1', [
-			...featureHydrationRelations,
-			'profile'
-		])
+		const result = await service.findCurrentUser('user-1', ['organizations', 'organizations.organization'], {
+			select
+		})
 
 		expect(service.findOne).toHaveBeenCalledWith('user-1', {
 			relations: [
@@ -152,9 +163,159 @@ describe('UserService', () => {
 				'role',
 				'role.rolePermissions',
 				'tenant',
-				...featureHydrationRelations,
-				'profile'
+				'organizations',
+				'organizations.organization'
+			],
+			select
+		})
+		expect(result).toBe(user)
+	})
+
+	it('limits current user organizations for the bootstrap query when explicitly requested', async () => {
+		const user = { id: 'user-1', tenantId: 'tenant-1' }
+		const select = {
+			id: true,
+			email: true,
+			organizations: {
+				id: true,
+				userId: true,
+				tenantId: true,
+				organizationId: true,
+				isDefault: true,
+				isActive: true,
+				organization: {
+					id: true,
+					name: true,
+					isDefault: true,
+					isActive: true
+				}
+			}
+		}
+		const membership = {
+			id: 'membership-1',
+			userId: 'user-1',
+			tenantId: 'tenant-1',
+			organizationId: 'org-1',
+			isDefault: true,
+			isActive: true,
+			organization: { id: 'org-1', name: 'Org', isActive: true }
+		}
+
+		service.findOne = jest.fn().mockResolvedValue(user)
+		userOrganizationService.findAll.mockResolvedValue({ items: [membership], total: 1 })
+
+		const result = await service.findCurrentUser('user-1', ['organizations', 'organizations.organization'], {
+			select,
+			currentOrganizationId: 'org-1',
+			limitOrganizations: true
+		})
+
+		expect(service.findOne).toHaveBeenCalledWith('user-1', {
+			relations: ['employee', 'role', 'role.rolePermissions', 'tenant'],
+			select: {
+				id: true,
+				email: true
+			}
+		})
+		expect(userOrganizationService.findAll).toHaveBeenCalledWith({
+			where: {
+				userId: 'user-1',
+				tenantId: 'tenant-1',
+				isActive: true,
+				organization: { isActive: true },
+				organizationId: 'org-1'
+			},
+			relations: ['organization'],
+			select: select.organizations,
+			order: { id: 'ASC' },
+			take: 1
+		})
+		expect(result.organizations).toEqual([membership])
+	})
+
+	it('filters limited bootstrap organization queries to active organizations with deterministic ordering', async () => {
+		const user = { id: 'user-1', tenantId: 'tenant-1' }
+
+		service.findOne = jest.fn().mockResolvedValue(user)
+		userOrganizationService.findAll
+			.mockResolvedValueOnce({ items: [], total: 0 })
+			.mockResolvedValueOnce({ items: [], total: 0 })
+			.mockResolvedValueOnce({ items: [], total: 0 })
+
+		await service.findCurrentUser('user-1', ['organizations', 'organizations.organization'], {
+			currentOrganizationId: 'missing-org',
+			limitOrganizations: true
+		})
+
+		expect(userOrganizationService.findAll).toHaveBeenNthCalledWith(1, {
+			where: {
+				userId: 'user-1',
+				tenantId: 'tenant-1',
+				isActive: true,
+				organization: { isActive: true },
+				organizationId: 'missing-org'
+			},
+			relations: ['organization'],
+			order: { id: 'ASC' },
+			take: 1
+		})
+		expect(userOrganizationService.findAll).toHaveBeenNthCalledWith(2, {
+			where: {
+				userId: 'user-1',
+				tenantId: 'tenant-1',
+				isActive: true,
+				organization: { isActive: true },
+				isDefault: true
+			},
+			relations: ['organization'],
+			order: { id: 'ASC' },
+			take: 1
+		})
+		expect(userOrganizationService.findAll).toHaveBeenNthCalledWith(3, {
+			where: {
+				userId: 'user-1',
+				tenantId: 'tenant-1',
+				isActive: true,
+				organization: { isActive: true }
+			},
+			relations: ['organization'],
+			order: { id: 'ASC' },
+			take: 1
+		})
+	})
+
+	it('keeps the original current-user query when organization limiting is not explicit', async () => {
+		const user = { id: 'user-1' }
+
+		service.findOne = jest.fn().mockResolvedValue(user)
+
+		const result = await service.findCurrentUser('user-1', ['organizations', 'organizations.organization'], {
+			limitOrganizations: false
+		})
+
+		expect(service.findOne).toHaveBeenCalledWith('user-1', {
+			relations: [
+				'employee',
+				'role',
+				'role.rolePermissions',
+				'tenant',
+				'organizations',
+				'organizations.organization'
 			]
+		})
+		expect(userOrganizationService.findAll).not.toHaveBeenCalled()
+		expect(result).toBe(user)
+	})
+
+	it('keeps unknown current-user relations on the original findOne path', async () => {
+		const user = { id: 'user-1' }
+
+		service.findOne = jest.fn().mockResolvedValue(user)
+
+		const result = await service.findCurrentUser('user-1', [...featureHydrationRelations, 'profile'])
+
+		expect(service.findOne).toHaveBeenCalledWith('user-1', {
+			relations: ['employee', 'role', 'role.rolePermissions', 'tenant', ...featureHydrationRelations, 'profile']
 		})
 		expect(featureOrganizationRepository.find).not.toHaveBeenCalled()
 		expect(result).toBe(user)

--- a/packages/server/src/user/user.service.ts
+++ b/packages/server/src/user/user.service.ts
@@ -3,7 +3,7 @@ import { BadRequestException, ForbiddenException, Injectable, Logger, NotFoundEx
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { InjectRepository } from '@nestjs/typeorm'
 import type { Cache } from 'cache-manager'
-import { Repository, InsertResult, Like, Brackets, WhereExpressionBuilder, In, FindOneOptions, DeleteResult, IsNull } from 'typeorm'
+import { Repository, InsertResult, Like, Brackets, WhereExpressionBuilder, In, FindOneOptions, DeleteResult, IsNull, FindManyOptions, FindOptionsSelect, FindOptionsWhere } from 'typeorm'
 import bcrypt from 'bcryptjs'
 import { environment as env } from '@xpert-ai/server-config'
 import { nanoid } from 'nanoid'
@@ -14,6 +14,7 @@ import { RequestContext } from '../core/context'
 import { EmailVerification } from './email-verification/email-verification.entity'
 import { UserPublicDTO } from './dto'
 import { UserOrganizationService } from '../user-organization/user-organization.services'
+import { UserOrganization } from '../user-organization/user-organization.entity'
 import { EVENT_USER_ORGANIZATION_DELETED, UserOrganizationDeletedEvent } from './events'
 import { FeatureOrganization } from '../feature/feature-organization.entity'
 import {
@@ -26,6 +27,7 @@ import {
 const REQUEST_CONTEXT_USER_RELATIONS = ['role', 'role.rolePermissions', 'employee'] as const
 const CURRENT_USER_CORE_RELATIONS = ['employee', 'role', 'role.rolePermissions', 'tenant'] as const
 const CURRENT_USER_BOOTSTRAP_RELATIONS = ['organizations', 'organizations.organization'] as const
+const CURRENT_USER_LIMITABLE_ORGANIZATION_RELATIONS: ReadonlySet<string> = new Set(CURRENT_USER_BOOTSTRAP_RELATIONS)
 const CURRENT_USER_FEATURE_RELATIONS = [
 	'tenant.featureOrganizations',
 	'tenant.featureOrganizations.feature',
@@ -44,8 +46,59 @@ type CurrentUserFeatureContext = {
 	organizationFeatureOrganizations: IFeatureOrganization[]
 }
 
+export type CurrentUserRelationSelect = FindOptionsSelect<User>
+export type CurrentUserFindOptions = {
+	select?: CurrentUserRelationSelect
+	currentOrganizationId?: string | null
+	limitOrganizations?: boolean
+}
+
+type CurrentUserOrganizationSelect = FindManyOptions<UserOrganization>['select']
+type CurrentUserOrganizationWhere = FindOptionsWhere<UserOrganization>
+
 function resolveCurrentUserRelations(relations?: string[]) {
 	return Array.from(new Set([...CURRENT_USER_CORE_RELATIONS, ...(relations ?? [])]))
+}
+
+function isCurrentUserOrganizationRelation(relation: string) {
+	return relation === 'organizations' || relation.startsWith('organizations.')
+}
+
+function shouldLimitCurrentUserOrganizations(relations?: string[], options?: CurrentUserFindOptions) {
+	if (!options?.limitOrganizations) {
+		return false
+	}
+
+	const organizationRelations = (relations ?? []).filter(isCurrentUserOrganizationRelation)
+	return (
+		organizationRelations.length > 0 &&
+		organizationRelations.every((relation) => CURRENT_USER_LIMITABLE_ORGANIZATION_RELATIONS.has(relation))
+	)
+}
+
+function resolveBaseCurrentUserRelations(relations?: string[]) {
+	return (relations ?? []).filter((relation) => !isCurrentUserOrganizationRelation(relation))
+}
+
+function splitCurrentUserSelect(select?: CurrentUserRelationSelect) {
+	if (!select) {
+		return {
+			baseSelect: undefined,
+			organizationSelect: undefined
+		}
+	}
+
+	const baseSelect = { ...select }
+	const organizationSelect = baseSelect.organizations
+	delete baseSelect.organizations
+
+	return {
+		baseSelect: Object.keys(baseSelect).length ? baseSelect : undefined,
+		organizationSelect:
+			organizationSelect && typeof organizationSelect === 'object' && !Array.isArray(organizationSelect)
+				? (organizationSelect as CurrentUserOrganizationSelect)
+				: undefined
+	}
 }
 
 function isKnownCurrentUserFeatureHydrationRelations(relations?: string[]) {
@@ -87,14 +140,84 @@ export class UserService extends TenantAwareCrudService<User> {
 		super(userRepository)
 	}
 
-	async findCurrentUser(id: string, relations?: string[]): Promise<User> {
+	async findCurrentUser(id: string, relations?: string[], options?: CurrentUserFindOptions): Promise<User> {
 		if (isKnownCurrentUserFeatureHydrationRelations(relations) && this.featureOrganizationRepository) {
 			return this.findCurrentUserFeatureContext(id, relations ?? [])
 		}
 
+		if (shouldLimitCurrentUserOrganizations(relations, options)) {
+			return this.findCurrentUserWithLimitedOrganizations(id, relations, options)
+		}
+
 		return this.findOne(id, {
-			relations: resolveCurrentUserRelations(relations)
+			relations: resolveCurrentUserRelations(relations),
+			...(options?.select ? { select: options.select } : {})
 		})
+	}
+
+	private async findCurrentUserWithLimitedOrganizations(
+		id: string,
+		relations?: string[],
+		options?: CurrentUserFindOptions
+	) {
+		const { baseSelect, organizationSelect } = splitCurrentUserSelect(options?.select)
+		const user = await this.findOne(id, {
+			relations: resolveCurrentUserRelations(resolveBaseCurrentUserRelations(relations)),
+			...(baseSelect ? { select: baseSelect } : {})
+		})
+		user.organizations = await this.findCurrentUserBootstrapOrganizations(
+			user,
+			id,
+			options?.currentOrganizationId,
+			organizationSelect
+		)
+		return user
+	}
+
+	private async findCurrentUserBootstrapOrganizations(
+		user: User,
+		userId: string,
+		currentOrganizationId?: string | null,
+		select?: CurrentUserOrganizationSelect
+	) {
+		const tenantId = RequestContext.currentTenantId() ?? user.tenantId ?? user.tenant?.id
+		const baseWhere = {
+			userId,
+			...(tenantId ? { tenantId } : {}),
+			isActive: true
+		}
+		const order: FindManyOptions<UserOrganization>['order'] = { id: 'ASC' }
+		const organizationQuery = async (where: CurrentUserOrganizationWhere) => {
+			const { items } = await this.userOrganizationService.findAll({
+				where: {
+					...where,
+					organization: { isActive: true }
+				},
+				relations: ['organization'],
+				...(select ? { select } : {}),
+				order,
+				take: 1
+			})
+
+			return items[0] ?? null
+		}
+
+		const preferredMembership = currentOrganizationId
+			? await organizationQuery({
+					...baseWhere,
+					organizationId: currentOrganizationId
+			  })
+			: null
+
+		const membership =
+			preferredMembership ??
+			(await organizationQuery({
+				...baseWhere,
+				isDefault: true
+			})) ??
+			(await organizationQuery(baseWhere))
+
+		return membership ? [membership] : []
 	}
 
 	private async findCurrentUserFeatureContext(id: string, relations: string[]) {


### PR DESCRIPTION
## Summary
Optimizes the current-user bootstrap load by limiting the heavy organizations relation to the current/default active organization and moving full organization membership loading to the organization selector menu.

## Problem
`/api/user/me` supports dynamic relations. When the bootstrap path requested `organizations` and `organizations.organization`, users with many organization memberships paid for loading every membership and organization before first render.

## Fix
- Added optional `/user/me` select/options support while preserving existing no-select and dynamic relation behavior.
- Limited only the bootstrap organizations relation when `limitOrganizations` is explicit and the relation set is safe to limit.
- Added lightweight current-user select presets for app bootstrap and organization lazy loading.
- Lazy-loads full organizations when the organization selector opens and refreshes feature hydration when needed so organization feature menus remain correct.

## Validation
- `git diff --check`
- `pnpm jest --config packages/server/jest.config.ts packages/server/src/user/user.service.spec.ts --runInBand`
- `pnpm nx build cloud --skip-nx-cache` failed only at Angular external font inlining because Google Fonts TLS verification hit `unable to get local issuer certificate` locally.
- `NODE_TLS_REJECT_UNAUTHORIZED=0 pnpm nx build cloud --skip-nx-cache`