### PR TITLE
fix: record tool component metrics

### DIFF
--- a/packages/server-ai/src/metrics/application-metrics.spec.ts
+++ b/packages/server-ai/src/metrics/application-metrics.spec.ts
@@ -73,6 +73,67 @@ describe('ApplicationMetricsRegistry', () => {
         )
     })
 
+    it('records completed tool component transitions without double counting', () => {
+        const registry = new ApplicationMetricsRegistry()
+        const runningContent = [
+            {
+                id: 'tool-1',
+                type: 'component',
+                data: {
+                    toolset: 'browser_automation',
+                    tool: 'host_page_snapshot',
+                    status: 'running',
+                    created_date: '2026-05-27T00:00:00.000Z'
+                }
+            }
+        ]
+        const completedContent = [
+            {
+                id: 'tool-1',
+                type: 'component',
+                data: {
+                    toolset: 'browser_automation',
+                    tool: 'host_page_snapshot',
+                    status: 'success',
+                    created_date: '2026-05-27T00:00:00.000Z',
+                    end_date: '2026-05-27T00:00:02.000Z'
+                }
+            }
+        ]
+
+        registry.recordToolComponentMessage(
+            {
+                id: 'tool-1',
+                type: 'component',
+                data: {
+                    status: 'success',
+                    end_date: '2026-05-27T00:00:02.000Z'
+                }
+            },
+            runningContent
+        )
+        registry.recordToolComponentMessage(
+            {
+                id: 'tool-1',
+                type: 'component',
+                data: {
+                    status: 'success',
+                    end_date: '2026-05-27T00:00:02.000Z'
+                }
+            },
+            completedContent
+        )
+
+        const output = registry.render()
+
+        expect(output).toContain(
+            'xpert_tool_calls_total{status="success",tool="host_page_snapshot",toolset="browser_automation"} 1'
+        )
+        expect(output).toContain(
+            'xpert_tool_duration_seconds_sum{status="success",tool="host_page_snapshot",toolset="browser_automation"} 2'
+        )
+    })
+
     it('exposes a singleton registry for instrumentation call sites', () => {
         applicationMetrics.reset()
         applicationMetrics.recordChatRequest({ action: 'follow_up', from: 'api', status: 'queued', durationMs: 10 })

--- a/packages/server-ai/src/metrics/application-metrics.ts
+++ b/packages/server-ai/src/metrics/application-metrics.ts
@@ -38,6 +38,12 @@ type ToolMessageMetricInput = {
     end_date?: unknown
 }
 
+type ToolComponentMetricInput = {
+    id?: unknown
+    type?: unknown
+    data?: unknown
+}
+
 class CounterMetric {
     private readonly samples = new Map<string, { labels: MetricLabels; value: number }>()
 
@@ -308,6 +314,31 @@ export class ApplicationMetricsRegistry {
         }
     }
 
+    recordToolComponentMessage(input: unknown, previousContent: unknown) {
+        const component = toolComponentMetricInput(input)
+        if (!component) {
+            return
+        }
+
+        const data = toolMessageMetricInput(component.data)
+        if (!data) {
+            return
+        }
+
+        const status = stringValue(data.status)
+        if (!status || status === 'running') {
+            return
+        }
+
+        const previousData = findToolComponentData(previousContent, component.id)
+        const previousStatus = stringValue(previousData?.status)
+        if (previousStatus && previousStatus !== 'running') {
+            return
+        }
+
+        this.recordToolMessage(mergeToolMessageMetricInput(previousData, data))
+    }
+
     render() {
         return (
             [
@@ -427,11 +458,75 @@ function formatNumber(value: number) {
 }
 
 function isToolMessageMetricInput(value: unknown): value is ToolMessageMetricInput {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    const candidate = toolMessageMetricInput(value)
+    if (!candidate) {
         return false
     }
-    const candidate = value as ToolMessageMetricInput
     return stringValue(candidate.tool) !== null || stringValue(candidate.toolset) !== null
+}
+
+function toolMessageMetricInput(value: unknown) {
+    if (!isMetricObject(value)) {
+        return null
+    }
+
+    return {
+        toolset: objectProperty(value, 'toolset'),
+        tool: objectProperty(value, 'tool'),
+        status: objectProperty(value, 'status'),
+        created_date: objectProperty(value, 'created_date'),
+        end_date: objectProperty(value, 'end_date')
+    } satisfies ToolMessageMetricInput
+}
+
+function toolComponentMetricInput(value: unknown) {
+    if (!isMetricObject(value)) {
+        return null
+    }
+    const type = objectProperty(value, 'type')
+    if (type !== 'component') {
+        return null
+    }
+
+    return {
+        id: objectProperty(value, 'id'),
+        type,
+        data: objectProperty(value, 'data')
+    } satisfies ToolComponentMetricInput
+}
+
+function findToolComponentData(content: unknown, id: unknown) {
+    const targetId = stringValue(id)
+    if (!targetId || !Array.isArray(content)) {
+        return null
+    }
+
+    for (const item of content) {
+        const component = toolComponentMetricInput(item)
+        if (!component || stringValue(component.id) !== targetId) {
+            continue
+        }
+        return toolMessageMetricInput(component.data)
+    }
+    return null
+}
+
+function mergeToolMessageMetricInput(previous: ToolMessageMetricInput | null, incoming: ToolMessageMetricInput) {
+    return {
+        toolset: incoming.toolset ?? previous?.toolset,
+        tool: incoming.tool ?? previous?.tool,
+        status: incoming.status ?? previous?.status,
+        created_date: previous?.created_date ?? incoming.created_date,
+        end_date: incoming.end_date ?? previous?.end_date
+    } satisfies ToolMessageMetricInput
+}
+
+function isMetricObject(value: unknown): value is object {
+    return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function objectProperty(value: object, key: string): unknown {
+    return Object.getOwnPropertyDescriptor(value, key)?.value
 }
 
 function eventDurationSeconds(start: unknown, end: unknown) {

--- a/packages/server-ai/src/xpert/commands/handlers/chat.handler.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/chat.handler.ts
@@ -745,6 +745,7 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                                     fallbackStreamId: aiMessage?.id ?? executionId
                                 })
 
+                                applicationMetrics.recordToolComponentMessage(event.data.data, aiMessage.content)
                                 appendMessageContent(aiMessage, event.data.data, messageContext)
                                 result = appendMessagePlainText(result, event.data.data, messageContext)
                             } else if (event.data.type === ChatMessageTypeEnum.EVENT) {


### PR DESCRIPTION
## Summary

Fixes the Prometheus tool-call metrics path so completed agent tool calls emitted as `MESSAGE` component chunks increment `xpert_tool_calls_total` and observe `xpert_tool_duration_seconds`.

## Root Cause

The existing tool metrics instrumentation only handled `EVENT / ON_TOOL_MESSAGE`. Real agent tool calls are emitted as component messages: `on_tool_start` carries the tool metadata and `status=running`, while `on_tool_end` sends the same component id with `status=success` and `end_date`. Because the metrics code did not inspect this `MESSAGE component` path, the metric family was registered but no tool-call samples were produced.

## Changes

- Add `recordToolComponentMessage` to process completed component messages.
- Merge the completion chunk with the prior running component by id to recover `toolset`, `tool`, and `created_date`.
- Avoid double counting when the existing component is already completed.
- Keep the existing `EVENT / ON_TOOL_MESSAGE` instrumentation as a fallback path.
- Add a focused regression test for the start/end component transition.

## Validation

- `git diff --check`
- `pnpm nx test server-ai --testFile=packages/server-ai/src/metrics/application-metrics.spec.ts --runInBand --skip-nx-cache`
- `pnpm nx build server-ai --skip-nx-cache`

Note: the isolated worktree needed a local `pnpm install --frozen-lockfile --ignore-scripts --config.strict-ssl=false` because this machine's npm TLS certificate chain failed for a few registry downloads with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`. No project config was changed.