### PR TITLE
[codex] Show published xpert version in studio header

### DIFF
--- a/apps/cloud/src/app/features/setting/organizations/organizations.component.html
+++ b/apps/cloud/src/app/features/setting/organizations/organizations.component.html
@@ -74,17 +74,17 @@
       } @else {
         @if (isTenantScope()) {
           <div class="overflow-x-auto">
-            <table class="w-full min-w-[900px] table-fixed text-left text-sm">
+            <table class="w-full min-w-[1180px] text-left text-sm">
               <thead class="bg-background-default-subtle text-text-secondary">
                 <tr>
-                  <th class="px-4 py-3 font-semibold">
+                  <th class="w-20 px-4 py-3 font-semibold">
                     {{ 'PAC.KEY_WORDS.IsDefault' | translate: { Default: 'Default' } }}
                   </th>
-                  <th class="px-4 py-3 font-semibold">
+                  <th class="w-24 px-4 py-3 font-semibold">
                     {{ 'PAC.KEY_WORDS.Logo' | translate: { Default: 'Logo' } }}
                   </th>
-                  <th class="px-4 py-3 font-semibold">
-                    {{ 'PAC.KEY_WORDS.ID' | translate: { Default: 'Identifier' } }}
+                  <th class="min-w-[280px] px-4 py-3 font-semibold">
+                    {{ 'PAC.ORGANIZATIONS_PAGE.Organization.OrganizationId' | translate: { Default: 'Organization ID' } }}
                   </th>
                   <th class="px-4 py-3 font-semibold">
                     {{ 'PAC.KEY_WORDS.NAME' | translate: { Default: 'Name' } }}
@@ -124,10 +124,9 @@
                         class="block h-10 w-10 overflow-hidden rounded-2xl border border-divider-regular bg-components-input-bg-normal"
                       />
                     </td>
-                    <td class="px-4 py-4 align-middle truncate">
+                    <td class="min-w-[280px] px-4 py-4 align-middle whitespace-nowrap">
                       <div class="space-y-1 whitespace-nowrap">
                         <div class="font-medium text-text-primary">{{ organizationIdentifier(organization) }}</div>
-                        <!-- <div class="text-xs text-text-tertiary">{{ organization.id }}</div> -->
                       </div>
                     </td>
                     <td class="px-4 py-4 align-middle truncate">
@@ -316,6 +315,15 @@
             @case ('general') {
               <form [formGroup]="form" class="grid w-full min-w-0 gap-6 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.8fr)]">
                 <div class="grid gap-x-6 gap-y-7 md:grid-cols-2">
+                  <div class="form-field md:col-span-2">
+                    <span class="form-label">
+                      {{ 'PAC.ORGANIZATIONS_PAGE.Organization.OrganizationId' | translate: { Default: 'Organization ID' } }}
+                    </span>
+                    <span data-testid="organization-id-value" class="break-all text-base text-text-primary">
+                      {{ selectedOrganization()?.id || '-' }}
+                    </span>
+                  </div>
+
                   <label class="form-field md:col-span-2">
                     <span class="form-label">{{ 'PAC.KEY_WORDS.NAME' | translate: { Default: 'Name' } }}</span>
                     <input z-input formControlName="name" />

--- a/apps/cloud/src/app/features/setting/organizations/organizations.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/organizations/organizations.component.spec.ts
@@ -1,0 +1,180 @@
+import { Dialog } from '@angular/cdk/dialog'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
+import { TestBed } from '@angular/core/testing'
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router'
+import { TranslateModule, TranslateService } from '@ngx-translate/core'
+import { IOrganization } from '@xpert-ai/contracts'
+import { UsersService } from '@xpert-ai/cloud/state'
+import { firstValueFrom, of } from 'rxjs'
+import {
+  OrganizationsService,
+  RequestScopeLevel,
+  ScreenshotService,
+  Store,
+  ToastrService
+} from '../../../@core'
+import { OrganizationsComponent } from './organizations.component'
+
+const organization: IOrganization = {
+  id: 'org-1',
+  name: 'Acme',
+  isDefault: true,
+  profile_link: 'acme',
+  totalEmployees: 0,
+  banner: '',
+  short_description: '',
+  client_focus: '',
+  overview: '',
+  currency: 'USD',
+  isActive: true,
+  defaultValueDateType: 'TODAY',
+  tags: []
+}
+
+class MockStore {
+  activeScope = { level: RequestScopeLevel.ORGANIZATION, organizationId: organization.id }
+  selectedOrganization = organization
+  organizationId = organization.id
+  featureTenant = []
+  featureOrganizations = []
+  user = { organizations: [{ organization, isDefault: true }] }
+
+  selectActiveScope() {
+    return of(this.activeScope)
+  }
+
+  hasPermission() {
+    return true
+  }
+}
+
+describe('OrganizationsComponent', () => {
+  let store: MockStore
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule()
+    store = new MockStore()
+
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, TranslateModule.forRoot(), OrganizationsComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({})),
+            snapshot: {
+              paramMap: convertToParamMap({})
+            }
+          }
+        },
+        {
+          provide: Router,
+          useValue: {
+            navigate: jest.fn()
+          }
+        },
+        {
+          provide: Store,
+          useValue: store
+        },
+        {
+          provide: OrganizationsService,
+          useValue: {
+            getById: jest.fn(() => of(organization)),
+            getAll: jest.fn(() => of({ items: [organization], total: 1 })),
+            update: jest.fn(() => of(organization)),
+            demo: jest.fn(() => of({}))
+          }
+        },
+        {
+          provide: UsersService,
+          useValue: {
+            getMe: jest.fn(() => Promise.resolve({ organizations: [{ organization, isDefault: true }] }))
+          }
+        },
+        {
+          provide: Dialog,
+          useValue: {
+            open: jest.fn()
+          }
+        },
+        {
+          provide: ToastrService,
+          useValue: {
+            success: jest.fn(),
+            error: jest.fn()
+          }
+        },
+        {
+          provide: ScreenshotService,
+          useValue: {
+            create: jest.fn()
+          }
+        }
+      ]
+    }).compileComponents()
+  })
+
+  afterEach(() => {
+    TestBed.resetTestingModule()
+    jest.clearAllMocks()
+  })
+
+  it('renders the selected organization id as text in the general field', async () => {
+    const fixture = TestBed.createComponent(OrganizationsComponent)
+
+    fixture.detectChanges()
+    await fixture.whenStable()
+    fixture.detectChanges()
+
+    const idValue = fixture.nativeElement.querySelector<HTMLElement>('[data-testid="organization-id-value"]')
+
+    expect(idValue).not.toBeNull()
+    expect(idValue?.textContent?.trim()).toBe(organization.id)
+    expect(fixture.nativeElement.querySelector('[data-testid="organization-id-input"]')).toBeNull()
+  })
+
+  it('renders a readable tenant organization id column', async () => {
+    store.activeScope = { level: RequestScopeLevel.TENANT }
+
+    const translate = TestBed.inject(TranslateService)
+    translate.setTranslation('zh-Hans', {
+      PAC: {
+        KEY_WORDS: {
+          ACTION: '操作',
+          CURRENCY: '币种',
+          IsDefault: '默认',
+          Logo: '标识',
+          NAME: '名称',
+          Status: '状态',
+          TimeZone: '时区'
+        },
+        ORGANIZATIONS_PAGE: {
+          Organization: {
+            OrganizationId: '组织 ID'
+          }
+        }
+      }
+    })
+    await firstValueFrom(translate.use('zh-Hans'))
+
+    const fixture = TestBed.createComponent(OrganizationsComponent)
+
+    fixture.detectChanges()
+    await fixture.whenStable()
+    fixture.detectChanges()
+
+    const table = fixture.nativeElement.querySelector<HTMLTableElement>('table')
+    const headers = Array.from(fixture.nativeElement.querySelectorAll<HTMLTableCellElement>('thead th')).map((header) =>
+      header.textContent?.trim()
+    )
+    const idCell = fixture.nativeElement.querySelector<HTMLTableCellElement>('tbody tr td:nth-child(3)')
+
+    expect(headers).toContain('组织 ID')
+    expect(headers.filter((header) => header === '标识')).toHaveLength(1)
+    expect(table?.className).not.toContain('table-fixed')
+    expect(idCell?.textContent?.trim()).toBe(organization.id)
+    expect(idCell?.className).toContain('min-w-[280px]')
+    expect(idCell?.className).not.toContain('truncate')
+  })
+})

