### PR TITLE
feat: add copilot user usage summaries

### DIFF
--- a/apps/cloud/src/app/@core/services/copilot-usage.service.ts
+++ b/apps/cloud/src/app/@core/services/copilot-usage.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http'
 import { inject, Injectable } from '@angular/core'
 import { PaginationParams, toHttpParams } from '@xpert-ai/cloud/state'
-import { ICopilotOrganization, ICopilotUser, OrderTypeEnum } from '@xpert-ai/contracts'
+import { ICopilotOrganization, ICopilotUser, ICopilotUserUsageSummary, OrderTypeEnum } from '@xpert-ai/contracts'
 import { NGXLogger } from 'ngx-logger'
 import { map } from 'rxjs'
 import { API_COPILOT_ORGANIZATION, API_COPILOT_USER } from '../constants/app.constants'
@@ -36,11 +36,33 @@ export class CopilotUsageService {
       })
   }
 
+  getUserUsageSummaries(options: PaginationParams<ICopilotUserUsageSummary>) {
+    return this.httpClient.get<{ items: ICopilotUserUsageSummary[]; total?: number }>(API_COPILOT_USER + '/summary', {
+      params: toHttpParams({
+        ...options,
+        order: {
+          updatedAt: OrderTypeEnum.DESC
+        }
+      })
+    })
+  }
+
+  getUserUsageDetails(item: ICopilotUserUsageSummary) {
+    return this.httpClient.post<ICopilotUser[]>(API_COPILOT_USER + '/summary/details', item.groupKey)
+  }
+
   renewOrgLimit(id: string, tokenLimit: number, priceLimit: number) {
     return this.httpClient.post<ICopilotOrganization>(API_COPILOT_ORGANIZATION + `/${id}/renew`, { tokenLimit, priceLimit })
   }
 
   renewUserLimit(id: string, tokenLimit: number, priceLimit: number) {
     return this.httpClient.post<ICopilotUser>(API_COPILOT_USER + `/${id}/renew`, { tokenLimit, priceLimit })
+  }
+
+  renewUserUsageSummary(item: ICopilotUserUsageSummary, tokenLimit: number) {
+    return this.httpClient.post<ICopilotUserUsageSummary>(API_COPILOT_USER + '/summary/renew', {
+      ...item.groupKey,
+      tokenLimit
+    })
   }
 }

--- a/apps/cloud/src/app/features/setting/copilot/users/users.component.html
+++ b/apps/cloud/src/app/features/setting/copilot/users/users.component.html
@@ -1,148 +1,295 @@
-<div class="w-full relative overflow-auto flex-1" waIntersectionObserver waIntersectionThreshold="0.5">
-  <table class="table-fixed w-full text-sm text-left rtl:text-right text-text-tertiary dark:text-text-quaternary">
-    <thead class="text-sm text-text-secondary uppercase bg-background-default-subtle dark:bg-gray-700 dark:text-text-quaternary">
-      <tr>
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-64 truncate">
-          {{ 'PAC.KEY_WORDS.User' | translate: { Default: 'User' } }}
-        </th>
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-64">
-          {{ 'PAC.KEY_WORDS.Organization' | translate: { Default: 'Organization' } }}
-        </th>
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-48">
-          {{ 'PAC.KEY_WORDS.Provider' | translate: { Default: 'Provider' } }}
-        </th>
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-48 truncate">
-          {{ 'PAC.Copilot.Model' | translate: { Default: 'Model' } }}
-        </th>
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-32">
-          {{ 'PAC.KEY_WORDS.TokenUsed' | translate: { Default: 'Token Used' } }}
-        </th>
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-32">
-          {{ 'PAC.KEY_WORDS.TokenLimit' | translate: { Default: 'Token Limit' } }}
-        </th>
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-[180px]">
-          {{ 'PAC.KEY_WORDS.TokenTotalUsed' | translate: { Default: 'Token Total Used' } }}
-        </th>
-
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-[180px]">
-          {{ 'PAC.Copilot.PriceUsed' | translate: { Default: 'Price Used' } }}
-        </th>
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-[180px]">
-          {{ 'PAC.Copilot.PriceLimit' | translate: { Default: 'Price Limit' } }}
-        </th>
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-[180px]">
-          {{ 'PAC.Copilot.PriceTotalUsed' | translate: { Default: 'Price Total Used' } }}
-        </th>
-
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-32">
-          {{ 'PAC.KEY_WORDS.Currency' | translate: { Default: 'Currency' } }}
-        </th>
-        <th scope="col" class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-[180px]">
-          {{ 'PAC.Copilot.LastUsed' | translate: { Default: 'Last Used' } }}
-        </th>
-        <th
-          scope="col"
-          class="sticky top-0 right-0 whitespace-nowrap z-10 border-l border-solid border-divider-regular bg-background-default-subtle p-3 w-[240px]"
-        >
-          {{ 'PAC.KEY_WORDS.ACTION' | translate: { Default: 'Action' } }}
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      @for (item of usages(); track item.id) {
-        <tr class="row cursor-pointer bg-components-card-bg border-b border-divider-regular">
-          <td class="px-4 py-2 whitespace-nowrap truncate">
-            @if (item.user) {
-              <pac-user-profile-inline [user]="item.user" small />
-            }
-          </td>
-          <td class="px-4 py-2">
-            @if (item.organization) {
-              <div class="flex justify-start items-center overflow-hidden text-ellipsis">
-                <pac-org-avatar
-                  [organization]="item.organization"
-                  class="shrink-0 w-6 h-6 rounded-full overflow-hidden block mr-2"
-                />
-                <span class="whitespace-nowrap" [title]="item.organization.name">{{ item.organization.name }}</span>
-              </div>
-            }
-          </td>
-          <td class="px-4 py-2">{{ item.provider }}</td>
-          <td class="px-4 py-2">{{ item.model }}</td>
-          <td class="px-4 py-2">{{ item.tokenUsed | number: '0.0-0' }}</td>
-          <td class="px-4 py-2">{{ item.tokenLimit | number: '0.0-0' }}</td>
-          <td class="px-4 py-2">{{ item.tokenTotalUsed | number: '0.0-0' }}</td>
-
-          <td class="px-4 py-2">{{ item.priceUsed | number: '0.0-7' }}</td>
-          <td class="px-4 py-2">{{ item.priceLimit | number: '0.0-7' }}</td>
-          <td class="px-4 py-2">{{ item.priceTotalUsed | number: '0.0-7' }}</td>
-
-          <td class="px-4 py-2">{{ item.currency }}</td>
-          <td class="px-4 py-2">{{ item.updatedAt | relative }}</td>
-          <td class="px-4 py-2 sticky right-0 border-l border-solid border-divider-regular bg-background-default-subtle">
-            <div class="flex items-center gap-2" displayDensity="compact">
-              @if (editId() === item.id) {
-                <ngm-input
-                  type="number"
-                  simple
-                  [placeholder]="'PAC.Copilot.TokenLimit' | translate: { Default: 'Token Limit' }"
-                  [disabled]="loading()"
-                  [(ngModel)]="tokenLimit"
-                />
-                <ngm-input
-                  type="number"
-                  simple
-                  [placeholder]="'PAC.Copilot.PriceLimit' | translate: { Default: 'Price Limit' }"
-                  [disabled]="loading()"
-                  [(ngModel)]="priceLimit"
-                />
-                <button
-                  z-button
-                  zType="ghost"
-                  zSize="icon"
-                  zShape="circle"
-                  class="text-text-quaternary"
-                  [disabled]="loading()"
-                  [zTooltip]="'PAC.ChatBI.Save' | translate: { Default: 'Save' }"
-                  (click)="save(item.id)"
-                >
-                  <z-icon zType="save"></z-icon>
-                </button>
-              } @else {
-                <button
-                  z-button
-                  zType="ghost"
-                  zSize="icon"
-                  zShape="circle"
-                  class="text-text-quaternary"
-                  [disabled]="loading()"
-                  [zTooltip]="'PAC.ChatBI.RenewTokenLimit' | translate: { Default: 'Renew token limit' }"
-                  (click)="renewToken(item.id)"
-                >
-                  <z-icon zType="autorenew"></z-icon>
-                </button>
-              }
-            </div>
-          </td>
-        </tr>
-      }
-    </tbody>
-  </table>
-
-  @if (loading()) {
-    <div class="flex justify-center">
-      <ngm-spin />
-    </div>
-  }
-
-  @if (!done()) {
-    <button
-      (waIntersectionObservee)="onIntersection()"
-      class="w-full flex justify-center p-2 cursor-pointer hover:bg-hover-bg"
-      [disabled]="loading()"
-      (click)="onIntersection()"
+<div class="w-full relative flex-1 overflow-hidden px-4 py-3">
+  <div class="w-full h-full overflow-auto" waIntersectionObserver waIntersectionThreshold="0.5">
+    <table
+      z-table
+      zSize="compact"
+      class="table-fixed w-full text-sm text-left rtl:text-right text-text-tertiary dark:text-text-quaternary"
     >
-      <i class="ri-arrow-down-wide-line"></i>
-    </button>
-  }
+      <thead
+        z-table-header
+        class="text-sm text-text-secondary uppercase bg-background-default-subtle dark:text-text-quaternary"
+      >
+        <tr z-table-row>
+          <th
+            z-table-head
+            scope="col"
+            class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-64 truncate"
+          >
+            {{ 'PAC.KEY_WORDS.User' | translate: { Default: 'User' } }}
+          </th>
+          <th
+            z-table-head
+            scope="col"
+            class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-64"
+          >
+            {{ 'PAC.KEY_WORDS.Organization' | translate: { Default: 'Organization' } }}
+          </th>
+          <th
+            z-table-head
+            scope="col"
+            class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-48"
+          >
+            {{ 'PAC.KEY_WORDS.Provider' | translate: { Default: 'Provider' } }}
+          </th>
+          <th
+            z-table-head
+            scope="col"
+            class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-48 truncate"
+          >
+            {{ 'PAC.Copilot.Model' | translate: { Default: 'Model' } }}
+          </th>
+          <th
+            z-table-head
+            scope="col"
+            class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-32"
+          >
+            {{ 'PAC.KEY_WORDS.TokenUsed' | translate: { Default: 'Token Used' } }}
+          </th>
+          <th
+            z-table-head
+            scope="col"
+            class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-32"
+          >
+            {{ 'PAC.KEY_WORDS.TokenLimit' | translate: { Default: 'Token Limit' } }}
+          </th>
+          <th
+            z-table-head
+            scope="col"
+            class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-[180px]"
+          >
+            {{ 'PAC.KEY_WORDS.TokenTotalUsed' | translate: { Default: 'Token Total Used' } }}
+          </th>
+
+          <th
+            z-table-head
+            scope="col"
+            class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-[180px]"
+          >
+            {{ 'PAC.Copilot.PriceUsed' | translate: { Default: 'Price Used' } }}
+          </th>
+          <th
+            z-table-head
+            scope="col"
+            class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-[180px]"
+          >
+            {{ 'PAC.Copilot.PriceTotalUsed' | translate: { Default: 'Price Total Used' } }}
+          </th>
+
+          <th
+            z-table-head
+            scope="col"
+            class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-32"
+          >
+            {{ 'PAC.KEY_WORDS.Currency' | translate: { Default: 'Currency' } }}
+          </th>
+          <th
+            z-table-head
+            scope="col"
+            class="sticky top-0 whitespace-nowrap z-10 bg-background-default-subtle p-3 w-[180px]"
+          >
+            {{ 'PAC.Copilot.LastUsed' | translate: { Default: 'Last Used' } }}
+          </th>
+          <th
+            z-table-head
+            zTableStickyEnd
+            [zTableStickyEnd]="0"
+            [zTableStickyZIndex]="10"
+            scope="col"
+            class="sticky top-0 whitespace-nowrap border-l border-solid border-divider-regular bg-background-default-subtle p-3 w-[240px]"
+          >
+            {{ 'PAC.KEY_WORDS.ACTION' | translate: { Default: 'Action' } }}
+          </th>
+        </tr>
+      </thead>
+      <tbody z-table-body>
+        @for (item of usages(); track item.id) {
+          <tr
+            z-table-row
+            class="row cursor-pointer bg-components-card-bg border-b border-divider-regular"
+            (click)="toggleDetails(item)"
+          >
+            <td z-table-cell class="px-4 py-2 whitespace-nowrap truncate">
+              <div class="flex min-w-0 items-center gap-2">
+                <button
+                  z-button
+                  zType="ghost"
+                  zSize="icon"
+                  zShape="circle"
+                  class="shrink-0 text-text-quaternary"
+                  [zTooltip]="
+                    isExpanded(item)
+                      ? ('PAC.ACTIONS.Collapse' | translate: { Default: 'Collapse' })
+                      : ('PAC.ACTIONS.Expand' | translate: { Default: 'Expand' })
+                  "
+                  (click)="toggleDetails(item); $event.stopPropagation()"
+                >
+                  <z-icon [zType]="isExpanded(item) ? 'chevron-down' : 'chevron-right'"></z-icon>
+                </button>
+                @if (item.user) {
+                  <pac-user-profile-inline class="min-w-0" [user]="item.user" small />
+                }
+              </div>
+            </td>
+            <td z-table-cell class="px-4 py-2">
+              @if (item.org) {
+                <div class="flex justify-start items-center overflow-hidden text-ellipsis">
+                  <pac-org-avatar
+                    [organization]="item.org"
+                    class="shrink-0 w-6 h-6 rounded-full overflow-hidden block mr-2"
+                  />
+                  <span class="whitespace-nowrap" [title]="item.org.name">{{ item.org.name }}</span>
+                </div>
+              }
+            </td>
+            <td z-table-cell class="px-4 py-2">{{ item.provider }}</td>
+            <td z-table-cell class="px-4 py-2">{{ item.model }}</td>
+            <td z-table-cell class="px-4 py-2">{{ item.tokenUsed | number: '0.0-0' }}</td>
+            <td z-table-cell class="px-4 py-2">{{ item.tokenLimit | number: '0.0-0' }}</td>
+            <td z-table-cell class="px-4 py-2">{{ item.tokenTotalUsed | number: '0.0-0' }}</td>
+
+            <td z-table-cell class="px-4 py-2">{{ item.priceUsed | number: '0.0-7' }}</td>
+            <td z-table-cell class="px-4 py-2">{{ item.priceTotalUsed | number: '0.0-7' }}</td>
+
+            <td z-table-cell class="px-4 py-2">{{ item.currency }}</td>
+            <td z-table-cell class="px-4 py-2">{{ item.updatedAt | relative }}</td>
+            <td
+              z-table-cell
+              zTableStickyEnd
+              [zTableStickyEnd]="0"
+              [zTableStickyZIndex]="4"
+              class="px-4 py-2 border-l border-solid border-divider-regular bg-components-card-bg"
+            >
+              <div class="flex items-center gap-2" displayDensity="compact">
+                @if (editId() === item.id) {
+                  <input
+                    z-input
+                    type="number"
+                    zSize="sm"
+                    class="w-44"
+                    [placeholder]="'PAC.Copilot.TokenLimit' | translate: { Default: 'Token Limit' }"
+                    [disabled]="loading()"
+                    [ngModel]="tokenLimit()"
+                    (ngModelChange)="setTokenLimit($event)"
+                    (click)="$event.stopPropagation()"
+                  />
+                  <button
+                    z-button
+                    zType="ghost"
+                    zSize="icon"
+                    zShape="circle"
+                    class="text-text-quaternary"
+                    [disabled]="loading()"
+                    [zTooltip]="'PAC.ChatBI.Save' | translate: { Default: 'Save' }"
+                    (click)="save(item); $event.stopPropagation()"
+                  >
+                    <z-icon zType="save"></z-icon>
+                  </button>
+                } @else {
+                  <button
+                    z-button
+                    zType="ghost"
+                    zSize="icon"
+                    zShape="circle"
+                    class="text-text-quaternary"
+                    [disabled]="loading()"
+                    [zTooltip]="'PAC.ChatBI.RenewTokenLimit' | translate: { Default: 'Renew token limit' }"
+                    (click)="renewToken(item); $event.stopPropagation()"
+                  >
+                    <z-icon zType="autorenew"></z-icon>
+                  </button>
+                }
+              </div>
+            </td>
+          </tr>
+          @if (isExpanded(item)) {
+            <tr z-table-row class="bg-background-default-subtle border-b border-divider-regular">
+              <td z-table-cell colspan="12" class="p-0">
+                <div class="px-12 py-3">
+                  @if (isLoadingDetails(item)) {
+                    <div class="flex justify-center py-4">
+                      <ngm-spin />
+                    </div>
+                  } @else if (item.details?.length) {
+                    <table
+                      z-table
+                      zSize="compact"
+                      class="w-full table-fixed text-xs text-left text-text-tertiary dark:text-text-quaternary"
+                    >
+                      <thead z-table-header class="text-text-secondary">
+                        <tr z-table-row>
+                          <th z-table-head scope="col" class="px-3 py-2 w-64 truncate">
+                            {{ 'PAC.KEY_WORDS.Thread' | translate: { Default: 'Thread' } }}
+                          </th>
+                          <th z-table-head scope="col" class="px-3 py-2 w-48 truncate">
+                            {{ 'PAC.KEY_WORDS.Xpert' | translate: { Default: 'Xpert' } }}
+                          </th>
+                          <th z-table-head scope="col" class="px-3 py-2 w-40 truncate">
+                            {{ 'PAC.Copilot.UsageHour' | translate: { Default: 'Usage Hour' } }}
+                          </th>
+                          <th z-table-head scope="col" class="px-3 py-2 w-32">
+                            {{ 'PAC.KEY_WORDS.TokenUsed' | translate: { Default: 'Token Used' } }}
+                          </th>
+                          <th z-table-head scope="col" class="px-3 py-2 w-[180px]">
+                            {{ 'PAC.KEY_WORDS.TokenTotalUsed' | translate: { Default: 'Token Total Used' } }}
+                          </th>
+                          <th z-table-head scope="col" class="px-3 py-2 w-[180px]">
+                            {{ 'PAC.Copilot.PriceUsed' | translate: { Default: 'Price Used' } }}
+                          </th>
+                          <th z-table-head scope="col" class="px-3 py-2 w-[180px]">
+                            {{ 'PAC.Copilot.PriceTotalUsed' | translate: { Default: 'Price Total Used' } }}
+                          </th>
+                          <th z-table-head scope="col" class="px-3 py-2 w-[180px]">
+                            {{ 'PAC.Copilot.LastUsed' | translate: { Default: 'Last Used' } }}
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody z-table-body>
+                        @for (detail of item.details; track detail.id) {
+                          <tr z-table-row class="border-t border-divider-regular">
+                            <td z-table-cell class="px-3 py-2 truncate" [title]="detail.threadId">
+                              {{ detail.threadId || '-' }}
+                            </td>
+                            <td z-table-cell class="px-3 py-2 truncate" [title]="detail.xpertId">
+                              {{ detail.xpertId || '-' }}
+                            </td>
+                            <td z-table-cell class="px-3 py-2 truncate">{{ detail.usageHour || '-' }}</td>
+                            <td z-table-cell class="px-3 py-2">{{ detail.tokenUsed | number: '0.0-0' }}</td>
+                            <td z-table-cell class="px-3 py-2">{{ detail.tokenTotalUsed | number: '0.0-0' }}</td>
+                            <td z-table-cell class="px-3 py-2">{{ detail.priceUsed | number: '0.0-7' }}</td>
+                            <td z-table-cell class="px-3 py-2">{{ detail.priceTotalUsed | number: '0.0-7' }}</td>
+                            <td z-table-cell class="px-3 py-2">{{ detail.updatedAt | relative }}</td>
+                          </tr>
+                        }
+                      </tbody>
+                    </table>
+                  } @else {
+                    <div class="py-4 text-center text-text-quaternary">
+                      {{ 'PAC.Copilot.NoUsageDetails' | translate: { Default: 'No usage details' } }}
+                    </div>
+                  }
+                </div>
+              </td>
+            </tr>
+          }
+        }
+      </tbody>
+    </table>
+
+    @if (loading()) {
+      <div class="flex justify-center">
+        <ngm-spin />
+      </div>
+    }
+
+    @if (!done()) {
+      <button
+        (waIntersectionObservee)="onIntersection()"
+        class="w-full flex justify-center p-2 cursor-pointer hover:bg-hover-bg"
+        [disabled]="loading()"
+        (click)="onIntersection()"
+      >
+        <i class="ri-arrow-down-wide-line"></i>
+      </button>
+    }
+  </div>
 </div>

