### PR TITLE
[codex] Show organization menu loading state

### DIFF
--- a/apps/cloud/src/app/@theme/header/organization-selector/organization-selector.component.html
+++ b/apps/cloud/src/app/@theme/header/organization-selector/organization-selector.component.html
@@ -3,11 +3,7 @@
   class="w-full mx-2 rounded-lg border border-divider-regular bg-components-card-bg/70 p-2 transition-colors hover:bg-hover-bg"
   [class.cursor-pointer]="canOpenMenu()"
   [class.cursor-default]="!canOpenMenu()"
-  [zTooltip]="
-    ('PAC.Scope.Switch' | translate: { Default: 'Switch scope' }) +
-    ': ' +
-    scopeLabel()
-  "
+  [zTooltip]="('PAC.Scope.Switch' | translate: { Default: 'Switch scope' }) + ': ' + scopeLabel()"
   zPosition="right"
   [zDisabled]="!isCollapsed()"
   [cdkMenuTriggerFor]="canOpenMenu() ? menu : null"
@@ -16,7 +12,9 @@
 >
   <div class="flex items-center gap-2">
     @if (isTenantScope()) {
-      <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-primary-100 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300">
+      <div
+        class="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-primary-100 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300"
+      >
         <i class="ri-building-4-line text-base"></i>
       </div>
     } @else if (currentOrganization()) {
@@ -46,13 +44,24 @@
       <ngm-search class="w-full mb-1 rounded-lg overflow-hidden" [(ngModel)]="searchTerm" />
     </div>
 
+    @if (organizationsLoading()) {
+      <div class="flex items-center gap-2 px-3 py-2 text-sm text-text-secondary" role="status" aria-live="polite">
+        <i class="ri-loader-4-line shrink-0 animate-spin text-base text-text-tertiary"></i>
+        <span class="truncate">
+          {{ 'PAC.Organization.Loading' | translate: { Default: 'Loading organizations...' } }}
+        </span>
+      </div>
+    }
+
     @if (showTenantScopeItem()) {
       <div class="px-3 pb-1 pt-2 text-[10px] uppercase tracking-[0.24em] text-text-tertiary">
         {{ 'PAC.Scope.TenantSection' | translate: { Default: 'Tenant Console' } }}
       </div>
       <div cdkMenuItem [class.active]="isTenantScope()" (click)="selectTenantScope()">
         <div class="flex items-start gap-3 overflow-hidden">
-          <div class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-primary-100 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300">
+          <div
+            class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-primary-100 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300"
+          >
             <i class="ri-building-4-line text-base"></i>
           </div>
           <div class="min-w-0">
@@ -60,7 +69,10 @@
               {{ 'PAC.Scope.TenantLabel' | translate: { Default: 'Tenant defaults and governance' } }}
             </div>
             <div class="truncate text-xs text-text-secondary">
-              {{ 'PAC.Scope.TenantHint' | translate: { Default: 'Manage tenant-wide defaults, organizations, and inherited configuration.' } }}
+              {{
+                'PAC.Scope.TenantHint'
+                  | translate: { Default: 'Manage tenant-wide defaults, organizations, and inherited configuration.' }
+              }}
             </div>
           </div>
         </div>

--- a/apps/cloud/src/app/@theme/header/organization-selector/organization-selector.component.spec.ts
+++ b/apps/cloud/src/app/@theme/header/organization-selector/organization-selector.component.spec.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('OrganizationSelectorComponent template', () => {
+  it('shows organization loading feedback while the menu data request is pending', () => {
+    const template = readFileSync(join(__dirname, 'organization-selector.component.html'), 'utf8')
+
+    expect(template).toContain('@if (organizationsLoading())')
+    expect(template).toContain('PAC.Organization.Loading')
+    expect(template).toContain('ri-loader-4-line')
+  })
+})

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -134,6 +134,7 @@
       "RegistryTenantHelp": "Tenant scope shows every organization in the tenant. Pick a row to open its details workspace.",
       "RegistryOrganizationHelp": "Organization scope is narrowed to the current organization so you can review its details in place.",
       "LoadFailed": "Unable to load organizations",
+      "Loading": "Loading organizations...",
       "EmptyStateTitle": "No organizations available",
       "EmptyStateDescription": "There is no organization in the current scope yet. Add one from tenant scope or switch to an organization context first.",
       "TabGeneral": "General",

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -1290,6 +1290,7 @@
       "MembersHint": "管理当前组织内用户的成员状态、默认组织和组织级访问关系。",
       "MemberAdded": "成员添加成功",
       "NoMembers": "当前组织暂无成员。",
+      "Loading": "正在加载组织...",
       "EmptySearch": "没有匹配的组织。"
     },
     "Role": {

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -2611,6 +2611,7 @@
       "MembersHint": "管理当前组织内用户的成员状态、默认组织和组织级访问关系。",
       "MemberAdded": "成员添加成功",
       "NoMembers": "当前组织暂无成员。",
+      "Loading": "正在加载组织...",
       "EmptySearch": "没有匹配的组织。"
     },
     "Role": {

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -1969,6 +1969,7 @@
       "MembersHint": "管理目前組織內用戶的成員狀態、默認組織與組織級訪問關係。",
       "MemberAdded": "成員新增成功",
       "NoMembers": "目前組織暫無成員。",
+      "Loading": "正在載入組織...",
       "EmptySearch": "沒有匹配的組織。"
     },
     "Role": {


### PR DESCRIPTION
## Summary

- Show an inline loading state while the organization selector menu is fetching the full organization list.
- Add localized loading copy for English, Simplified Chinese, and Traditional Chinese assets.
- Add a focused template regression test that checks the menu consumes `organizationsLoading()`.

## Root cause

`OrganizationSelectorComponent` already tracked the pending request with `organizationsLoading`, but the menu template did not render that state. During the full organization load, users saw the existing menu content without feedback and could mistake the delay for a frozen page or an empty organization list.

## Validation

- `pnpm jest --config apps/cloud/jest.config.ts apps/cloud/src/app/@theme/header/organization-selector/organization-selector.component.spec.ts --runInBand`
- `git diff --check`
- `pnpm nx build cloud --skip-nx-cache`

The full cloud build passed with existing bundle budget and CommonJS warnings.