--- a/apps/cloud/src/app/features/setting/organizations/organizations.component.ts
+++ b/apps/cloud/src/app/features/setting/organizations/organizations.component.ts
@@ -423,7 +423,7 @@ export class OrganizationsComponent {
   }
 
   organizationIdentifier(organization: IOrganization) {
-    return organization?.profile_link || organization?.id || '-'
+    return organization?.id || '-'
   }
 
   organizationStatusLabel(organization: IOrganization) {

--- a/apps/cloud/src/app/features/xpert/studio/header/header.component.html
+++ b/apps/cloud/src/app/features/xpert/studio/header/header.component.html
@@ -14,8 +14,14 @@
     >
   }
   @if (latestPublishDate()) {
-    <span class="flex items-center mx-1">·</span>{{ 'PAC.Xpert.Published' | translate: { Default: 'Published' } }}
-    {{ latestPublishDate() }}
+    <span class="flex items-center mx-1">·</span>
+    <span class="truncate">
+      <span>{{ 'PAC.Xpert.Published' | translate: { Default: 'Published' } }}</span>
+      @if (version()) {
+        <span>：v{{ version() }}</span>
+      }
+      <span class="ml-1">{{ latestPublishDate() }}</span>
+    </span>
   }
 </div>
 

--- a/apps/cloud/src/app/features/xpert/studio/header/header.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/studio/header/header.component.spec.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('XpertStudioHeaderComponent template', () => {
+  const template = readFileSync(join(__dirname, 'header.component.html'), 'utf8')
+
+  it('adds the current version to the published status only when a version exists', () => {
+    const start = template.indexOf('@if (latestPublishDate())')
+    const end = template.indexOf('<div class="flex-1"></div>', start)
+    const publishedStatus = template.slice(start, end)
+
+    expect(publishedStatus).toContain("{{ 'PAC.Xpert.Published' | translate: { Default: 'Published' } }}")
+    expect(publishedStatus).toContain('@if (version())')
+    expect(publishedStatus).toContain('v{{ version() }}')
+    expect(publishedStatus).not.toContain('PAC.Xpert.Draft')
+  })
+})

