### PR TITLE
[codex] Add MCP JSON import flow

### DIFF
--- a/apps/cloud/src/app/@shared/mcp/import-json/import-json.component.html
+++ b/apps/cloud/src/app/@shared/mcp/import-json/import-json.component.html
@@ -1,0 +1,48 @@
+<div class="flex w-[640px] max-w-[calc(100vw-2rem)] flex-col rounded-2xl bg-components-panel-bg p-6 shadow-xl">
+  <div class="mb-4 flex items-start justify-between gap-4">
+    <div>
+      <div class="text-xl font-semibold text-text-primary">
+        {{ 'PAC.MCP.CreateFromJson' | translate: { Default: 'Create from JSON' } }}
+      </div>
+      <div class="mt-1 text-sm text-text-tertiary">
+        {{ 'PAC.MCP.PasteMCPJson' | translate: { Default: 'Paste an MCP JSON config to create a toolset.' } }}
+      </div>
+      <div class="mt-2 flex items-start gap-1 text-xs text-text-warning">
+        <i class="ri-information-line mt-0.5"></i>
+        <span>
+          {{
+            'PAC.MCP.UrlOnlySSECompatibility'
+              | translate: { Default: 'URL-only configs are imported as SSE for legacy compatibility.' }
+          }}
+        </span>
+      </div>
+    </div>
+    <button type="button" class="btn btn-tertiary btn-medium px-2" (click)="close()">
+      <i class="ri-close-line"></i>
+    </button>
+  </div>
+
+  <textarea
+    class="min-h-80 w-full resize-y rounded-lg border border-divider-regular bg-components-input-bg-normal px-3 py-2 font-mono text-sm text-text-primary outline-none placeholder:text-components-input-text-placeholder focus:border-components-input-border-active focus:bg-components-input-bg-active"
+    [ngModel]="value()"
+    (ngModelChange)="updateValue($event)"
+    spellcheck="false"
+  ></textarea>
+
+  @if (error()) {
+    <div class="mt-3 flex items-start gap-2 rounded-lg bg-state-destructive-hover px-3 py-2 text-sm text-text-destructive">
+      <i class="ri-error-warning-line mt-0.5"></i>
+      <span>{{ error() }}</span>
+    </div>
+  }
+
+  <div class="mt-5 flex justify-end gap-2">
+    <button type="button" class="btn btn-secondary btn-large" (click)="close()">
+      {{ 'PAC.ACTIONS.Cancel' | translate: { Default: 'Cancel' } }}
+    </button>
+    <button type="button" class="btn btn-primary btn-large" (click)="importJson()">
+      <i class="ri-file-code-line mr-1"></i>
+      {{ 'PAC.MCP.NextStep' | translate: { Default: 'Next Step' } }}
+    </button>
+  </div>
+</div>

--- a/apps/cloud/src/app/@shared/mcp/import-json/import-json.component.spec.ts
+++ b/apps/cloud/src/app/@shared/mcp/import-json/import-json.component.spec.ts
@@ -1,0 +1,54 @@
+import { MCPServerType, XpertToolsetCategoryEnum } from '@cloud/app/@core'
+import { createMCPToolsetFromJson } from './import-json.component'
+
+describe('createMCPToolsetFromJson', () => {
+  it('creates a stdio MCP toolset from mcpServers JSON', () => {
+    const toolset = createMCPToolsetFromJson(`{
+      "mcpServers": {
+        "edgeone-pages-mcp-server": {
+          "command": "npx",
+          "args": [
+            "edgeone-pages-mcp"
+          ]
+        }
+      }
+    }`)
+
+    expect(toolset.name).toBe('edgeone-pages-mcp-server')
+    expect(toolset.category).toBe(XpertToolsetCategoryEnum.MCP)
+    expect(toolset.type).toBe(MCPServerType.STDIO)
+    expect(JSON.parse(toolset.schema)).toEqual({
+      mcpServers: {
+        '': {
+          type: MCPServerType.STDIO,
+          command: 'npx',
+          args: ['edgeone-pages-mcp']
+        }
+      }
+    })
+  })
+
+  it('imports a URL-only MCP server as SSE for legacy compatibility', () => {
+    const toolset = createMCPToolsetFromJson(`{
+      "mcpServers": {
+        "legacy-remote": {
+          "url": "https://example.com/sse"
+        }
+      }
+    }`)
+
+    expect(toolset.type).toBe(MCPServerType.SSE)
+    expect(JSON.parse(toolset.schema)).toEqual({
+      mcpServers: {
+        '': {
+          type: MCPServerType.SSE,
+          url: 'https://example.com/sse'
+        }
+      }
+    })
+  })
+
+  it('rejects JSON without an MCP server map', () => {
+    expect(() => createMCPToolsetFromJson('{"name":"not mcp"}')).toThrow('MCP JSON must include mcpServers or servers')
+  })
+})

