### PR TITLE
fix: hide builtin middleware from picker

### DIFF
--- a/apps/cloud/src/app/features/xpert/studio/components/context-menu/context-menu.component.ts
+++ b/apps/cloud/src/app/features/xpert/studio/components/context-menu/context-menu.component.ts
@@ -73,6 +73,7 @@ import {
   genXpertSkillKey,
   IWFNMiddleware,
   genXpertMiddlewareKey,
+  isUserAddableAgentMiddleware,
   injectXpertAgentAPI,
   TAgentMiddlewareMeta,
   TXpertTeamNode,
@@ -187,6 +188,9 @@ export class XpertStudioContextMenuComponent {
     () =>
       this.agentMiddlewares()?.filter((middleware) => {
         const term = this.#searchMiddlewaresTerm()?.toLowerCase().trim()
+        if (!isUserAddableAgentMiddleware(middleware.meta)) {
+          return false
+        }
         return term
           ? middleware.meta.name.toLowerCase().includes(term) ||
               this.i18n.transform(middleware.meta.label).toLowerCase().includes(term)
@@ -274,7 +278,10 @@ export class XpertStudioContextMenuComponent {
   }
 
   middlewareRemainingConfigCount(middleware: { meta: TAgentMiddlewareMeta } | null | undefined) {
-    return Math.max(0, this.middlewareConfigEntries(middleware).length - this.middlewareConfigPreview(middleware).length)
+    return Math.max(
+      0,
+      this.middlewareConfigEntries(middleware).length - this.middlewareConfigPreview(middleware).length
+    )
   }
 
   createAgent(menu: CdkMenu, byNode: TXpertTeamNode) {

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.spec.ts
@@ -971,6 +971,42 @@ describe('XpertNewBlankComponent', () => {
     expect(component.middlewareProviderOptions().map((provider) => provider.meta.name)).toEqual(['guard'])
   })
 
+  it('hides builtin middleware from the middleware picker options', async () => {
+    const { component } = await createComponent(
+      {
+        type: XpertTypeEnum.Agent
+      },
+      {
+        middlewareProviders: [
+          {
+            meta: {
+              name: 'guard',
+              label: {
+                en_US: 'Guard'
+              }
+            }
+          },
+          {
+            meta: {
+              name: 'FileUnderstandingMiddleware',
+              label: {
+                en_US: 'File Understanding'
+              },
+              builtin: true
+            }
+          }
+        ]
+      }
+    )
+
+    component.selectedMiddlewares.set(['FileUnderstandingMiddleware', 'legacy-middleware'])
+
+    expect(component.middlewareProviderOptions().map((provider) => provider.meta.name)).toEqual([
+      'guard',
+      'legacy-middleware'
+    ])
+  })
+
   it('auto-enables required middleware features when creating a blank xpert', async () => {
     const createdXpert = createAgentXpert('created-xpert')
     const { component, fixture, xpertService } = await createComponent(

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.ts
@@ -23,6 +23,7 @@ import {
   I18nObject,
   getErrorMessage,
   ICopilotModel,
+  isUserAddableAgentMiddleware,
   ISkillPackage,
   ISkillRepositoryIndex,
   IXpert,
@@ -148,8 +149,7 @@ export const BLANK_XPERT_DIALOG_CATEGORY = {
   CLAW: 'claw'
 } as const
 
-export type BlankXpertDialogCategory =
-  (typeof BLANK_XPERT_DIALOG_CATEGORY)[keyof typeof BLANK_XPERT_DIALOG_CATEGORY]
+export type BlankXpertDialogCategory = (typeof BLANK_XPERT_DIALOG_CATEGORY)[keyof typeof BLANK_XPERT_DIALOG_CATEGORY]
 
 export function normalizeBlankXpertDialogCategory(
   category: string | null | undefined
@@ -425,15 +425,24 @@ export class XpertNewBlankComponent {
     )
   )
   readonly middlewareProviderOptions = computed<BlankMiddlewareProviderOption[]>(() => {
-    const availableProviders = uniqueByName<BlankMiddlewareProviderOption>(
+    const runtimeProviders = uniqueByName<BlankMiddlewareProviderOption>(
       this.middlewareProviders().map(({ meta }) => ({ meta })),
       (provider) => provider.meta.name
     ).filter((provider) => provider.meta.name !== BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER)
+    const builtinProviderNames = new Set(
+      runtimeProviders
+        .filter((provider) => !isUserAddableAgentMiddleware(provider.meta))
+        .map((provider) => provider.meta.name)
+    )
+    const availableProviders = runtimeProviders.filter((provider) => isUserAddableAgentMiddleware(provider.meta))
     const availableNames = new Set(availableProviders.map((provider) => provider.meta.name))
     const unavailableTemplateSelections = this.selectedMiddlewares()
       .filter(
         (provider) =>
-          !!provider && provider !== BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER && !availableNames.has(provider)
+          !!provider &&
+          provider !== BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER &&
+          !availableNames.has(provider) &&
+          !builtinProviderNames.has(provider)
       )
       .map((provider) => ({
         meta: {
@@ -849,7 +858,10 @@ export class XpertNewBlankComponent {
     }
 
     const primaryAgentPrompt = this.buildInitialPrimaryAgentPrompt()
-    const nextDraft = this.withInitialPrimaryAgentPromptInDraft(this.buildTemplateImportDraft(draft), primaryAgentPrompt)
+    const nextDraft = this.withInitialPrimaryAgentPromptInDraft(
+      this.buildTemplateImportDraft(draft),
+      primaryAgentPrompt
+    )
     const xpert = await firstValueFrom(this.xpertService.importDSL(nextDraft))
     const hydratedXpert = this.withInitialPrimaryAgentPrompt(xpert, primaryAgentPrompt)
     const preparedXpert = await this.provisionKnowledgebaseIfNeeded(hydratedXpert)
@@ -974,7 +986,11 @@ export class XpertNewBlankComponent {
       const skillPackage = await firstValueFrom(
         this.#skillPackageService.installPackage(workspaceId, item.id).pipe(take(1))
       )
-      if (!this.usesWorkspaceSkillDefaults() && item.repository?.provider === WORKSPACE_PUBLIC_SKILL_SOURCE_PROVIDER && item.repositoryId) {
+      if (
+        !this.usesWorkspaceSkillDefaults() &&
+        item.repository?.provider === WORKSPACE_PUBLIC_SKILL_SOURCE_PROVIDER &&
+        item.repositoryId
+      ) {
         const repositoryDefault = this.selectedRepositoryDefault()
         const disabledSkillIds =
           repositoryDefault?.repositoryId === item.repositoryId
@@ -1058,7 +1074,8 @@ export class XpertNewBlankComponent {
   }
 
   private buildTemplateImportDraft(draft: TXpertTeamDraft) {
-    const selectedCopilotModel = this.copilotModel() ?? draft.team.agent?.copilotModel ?? draft.team.copilotModel ?? null
+    const selectedCopilotModel =
+      this.copilotModel() ?? draft.team.agent?.copilotModel ?? draft.team.copilotModel ?? null
     const finalDraft = this.isAgentType()
       ? applyAgentTemplateWizardState(draft, this.getSelections(), {
           defaultCopilotModel: selectedCopilotModel,

--- a/packages/contracts/src/ai/middleware.model.spec.ts
+++ b/packages/contracts/src/ai/middleware.model.spec.ts
@@ -4,6 +4,7 @@ import {
   IWFNMiddleware,
   LEGACY_SANDBOX_COMPRESSION_MIDDLEWARE_NAME,
   isRequiredMiddleware,
+  isUserAddableAgentMiddleware,
   normalizeMiddlewareNode,
   normalizeMiddlewareNodes,
   normalizeMiddlewareProvider
@@ -15,9 +16,7 @@ describe('middleware model helpers', () => {
     expect(normalizeMiddlewareProvider(LEGACY_SANDBOX_COMPRESSION_MIDDLEWARE_NAME)).toBe(
       CONTEXT_COMPRESSION_MIDDLEWARE_NAME
     )
-    expect(normalizeMiddlewareProvider(CONTEXT_COMPRESSION_MIDDLEWARE_NAME)).toBe(
-      CONTEXT_COMPRESSION_MIDDLEWARE_NAME
-    )
+    expect(normalizeMiddlewareProvider(CONTEXT_COMPRESSION_MIDDLEWARE_NAME)).toBe(CONTEXT_COMPRESSION_MIDDLEWARE_NAME)
     expect(normalizeMiddlewareProvider(undefined)).toBe('')
   })
 
@@ -48,5 +47,12 @@ describe('middleware model helpers', () => {
     expect(isRequiredMiddleware({ required: false })).toBe(false)
     expect(isRequiredMiddleware({})).toBe(false)
     expect(isRequiredMiddleware(null)).toBe(false)
+  })
+
+  it('treats builtin middleware strategies as not user addable', () => {
+    expect(isUserAddableAgentMiddleware({ builtin: true })).toBe(false)
+    expect(isUserAddableAgentMiddleware({ builtin: false })).toBe(true)
+    expect(isUserAddableAgentMiddleware({})).toBe(true)
+    expect(isUserAddableAgentMiddleware(null)).toBe(true)
   })
 })

--- a/packages/contracts/src/ai/middleware.model.ts
+++ b/packages/contracts/src/ai/middleware.model.ts
@@ -77,6 +77,11 @@ export type TAgentMiddlewareMeta = {
   configSchema?: JsonSchemaObjectType
   features?: Array<TXpertFeatureKey | string>
   slashCommands?: SkillSlashCommand[]
+  builtin?: boolean
+}
+
+export function isUserAddableAgentMiddleware(meta?: Pick<TAgentMiddlewareMeta, 'builtin'> | null) {
+  return meta?.builtin !== true
 }
 
 const normalizeNodeKey = (key: string) => key?.split('/')?.[0]

--- a/packages/server-ai/src/file-understanding/middlewares/file-understanding.middleware.spec.ts
+++ b/packages/server-ai/src/file-understanding/middlewares/file-understanding.middleware.spec.ts
@@ -32,10 +32,10 @@ describe('FileUnderstandingMiddleware', () => {
         const queryBus = {
             execute: jest.fn()
         }
-        const middleware = await Promise.resolve(
-            new FileUnderstandingMiddleware(queryBus as any).createMiddleware(undefined, createContext())
-        )
+        const strategy = new FileUnderstandingMiddleware(queryBus as any)
+        const middleware = await Promise.resolve(strategy.createMiddleware(undefined, createContext()))
 
+        expect(strategy.meta.builtin).toBe(true)
         expect(middleware.name).toBe(FILE_UNDERSTANDING_MIDDLEWARE_NAME)
         expect(middleware.tools?.map((item) => item.name)).toEqual([
             'file_search',

--- a/packages/server-ai/src/file-understanding/middlewares/file-understanding.middleware.ts
+++ b/packages/server-ai/src/file-understanding/middlewares/file-understanding.middleware.ts
@@ -34,6 +34,7 @@ export class FileUnderstandingMiddleware implements IAgentMiddlewareStrategy<Fil
             en_US: 'Built-in tools for searching, reading, previewing, and citing parsed conversation files.',
             zh_Hans: '内置的会话文件检索、读取、预览和引用工具。'
         },
+        builtin: true,
         icon: {
             type: 'svg',
             value: '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 2h9l5 5v15H6V2Zm8 1.5V8h4.5L14 3.5ZM8 12h8v1.5H8V12Zm0 3h8v1.5H8V15Zm0 3h5v1.5H8V18Z"/></svg>',


### PR DESCRIPTION
## Summary

- add a `builtin` middleware metadata flag and shared helper for user-addable middleware checks
- mark `FileUnderstandingMiddleware` as builtin
- hide builtin middleware from the studio context menu and blank xpert middleware picker

## Root cause

`FileUnderstandingMiddleware` is already mounted by runtime as a required internal middleware, but the same provider was still exposed in user-facing middleware pickers. Manually adding it could create duplicate tool nodes such as `file_search`.

## Validation

- `pnpm nx test contracts --testFile=packages/contracts/src/ai/middleware.model.spec.ts --runInBand --skip-nx-cache`
- `pnpm nx test server-ai --testFile=packages/server-ai/src/file-understanding/middlewares/file-understanding.middleware.spec.ts --runInBand --skip-nx-cache`
- `pnpm nx test cloud --testFile=apps/cloud/src/app/features/xpert/xpert/blank/blank.component.spec.ts --runInBand --skip-nx-cache`
- `pnpm exec tsc -p apps/cloud/tsconfig.app.json --noEmit`
- commit hook `format:fix` and staged hardcoded color / TypeORM column checks