--- a/apps/cloud/src/app/features/xpert/studio/studio.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/studio/studio.component.spec.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('XpertStudioComponent template', () => {
+  const template = readFileSync(join(__dirname, 'studio.component.html'), 'utf8')
+
+  it('does not render a separate canvas version badge', () => {
+    expect(template).not.toContain('data-testid="xpert-studio-canvas-version"')
+  })
+})

--- a/apps/cloud/src/app/features/xpert/xpert/xpert.component.html
+++ b/apps/cloud/src/app/features/xpert/xpert/xpert.component.html
@@ -40,6 +40,9 @@
         </div>
         <div class="flex items-center text-xs leading-[18px] font-medium text-text-tertiary gap-1">
           <div class="shrink-0 px-1 border border-(--border) uppercase rounded-[5px] truncate">{{xpert()?.type}}</div>
+          @if (xpert()?.version) {
+            <div class="shrink-0 px-1 border border-(--border) rounded-[5px] truncate">v{{ xpert()?.version }}</div>
+          }
         </div>
       </div>
     }

--- a/apps/cloud/src/app/features/xpert/xpert/xpert.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/xpert.component.spec.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('XpertComponent template', () => {
+  const template = readFileSync(join(__dirname, 'xpert.component.html'), 'utf8')
+
+  it('shows the published version next to the xpert type badge only when a version exists', () => {
+    const start = template.indexOf('<div class="flex items-center text-xs')
+    const end = template.indexOf('</div>\n      </div>', start)
+    const typeBadgeRow = template.slice(start, end)
+
+    expect(typeBadgeRow).toContain('{{xpert()?.type}}')
+    expect(typeBadgeRow).toContain('@if (xpert()?.version)')
+    expect(typeBadgeRow).toContain('v{{ xpert()?.version }}')
+  })
+})

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -447,6 +447,9 @@
         "ACCESS_DELETE_ACCOUNT": "Access Delete Account",
         "ACCESS_DELETE_ALL_DATA": "Access Delete All Data",
         "ORG_DEMO_EDIT": "Edit Organization Demo"