--- a/apps/cloud/src/app/features/setting/copilot/users/users.component.ts
+++ b/apps/cloud/src/app/features/setting/copilot/users/users.component.ts
@@ -14,12 +14,19 @@ import { switchMap, tap } from 'rxjs/operators'
 import {
   CopilotUsageService,
   DateRelativePipe,
-  ICopilotUser,
+  ICopilotUserUsageSummary,
   injectFormatRelative,
   OrderTypeEnum,
   ToastrService
 } from '../../../../@core'
-import { ZardButtonComponent, ZardDialogService, ZardIconComponent, ZardTooltipImports } from '@xpert-ai/headless-ui'
+import {
+  ZardButtonComponent,
+  ZardDialogService,
+  ZardIconComponent,
+  ZardInputDirective,
+  ZardTableImports,
+  ZardTooltipImports
+} from '@xpert-ai/headless-ui'
 @Component({
   standalone: true,
   selector: 'pac-settings-copilot-users',
@@ -35,6 +42,8 @@ import { ZardButtonComponent, ZardDialogService, ZardIconComponent, ZardTooltipI
     ZardButtonComponent,
     WaIntersectionObserver,
     NgmCommonModule,
+    ZardInputDirective,
+    ...ZardTableImports,
     OrgAvatarComponent,
     UserProfileInlineComponent,
     DateRelativePipe
@@ -52,11 +61,12 @@ export class CopilotUsersComponent {
   readonly formatRelative = injectFormatRelative()
   readonly locale = inject(LOCALE_ID)
 
-  readonly usages = signal<ICopilotUser[]>([])
+  readonly usages = signal<ICopilotUserUsageSummary[]>([])
+  readonly expandedIds = signal<Set<string>>(new Set())
+  readonly detailLoadingIds = signal<Set<string>>(new Set())
 
   readonly editId = signal<string | null>(null)
   readonly tokenLimit = model<number>(null)
-  readonly priceLimit = model<number>(null)
 
   readonly loading = signal(false)
   readonly pageSize = 20
@@ -67,17 +77,23 @@ export class CopilotUsersComponent {
     this.loadMore()
   }
 
-  renewToken(id: string) {
-    this.editId.set(id)
+  renewToken(item: ICopilotUserUsageSummary) {
+    this.tokenLimit.set(item.tokenLimit)
+    this.editId.set(this.usageId(item))
   }
 
-  save(id: string) {
+  setTokenLimit(value: string | number | null) {
+    this.tokenLimit.set(value === null || value === '' ? null : Number(value))
+  }
+
+  save(item: ICopilotUserUsageSummary) {
     this.loading.set(true)
-    this.usageService.renewUserLimit(id, this.tokenLimit(), this.priceLimit()).subscribe({
+    this.usageService.renewUserUsageSummary(item, this.tokenLimit()).subscribe({
       next: (result) => {
-        this.usages.update((records) => records.map((item) => (item.id === id ? { ...item, ...result } : item)))
+        this.usages.update((records) =>
+          records.map((record) => (this.usageId(record) === this.usageId(item) ? { ...record, ...result } : record))
+        )
         this.tokenLimit.set(null)
-        this.priceLimit.set(null)
         this.editId.set(null)
         this.loading.set(false)
       },
@@ -92,7 +108,7 @@ export class CopilotUsersComponent {
     return origin$.pipe(
       switchMap(() => {
         this.loading.set(true)
-        return this.usageService.getUserUsages({
+        return this.usageService.getUserUsageSummaries({
           order: { updatedAt: OrderTypeEnum.DESC },
           take: this.pageSize,
           skip: this.currentPage() * this.pageSize
@@ -113,6 +129,65 @@ export class CopilotUsersComponent {
       })
     )
   })
+
+  toggleDetails(item: ICopilotUserUsageSummary) {
+    const id = this.usageId(item)
+    const shouldExpand = !this.expandedIds().has(id)
+    this.expandedIds.update((state) => {
+      const next = new Set(state)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+
+    if (shouldExpand && item.details === undefined) {
+      this.loadDetails(item)
+    }
+  }
+
+  isExpanded(item: ICopilotUserUsageSummary) {
+    return this.expandedIds().has(this.usageId(item))
+  }
+
+  isLoadingDetails(item: ICopilotUserUsageSummary) {
+    return this.detailLoadingIds().has(this.usageId(item))
+  }
+
+  loadDetails(item: ICopilotUserUsageSummary) {
+    const id = this.usageId(item)
+    this.setDetailLoading(id, true)
+    this.usageService.getUserUsageDetails(item).subscribe({
+      next: (details) => {
+        this.usages.update((records) =>
+          records.map((record) => (this.usageId(record) === id ? { ...record, details } : record))
+        )
+        this.setDetailLoading(id, false)
+      },
+      error: (error) => {
+        this.setDetailLoading(id, false)
+        this._toastrService.error(error, 'Error')
+      }
+    })
+  }
+
+  usageId(item: ICopilotUserUsageSummary) {
+    return String(item.id)
+  }
+
+  private setDetailLoading(id: string, loading: boolean) {
+    this.detailLoadingIds.update((state) => {
+      const next = new Set(state)
+      if (loading) {
+        next.add(id)
+      } else {
+        next.delete(id)
+      }
+      return next
+    })
+  }
 
   onIntersection() {
     if (!this.loading() && !this.done()) {

--- a/packages/contracts/src/ai/copilot-user.model.ts
+++ b/packages/contracts/src/ai/copilot-user.model.ts
@@ -7,7 +7,7 @@ import { ICopilot, TCopilotTokenUsage } from './copilot.model'
 export const USAGE_HOUR_FORMAT = 'yyyy-MM-dd HH'
 
 /**
- * 
+ *
  */
 export interface ICopilotUser extends IBasePerTenantAndOrganizationEntityModel, TCopilotTokenUsage {
   orgId?: string
@@ -30,3 +30,30 @@ export interface ICopilotUser extends IBasePerTenantAndOrganizationEntityModel, 
   tokenTotalUsed?: number
   priceTotalUsed?: number
 }
+
+export interface ICopilotUserUsageGroupKey {
+  tenantId?: string
+  organizationId?: string
+  orgId?: string | null
+  userId?: string
+  provider?: AiProvider | string
+  model?: string
+  currency?: string | null
+}
+
+export interface ICopilotUserUsageSummary extends IBasePerTenantAndOrganizationEntityModel, TCopilotTokenUsage {
+  orgId?: string | null
+  org?: IOrganization
+  userId?: string
+  user?: IUser
+  provider?: AiProvider | string
+  model?: string
+  currency?: string | null
+  tokenTotalUsed?: number
+  priceTotalUsed?: number
+  groupKey: ICopilotUserUsageGroupKey
+  details?: ICopilotUser[]
+}
+
+export type TCopilotUserUsageSummaryRenewInput = ICopilotUserUsageGroupKey &
+  Pick<TCopilotTokenUsage, 'tokenLimit' | 'priceLimit'>

--- a/packages/contracts/src/ai/copilot-user.model.ts
+++ b/packages/contracts/src/ai/copilot-user.model.ts
@@ -7,7 +7,7 @@ import { ICopilot, TCopilotTokenUsage } from './copilot.model'
 export const USAGE_HOUR_FORMAT = 'yyyy-MM-dd HH'
 
 /**
- *
+ * 
  */
 export interface ICopilotUser extends IBasePerTenantAndOrganizationEntityModel, TCopilotTokenUsage {
   orgId?: string

--- a/packages/server-ai/src/copilot-user/copilot-user.controller.ts
+++ b/packages/server-ai/src/copilot-user/copilot-user.controller.ts
@@ -1,21 +1,21 @@
 import {
-    AIPermissionsEnum,
-    ICopilotUser,
-    ICopilotUserUsageGroupKey,
-    ICopilotUserUsageSummary,
-    IPagination,
-    TCopilotUserUsageSummaryRenewInput
+	AIPermissionsEnum,
+	ICopilotUser,
+	ICopilotUserUsageGroupKey,
+	ICopilotUserUsageSummary,
+	IPagination,
+	TCopilotUserUsageSummaryRenewInput
 } from '@xpert-ai/contracts'
 import {
-    CrudController,
-    OrganizationPublicDTO,
-    PaginationParams,
-    ParseJsonPipe,
-    PermissionGuard,
-    Permissions,
-    TransformInterceptor,
-    UserPublicDTO,
-    UseValidationPipe
+	CrudController,
+	OrganizationPublicDTO,
+	PaginationParams,
+	ParseJsonPipe,
+	PermissionGuard,
+	Permissions,
+	TransformInterceptor,
+	UserPublicDTO,
+	UseValidationPipe
 } from '@xpert-ai/server-core'
 import { Body, Controller, Get, Logger, Param, Post, Query, UseGuards, UseInterceptors } from '@nestjs/common'
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger'
@@ -28,73 +28,73 @@ import { PublicCopilotUserDto } from './dto/public-copilot-user'
 @UseInterceptors(TransformInterceptor)
 @Controller()
 export class CopilotUserController extends CrudController<CopilotUser> {
-    readonly #logger = new Logger(CopilotUserController.name)
+	readonly #logger = new Logger(CopilotUserController.name)
 
-    constructor(readonly service: CopilotUserService) {
-        super(service)
-    }
+	constructor(readonly service: CopilotUserService) {
+		super(service)
+	}
 
-    @UseGuards(PermissionGuard)
-    @Permissions(AIPermissionsEnum.COPILOT_EDIT)
-    @Get('summary')
-    @UseValidationPipe()
-    async getSummary(
-        @Query('$order', ParseJsonPipe) order: PaginationParams<CopilotUser>['order'],
-        @Query('$take') take: PaginationParams<CopilotUser>['take'],
-        @Query('$skip') skip: PaginationParams<CopilotUser>['skip']
-    ): Promise<IPagination<ICopilotUserUsageSummary>> {
-        const result = await this.service.findUserUsageSummaries({ order, take, skip })
-        return {
-            ...result,
-            items: result.items.map((item) => this.toPublicSummary(item))
-        }
-    }
+	@UseGuards(PermissionGuard)
+	@Permissions(AIPermissionsEnum.COPILOT_EDIT)
+	@Get('summary')
+	@UseValidationPipe()
+	async getSummary(
+		@Query('$order', ParseJsonPipe) order: PaginationParams<CopilotUser>['order'],
+		@Query('$take') take: PaginationParams<CopilotUser>['take'],
+		@Query('$skip') skip: PaginationParams<CopilotUser>['skip']
+	): Promise<IPagination<ICopilotUserUsageSummary>> {
+		const result = await this.service.findUserUsageSummaries({ order, take, skip })
+		return {
+			...result,
+			items: result.items.map((item) => this.toPublicSummary(item))
+		}
+	}
 
-    @UseGuards(PermissionGuard)
-    @Permissions(AIPermissionsEnum.COPILOT_EDIT)
-    @Get()
-    @UseValidationPipe()
-    async getAll(
-        @Query('$filter', ParseJsonPipe) where: PaginationParams<CopilotUser>['where'],
-        @Query('$relations', ParseJsonPipe) relations: PaginationParams<CopilotUser>['relations'],
-        @Query('$order', ParseJsonPipe) order: PaginationParams<CopilotUser>['order'],
-        @Query('$take') take: PaginationParams<CopilotUser>['take'],
-        @Query('$skip') skip: PaginationParams<CopilotUser>['skip']
-    ): Promise<IPagination<PublicCopilotUserDto>> {
-        const result = await this.service.findAll({ where, relations, order, take, skip })
-        return {
-            ...result,
-            items: result.items.map((_) => new PublicCopilotUserDto(_))
-        }
-    }
+	@UseGuards(PermissionGuard)
+	@Permissions(AIPermissionsEnum.COPILOT_EDIT)
+	@Get()
+	@UseValidationPipe()
+	async getAll(
+		@Query('$filter', ParseJsonPipe) where: PaginationParams<CopilotUser>['where'],
+		@Query('$relations', ParseJsonPipe) relations: PaginationParams<CopilotUser>['relations'],
+		@Query('$order', ParseJsonPipe) order: PaginationParams<CopilotUser>['order'],
+		@Query('$take') take: PaginationParams<CopilotUser>['take'],
+		@Query('$skip') skip: PaginationParams<CopilotUser>['skip']
+	): Promise<IPagination<PublicCopilotUserDto>> {
+		const result = await this.service.findAll({ where, relations, order, take, skip })
+		return {
+			...result,
+			items: result.items.map((_) => new PublicCopilotUserDto(_))
+		}
+	}
 
-    @UseGuards(PermissionGuard)
-    @Permissions(AIPermissionsEnum.COPILOT_EDIT)
-    @Post('summary/details')
-    async getSummaryDetails(@Body() entity: ICopilotUserUsageGroupKey) {
-        return (await this.service.findUserUsageDetails(entity)).map((detail) => new PublicCopilotUserDto(detail))
-    }
+	@UseGuards(PermissionGuard)
+	@Permissions(AIPermissionsEnum.COPILOT_EDIT)
+	@Post('summary/details')
+	async getSummaryDetails(@Body() entity: ICopilotUserUsageGroupKey) {
+		return (await this.service.findUserUsageDetails(entity)).map((detail) => new PublicCopilotUserDto(detail))
+	}
 
-    @UseGuards(PermissionGuard)
-    @Permissions(AIPermissionsEnum.COPILOT_EDIT)
-    @Post('summary/renew')
-    async renewSummary(@Body() entity: TCopilotUserUsageSummaryRenewInput) {
-        return this.toPublicSummary(await this.service.renewUserUsageSummary(entity))
-    }
+	@UseGuards(PermissionGuard)
+	@Permissions(AIPermissionsEnum.COPILOT_EDIT)
+	@Post('summary/renew')
+	async renewSummary(@Body() entity: TCopilotUserUsageSummaryRenewInput) {
+		return this.toPublicSummary(await this.service.renewUserUsageSummary(entity))
+	}
 
-    @UseGuards(PermissionGuard)
-    @Permissions(AIPermissionsEnum.COPILOT_EDIT)
-    @Post(':id/renew')
-    async renew(@Param('id') id: string, @Body() entity: Partial<ICopilotUser>) {
-        return await this.service.renew(id, entity)
-    }
+	@UseGuards(PermissionGuard)
+	@Permissions(AIPermissionsEnum.COPILOT_EDIT)
+	@Post(':id/renew')
+	async renew(@Param('id') id: string, @Body() entity: Partial<ICopilotUser>) {
+		return await this.service.renew(id, entity)
+	}
 
-    private toPublicSummary(item: ICopilotUserUsageSummary): ICopilotUserUsageSummary {
-        return {
-            ...item,
-            user: item.user ? (new UserPublicDTO(item.user) as ICopilotUser['user']) : undefined,
-            org: item.org ? (new OrganizationPublicDTO(item.org) as ICopilotUser['org']) : undefined,
-            details: item.details?.map((detail) => new PublicCopilotUserDto(detail) as ICopilotUser)
-        }
-    }
+	private toPublicSummary(item: ICopilotUserUsageSummary): ICopilotUserUsageSummary {
+		return {
+			...item,
+			user: item.user ? (new UserPublicDTO(item.user) as ICopilotUser['user']) : undefined,
+			org: item.org ? (new OrganizationPublicDTO(item.org) as ICopilotUser['org']) : undefined,
+			details: item.details?.map((detail) => new PublicCopilotUserDto(detail) as ICopilotUser)
+		}
+	}
 }

--- a/packages/server-ai/src/copilot-user/copilot-user.controller.ts
+++ b/packages/server-ai/src/copilot-user/copilot-user.controller.ts
@@ -1,12 +1,21 @@
-import { AIPermissionsEnum, ICopilotUser, IPagination } from '@xpert-ai/contracts'
 import {
-	CrudController,
-	PaginationParams,
-	ParseJsonPipe,
-	PermissionGuard,
-	Permissions,
-	TransformInterceptor,
-	UseValidationPipe
+    AIPermissionsEnum,
+    ICopilotUser,
+    ICopilotUserUsageGroupKey,
+    ICopilotUserUsageSummary,
+    IPagination,
+    TCopilotUserUsageSummaryRenewInput
+} from '@xpert-ai/contracts'
+import {
+    CrudController,
+    OrganizationPublicDTO,
+    PaginationParams,
+    ParseJsonPipe,
+    PermissionGuard,
+    Permissions,
+    TransformInterceptor,
+    UserPublicDTO,
+    UseValidationPipe
 } from '@xpert-ai/server-core'
 import { Body, Controller, Get, Logger, Param, Post, Query, UseGuards, UseInterceptors } from '@nestjs/common'
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger'
@@ -19,34 +28,73 @@ import { PublicCopilotUserDto } from './dto/public-copilot-user'
 @UseInterceptors(TransformInterceptor)
 @Controller()
 export class CopilotUserController extends CrudController<CopilotUser> {
-	readonly #logger = new Logger(CopilotUserController.name)
-	
-	constructor(readonly service: CopilotUserService) {
-		super(service)
-	}
+    readonly #logger = new Logger(CopilotUserController.name)
 
-	@UseGuards(PermissionGuard)
-	@Permissions(AIPermissionsEnum.COPILOT_EDIT)
-	@Get()
-	@UseValidationPipe()
-	async getAll(
-		@Query('$filter', ParseJsonPipe) where: PaginationParams<CopilotUser>['where'],
-		@Query('$relations', ParseJsonPipe) relations: PaginationParams<CopilotUser>['relations'],
-		@Query('$order', ParseJsonPipe) order: PaginationParams<CopilotUser>['order'],
-		@Query('$take') take: PaginationParams<CopilotUser>['take'],
-		@Query('$skip') skip: PaginationParams<CopilotUser>['skip']
-	): Promise<IPagination<PublicCopilotUserDto>> {
-		const result = await this.service.findAll({ where, relations, order, take, skip })
-		return {
-			...result,
-			items: result.items.map((_) => new PublicCopilotUserDto(_))
-		}
-	}
+    constructor(readonly service: CopilotUserService) {
+        super(service)
+    }
 
-	@UseGuards(PermissionGuard)
-	@Permissions(AIPermissionsEnum.COPILOT_EDIT)
-	@Post(':id/renew')
-	async renew(@Param('id') id: string, @Body() entity: Partial<ICopilotUser>) {
-		return await this.service.renew(id, entity)
-	}
+    @UseGuards(PermissionGuard)
+    @Permissions(AIPermissionsEnum.COPILOT_EDIT)
+    @Get('summary')
+    @UseValidationPipe()
+    async getSummary(
+        @Query('$order', ParseJsonPipe) order: PaginationParams<CopilotUser>['order'],
+        @Query('$take') take: PaginationParams<CopilotUser>['take'],
+        @Query('$skip') skip: PaginationParams<CopilotUser>['skip']
+    ): Promise<IPagination<ICopilotUserUsageSummary>> {
+        const result = await this.service.findUserUsageSummaries({ order, take, skip })
+        return {
+            ...result,
+            items: result.items.map((item) => this.toPublicSummary(item))
+        }
+    }
+
+    @UseGuards(PermissionGuard)
+    @Permissions(AIPermissionsEnum.COPILOT_EDIT)
+    @Get()
+    @UseValidationPipe()
+    async getAll(
+        @Query('$filter', ParseJsonPipe) where: PaginationParams<CopilotUser>['where'],
+        @Query('$relations', ParseJsonPipe) relations: PaginationParams<CopilotUser>['relations'],
+        @Query('$order', ParseJsonPipe) order: PaginationParams<CopilotUser>['order'],
+        @Query('$take') take: PaginationParams<CopilotUser>['take'],
+        @Query('$skip') skip: PaginationParams<CopilotUser>['skip']
+    ): Promise<IPagination<PublicCopilotUserDto>> {
+        const result = await this.service.findAll({ where, relations, order, take, skip })
+        return {
+            ...result,
+            items: result.items.map((_) => new PublicCopilotUserDto(_))
+        }
+    }
+
+    @UseGuards(PermissionGuard)
+    @Permissions(AIPermissionsEnum.COPILOT_EDIT)
+    @Post('summary/details')
+    async getSummaryDetails(@Body() entity: ICopilotUserUsageGroupKey) {
+        return (await this.service.findUserUsageDetails(entity)).map((detail) => new PublicCopilotUserDto(detail))
+    }
+
+    @UseGuards(PermissionGuard)
+    @Permissions(AIPermissionsEnum.COPILOT_EDIT)
+    @Post('summary/renew')
+    async renewSummary(@Body() entity: TCopilotUserUsageSummaryRenewInput) {
+        return this.toPublicSummary(await this.service.renewUserUsageSummary(entity))
+    }
+
+    @UseGuards(PermissionGuard)
+    @Permissions(AIPermissionsEnum.COPILOT_EDIT)
+    @Post(':id/renew')
+    async renew(@Param('id') id: string, @Body() entity: Partial<ICopilotUser>) {
+        return await this.service.renew(id, entity)
+    }
+
+    private toPublicSummary(item: ICopilotUserUsageSummary): ICopilotUserUsageSummary {
+        return {
+            ...item,
+            user: item.user ? (new UserPublicDTO(item.user) as ICopilotUser['user']) : undefined,
+            org: item.org ? (new OrganizationPublicDTO(item.org) as ICopilotUser['org']) : undefined,
+            details: item.details?.map((detail) => new PublicCopilotUserDto(detail) as ICopilotUser)
+        }
+    }
 }

--- a/packages/server-ai/src/copilot-user/copilot-user.service.spec.ts
+++ b/packages/server-ai/src/copilot-user/copilot-user.service.spec.ts
@@ -1,0 +1,316 @@
+import { OrderTypeEnum } from '@xpert-ai/contracts'
+import { RequestContext } from '@xpert-ai/server-core'
+import { Repository, SelectQueryBuilder } from 'typeorm'
+import { CopilotUser } from './copilot-user.entity'
+import { CopilotUserService } from './copilot-user.service'
+
+jest.mock('@xpert-ai/server-core', () => {
+    const actual = jest.requireActual('@xpert-ai/server-core')
+
+    return {
+        ...actual,
+        RequestContext: {
+            currentTenantId: jest.fn(),
+            getOrganizationId: jest.fn()
+        }
+    }
+})
+
+type CopilotUserRepositoryMock = {
+    createQueryBuilder: jest.Mock
+    find: jest.Mock
+    save: jest.Mock
+}
+
+function mockRequestContext() {
+    const currentTenantId = RequestContext.currentTenantId as jest.MockedFunction<typeof RequestContext.currentTenantId>
+    const getOrganizationId = RequestContext.getOrganizationId as jest.MockedFunction<
+        typeof RequestContext.getOrganizationId
+    >
+
+    currentTenantId.mockReturnValue('tenant-1')
+    getOrganizationId.mockReturnValue('org-1')
+}
+
+function createQueryBuilderMock(rawRows: Array<Record<string, unknown>>) {
+    const queryBuilder = {
+        leftJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        addGroupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rawRows)
+    }
+
+    return queryBuilder as unknown as SelectQueryBuilder<CopilotUser>
+}
+
+function createService(repository: CopilotUserRepositoryMock) {
+    return new CopilotUserService(repository as unknown as Repository<CopilotUser>)
+}
+
+describe('CopilotUserService', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockRequestContext()
+    })
+
+    it('groups user model usage into one quota row without preloading session details', async () => {
+        const rawRows = [
+            {
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                orgId: 'provider-org-1',
+                userId: 'user-1',
+                provider: 'tongyi',
+                model: 'qwen3.6-plus',
+                currency: 'CNY',
+                tokenUsed: '77',
+                priceUsed: '0.125',
+                tokenTotalUsed: '10',
+                priceTotalUsed: '0.02',
+                tokenLimit: '1000',
+                priceLimit: '2.5',
+                updatedAt: new Date('2026-05-29T01:30:00.000Z'),
+                userRelationId: 'user-1',
+                userFirstName: 'Yu',
+                userLastName: 'Rongku',
+                userEmail: 'yurongku@gmail.com',
+                userUsername: 'yu rongku',
+                userImageUrl: 'avatar.png',
+                orgRelationId: 'provider-org-1',
+                orgName: 'provider org',
+                orgImageUrl: 'org.png',
+                total: '1'
+            }
+        ]
+        const repository: CopilotUserRepositoryMock = {
+            createQueryBuilder: jest.fn().mockReturnValue(createQueryBuilderMock(rawRows)),
+            find: jest.fn(),
+            save: jest.fn()
+        }
+        const service = createService(repository)
+
+        const result = await service.findUserUsageSummaries({
+            order: { updatedAt: OrderTypeEnum.DESC },
+            take: 20,
+            skip: 0
+        })
+
+        expect(result.total).toBe(1)
+        expect(result.items).toHaveLength(1)
+        expect(result.items[0]).toMatchObject({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            orgId: 'provider-org-1',
+            userId: 'user-1',
+            provider: 'tongyi',
+            model: 'qwen3.6-plus',
+            currency: 'CNY',
+            tokenUsed: 77,
+            priceUsed: 0.125,
+            tokenTotalUsed: 10,
+            priceTotalUsed: 0.02,
+            tokenLimit: 1000,
+            priceLimit: 2.5,
+            user: {
+                id: 'user-1',
+                firstName: 'Yu',
+                lastName: 'Rongku',
+                email: 'yurongku@gmail.com',
+                username: 'yu rongku',
+                imageUrl: 'avatar.png'
+            },
+            org: {
+                id: 'provider-org-1',
+                name: 'provider org',
+                imageUrl: 'org.png'
+            }
+        })
+        expect(result.items[0].details).toBeUndefined()
+        expect(repository.find).not.toHaveBeenCalled()
+    })
+
+    it('loads user model usage details with request scoped tenant and organization', async () => {
+        const details = [
+            {
+                id: 'usage-thread-1',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                orgId: 'provider-org-1',
+                userId: 'user-1',
+                provider: 'tongyi',
+                model: 'qwen3.6-plus',
+                currency: 'CNY',
+                threadId: 'thread-1',
+                usageHour: '2026-05-29 01',
+                tokenUsed: 47
+            },
+            {
+                id: 'usage-thread-2',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                orgId: 'provider-org-1',
+                userId: 'user-1',
+                provider: 'tongyi',
+                model: 'qwen3.6-plus',
+                currency: 'CNY',
+                threadId: 'thread-2',
+                usageHour: '2026-05-29 01',
+                tokenUsed: 30
+            }
+        ] as CopilotUser[]
+        const repository: CopilotUserRepositoryMock = {
+            createQueryBuilder: jest.fn(),
+            find: jest.fn().mockResolvedValue(details),
+            save: jest.fn()
+        }
+        const service = createService(repository)
+
+        const result = await service.findUserUsageDetails({
+            tenantId: 'tenant-evil',
+            organizationId: 'org-evil',
+            orgId: 'provider-org-1',
+            userId: 'user-1',
+            provider: 'tongyi',
+            model: 'qwen3.6-plus',
+            currency: 'CNY'
+        })
+
+        const findOptions = repository.find.mock.calls[0]?.[0]
+        expect(result).toBe(details)
+        expect(findOptions?.where).toMatchObject({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            orgId: 'provider-org-1',
+            userId: 'user-1',
+            provider: 'tongyi',
+            model: 'qwen3.6-plus',
+            currency: 'CNY'
+        })
+        expect(findOptions?.where).not.toHaveProperty('threadId')
+        expect(findOptions?.where).not.toHaveProperty('usageHour')
+    })
+
+    it('rejects usage details and renew requests without required group identity fields', async () => {
+        const repository: CopilotUserRepositoryMock = {
+            createQueryBuilder: jest.fn(),
+            find: jest.fn(),
+            save: jest.fn()
+        }
+        const service = createService(repository)
+
+        await expect(service.findUserUsageDetails({ provider: 'tongyi' })).rejects.toThrow(
+            'Missing required copilot user usage group fields'
+        )
+        await expect(
+            service.renewUserUsageSummary({
+                userId: 'user-1',
+                tokenLimit: 1000
+            })
+        ).rejects.toThrow('Missing required copilot user usage group fields')
+        expect(repository.find).not.toHaveBeenCalled()
+        expect(repository.save).not.toHaveBeenCalled()
+    })
+
+    it('renews a user model quota group without deleting per-session history or clearing price limits', async () => {
+        const details = [
+            {
+                id: 'usage-thread-1',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                orgId: 'provider-org-1',
+                userId: 'user-1',
+                provider: 'tongyi',
+                model: 'qwen3.6-plus',
+                currency: 'CNY',
+                threadId: 'thread-1',
+                tokenUsed: 47,
+                tokenTotalUsed: 3,
+                priceUsed: 0.12,
+                priceTotalUsed: 0.01,
+                priceLimit: 1.5
+            },
+            {
+                id: 'usage-thread-2',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                orgId: 'provider-org-1',
+                userId: 'user-1',
+                provider: 'tongyi',
+                model: 'qwen3.6-plus',
+                currency: 'CNY',
+                threadId: 'thread-2',
+                tokenUsed: 30,
+                tokenTotalUsed: 0,
+                priceUsed: 0.005,
+                priceTotalUsed: 0,
+                priceLimit: 1.2
+            }
+        ] as CopilotUser[]
+        const repository: CopilotUserRepositoryMock = {
+            createQueryBuilder: jest.fn(),
+            find: jest.fn().mockResolvedValue(details),
+            save: jest.fn(async (records: CopilotUser[]) => records)
+        }
+        const service = createService(repository)
+
+        const result = await service.renewUserUsageSummary({
+            tenantId: 'tenant-evil',
+            organizationId: 'org-evil',
+            orgId: 'provider-org-1',
+            userId: 'user-1',
+            provider: 'tongyi',
+            model: 'qwen3.6-plus',
+            currency: 'CNY',
+            tokenLimit: 1000
+        })
+
+        const findOptions = repository.find.mock.calls[0]?.[0]
+        expect(findOptions?.where).toMatchObject({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            orgId: 'provider-org-1',
+            userId: 'user-1',
+            provider: 'tongyi',
+            model: 'qwen3.6-plus',
+            currency: 'CNY'
+        })
+        expect(repository.save).toHaveBeenCalledWith([
+            expect.objectContaining({
+                id: 'usage-thread-1',
+                tokenUsed: 0,
+                tokenTotalUsed: 50,
+                priceUsed: 0,
+                priceTotalUsed: 0.13,
+                tokenLimit: 1000,
+                priceLimit: 1.5
+            }),
+            expect.objectContaining({
+                id: 'usage-thread-2',
+                tokenUsed: 0,
+                tokenTotalUsed: 30,
+                priceUsed: 0,
+                priceTotalUsed: 0.005,
+                tokenLimit: 1000,
+                priceLimit: 1.2
+            })
+        ])
+        expect(result).toMatchObject({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            tokenUsed: 0,
+            priceUsed: 0,
+            tokenTotalUsed: 80,
+            priceTotalUsed: 0.135,
+            tokenLimit: 1000,
+            priceLimit: 1.5
+        })
+        expect(result.details).toHaveLength(2)
+    })
+})

--- a/packages/server-ai/src/copilot-user/copilot-user.service.ts
+++ b/packages/server-ai/src/copilot-user/copilot-user.service.ts
@@ -1,10 +1,10 @@
 import {
-    ICopilotUser,
-    ICopilotUserUsageGroupKey,
-    ICopilotUserUsageSummary,
-    IPagination,
-    OrderTypeEnum,
-    TCopilotUserUsageSummaryRenewInput
+	ICopilotUser,
+	ICopilotUserUsageGroupKey,
+	ICopilotUserUsageSummary,
+	IPagination,
+	OrderTypeEnum,
+	TCopilotUserUsageSummaryRenewInput
 } from '@xpert-ai/contracts'
 import { RequestContext, TenantOrganizationAwareCrudService } from '@xpert-ai/server-core'
 import { BadRequestException, Injectable, Logger } from '@nestjs/common'
@@ -13,439 +13,437 @@ import { FindOptionsWhere, IsNull, Repository } from 'typeorm'
 import { CopilotUser } from './copilot-user.entity'
 
 type CopilotUserUsageSummaryRaw = {
-    tenantId?: string | null
-    organizationId?: string | null
-    orgId?: string | null
-    userId?: string | null
-    provider?: string | null
-    model?: string | null
-    currency?: string | null
-    tokenUsed?: string | number | null
-    priceUsed?: string | number | null
-    tokenTotalUsed?: string | number | null
-    priceTotalUsed?: string | number | null
-    tokenLimit?: string | number | null
-    priceLimit?: string | number | null
-    updatedAt?: Date | string | null
-    userRelationId?: string | null
-    userFirstName?: string | null
-    userLastName?: string | null
-    userEmail?: string | null
-    userUsername?: string | null
-    userImageUrl?: string | null
-    orgRelationId?: string | null
-    orgName?: string | null
-    orgImageUrl?: string | null
-    total?: string | number | null
+	tenantId?: string | null
+	organizationId?: string | null
+	orgId?: string | null
+	userId?: string | null
+	provider?: string | null
+	model?: string | null
+	currency?: string | null
+	tokenUsed?: string | number | null
+	priceUsed?: string | number | null
+	tokenTotalUsed?: string | number | null
+	priceTotalUsed?: string | number | null
+	tokenLimit?: string | number | null
+	priceLimit?: string | number | null
+	updatedAt?: Date | string | null
+	userRelationId?: string | null
+	userFirstName?: string | null
+	userLastName?: string | null
+	userEmail?: string | null
+	userUsername?: string | null
+	userImageUrl?: string | null
+	orgRelationId?: string | null
+	orgName?: string | null
+	orgImageUrl?: string | null
+	total?: string | number | null
 }
 
 const GROUP_ID_SEPARATOR = '|'
 
 function toNumber(value: string | number | null | undefined) {
-    return value === null || value === undefined ? 0 : Number(value)
+	return value === null || value === undefined ? 0 : Number(value)
 }
 
 function toNullableString(value: string | null | undefined) {
-    return value === null || value === undefined ? null : value
+	return value === null || value === undefined ? null : value
 }
 
 function toOptionalString(value: string | null | undefined) {
-    return value === null || value === undefined ? undefined : value
+	return value === null || value === undefined ? undefined : value
 }
 
 function toOptionalNumber(value: string | number | null | undefined) {
-    return value === null || value === undefined ? undefined : Number(value)
+	return value === null || value === undefined ? undefined : Number(value)
 }
 
 function maxOptionalNumber(values: Array<string | number | null | undefined>) {
-    let max: number | undefined
-    for (const value of values) {
-        if (value !== null && value !== undefined) {
-            const numberValue = Number(value)
-            max = max === undefined ? numberValue : Math.max(max, numberValue)
-        }
-    }
+	let max: number | undefined
+	for (const value of values) {
+		if (value !== null && value !== undefined) {
+			const numberValue = Number(value)
+			max = max === undefined ? numberValue : Math.max(max, numberValue)
+		}
+	}
 
-    return max
+	return max
 }
 
 function encodeGroupPart(value: string | number | null | undefined) {
-    return encodeURIComponent(value === null || value === undefined ? '' : String(value))
+	return encodeURIComponent(value === null || value === undefined ? '' : String(value))
 }
 
 @Injectable()
 export class CopilotUserService extends TenantOrganizationAwareCrudService<CopilotUser> {
-    readonly #logger = new Logger(CopilotUserService.name)
+	readonly #logger = new Logger(CopilotUserService.name)
 
-    constructor(
-        @InjectRepository(CopilotUser)
-        repository: Repository<CopilotUser>
-    ) {
-        super(repository)
-    }
+	constructor(
+		@InjectRepository(CopilotUser)
+		repository: Repository<CopilotUser>
+	) {
+		super(repository)
+	}
 
-    /**
-     * Record usage of ai model for user in organization
-     */
-    async upsert(user: Partial<CopilotUser>): Promise<ICopilotUser> {
-        const existing = await this.findOneOrFailByOptions({
-            where: {
-                tenantId: user.tenantId,
-                organizationId: user.organizationId,
-                orgId: user.orgId ?? IsNull(),
-                xpertId: user.xpertId ?? IsNull(),
-                threadId: user.threadId ?? IsNull(),
-                userId: user.userId,
-                provider: user.provider,
-                model: user.model,
-                usageHour: user.usageHour ?? IsNull()
-            }
-        })
-        if (existing.success) {
-            existing.record.tokenUsed = (existing.record.tokenUsed ?? 0) + (user.tokenUsed ?? 0)
-            existing.record.priceUsed = Number(existing.record.priceUsed ?? 0) + Number(user.priceUsed ?? 0)
-            existing.record.tokenLimit ??= user.tokenLimit
-            existing.record.priceLimit ??= user.priceLimit
-            existing.record.currency ??= user.currency
-            return await this.repository.save(existing.record)
-        } else {
-            const usageSummary = await this.getUsageSummary({
-                tenantId: user.tenantId,
-                organizationId: user.organizationId,
-                orgId: user.orgId,
-                userId: user.userId,
-                provider: user.provider,
-                model: user.model
-            })
+	/**
+	 * Record usage of ai model for user in organization
+	 */
+	async upsert(user: Partial<CopilotUser>): Promise<ICopilotUser> {
+		const existing = await this.findOneOrFailByOptions({
+			where: {
+				tenantId: user.tenantId,
+				organizationId: user.organizationId,
+				orgId: user.orgId ?? IsNull(),
+				xpertId: user.xpertId ?? IsNull(),
+				threadId: user.threadId ?? IsNull(),
+				userId: user.userId,
+				provider: user.provider,
+				model: user.model,
+				usageHour: user.usageHour ?? IsNull()
+			}
+		})
+		if (existing.success) {
+			existing.record.tokenUsed = (existing.record.tokenUsed ?? 0) + (user.tokenUsed ?? 0)
+			existing.record.priceUsed = Number(existing.record.priceUsed ?? 0) + Number(user.priceUsed ?? 0)
+			existing.record.tokenLimit ??= user.tokenLimit
+			existing.record.priceLimit ??= user.priceLimit
+			existing.record.currency ??= user.currency
+			return await this.repository.save(existing.record)
+		} else {
+			const usageSummary = await this.getUsageSummary({
+				tenantId: user.tenantId,
+				organizationId: user.organizationId,
+				orgId: user.orgId,
+				userId: user.userId,
+				provider: user.provider,
+				model: user.model
+			})
 
-            return await this.create({
-                tenantId: user.tenantId,
-                organizationId: user.organizationId,
-                orgId: user.orgId,
-                xpertId: user.xpertId,
-                threadId: user.threadId,
-                userId: user.userId,
-                provider: user.provider,
-                model: user.model,
-                usageHour: user.usageHour,
-                tokenUsed: user.tokenUsed,
-                tokenLimit: usageSummary.tokenLimit ?? user.tokenLimit,
-                priceUsed: Number(user.priceUsed ?? 0),
-                priceLimit: usageSummary.priceLimit ?? user.priceLimit,
-                currency: user.currency
-            })
-        }
-    }
+			return await this.create({
+				tenantId: user.tenantId,
+				organizationId: user.organizationId,
+				orgId: user.orgId,
+				xpertId: user.xpertId,
+				threadId: user.threadId,
+				userId: user.userId,
+				provider: user.provider,
+				model: user.model,
+				usageHour: user.usageHour,
+				tokenUsed: user.tokenUsed,
+				tokenLimit: usageSummary.tokenLimit ?? user.tokenLimit,
+				priceUsed: Number(user.priceUsed ?? 0),
+				priceLimit: usageSummary.priceLimit ?? user.priceLimit,
+				currency: user.currency
+			})
+		}
+	}
 
-    async getUsageSummary(input: {
-        tenantId: string
-        organizationId?: string
-        orgId?: string | null
-        userId: string
-        provider: string
-        model?: string
-    }) {
-        const { tenantId, organizationId, orgId, userId, provider, model } = input
-        const query = this.repository
-            .createQueryBuilder('copilot_user')
-            .select('COALESCE(SUM(copilot_user.tokenUsed), 0)', 'tokenUsed')
-            .addSelect('COALESCE(SUM(copilot_user.priceUsed), 0)', 'priceUsed')
-            .addSelect('MAX(copilot_user.tokenLimit)', 'tokenLimit')
-            .addSelect('MAX(copilot_user.priceLimit)', 'priceLimit')
-            .where('copilot_user.tenantId = :tenantId', { tenantId })
-            .andWhere('copilot_user.userId = :userId', { userId })
-            .andWhere('copilot_user.provider = :provider', { provider })
+	async getUsageSummary(input: {
+		tenantId: string
+		organizationId?: string
+		orgId?: string | null
+		userId: string
+		provider: string
+		model?: string
+	}) {
+		const { tenantId, organizationId, orgId, userId, provider, model } = input
+		const query = this.repository
+			.createQueryBuilder('copilot_user')
+			.select('COALESCE(SUM(copilot_user.tokenUsed), 0)', 'tokenUsed')
+			.addSelect('COALESCE(SUM(copilot_user.priceUsed), 0)', 'priceUsed')
+			.addSelect('MAX(copilot_user.tokenLimit)', 'tokenLimit')
+			.addSelect('MAX(copilot_user.priceLimit)', 'priceLimit')
+			.where('copilot_user.tenantId = :tenantId', { tenantId })
+			.andWhere('copilot_user.userId = :userId', { userId })
+			.andWhere('copilot_user.provider = :provider', { provider })
 
-        if (organizationId) {
-            query.andWhere('copilot_user.organizationId = :organizationId', { organizationId })
-        } else {
-            query.andWhere('copilot_user.organizationId IS NULL')
-        }
+		if (organizationId) {
+			query.andWhere('copilot_user.organizationId = :organizationId', { organizationId })
+		} else {
+			query.andWhere('copilot_user.organizationId IS NULL')
+		}
 
-        if (model) {
-            query.andWhere('copilot_user.model = :model', { model })
-        } else {
-            query.andWhere('copilot_user.model IS NULL')
-        }
+		if (model) {
+			query.andWhere('copilot_user.model = :model', { model })
+		} else {
+			query.andWhere('copilot_user.model IS NULL')
+		}
 
-        if (orgId) {
-            query.andWhere('copilot_user.orgId = :orgId', { orgId })
-        } else {
-            query.andWhere('copilot_user.orgId IS NULL')
-        }
+		if (orgId) {
+			query.andWhere('copilot_user.orgId = :orgId', { orgId })
+		} else {
+			query.andWhere('copilot_user.orgId IS NULL')
+		}
 
-        const result = await query.getRawOne<{
-            tokenUsed?: string
-            priceUsed?: string
-            tokenLimit?: string
-            priceLimit?: string
-        }>()
+		const result = await query.getRawOne<{
+			tokenUsed?: string
+			priceUsed?: string
+			tokenLimit?: string
+			priceLimit?: string
+		}>()
 
-        return {
-            tokenUsed: Number(result?.tokenUsed ?? 0),
-            priceUsed: Number(result?.priceUsed ?? 0),
-            tokenLimit:
-                result?.tokenLimit !== null && result?.tokenLimit !== undefined ? Number(result.tokenLimit) : null,
-            priceLimit:
-                result?.priceLimit !== null && result?.priceLimit !== undefined ? Number(result.priceLimit) : null
-        }
-    }
+		return {
+			tokenUsed: Number(result?.tokenUsed ?? 0),
+			priceUsed: Number(result?.priceUsed ?? 0),
+			tokenLimit: result?.tokenLimit !== null && result?.tokenLimit !== undefined ? Number(result.tokenLimit) : null,
+			priceLimit: result?.priceLimit !== null && result?.priceLimit !== undefined ? Number(result.priceLimit) : null
+		}
+	}
 
-    async findUserUsageSummaries(options?: {
-        take?: number
-        skip?: number
-        order?: {
-            updatedAt?: unknown
-        }
-    }): Promise<IPagination<ICopilotUserUsageSummary>> {
-        const tenantId = RequestContext.currentTenantId()
-        const organizationId = RequestContext.getOrganizationId()
-        const take = Number(options?.take ?? 20)
-        const skip = Number(options?.skip ?? 0)
-        const updatedAtOrder =
-            options?.order?.updatedAt === OrderTypeEnum.ASC || options?.order?.updatedAt === 'ASC'
-                ? OrderTypeEnum.ASC
-                : OrderTypeEnum.DESC
+	async findUserUsageSummaries(options?: {
+		take?: number
+		skip?: number
+		order?: {
+			updatedAt?: unknown
+		}
+	}): Promise<IPagination<ICopilotUserUsageSummary>> {
+		const tenantId = RequestContext.currentTenantId()
+		const organizationId = RequestContext.getOrganizationId()
+		const take = Number(options?.take ?? 20)
+		const skip = Number(options?.skip ?? 0)
+		const updatedAtOrder =
+			options?.order?.updatedAt === OrderTypeEnum.ASC || options?.order?.updatedAt === 'ASC'
+				? OrderTypeEnum.ASC
+				: OrderTypeEnum.DESC
 
-        const query = this.repository
-            .createQueryBuilder('copilot_user')
-            .leftJoin('copilot_user.user', 'copilot_user_user')
-            .leftJoin('copilot_user.org', 'copilot_user_org')
-            .select('copilot_user.tenantId', 'tenantId')
-            .addSelect('copilot_user.organizationId', 'organizationId')
-            .addSelect('copilot_user.orgId', 'orgId')
-            .addSelect('copilot_user.userId', 'userId')
-            .addSelect('copilot_user.provider', 'provider')
-            .addSelect('copilot_user.model', 'model')
-            .addSelect('copilot_user.currency', 'currency')
-            .addSelect('COALESCE(SUM(copilot_user.tokenUsed), 0)', 'tokenUsed')
-            .addSelect('COALESCE(SUM(copilot_user.priceUsed), 0)', 'priceUsed')
-            .addSelect('COALESCE(SUM(copilot_user.tokenTotalUsed), 0)', 'tokenTotalUsed')
-            .addSelect('COALESCE(SUM(copilot_user.priceTotalUsed), 0)', 'priceTotalUsed')
-            .addSelect('MAX(copilot_user.tokenLimit)', 'tokenLimit')
-            .addSelect('MAX(copilot_user.priceLimit)', 'priceLimit')
-            .addSelect('MAX(copilot_user.updatedAt)', 'updatedAt')
-            .addSelect('copilot_user_user.id', 'userRelationId')
-            .addSelect('copilot_user_user.firstName', 'userFirstName')
-            .addSelect('copilot_user_user.lastName', 'userLastName')
-            .addSelect('copilot_user_user.email', 'userEmail')
-            .addSelect('copilot_user_user.username', 'userUsername')
-            .addSelect('copilot_user_user.imageUrl', 'userImageUrl')
-            .addSelect('copilot_user_org.id', 'orgRelationId')
-            .addSelect('copilot_user_org.name', 'orgName')
-            .addSelect('copilot_user_org.imageUrl', 'orgImageUrl')
-            .addSelect('COUNT(*) OVER()', 'total')
-            .where('copilot_user.tenantId = :tenantId', { tenantId })
-            .groupBy('copilot_user.tenantId')
-            .addGroupBy('copilot_user.organizationId')
-            .addGroupBy('copilot_user.orgId')
-            .addGroupBy('copilot_user.userId')
-            .addGroupBy('copilot_user.provider')
-            .addGroupBy('copilot_user.model')
-            .addGroupBy('copilot_user.currency')
-            .addGroupBy('copilot_user_user.id')
-            .addGroupBy('copilot_user_user.firstName')
-            .addGroupBy('copilot_user_user.lastName')
-            .addGroupBy('copilot_user_user.email')
-            .addGroupBy('copilot_user_user.username')
-            .addGroupBy('copilot_user_user.imageUrl')
-            .addGroupBy('copilot_user_org.id')
-            .addGroupBy('copilot_user_org.name')
-            .addGroupBy('copilot_user_org.imageUrl')
-            .orderBy('MAX(copilot_user.updatedAt)', updatedAtOrder)
-            .take(take)
-            .skip(skip)
+		const query = this.repository
+			.createQueryBuilder('copilot_user')
+			.leftJoin('copilot_user.user', 'copilot_user_user')
+			.leftJoin('copilot_user.org', 'copilot_user_org')
+			.select('copilot_user.tenantId', 'tenantId')
+			.addSelect('copilot_user.organizationId', 'organizationId')
+			.addSelect('copilot_user.orgId', 'orgId')
+			.addSelect('copilot_user.userId', 'userId')
+			.addSelect('copilot_user.provider', 'provider')
+			.addSelect('copilot_user.model', 'model')
+			.addSelect('copilot_user.currency', 'currency')
+			.addSelect('COALESCE(SUM(copilot_user.tokenUsed), 0)', 'tokenUsed')
+			.addSelect('COALESCE(SUM(copilot_user.priceUsed), 0)', 'priceUsed')
+			.addSelect('COALESCE(SUM(copilot_user.tokenTotalUsed), 0)', 'tokenTotalUsed')
+			.addSelect('COALESCE(SUM(copilot_user.priceTotalUsed), 0)', 'priceTotalUsed')
+			.addSelect('MAX(copilot_user.tokenLimit)', 'tokenLimit')
+			.addSelect('MAX(copilot_user.priceLimit)', 'priceLimit')
+			.addSelect('MAX(copilot_user.updatedAt)', 'updatedAt')
+			.addSelect('copilot_user_user.id', 'userRelationId')
+			.addSelect('copilot_user_user.firstName', 'userFirstName')
+			.addSelect('copilot_user_user.lastName', 'userLastName')
+			.addSelect('copilot_user_user.email', 'userEmail')
+			.addSelect('copilot_user_user.username', 'userUsername')
+			.addSelect('copilot_user_user.imageUrl', 'userImageUrl')
+			.addSelect('copilot_user_org.id', 'orgRelationId')
+			.addSelect('copilot_user_org.name', 'orgName')
+			.addSelect('copilot_user_org.imageUrl', 'orgImageUrl')
+			.addSelect('COUNT(*) OVER()', 'total')
+			.where('copilot_user.tenantId = :tenantId', { tenantId })
+			.groupBy('copilot_user.tenantId')
+			.addGroupBy('copilot_user.organizationId')
+			.addGroupBy('copilot_user.orgId')
+			.addGroupBy('copilot_user.userId')
+			.addGroupBy('copilot_user.provider')
+			.addGroupBy('copilot_user.model')
+			.addGroupBy('copilot_user.currency')
+			.addGroupBy('copilot_user_user.id')
+			.addGroupBy('copilot_user_user.firstName')
+			.addGroupBy('copilot_user_user.lastName')
+			.addGroupBy('copilot_user_user.email')
+			.addGroupBy('copilot_user_user.username')
+			.addGroupBy('copilot_user_user.imageUrl')
+			.addGroupBy('copilot_user_org.id')
+			.addGroupBy('copilot_user_org.name')
+			.addGroupBy('copilot_user_org.imageUrl')
+			.orderBy('MAX(copilot_user.updatedAt)', updatedAtOrder)
+			.take(take)
+			.skip(skip)
 
-        if (organizationId) {
-            query.andWhere('copilot_user.organizationId = :organizationId', { organizationId })
-        } else {
-            query.andWhere('copilot_user.organizationId IS NULL')
-        }
+		if (organizationId) {
+			query.andWhere('copilot_user.organizationId = :organizationId', { organizationId })
+		} else {
+			query.andWhere('copilot_user.organizationId IS NULL')
+		}
 
-        const rows = await query.getRawMany<CopilotUserUsageSummaryRaw>()
-        const items = rows.map((row) => this.toUserUsageSummary(row))
+		const rows = await query.getRawMany<CopilotUserUsageSummaryRaw>()
+		const items = rows.map((row) => this.toUserUsageSummary(row))
 
-        return {
-            items,
-            total: rows.length ? toNumber(rows[0].total) : 0
-        }
-    }
+		return {
+			items,
+			total: rows.length ? toNumber(rows[0].total) : 0
+		}
+	}
 
-    async findUserUsageDetails(input: ICopilotUserUsageGroupKey) {
-        this.assertUserUsageGroupInput(input)
-        return await this.findUserUsageGroupDetails(this.toGroupKey(input))
-    }
+	async findUserUsageDetails(input: ICopilotUserUsageGroupKey) {
+		this.assertUserUsageGroupInput(input)
+		return await this.findUserUsageGroupDetails(this.toGroupKey(input))
+	}
 
-    async renewUserUsageSummary(input: TCopilotUserUsageSummaryRenewInput): Promise<ICopilotUserUsageSummary> {
-        this.assertUserUsageGroupInput(input)
-        const groupKey = this.toGroupKey(input)
-        const details = await this.findUserUsageGroupDetails(groupKey)
-        const records = details.map((record) => {
-            record.tokenTotalUsed = (record.tokenTotalUsed ?? 0) + (record.tokenUsed ?? 0)
-            record.priceTotalUsed = Number(record.priceTotalUsed ?? 0) + Number(record.priceUsed ?? 0)
-            record.tokenUsed = 0
-            record.priceUsed = 0
-            record.tokenLimit = input.tokenLimit
-            if (input.priceLimit !== undefined) {
-                record.priceLimit = input.priceLimit
-            }
-            return record
-        })
-        const saved = records.length ? await this.repository.save(records) : []
+	async renewUserUsageSummary(input: TCopilotUserUsageSummaryRenewInput): Promise<ICopilotUserUsageSummary> {
+		this.assertUserUsageGroupInput(input)
+		const groupKey = this.toGroupKey(input)
+		const details = await this.findUserUsageGroupDetails(groupKey)
+		const records = details.map((record) => {
+			record.tokenTotalUsed = (record.tokenTotalUsed ?? 0) + (record.tokenUsed ?? 0)
+			record.priceTotalUsed = Number(record.priceTotalUsed ?? 0) + Number(record.priceUsed ?? 0)
+			record.tokenUsed = 0
+			record.priceUsed = 0
+			record.tokenLimit = input.tokenLimit
+			if (input.priceLimit !== undefined) {
+				record.priceLimit = input.priceLimit
+			}
+			return record
+		})
+		const saved = records.length ? await this.repository.save(records) : []
 
-        return this.toRenewedUserUsageSummary({ ...input, ...groupKey }, saved)
-    }
+		return this.toRenewedUserUsageSummary({ ...input, ...groupKey }, saved)
+	}
 
-    private toUserUsageSummary(row: CopilotUserUsageSummaryRaw): ICopilotUserUsageSummary {
-        const groupKey = this.toGroupKey(row)
+	private toUserUsageSummary(row: CopilotUserUsageSummaryRaw): ICopilotUserUsageSummary {
+		const groupKey = this.toGroupKey(row)
 
-        return {
-            id: this.buildGroupId(groupKey),
-            tenantId: groupKey.tenantId,
-            organizationId: groupKey.organizationId ?? undefined,
-            orgId: groupKey.orgId,
-            userId: groupKey.userId,
-            user: this.toSummaryUser(row),
-            org: this.toSummaryOrg(row),
-            provider: groupKey.provider,
-            model: groupKey.model,
-            currency: groupKey.currency,
-            tokenUsed: toNumber(row.tokenUsed),
-            priceUsed: toNumber(row.priceUsed),
-            tokenTotalUsed: toNumber(row.tokenTotalUsed),
-            priceTotalUsed: toNumber(row.priceTotalUsed),
-            tokenLimit: toOptionalNumber(row.tokenLimit),
-            priceLimit: toOptionalNumber(row.priceLimit),
-            updatedAt: row.updatedAt ? new Date(row.updatedAt) : undefined,
-            groupKey
-        }
-    }
+		return {
+			id: this.buildGroupId(groupKey),
+			tenantId: groupKey.tenantId,
+			organizationId: groupKey.organizationId ?? undefined,
+			orgId: groupKey.orgId,
+			userId: groupKey.userId,
+			user: this.toSummaryUser(row),
+			org: this.toSummaryOrg(row),
+			provider: groupKey.provider,
+			model: groupKey.model,
+			currency: groupKey.currency,
+			tokenUsed: toNumber(row.tokenUsed),
+			priceUsed: toNumber(row.priceUsed),
+			tokenTotalUsed: toNumber(row.tokenTotalUsed),
+			priceTotalUsed: toNumber(row.priceTotalUsed),
+			tokenLimit: toOptionalNumber(row.tokenLimit),
+			priceLimit: toOptionalNumber(row.priceLimit),
+			updatedAt: row.updatedAt ? new Date(row.updatedAt) : undefined,
+			groupKey
+		}
+	}
 
-    private toRenewedUserUsageSummary(
-        input: TCopilotUserUsageSummaryRenewInput,
-        details: CopilotUser[]
-    ): ICopilotUserUsageSummary {
-        const groupKey = this.toGroupKey(input)
-        const first = details[0]
+	private toRenewedUserUsageSummary(
+		input: TCopilotUserUsageSummaryRenewInput,
+		details: CopilotUser[]
+	): ICopilotUserUsageSummary {
+		const groupKey = this.toGroupKey(input)
+		const first = details[0]
 
-        return {
-            id: this.buildGroupId(groupKey),
-            tenantId: groupKey.tenantId,
-            organizationId: groupKey.organizationId ?? undefined,
-            orgId: groupKey.orgId,
-            userId: groupKey.userId,
-            user: first?.user,
-            org: first?.org,
-            provider: groupKey.provider,
-            model: groupKey.model,
-            currency: groupKey.currency,
-            tokenUsed: 0,
-            priceUsed: 0,
-            tokenTotalUsed: details.reduce((sum, item) => sum + (item.tokenTotalUsed ?? 0), 0),
-            priceTotalUsed: details.reduce((sum, item) => sum + Number(item.priceTotalUsed ?? 0), 0),
-            tokenLimit: input.tokenLimit,
-            priceLimit: input.priceLimit ?? maxOptionalNumber(details.map((item) => item.priceLimit)),
-            updatedAt: first?.updatedAt,
-            groupKey,
-            details
-        }
-    }
+		return {
+			id: this.buildGroupId(groupKey),
+			tenantId: groupKey.tenantId,
+			organizationId: groupKey.organizationId ?? undefined,
+			orgId: groupKey.orgId,
+			userId: groupKey.userId,
+			user: first?.user,
+			org: first?.org,
+			provider: groupKey.provider,
+			model: groupKey.model,
+			currency: groupKey.currency,
+			tokenUsed: 0,
+			priceUsed: 0,
+			tokenTotalUsed: details.reduce((sum, item) => sum + (item.tokenTotalUsed ?? 0), 0),
+			priceTotalUsed: details.reduce((sum, item) => sum + Number(item.priceTotalUsed ?? 0), 0),
+			tokenLimit: input.tokenLimit,
+			priceLimit: input.priceLimit ?? maxOptionalNumber(details.map((item) => item.priceLimit)),
+			updatedAt: first?.updatedAt,
+			groupKey,
+			details
+		}
+	}
 
-    private async findUserUsageGroupDetails(groupKey: ICopilotUserUsageGroupKey) {
-        return await this.repository.find({
-            where: this.toGroupWhere(groupKey),
-            relations: ['user', 'org'],
-            order: {
-                updatedAt: OrderTypeEnum.DESC
-            }
-        })
-    }
+	private async findUserUsageGroupDetails(groupKey: ICopilotUserUsageGroupKey) {
+		return await this.repository.find({
+			where: this.toGroupWhere(groupKey),
+			relations: ['user', 'org'],
+			order: {
+				updatedAt: OrderTypeEnum.DESC
+			}
+		})
+	}
 
-    private toGroupWhere(groupKey: ICopilotUserUsageGroupKey): FindOptionsWhere<CopilotUser> {
-        const tenantId = RequestContext.currentTenantId()
-        const organizationId = RequestContext.getOrganizationId()
+	private toGroupWhere(groupKey: ICopilotUserUsageGroupKey): FindOptionsWhere<CopilotUser> {
+		const tenantId = RequestContext.currentTenantId()
+		const organizationId = RequestContext.getOrganizationId()
 
-        return {
-            tenantId,
-            organizationId: organizationId ?? IsNull(),
-            orgId: groupKey.orgId ?? IsNull(),
-            userId: groupKey.userId,
-            provider: groupKey.provider,
-            model: groupKey.model ?? IsNull(),
-            currency: groupKey.currency ?? IsNull()
-        }
-    }
+		return {
+			tenantId,
+			organizationId: organizationId ?? IsNull(),
+			orgId: groupKey.orgId ?? IsNull(),
+			userId: groupKey.userId,
+			provider: groupKey.provider,
+			model: groupKey.model ?? IsNull(),
+			currency: groupKey.currency ?? IsNull()
+		}
+	}
 
-    private assertUserUsageGroupInput(input: ICopilotUserUsageGroupKey) {
-        if (!input.userId || !input.provider) {
-            throw new BadRequestException('Missing required copilot user usage group fields')
-        }
-    }
+	private assertUserUsageGroupInput(input: ICopilotUserUsageGroupKey) {
+		if (!input.userId || !input.provider) {
+			throw new BadRequestException('Missing required copilot user usage group fields')
+		}
+	}
 
-    private toGroupKey(input: ICopilotUserUsageGroupKey): ICopilotUserUsageGroupKey {
-        return {
-            tenantId: RequestContext.currentTenantId(),
-            organizationId: RequestContext.getOrganizationId() ?? null,
-            orgId: input.orgId ?? null,
-            userId: input.userId,
-            provider: input.provider,
-            model: input.model,
-            currency: toNullableString(input.currency)
-        }
-    }
+	private toGroupKey(input: ICopilotUserUsageGroupKey): ICopilotUserUsageGroupKey {
+		return {
+			tenantId: RequestContext.currentTenantId(),
+			organizationId: RequestContext.getOrganizationId() ?? null,
+			orgId: input.orgId ?? null,
+			userId: input.userId,
+			provider: input.provider,
+			model: input.model,
+			currency: toNullableString(input.currency)
+		}
+	}
 
-    private buildGroupId(groupKey: ICopilotUserUsageGroupKey) {
-        return [
-            groupKey.tenantId,
-            groupKey.organizationId,
-            groupKey.orgId,
-            groupKey.userId,
-            groupKey.provider,
-            groupKey.model,
-            groupKey.currency
-        ]
-            .map(encodeGroupPart)
-            .join(GROUP_ID_SEPARATOR)
-    }
+	private buildGroupId(groupKey: ICopilotUserUsageGroupKey) {
+		return [
+			groupKey.tenantId,
+			groupKey.organizationId,
+			groupKey.orgId,
+			groupKey.userId,
+			groupKey.provider,
+			groupKey.model,
+			groupKey.currency
+		]
+			.map(encodeGroupPart)
+			.join(GROUP_ID_SEPARATOR)
+	}
 
-    private toSummaryUser(row: CopilotUserUsageSummaryRaw): ICopilotUser['user'] {
-        const id = toOptionalString(row.userRelationId)
-        return id
-            ? {
-                  id,
-                  firstName: toOptionalString(row.userFirstName),
-                  lastName: toOptionalString(row.userLastName),
-                  email: toOptionalString(row.userEmail),
-                  username: toOptionalString(row.userUsername),
-                  imageUrl: toOptionalString(row.userImageUrl)
-              }
-            : undefined
-    }
+	private toSummaryUser(row: CopilotUserUsageSummaryRaw): ICopilotUser['user'] {
+		const id = toOptionalString(row.userRelationId)
+		return id
+			? {
+				  id,
+				  firstName: toOptionalString(row.userFirstName),
+				  lastName: toOptionalString(row.userLastName),
+				  email: toOptionalString(row.userEmail),
+				  username: toOptionalString(row.userUsername),
+				  imageUrl: toOptionalString(row.userImageUrl)
+			  }
+			: undefined
+	}
 
-    private toSummaryOrg(row: CopilotUserUsageSummaryRaw): ICopilotUser['org'] {
-        const id = toOptionalString(row.orgRelationId)
-        return id
-            ? ({
-                  id,
-                  name: toOptionalString(row.orgName),
-                  imageUrl: toOptionalString(row.orgImageUrl)
-              } as ICopilotUser['org'])
-            : undefined
-    }
+	private toSummaryOrg(row: CopilotUserUsageSummaryRaw): ICopilotUser['org'] {
+		const id = toOptionalString(row.orgRelationId)
+		return id
+			? ({
+				  id,
+				  name: toOptionalString(row.orgName),
+				  imageUrl: toOptionalString(row.orgImageUrl)
+			  } as ICopilotUser['org'])
+			: undefined
+	}
 
-    async renew(id: string, entity: Partial<ICopilotUser>) {
-        const record = await this.findOne(id, {
-            where: {
-                tenantId: RequestContext.currentTenantId(),
-                organizationId: RequestContext.getOrganizationId()
-            }
-        })
-        record.tokenTotalUsed += record.tokenUsed
-        record.priceTotalUsed += Number(record.priceUsed ?? 0)
-        record.tokenUsed = 0
-        record.priceUsed = 0
-        record.tokenLimit = entity.tokenLimit
-        record.priceLimit = entity.priceLimit
-        return await this.repository.save(record)
-    }
+	async renew(id: string, entity: Partial<ICopilotUser>) {
+		const record = await this.findOne(id, {
+			where: {
+				tenantId: RequestContext.currentTenantId(),
+				organizationId: RequestContext.getOrganizationId()
+			}
+		})
+		record.tokenTotalUsed += record.tokenUsed
+		record.priceTotalUsed += Number(record.priceUsed ?? 0)
+		record.tokenUsed = 0
+		record.priceUsed = 0
+		record.tokenLimit = entity.tokenLimit
+		record.priceLimit = entity.priceLimit
+		return await this.repository.save(record)
+	}
 }

--- a/packages/server-ai/src/copilot-user/copilot-user.service.ts
+++ b/packages/server-ai/src/copilot-user/copilot-user.service.ts
@@ -1,127 +1,451 @@
-import { ICopilotUser } from '@xpert-ai/contracts'
+import {
+    ICopilotUser,
+    ICopilotUserUsageGroupKey,
+    ICopilotUserUsageSummary,
+    IPagination,
+    OrderTypeEnum,
+    TCopilotUserUsageSummaryRenewInput
+} from '@xpert-ai/contracts'
 import { RequestContext, TenantOrganizationAwareCrudService } from '@xpert-ai/server-core'
-import { Injectable, Logger } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { IsNull, Repository } from 'typeorm'
+import { FindOptionsWhere, IsNull, Repository } from 'typeorm'
 import { CopilotUser } from './copilot-user.entity'
+
+type CopilotUserUsageSummaryRaw = {
+    tenantId?: string | null
+    organizationId?: string | null
+    orgId?: string | null
+    userId?: string | null
+    provider?: string | null
+    model?: string | null
+    currency?: string | null
+    tokenUsed?: string | number | null
+    priceUsed?: string | number | null
+    tokenTotalUsed?: string | number | null
+    priceTotalUsed?: string | number | null
+    tokenLimit?: string | number | null
+    priceLimit?: string | number | null
+    updatedAt?: Date | string | null
+    userRelationId?: string | null
+    userFirstName?: string | null
+    userLastName?: string | null
+    userEmail?: string | null
+    userUsername?: string | null
+    userImageUrl?: string | null
+    orgRelationId?: string | null
+    orgName?: string | null
+    orgImageUrl?: string | null
+    total?: string | number | null
+}
+
+const GROUP_ID_SEPARATOR = '|'
+
+function toNumber(value: string | number | null | undefined) {
+    return value === null || value === undefined ? 0 : Number(value)
+}
+
+function toNullableString(value: string | null | undefined) {
+    return value === null || value === undefined ? null : value
+}
+
+function toOptionalString(value: string | null | undefined) {
+    return value === null || value === undefined ? undefined : value
+}
+
+function toOptionalNumber(value: string | number | null | undefined) {
+    return value === null || value === undefined ? undefined : Number(value)
+}
+
+function maxOptionalNumber(values: Array<string | number | null | undefined>) {
+    let max: number | undefined
+    for (const value of values) {
+        if (value !== null && value !== undefined) {
+            const numberValue = Number(value)
+            max = max === undefined ? numberValue : Math.max(max, numberValue)
+        }
+    }
+
+    return max
+}
+
+function encodeGroupPart(value: string | number | null | undefined) {
+    return encodeURIComponent(value === null || value === undefined ? '' : String(value))
+}
 
 @Injectable()
 export class CopilotUserService extends TenantOrganizationAwareCrudService<CopilotUser> {
-	readonly #logger = new Logger(CopilotUserService.name)
+    readonly #logger = new Logger(CopilotUserService.name)
 
-	constructor(
-		@InjectRepository(CopilotUser)
-		repository: Repository<CopilotUser>
-	) {
-		super(repository)
-	}
+    constructor(
+        @InjectRepository(CopilotUser)
+        repository: Repository<CopilotUser>
+    ) {
+        super(repository)
+    }
 
-	/**
-	 * Record usage of ai model for user in organization
-	 */
-	async upsert(user: Partial<CopilotUser>): Promise<ICopilotUser> {
-		const existing = await this.findOneOrFailByOptions({
-			where: {
-				tenantId: user.tenantId,
-				organizationId: user.organizationId,
-				orgId: user.orgId ?? IsNull(),
-				xpertId: user.xpertId ?? IsNull(),
-				threadId: user.threadId ?? IsNull(),
-				userId: user.userId,
-				provider: user.provider,
-				model: user.model,
-				usageHour: user.usageHour ?? IsNull()
-			}
-		})
-		if (existing.success) {
-			existing.record.tokenUsed = (existing.record.tokenUsed ?? 0) + (user.tokenUsed ?? 0)
-			existing.record.priceUsed = Number(existing.record.priceUsed ?? 0) + Number(user.priceUsed ?? 0)
-			existing.record.currency ??= user.currency
-			return await this.repository.save(existing.record)
-		} else {
-			return await this.create({
-				tenantId: user.tenantId,
-				organizationId: user.organizationId,
-				orgId: user.orgId,
-				xpertId: user.xpertId,
-				threadId: user.threadId,
-				userId: user.userId,
-				provider: user.provider,
-				model: user.model,
-				usageHour: user.usageHour,
-				tokenUsed: user.tokenUsed,
-				tokenLimit: user.tokenLimit,
-				priceUsed: Number(user.priceUsed ?? 0),
-				currency: user.currency
-			})
-		}
-	}
+    /**
+     * Record usage of ai model for user in organization
+     */
+    async upsert(user: Partial<CopilotUser>): Promise<ICopilotUser> {
+        const existing = await this.findOneOrFailByOptions({
+            where: {
+                tenantId: user.tenantId,
+                organizationId: user.organizationId,
+                orgId: user.orgId ?? IsNull(),
+                xpertId: user.xpertId ?? IsNull(),
+                threadId: user.threadId ?? IsNull(),
+                userId: user.userId,
+                provider: user.provider,
+                model: user.model,
+                usageHour: user.usageHour ?? IsNull()
+            }
+        })
+        if (existing.success) {
+            existing.record.tokenUsed = (existing.record.tokenUsed ?? 0) + (user.tokenUsed ?? 0)
+            existing.record.priceUsed = Number(existing.record.priceUsed ?? 0) + Number(user.priceUsed ?? 0)
+            existing.record.tokenLimit ??= user.tokenLimit
+            existing.record.priceLimit ??= user.priceLimit
+            existing.record.currency ??= user.currency
+            return await this.repository.save(existing.record)
+        } else {
+            const usageSummary = await this.getUsageSummary({
+                tenantId: user.tenantId,
+                organizationId: user.organizationId,
+                orgId: user.orgId,
+                userId: user.userId,
+                provider: user.provider,
+                model: user.model
+            })
 
-	async getUsageSummary(input: {
-		tenantId: string
-		organizationId?: string
-		orgId?: string | null
-		userId: string
-		provider: string
-		model?: string
-	}) {
-		const { tenantId, organizationId, orgId, userId, provider, model } = input
-		const query = this.repository
-			.createQueryBuilder('copilot_user')
-			.select('COALESCE(SUM(copilot_user.tokenUsed), 0)', 'tokenUsed')
-			.addSelect('COALESCE(SUM(copilot_user.priceUsed), 0)', 'priceUsed')
-			.addSelect('MAX(copilot_user.tokenLimit)', 'tokenLimit')
-			.addSelect('MAX(copilot_user.priceLimit)', 'priceLimit')
-			.where('copilot_user.tenantId = :tenantId', { tenantId })
-			.andWhere('copilot_user.userId = :userId', { userId })
-			.andWhere('copilot_user.provider = :provider', { provider })
+            return await this.create({
+                tenantId: user.tenantId,
+                organizationId: user.organizationId,
+                orgId: user.orgId,
+                xpertId: user.xpertId,
+                threadId: user.threadId,
+                userId: user.userId,
+                provider: user.provider,
+                model: user.model,
+                usageHour: user.usageHour,
+                tokenUsed: user.tokenUsed,
+                tokenLimit: usageSummary.tokenLimit ?? user.tokenLimit,
+                priceUsed: Number(user.priceUsed ?? 0),
+                priceLimit: usageSummary.priceLimit ?? user.priceLimit,
+                currency: user.currency
+            })
+        }
+    }
 
-		if (organizationId) {
-			query.andWhere('copilot_user.organizationId = :organizationId', { organizationId })
-		} else {
-			query.andWhere('copilot_user.organizationId IS NULL')
-		}
+    async getUsageSummary(input: {
+        tenantId: string
+        organizationId?: string
+        orgId?: string | null
+        userId: string
+        provider: string
+        model?: string
+    }) {
+        const { tenantId, organizationId, orgId, userId, provider, model } = input
+        const query = this.repository
+            .createQueryBuilder('copilot_user')
+            .select('COALESCE(SUM(copilot_user.tokenUsed), 0)', 'tokenUsed')
+            .addSelect('COALESCE(SUM(copilot_user.priceUsed), 0)', 'priceUsed')
+            .addSelect('MAX(copilot_user.tokenLimit)', 'tokenLimit')
+            .addSelect('MAX(copilot_user.priceLimit)', 'priceLimit')
+            .where('copilot_user.tenantId = :tenantId', { tenantId })
+            .andWhere('copilot_user.userId = :userId', { userId })
+            .andWhere('copilot_user.provider = :provider', { provider })
 
-		if (model) {
-			query.andWhere('copilot_user.model = :model', { model })
-		} else {
-			query.andWhere('copilot_user.model IS NULL')
-		}
+        if (organizationId) {
+            query.andWhere('copilot_user.organizationId = :organizationId', { organizationId })
+        } else {
+            query.andWhere('copilot_user.organizationId IS NULL')
+        }
 
-		if (orgId) {
-			query.andWhere('copilot_user.orgId = :orgId', { orgId })
-		} else {
-			query.andWhere('copilot_user.orgId IS NULL')
-		}
+        if (model) {
+            query.andWhere('copilot_user.model = :model', { model })
+        } else {
+            query.andWhere('copilot_user.model IS NULL')
+        }
 
-		const result = await query.getRawOne<{
-			tokenUsed?: string
-			priceUsed?: string
-			tokenLimit?: string
-			priceLimit?: string
-		}>()
+        if (orgId) {
+            query.andWhere('copilot_user.orgId = :orgId', { orgId })
+        } else {
+            query.andWhere('copilot_user.orgId IS NULL')
+        }
 
-		return {
-			tokenUsed: Number(result?.tokenUsed ?? 0),
-			priceUsed: Number(result?.priceUsed ?? 0),
-			tokenLimit: result?.tokenLimit !== null && result?.tokenLimit !== undefined ? Number(result.tokenLimit) : null,
-			priceLimit: result?.priceLimit !== null && result?.priceLimit !== undefined ? Number(result.priceLimit) : null
-		}
-	}
+        const result = await query.getRawOne<{
+            tokenUsed?: string
+            priceUsed?: string
+            tokenLimit?: string
+            priceLimit?: string
+        }>()
 
-	async renew(id: string, entity: Partial<ICopilotUser>) {
-		const record = await this.findOne(id, {
-			where: {
-				tenantId: RequestContext.currentTenantId(),
-				organizationId: RequestContext.getOrganizationId()
-			}
-		})
-		record.tokenTotalUsed += record.tokenUsed
-		record.priceTotalUsed += Number(record.priceUsed ?? 0)
-		record.tokenUsed = 0
-		record.priceUsed = 0
-		record.tokenLimit = entity.tokenLimit
-		record.priceLimit = entity.priceLimit
-		return await this.repository.save(record)
-	}
+        return {
+            tokenUsed: Number(result?.tokenUsed ?? 0),
+            priceUsed: Number(result?.priceUsed ?? 0),
+            tokenLimit:
+                result?.tokenLimit !== null && result?.tokenLimit !== undefined ? Number(result.tokenLimit) : null,
+            priceLimit:
+                result?.priceLimit !== null && result?.priceLimit !== undefined ? Number(result.priceLimit) : null
+        }
+    }
+
+    async findUserUsageSummaries(options?: {
+        take?: number
+        skip?: number
+        order?: {
+            updatedAt?: unknown
+        }
+    }): Promise<IPagination<ICopilotUserUsageSummary>> {
+        const tenantId = RequestContext.currentTenantId()
+        const organizationId = RequestContext.getOrganizationId()
+        const take = Number(options?.take ?? 20)
+        const skip = Number(options?.skip ?? 0)
+        const updatedAtOrder =
+            options?.order?.updatedAt === OrderTypeEnum.ASC || options?.order?.updatedAt === 'ASC'
+                ? OrderTypeEnum.ASC
+                : OrderTypeEnum.DESC
+
+        const query = this.repository
+            .createQueryBuilder('copilot_user')
+            .leftJoin('copilot_user.user', 'copilot_user_user')
+            .leftJoin('copilot_user.org', 'copilot_user_org')
+            .select('copilot_user.tenantId', 'tenantId')
+            .addSelect('copilot_user.organizationId', 'organizationId')
+            .addSelect('copilot_user.orgId', 'orgId')
+            .addSelect('copilot_user.userId', 'userId')
+            .addSelect('copilot_user.provider', 'provider')
+            .addSelect('copilot_user.model', 'model')
+            .addSelect('copilot_user.currency', 'currency')
+            .addSelect('COALESCE(SUM(copilot_user.tokenUsed), 0)', 'tokenUsed')
+            .addSelect('COALESCE(SUM(copilot_user.priceUsed), 0)', 'priceUsed')
+            .addSelect('COALESCE(SUM(copilot_user.tokenTotalUsed), 0)', 'tokenTotalUsed')
+            .addSelect('COALESCE(SUM(copilot_user.priceTotalUsed), 0)', 'priceTotalUsed')
+            .addSelect('MAX(copilot_user.tokenLimit)', 'tokenLimit')
+            .addSelect('MAX(copilot_user.priceLimit)', 'priceLimit')
+            .addSelect('MAX(copilot_user.updatedAt)', 'updatedAt')
+            .addSelect('copilot_user_user.id', 'userRelationId')
+            .addSelect('copilot_user_user.firstName', 'userFirstName')
+            .addSelect('copilot_user_user.lastName', 'userLastName')
+            .addSelect('copilot_user_user.email', 'userEmail')
+            .addSelect('copilot_user_user.username', 'userUsername')
+            .addSelect('copilot_user_user.imageUrl', 'userImageUrl')
+            .addSelect('copilot_user_org.id', 'orgRelationId')
+            .addSelect('copilot_user_org.name', 'orgName')
+            .addSelect('copilot_user_org.imageUrl', 'orgImageUrl')
+            .addSelect('COUNT(*) OVER()', 'total')
+            .where('copilot_user.tenantId = :tenantId', { tenantId })
+            .groupBy('copilot_user.tenantId')
+            .addGroupBy('copilot_user.organizationId')
+            .addGroupBy('copilot_user.orgId')
+            .addGroupBy('copilot_user.userId')
+            .addGroupBy('copilot_user.provider')
+            .addGroupBy('copilot_user.model')
+            .addGroupBy('copilot_user.currency')
+            .addGroupBy('copilot_user_user.id')
+            .addGroupBy('copilot_user_user.firstName')
+            .addGroupBy('copilot_user_user.lastName')
+            .addGroupBy('copilot_user_user.email')
+            .addGroupBy('copilot_user_user.username')
+            .addGroupBy('copilot_user_user.imageUrl')
+            .addGroupBy('copilot_user_org.id')
+            .addGroupBy('copilot_user_org.name')
+            .addGroupBy('copilot_user_org.imageUrl')
+            .orderBy('MAX(copilot_user.updatedAt)', updatedAtOrder)
+            .take(take)
+            .skip(skip)
+
+        if (organizationId) {
+            query.andWhere('copilot_user.organizationId = :organizationId', { organizationId })
+        } else {
+            query.andWhere('copilot_user.organizationId IS NULL')
+        }
+
+        const rows = await query.getRawMany<CopilotUserUsageSummaryRaw>()
+        const items = rows.map((row) => this.toUserUsageSummary(row))
+
+        return {
+            items,
+            total: rows.length ? toNumber(rows[0].total) : 0
+        }
+    }
+
+    async findUserUsageDetails(input: ICopilotUserUsageGroupKey) {
+        this.assertUserUsageGroupInput(input)
+        return await this.findUserUsageGroupDetails(this.toGroupKey(input))
+    }
+
+    async renewUserUsageSummary(input: TCopilotUserUsageSummaryRenewInput): Promise<ICopilotUserUsageSummary> {
+        this.assertUserUsageGroupInput(input)
+        const groupKey = this.toGroupKey(input)
+        const details = await this.findUserUsageGroupDetails(groupKey)
+        const records = details.map((record) => {
+            record.tokenTotalUsed = (record.tokenTotalUsed ?? 0) + (record.tokenUsed ?? 0)
+            record.priceTotalUsed = Number(record.priceTotalUsed ?? 0) + Number(record.priceUsed ?? 0)
+            record.tokenUsed = 0
+            record.priceUsed = 0
+            record.tokenLimit = input.tokenLimit
+            if (input.priceLimit !== undefined) {
+                record.priceLimit = input.priceLimit
+            }
+            return record
+        })
+        const saved = records.length ? await this.repository.save(records) : []
+
+        return this.toRenewedUserUsageSummary({ ...input, ...groupKey }, saved)
+    }
+
+    private toUserUsageSummary(row: CopilotUserUsageSummaryRaw): ICopilotUserUsageSummary {
+        const groupKey = this.toGroupKey(row)
+
+        return {
+            id: this.buildGroupId(groupKey),
+            tenantId: groupKey.tenantId,
+            organizationId: groupKey.organizationId ?? undefined,
+            orgId: groupKey.orgId,
+            userId: groupKey.userId,
+            user: this.toSummaryUser(row),
+            org: this.toSummaryOrg(row),
+            provider: groupKey.provider,
+            model: groupKey.model,
+            currency: groupKey.currency,
+            tokenUsed: toNumber(row.tokenUsed),
+            priceUsed: toNumber(row.priceUsed),
+            tokenTotalUsed: toNumber(row.tokenTotalUsed),
+            priceTotalUsed: toNumber(row.priceTotalUsed),
+            tokenLimit: toOptionalNumber(row.tokenLimit),
+            priceLimit: toOptionalNumber(row.priceLimit),
+            updatedAt: row.updatedAt ? new Date(row.updatedAt) : undefined,
+            groupKey
+        }
+    }
+
+    private toRenewedUserUsageSummary(
+        input: TCopilotUserUsageSummaryRenewInput,
+        details: CopilotUser[]
+    ): ICopilotUserUsageSummary {
+        const groupKey = this.toGroupKey(input)
+        const first = details[0]
+
+        return {
+            id: this.buildGroupId(groupKey),
+            tenantId: groupKey.tenantId,
+            organizationId: groupKey.organizationId ?? undefined,
+            orgId: groupKey.orgId,
+            userId: groupKey.userId,
+            user: first?.user,
+            org: first?.org,
+            provider: groupKey.provider,
+            model: groupKey.model,
+            currency: groupKey.currency,
+            tokenUsed: 0,
+            priceUsed: 0,
+            tokenTotalUsed: details.reduce((sum, item) => sum + (item.tokenTotalUsed ?? 0), 0),
+            priceTotalUsed: details.reduce((sum, item) => sum + Number(item.priceTotalUsed ?? 0), 0),
+            tokenLimit: input.tokenLimit,
+            priceLimit: input.priceLimit ?? maxOptionalNumber(details.map((item) => item.priceLimit)),
+            updatedAt: first?.updatedAt,
+            groupKey,
+            details
+        }
+    }
+
+    private async findUserUsageGroupDetails(groupKey: ICopilotUserUsageGroupKey) {
+        return await this.repository.find({
+            where: this.toGroupWhere(groupKey),
+            relations: ['user', 'org'],
+            order: {
+                updatedAt: OrderTypeEnum.DESC
+            }
+        })
+    }
+
+    private toGroupWhere(groupKey: ICopilotUserUsageGroupKey): FindOptionsWhere<CopilotUser> {
+        const tenantId = RequestContext.currentTenantId()
+        const organizationId = RequestContext.getOrganizationId()
+
+        return {
+            tenantId,
+            organizationId: organizationId ?? IsNull(),
+            orgId: groupKey.orgId ?? IsNull(),
+            userId: groupKey.userId,
+            provider: groupKey.provider,
+            model: groupKey.model ?? IsNull(),
+            currency: groupKey.currency ?? IsNull()
+        }
+    }
+
+    private assertUserUsageGroupInput(input: ICopilotUserUsageGroupKey) {
+        if (!input.userId || !input.provider) {
+            throw new BadRequestException('Missing required copilot user usage group fields')
+        }
+    }
+
+    private toGroupKey(input: ICopilotUserUsageGroupKey): ICopilotUserUsageGroupKey {
+        return {
+            tenantId: RequestContext.currentTenantId(),
+            organizationId: RequestContext.getOrganizationId() ?? null,
+            orgId: input.orgId ?? null,
+            userId: input.userId,
+            provider: input.provider,
+            model: input.model,
+            currency: toNullableString(input.currency)
+        }
+    }
+
+    private buildGroupId(groupKey: ICopilotUserUsageGroupKey) {
+        return [
+            groupKey.tenantId,
+            groupKey.organizationId,
+            groupKey.orgId,
+            groupKey.userId,
+            groupKey.provider,
+            groupKey.model,
+            groupKey.currency
+        ]
+            .map(encodeGroupPart)
+            .join(GROUP_ID_SEPARATOR)
+    }
+
+    private toSummaryUser(row: CopilotUserUsageSummaryRaw): ICopilotUser['user'] {
+        const id = toOptionalString(row.userRelationId)
+        return id
+            ? {
+                  id,
+                  firstName: toOptionalString(row.userFirstName),
+                  lastName: toOptionalString(row.userLastName),
+                  email: toOptionalString(row.userEmail),
+                  username: toOptionalString(row.userUsername),
+                  imageUrl: toOptionalString(row.userImageUrl)
+              }
+            : undefined
+    }
+
+    private toSummaryOrg(row: CopilotUserUsageSummaryRaw): ICopilotUser['org'] {
+        const id = toOptionalString(row.orgRelationId)
+        return id
+            ? ({
+                  id,
+                  name: toOptionalString(row.orgName),
+                  imageUrl: toOptionalString(row.orgImageUrl)
+              } as ICopilotUser['org'])
+            : undefined
+    }
+
+    async renew(id: string, entity: Partial<ICopilotUser>) {
+        const record = await this.findOne(id, {
+            where: {
+                tenantId: RequestContext.currentTenantId(),
+                organizationId: RequestContext.getOrganizationId()
+            }
+        })
+        record.tokenTotalUsed += record.tokenUsed
+        record.priceTotalUsed += Number(record.priceUsed ?? 0)
+        record.tokenUsed = 0
+        record.priceUsed = 0
+        record.tokenLimit = entity.tokenLimit
+        record.priceLimit = entity.priceLimit
+        return await this.repository.save(record)
+    }
 }


### PR DESCRIPTION
## Summary
- Add grouped Copilot user/model usage summary, lazy detail loading, and group renew API.
- Update the settings usage table to use `z-table`/`z-input` with expandable per-session details.
- Keep renew scoped to request tenant/organization and validate required group identity fields.

## Validation
- `git diff --check origin/develop...HEAD`
- `pnpm nx test server-ai --testFile=packages/server-ai/src/copilot-user/copilot-user.service.spec.ts --runInBand --skip-nx-cache`
- `pnpm nx build server-ai --skip-nx-cache`
- `pnpm nx build cloud --configuration=development --skip-nx-cache`