--- a/apps/cloud/src/app/@shared/mcp/import-json/import-json.component.ts
+++ b/apps/cloud/src/app/@shared/mcp/import-json/import-json.component.ts
@@ -1,0 +1,278 @@
+import { DialogRef } from '@angular/cdk/dialog'
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core'
+import { FormsModule } from '@angular/forms'
+import { TranslateModule } from '@ngx-translate/core'
+import {
+  IXpertToolset,
+  MCPServerType,
+  TMCPServer,
+  XpertToolsetCategoryEnum
+} from '@cloud/app/@core'
+
+type JsonObject = {
+  [key: string]: unknown
+}
+
+type StringMap = {
+  [key: string]: string
+}
+
+type MCPServerJsonMap = {
+  [name: string]: JsonObject
+}
+
+type MCPServerEntry = {
+  name: string
+  server: JsonObject
+}
+
+const sampleMCPJson = `{
+  "mcpServers": {
+    "edgeone-pages-mcp-server": {
+      "command": "npx",
+      "args": [
+        "edgeone-pages-mcp"
+      ]
+    }
+  }
+}`
+
+export function createMCPToolsetFromJson(source: string): Partial<IXpertToolset> {
+  const parsed: unknown = JSON.parse(source)
+  const entry = readFirstMCPServer(parsed)
+  const server = normalizeMCPServer(entry.server)
+
+  return {
+    name: entry.name || 'MCP Toolset',
+    category: XpertToolsetCategoryEnum.MCP,
+    type: server.type,
+    schema: JSON.stringify({
+      mcpServers: {
+        '': server
+      }
+    })
+  }
+}
+
+@Component({
+  standalone: true,
+  selector: 'pac-mcp-import-json',
+  imports: [FormsModule, TranslateModule],
+  templateUrl: './import-json.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MCPImportJsonComponent {
+  readonly #dialogRef = inject(DialogRef<Partial<IXpertToolset> | undefined>)
+
+  readonly value = signal(sampleMCPJson)
+  readonly error = signal<string>(null)
+
+  updateValue(value: string) {
+    this.value.set(value)
+    this.error.set(null)
+  }
+
+  importJson() {
+    try {
+      this.#dialogRef.close(createMCPToolsetFromJson(this.value()))
+    } catch (error) {
+      this.error.set(error instanceof Error ? error.message : 'Invalid MCP JSON')
+    }
+  }
+
+  close() {
+    this.#dialogRef.close()
+  }
+}
+
+function readFirstMCPServer(value: unknown): MCPServerEntry {
+  if (!isJsonObject(value)) {
+    throw new Error('MCP JSON must be an object')
+  }
+
+  const servers = readServerMap(value.mcpServers) ?? readServerMap(value.servers)
+  if (!servers) {
+    throw new Error('MCP JSON must include mcpServers or servers')
+  }
+
+  const serverName = Object.keys(servers)[0]
+  if (!serverName) {
+    throw new Error('MCP JSON must include at least one server')
+  }
+
+  return {
+    name: serverName,
+    server: servers[serverName]
+  }
+}
+
+function normalizeMCPServer(value: JsonObject): TMCPServer {
+  const type = readMCPServerType(value.type) ?? readMCPServerType(value.transport) ?? inferMCPServerType(value)
+  if (!type) {
+    throw new Error('MCP server must include command or url')
+  }
+
+  const server: TMCPServer = { type }
+
+  const command = readString(value.command)
+  if (command) {
+    server.command = command
+  }
+  const args = readStringArray(value.args)
+  if (args) {
+    server.args = args
+  }
+  const env = readStringMap(value.env)
+  if (env) {
+    server.env = env
+  }
+  const encoding = readString(value.encoding)
+  if (encoding) {
+    server.encoding = encoding
+  }
+  const encodingErrorHandler = readString(value.encodingErrorHandler)
+  if (encodingErrorHandler) {
+    server.encodingErrorHandler = encodingErrorHandler
+  }
+  const url = readString(value.url)
+  if (url) {
+    server.url = url
+  }
+  const headers = readStringMap(value.headers)
+  if (headers) {
+    server.headers = headers
+  }
+  const useNodeEventSource = readBoolean(value.useNodeEventSource)
+  if (useNodeEventSource !== null) {
+    server.useNodeEventSource = useNodeEventSource
+  }
+  const automaticSSEFallback = readBoolean(value.automaticSSEFallback)
+  if (automaticSSEFallback !== null) {
+    server.automaticSSEFallback = automaticSSEFallback
+  }
+  const defaultToolTimeout = readPositiveNumber(value.defaultToolTimeout)
+  if (defaultToolTimeout) {
+    server.defaultToolTimeout = defaultToolTimeout
+  }
+  copyFiles(value, server)
+  const toolNamePrefix = readString(value.toolNamePrefix)
+  if (toolNamePrefix) {
+    server.toolNamePrefix = toolNamePrefix
+  }
+  const initScripts = readString(value.initScripts)
+  if (initScripts) {
+    server.initScripts = initScripts
+  }
+  copyReconnect(value, server)
+
+  return server
+}
+
+function readServerMap(value: unknown): MCPServerJsonMap | null {
+  if (!isJsonObject(value)) {
+    return null
+  }
+
+  const servers: MCPServerJsonMap = {}
+  for (const name of Object.keys(value)) {
+    const server = value[name]
+    if (!isJsonObject(server)) {
+      continue
+    }
+    servers[name] = server
+  }
+
+  return Object.keys(servers).length ? servers : null
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readMCPServerType(value: unknown): MCPServerType | null {
+  if (value === MCPServerType.SSE || value === MCPServerType.HTTP || value === MCPServerType.STDIO || value === MCPServerType.CODE) {
+    return value
+  }
+  return null
+}
+
+function inferMCPServerType(value: JsonObject): MCPServerType | null {
+  if (typeof value.command === 'string') {
+    return MCPServerType.STDIO
+  }
+  if (typeof value.url === 'string') {
+    return MCPServerType.SSE
+  }
+  return null
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+function readStringArray(value: unknown): string[] | null {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string') ? value : null
+}
+
+function readStringMap(value: unknown): StringMap | null {
+  if (!isJsonObject(value)) {
+    return null
+  }
+
+  const result: StringMap = {}
+  for (const name of Object.keys(value)) {
+    const item = value[name]
+    if (typeof item === 'string') {
+      result[name] = item
+    }
+  }
+
+  return Object.keys(result).length ? result : null
+}
+
+function readBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null
+}
+
+function readPositiveNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null
+}
+
+function copyFiles(source: JsonObject, target: TMCPServer) {
+  const value = source.files
+  if (!Array.isArray(value)) {
+    return
+  }
+
+  const files = value.flatMap((file) =>
+    isJsonObject(file) && typeof file.name === 'string' && typeof file.content === 'string'
+      ? [{ name: file.name, content: file.content }]
+      : []
+  )
+
+  if (files.length) {
+    target.files = files
+  }
+}
+
+function copyReconnect(source: JsonObject, target: TMCPServer) {
+  const value = source.reconnect
+  if (!isJsonObject(value)) {
+    return
+  }
+
+  const reconnect: NonNullable<TMCPServer['reconnect']> = {}
+  if (typeof value.enabled === 'boolean') {
+    reconnect.enabled = value.enabled
+  }
+  if (typeof value.maxAttempts === 'number' && Number.isFinite(value.maxAttempts)) {
+    reconnect.maxAttempts = value.maxAttempts
+  }
+  if (typeof value.delayMs === 'number' && Number.isFinite(value.delayMs)) {
+    reconnect.delayMs = value.delayMs
+  }
+
+  if (Object.keys(reconnect).length) {
+    target.reconnect = reconnect
+  }
+}

--- a/apps/cloud/src/app/@shared/mcp/index.ts
+++ b/apps/cloud/src/app/@shared/mcp/index.ts
@@ -1,4 +1,5 @@
 export * from './server/server.component'
 export * from './manage/manage.component'
+export * from './import-json/import-json.component'
 export * from './marketplace/marketplace.component'
 export * from './toolsets/toolsets.component'

--- a/apps/cloud/src/app/@shared/mcp/toolsets/toolsets.component.html
+++ b/apps/cloud/src/app/@shared/mcp/toolsets/toolsets.component.html
@@ -11,7 +11,16 @@
     [helpTitle]="'PAC.Xpert.LearnCreateMCPTool' | translate: {Default: 'Learn more about Xpert MCP toolset'}"
     helpUrl="/docs/ai/tool/mcp/"
     (create)="createTool()"
-  />
+  >
+    <button
+      type="button"
+      class="mx-4 mb-4 flex w-[calc(100%-2rem)] items-center rounded-lg px-4 py-2 text-sm font-medium text-text-secondary hover:bg-hover-bg hover:text-primary-600"
+      (click)="importFromJson($event)"
+    >
+      <i class="ri-file-code-line mr-2 text-base"></i>
+      {{ 'PAC.MCP.CreateFromJson' | translate: { Default: 'Create from JSON' } }}
+    </button>
+  </ngm-card-create>
 
   @for (toolset of toolsets(); track toolset.id) {
     <xpert-toolset-card class="col-span-1 min-h-[140px] cursor-pointer bg-components-card-bg"

--- a/apps/cloud/src/app/@shared/mcp/toolsets/toolsets.component.ts
+++ b/apps/cloud/src/app/@shared/mcp/toolsets/toolsets.component.ts
@@ -31,6 +31,7 @@ import {
 } from '@cloud/app/@core'
 import { AppService } from '@cloud/app/app.service'
 import { toSignal } from '@angular/core/rxjs-interop'
+import { MCPImportJsonComponent } from '../import-json/import-json.component'
 import { XpertMCPManageComponent } from '../manage/manage.component'
 
 @Component({
@@ -150,6 +151,37 @@ export class MCPToolsetsComponent {
         next: (saved) => {
           if (saved) {
             this.refresh()
+          }
+        }
+      })
+  }
+
+  importFromJson(event: Event) {
+    event.stopPropagation()
+    this.#dialog
+      .open<Partial<IXpertToolset>>(MCPImportJsonComponent, {
+        backdropClass: 'backdrop-blur-lg-white',
+        disableClose: true
+      })
+      .closed.subscribe({
+        next: (toolset) => {
+          if (toolset) {
+            this.#dialog
+              .open(XpertMCPManageComponent, {
+                backdropClass: 'backdrop-blur-lg-white',
+                disableClose: true,
+                data: {
+                  workspaceId: this.workspaceId(),
+                  toolset
+                }
+              })
+              .closed.subscribe({
+                next: (saved) => {
+                  if (saved) {
+                    this.refresh()
+                  }
+                }
+              })
           }
         }
       })

--- a/apps/cloud/src/app/features/xpert/workspace/mcp-tools/tools.component.html
+++ b/apps/cloud/src/app/features/xpert/workspace/mcp-tools/tools.component.html
@@ -19,6 +19,14 @@
       <i class="ri-add-line mr-2 shrink-0 text-base"></i>
       {{ 'PAC.Xpert.CreateMCPTool' | translate: {Default: 'Create MCP Toolset'} }}
     </div>
+    <button
+      type="button"
+      class="mb-1 flex w-full items-center rounded-lg px-6 py-[7px] text-left text-[13px] font-medium leading-[18px] text-text-secondary hover:bg-hover-bg hover:text-primary-600"
+      (click)="importFromJson($event)"
+    >
+      <i class="ri-file-code-line mr-2 shrink-0 text-base"></i>
+      {{ 'PAC.MCP.CreateFromJson' | translate: { Default: 'Create from JSON' } }}
+    </button>
   </ngm-card-create>
 
   @for (toolset of toolsets(); track toolset.id) {

--- a/apps/cloud/src/app/features/xpert/workspace/mcp-tools/tools.component.ts
+++ b/apps/cloud/src/app/features/xpert/workspace/mcp-tools/tools.component.ts
@@ -32,7 +32,7 @@ import {
 import { AppService } from '../../../../app.service'
 import { XpertWorkspaceHomeComponent } from '../home/home.component'
 import { injectQueryParams } from 'ngxtension/inject-query-params'
-import { MCPMarketplaceComponent, XpertMCPManageComponent } from '@cloud/app/@shared/mcp'
+import { MCPImportJsonComponent, MCPMarketplaceComponent, XpertMCPManageComponent } from '@cloud/app/@shared/mcp'
 
 @Component({
   standalone: true,
@@ -163,6 +163,37 @@ export class XpertWorkspaceMCPToolsComponent {
         next: (saved) => {
           if (saved) {
             this.refresh()
+          }
+        }
+      })
+  }
+
+  importFromJson(event: Event) {
+    event.stopPropagation()
+    this.#dialog
+      .open<Partial<IXpertToolset>>(MCPImportJsonComponent, {
+        backdropClass: 'backdrop-blur-lg-white',
+        disableClose: true
+      })
+      .closed.subscribe({
+        next: (toolset) => {
+          if (toolset) {
+            this.#dialog
+              .open(XpertMCPManageComponent, {
+                backdropClass: 'backdrop-blur-lg-white',
+                disableClose: true,
+                data: {
+                  workspaceId: this.workspaceId(),
+                  toolset
+                }
+              })
+              .closed.subscribe({
+                next: (saved) => {
+                  if (saved) {
+                    this.refresh()
+                  }
+                }
+              })
           }
         }
       })

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -52,6 +52,11 @@
       "Enabled": "Enabled",
       "NoTools": "No tools"
     },
+    "MCP": {
+      "CreateFromJson": "Create from JSON",
+      "PasteMCPJson": "Paste an MCP JSON config to create a toolset.",
+      "UrlOnlySSECompatibility": "URL-only configs are imported as SSE for legacy compatibility."
+    },
     "Chat": {
       "QuoteSelection": "Quote selection",
       "RemoveReference": "Remove reference",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -87,6 +87,11 @@
       "NoTools": "No tools",
       "Reset": "Reset"
     },
+    "MCP": {
+      "CreateFromJson": "Create from JSON",
+      "PasteMCPJson": "Paste an MCP JSON config to create a toolset.",
+      "UrlOnlySSECompatibility": "URL-only configs are imported as SSE for legacy compatibility."
+    },
     "MENU": {
       "AGENT": "Agent",
       "ORGANIZATIONS": "Organizations",

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -275,6 +275,11 @@
       "NoTools": "无工具",
       "NoFields": "暂无字段"
     },
+    "MCP": {
+      "CreateFromJson": "从 JSON 创建",
+      "PasteMCPJson": "粘贴 MCP JSON 配置以创建工具集。",
+      "UrlOnlySSECompatibility": "未声明类型的 URL 配置会按 SSE 导入，以兼容旧配置。"
+    },
     "Chat": {
       "QuoteSelection": "引用选中内容",
       "RemoveReference": "移除引用",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -5014,7 +5014,10 @@
       "ReconnectMaxAttempts": "最大尝试连接次数",
       "ReconnectDelayMs": "重启尝试之间的延迟（以毫秒为单位）",
       "ToolNamePrefix": "工具名前缀",
-      "MoreMCPTools": "更多 MCP 工具"
+      "MoreMCPTools": "更多 MCP 工具",
+      "CreateFromJson": "从 JSON 创建",
+      "PasteMCPJson": "粘贴 MCP JSON 配置以创建工具集。",
+      "UrlOnlySSECompatibility": "未声明类型的 URL 配置会按 SSE 导入，以兼容旧配置。"
     },
     "title": {
       "short": "Xpert AI"

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -3846,7 +3846,10 @@
       "ReconnectMaxAttempts": "最大嘗試連接次數",
       "ReconnectDelayMs": "重啟嘗試之間的延遲（以毫秒為單位）",
       "ToolNamePrefix": "工具名前綴",
-      "MoreMCPTools": "更多 MCP 工具"
+      "MoreMCPTools": "更多 MCP 工具",
+      "CreateFromJson": "從 JSON 創建",
+      "PasteMCPJson": "貼上 MCP JSON 配置以創建工具集。",
+      "UrlOnlySSECompatibility": "未聲明類型的 URL 配置會按 SSE 導入，以兼容舊配置。"
     },
     "title": {
       "short": "Xpert AI"


### PR DESCRIPTION
## Summary

Adds a JSON import entry point for MCP toolsets so users can paste an MCP config object, preview the parsed toolset, then reuse the existing MCP manage dialog to test the connection and save it.

The parser accepts the current `mcpServers` shape and the legacy `servers` shape, normalizes the first server into the existing single-server UI schema, and infers the MCP server type from explicit `type`/`transport` or from `command`/`url` fields.

## Scope

- Add the shared MCP JSON import dialog and focused parser tests.
- Add import actions to the MCP toolset creation surfaces.
- Add localized strings for English, simplified Chinese, and traditional Chinese.
- Preserve the existing manage/test/save flow by opening `XpertMCPManageComponent` after parsing.

## Validation

- `git diff --cached --check`
- pre-commit `format:fix`
- pre-commit hardcoded color usage check
- pre-commit TypeORM column type check
- `pnpm nx test cloud --testFile=apps/cloud/src/app/@shared/mcp/import-json/import-json.component.spec.ts --runInBand`

## Notes

The current UI schema is still single-server oriented, so importing a JSON object with multiple MCP servers uses the first parsed server only.