+      },
+      "Organization": {
+        "OrganizationId": "Organization ID"
       }
     }
   },

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -1149,6 +1149,7 @@
         "DEMO": "Demo",
         "GENERATE_DEMO": "Generate Demo",
         "RegenerateDemo": "Re-generate Demo",
+        "OrganizationId": "Organization ID",
         "OfficialName": "Official Name",
         "ProfileLink": "Profile Link",
         "Website": "Website",

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -1899,6 +1899,7 @@
         "DEMO": "演示数据",
         "GENERATE_DEMO": "生成演示数据",
         "RegenerateDemo": "重新生成演示数据",
+        "OrganizationId": "组织 ID",
         "TotalEmployees": "总员工数",
         "BasicInfo": "基础信息",
         "OtherInfo": "其他信息",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -5276,6 +5276,7 @@
         "DEMO": "演示数据",
         "GENERATE_DEMO": "生成演示数据",
         "RegenerateDemo": "重新生成演示数据",
+        "OrganizationId": "组织 ID",
         "TotalEmployees": "总员工数",
         "BasicInfo": "基础信息",
         "OtherInfo": "其他信息",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -4036,6 +4036,7 @@
         "DEMO": "演示數據",
         "GENERATE_DEMO": "生成演示數據",
         "RegenerateDemo": "重新生成演示數據",
+        "OrganizationId": "組織 ID",
         "TotalEmployees": "總員工數",
         "BasicInfo": "基礎信息",
         "OtherInfo": "其他信息",


### PR DESCRIPTION
## Summary
- show the current xpert version inline with the existing published status in the Studio header
- keep draft state from showing a version in that status area
- add focused template contract tests for the header status and absence of the old canvas badge
- show organization IDs in organization settings, including a readable tenant registry ID column

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm nx test cloud --testFile=apps/cloud/src/app/features/xpert/studio/header/header.component.spec.ts`
- `pnpm nx test cloud --testFile=apps/cloud/src/app/features/xpert/studio/studio.component.spec.ts`
- `pnpm exec prettier --check apps/cloud/src/app/features/xpert/studio/header/header.component.html apps/cloud/src/app/features/xpert/studio/header/header.component.spec.ts apps/cloud/src/app/features/xpert/studio/studio.component.spec.ts`
- `pnpm nx lint cloud --lintFilePatterns=apps/cloud/src/app/features/xpert/studio/header/header.component.html --lintFilePatterns=apps/cloud/src/app/features/xpert/studio/header/header.component.spec.ts --lintFilePatterns=apps/cloud/src/app/features/xpert/studio/studio.component.spec.ts`
- `pnpm nx build cloud --configuration=development`
- `pnpm exec jest --config apps/cloud/jest.config.ts --runTestsByPath apps/cloud/src/app/features/setting/organizations/organizations.component.spec.ts --runInBand`
- `node -e "for (const f of ['apps/cloud/src/assets/i18n/en.json','apps/cloud/src/assets/i18n/en-US.json','apps/cloud/src/assets/i18n/zh-CN.json','apps/cloud/src/assets/i18n/zh-Hans.json','apps/cloud/src/assets/i18n/zh-Hant.json']) JSON.parse(require('fs').readFileSync(f, 'utf8')); console.log('i18n json ok')"`
- `git diff --check`