### PR TITLE
fix: consume follow-ups one at a time

### DIFF
--- a/packages/server-ai/src/shared/agent/persisted-follow-up.spec.ts
+++ b/packages/server-ai/src/shared/agent/persisted-follow-up.spec.ts
@@ -53,7 +53,7 @@ describe('persisted follow-up helpers', () => {
         })
     })
 
-    it('collects only pending follow-ups for the same target execution', () => {
+    it('collects only the matched pending follow-up by client message id', () => {
         const collected = collectPendingFollowUpsByClientMessageId(
             [
                 {
@@ -106,17 +106,14 @@ describe('persisted follow-up helpers', () => {
             items: [
                 expect.objectContaining({
                     id: 'follow-up-1'
-                }),
-                expect.objectContaining({
-                    id: 'follow-up-2'
                 })
             ],
             mergedHumanInput: {
-                input: 'first\n\nsecond'
+                input: 'first'
             },
             targetExecutionId: 'run-1',
-            messageIds: ['follow-up-1', 'follow-up-2'],
-            clientMessageIds: ['client-1', 'client-2']
+            messageIds: ['follow-up-1'],
+            clientMessageIds: ['client-1']
         })
     })
 })

--- a/packages/server-ai/src/shared/agent/persisted-follow-up.ts
+++ b/packages/server-ai/src/shared/agent/persisted-follow-up.ts
@@ -4,7 +4,6 @@ type TFollowUpMessageLike = {
     id?: string | null
     role?: string | null
     content?: unknown
-    createdAt?: Date | string | null
     references?: unknown
     attachments?: unknown
     fileAssets?: unknown
@@ -31,50 +30,8 @@ function normalizeString(value: unknown): string | null {
     return normalized || null
 }
 
-function normalizeMessageTimestamp(value: unknown): number | null {
-    if (!value) {
-        return null
-    }
-
-    if (value instanceof Date) {
-        return Number.isFinite(value.getTime()) ? value.getTime() : null
-    }
-
-    if (typeof value === 'string') {
-        const parsed = Date.parse(value)
-        return Number.isFinite(parsed) ? parsed : null
-    }
-
-    return null
-}
-
 function isPendingFollowUpMessage<T extends TFollowUpMessageLike>(message: T | null | undefined): message is T {
     return message?.role === 'human' && message.followUpStatus === 'pending'
-}
-
-function sortPendingFollowUps<T extends TFollowUpMessageLike>(messages: T[] | null | undefined): T[] {
-    return [...(messages ?? [])]
-        .map((message, index) => ({
-            message,
-            index,
-            timestamp: normalizeMessageTimestamp(message?.createdAt)
-        }))
-        .sort((left, right) => {
-            if (left.timestamp != null && right.timestamp != null && left.timestamp !== right.timestamp) {
-                return left.timestamp - right.timestamp
-            }
-
-            if (left.timestamp != null && right.timestamp == null) {
-                return -1
-            }
-
-            if (left.timestamp == null && right.timestamp != null) {
-                return 1
-            }
-
-            return left.index - right.index
-        })
-        .map(({ message }) => message)
 }
 
 function mergeInputText(previousInput: unknown, nextInput: unknown): string | undefined {
@@ -224,24 +181,17 @@ export function collectPendingFollowUpsByClientMessageId<T extends TFollowUpMess
         return null
     }
 
-    const normalizedTargetExecutionId = normalizeString(matched.targetExecutionId)
-    const pendingMessages = sortPendingFollowUps(messages).filter(isPendingFollowUpMessage)
-    const items =
-        normalizedTargetExecutionId != null
-            ? pendingMessages.filter(
-                  (message) => normalizeString(message.targetExecutionId) === normalizedTargetExecutionId
-              )
-            : [matched]
+    const items = [matched]
 
     return {
         matched,
-        items: items.length ? items : [matched],
-        mergedHumanInput: mergeFollowUpHumanInputs((items.length ? items : [matched]).map(readPersistedFollowUpInput)),
-        targetExecutionId: normalizedTargetExecutionId,
-        messageIds: (items.length ? items : [matched])
+        items,
+        mergedHumanInput: mergeFollowUpHumanInputs(items.map(readPersistedFollowUpInput)),
+        targetExecutionId: normalizeString(matched.targetExecutionId),
+        messageIds: items
             .map((message) => normalizeString(message.id))
             .filter((messageId): messageId is string => Boolean(messageId)),
-        clientMessageIds: (items.length ? items : [matched])
+        clientMessageIds: items
             .map((message) => readFollowUpClientMessageId(message) ?? normalizeString(message.id))
             .filter((messageId): messageId is string => Boolean(messageId))
     }

--- a/packages/server-ai/src/xpert-agent/commands/handlers/create-node-consume-pending-steer-follow-ups.handler.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/create-node-consume-pending-steer-follow-ups.handler.ts
@@ -52,7 +52,8 @@ export class CreateNodeConsumePendingSteerFollowUpsHandler implements ICommandHa
                     }
                 }
 
-                const mergedHumanInput = hydrateHumanInput(mergePendingFollowUpHumans(pendingFollowUps))
+                const [nextFollowUp, ...remainingFollowUps] = pendingFollowUps
+                const mergedHumanInput = hydrateHumanInput(mergePendingFollowUpHumans([nextFollowUp]))
                 const humanState = {
                     ...state,
                     [STATE_VARIABLE_HUMAN]: mergedHumanInput
@@ -68,10 +69,10 @@ export class CreateNodeConsumePendingSteerFollowUpsHandler implements ICommandHa
                 const rootAgentKey = configurable.rootAgentKey ?? agentKey
                 const primaryChannel = rootAgentKey ? channelName(rootAgentKey) : agentChannel
                 const visibleAt = new Date()
-                const messageIds = pendingFollowUps
+                const messageIds = [nextFollowUp]
                     .map((item) => item.messageId)
                     .filter((messageId): messageId is string => Boolean(messageId))
-                const clientMessageIds = pendingFollowUps
+                const clientMessageIds = [nextFollowUp]
                     .map((item) => item.clientMessageId ?? item.messageId)
                     .filter((messageId): messageId is string => Boolean(messageId))
 
@@ -110,7 +111,7 @@ export class CreateNodeConsumePendingSteerFollowUpsHandler implements ICommandHa
                     messages: [humanMessage],
                     [STATE_VARIABLE_SYS]: state[STATE_VARIABLE_SYS],
                     [STATE_VARIABLE_HUMAN]: mergedHumanInput,
-                    [STATE_VARIABLE_PENDING_FOLLOW_UPS]: [],
+                    [STATE_VARIABLE_PENDING_FOLLOW_UPS]: remainingFollowUps,
                     [primaryChannel]: channelUpdate,
                     ...(agentChannel !== primaryChannel
                         ? {

--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts
@@ -167,18 +167,9 @@ describe('subgraph steer follow-up pre-turn node handlers', () => {
             } as any
         )
 
-        const expectedMessageContent = [
-            'steer input 1',
-            '',
-            'steer input 2',
-            '',
-            'Referenced content:',
-            '[Quoted text]',
-            '> ref-1',
-            '',
-            '[Quoted text]',
-            '> ref-2'
-        ].join('\n')
+        const expectedMessageContent = ['steer input 1', '', 'Referenced content:', '[Quoted text]', '> ref-1'].join(
+            '\n'
+        )
         const getMessageContent = (message: unknown) => {
             if (!message || typeof message !== 'object') {
                 return undefined
@@ -205,30 +196,28 @@ describe('subgraph steer follow-up pre-turn node handlers', () => {
 
         expect(result).toEqual(
             expect.objectContaining({
-                input: 'steer input 1\n\nsteer input 2',
+                input: 'steer input 1',
                 [STATE_VARIABLE_HUMAN]: {
-                    input: 'steer input 1\n\nsteer input 2',
+                    input: 'steer input 1',
                     files: [
                         expect.objectContaining({
                             id: 'file-1'
-                        }),
-                        expect.objectContaining({
-                            id: 'file-2'
                         })
                     ],
                     references: [
                         expect.objectContaining({
                             type: 'quote',
                             text: 'ref-1'
-                        }),
-                        expect.objectContaining({
-                            type: 'quote',
-                            text: 'ref-2'
                         })
                     ],
-                    custom: 'late'
+                    custom: 'early'
                 },
-                [STATE_VARIABLE_PENDING_FOLLOW_UPS]: []
+                [STATE_VARIABLE_PENDING_FOLLOW_UPS]: [
+                    expect.objectContaining({
+                        messageId: 'db-message-2',
+                        clientMessageId: 'client-message-2'
+                    })
+                ]
             })
         )
         expect(getMessageContent(result.messages[0])).toBe(expectedMessageContent)
@@ -238,10 +227,6 @@ describe('subgraph steer follow-up pre-turn node handlers', () => {
             expect.arrayContaining([
                 expect.objectContaining({
                     id: 'db-message-1',
-                    followUpStatus: 'consumed'
-                }),
-                expect.objectContaining({
-                    id: 'db-message-2',
                     followUpStatus: 'consumed'
                 })
             ])
@@ -255,7 +240,8 @@ describe('subgraph steer follow-up pre-turn node handlers', () => {
                         type: 'follow_up_consumed',
                         mode: 'steer',
                         executionId: 'execution-1',
-                        clientMessageIds: ['client-message-1', 'client-message-2']
+                        clientMessageIds: ['client-message-1'],
+                        messageIds: ['db-message-1']
                     })
                 })
             })

--- a/packages/server-ai/src/xpert/commands/handlers/chat.handler.spec.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/chat.handler.spec.ts
@@ -32,6 +32,8 @@ import { XpertAgentExecutionOneQuery } from '../../../xpert-agent-execution/quer
 import { XpertChatCommand } from '../chat.command'
 import { XpertChatHandler } from './chat.handler'
 
+type XpertChatCommandOptions = NonNullable<ConstructorParameters<typeof XpertChatCommand>[1]>
+
 describe('XpertChatHandler', () => {
     let xpertService: { findOne: jest.Mock }
     let assistantBindingService: {
@@ -1074,6 +1076,156 @@ describe('XpertChatHandler', () => {
         )
     })
 
+    it('targets steer follow-ups by ai message before a stale execution id', async () => {
+        const commands: unknown[] = []
+        queryBus.execute.mockResolvedValue({
+            id: 'conversation-1',
+            threadId: 'thread-1',
+            status: 'busy',
+            operation: null,
+            messages: [
+                {
+                    id: 'ai-current',
+                    role: 'ai',
+                    content: 'Current answer',
+                    executionId: 'execution-current'
+                },
+                {
+                    id: 'ai-old',
+                    role: 'ai',
+                    content: 'Old answer',
+                    executionId: 'execution-old'
+                }
+            ]
+        })
+        commandBus.execute.mockImplementation(async (command) => {
+            commands.push(command)
+            if (command instanceof ChatMessageUpsertCommand) {
+                return command.entity
+            }
+            return null
+        })
+
+        const stream = await handler.execute(
+            new XpertChatCommand(
+                {
+                    action: 'follow_up',
+                    conversationId: 'conversation-1',
+                    mode: 'steer',
+                    target: {
+                        aiMessageId: 'ai-current',
+                        executionId: 'execution-old'
+                    },
+                    message: {
+                        clientMessageId: 'client-follow-up-1',
+                        input: {
+                            input: 'Run this before queued follow-ups'
+                        }
+                    }
+                },
+                {
+                    xpertId: 'xpert-1'
+                } satisfies XpertChatCommandOptions
+            )
+        )
+
+        await lastValueFrom(stream.pipe(toArray()))
+
+        const followUpCommand = commands.find(
+            (command) => command instanceof ChatMessageUpsertCommand
+        ) as ChatMessageUpsertCommand
+        expect(followUpCommand.entity).toEqual(
+            expect.objectContaining({
+                parent: expect.objectContaining({ id: 'ai-current' }),
+                executionId: 'execution-current',
+                targetExecutionId: 'execution-current'
+            })
+        )
+    })
+
+    it('promotes an existing pending queue follow-up to steer by client message id', async () => {
+        const commands: unknown[] = []
+        queryBus.execute.mockResolvedValue({
+            id: 'conversation-1',
+            threadId: 'thread-1',
+            status: 'busy',
+            operation: null,
+            messages: [
+                {
+                    id: 'ai-current',
+                    role: 'ai',
+                    content: 'Current answer',
+                    executionId: 'execution-current'
+                },
+                {
+                    id: 'queued-follow-up-1',
+                    role: 'human',
+                    content: 'Run this before queued follow-ups',
+                    followUpMode: 'queue',
+                    followUpStatus: 'pending',
+                    targetExecutionId: 'execution-current',
+                    thirdPartyMessage: {
+                        followUpClientMessageId: 'client-follow-up-1',
+                        followUpInput: {
+                            input: 'Run this before queued follow-ups'
+                        }
+                    }
+                }
+            ]
+        })
+        commandBus.execute.mockImplementation(async (command) => {
+            commands.push(command)
+            if (command instanceof ChatMessageUpsertCommand) {
+                return command.entity
+            }
+            return null
+        })
+
+        const stream = await handler.execute(
+            new XpertChatCommand(
+                {
+                    action: 'follow_up',
+                    conversationId: 'conversation-1',
+                    mode: 'steer',
+                    target: {
+                        aiMessageId: 'ai-current',
+                        executionId: 'execution-current'
+                    },
+                    message: {
+                        clientMessageId: 'client-follow-up-1',
+                        input: {
+                            input: 'Run this before queued follow-ups'
+                        }
+                    }
+                },
+                {
+                    xpertId: 'xpert-1'
+                } satisfies XpertChatCommandOptions
+            )
+        )
+
+        await lastValueFrom(stream.pipe(toArray()))
+
+        const followUpCommand = commands.find(
+            (command) => command instanceof ChatMessageUpsertCommand
+        ) as ChatMessageUpsertCommand
+        expect(followUpCommand.entity).toEqual(
+            expect.objectContaining({
+                id: 'queued-follow-up-1',
+                parent: expect.objectContaining({ id: 'ai-current' }),
+                role: 'human',
+                followUpMode: 'steer',
+                followUpStatus: 'pending',
+                executionId: 'execution-current',
+                targetExecutionId: 'execution-current',
+                visibleAt: null,
+                thirdPartyMessage: expect.objectContaining({
+                    followUpClientMessageId: 'client-follow-up-1'
+                })
+            })
+        )
+    })
+
     it('rejects interrupted follow-ups when there is no waiting operation', async () => {
         queryBus.execute.mockResolvedValue({
             id: 'conversation-1',
@@ -1280,7 +1432,7 @@ describe('XpertChatHandler', () => {
         expect(humanCommands[0].entity.visibleAt).toBeInstanceOf(Date)
     })
 
-    it('merges queued pending follow-ups for the same target execution into one send turn', async () => {
+    it('consumes only the matched queued pending follow-up on each send turn', async () => {
         const commands: any[] = []
         commandBus.execute.mockImplementation(async (command) => {
             commands.push(command)
@@ -1430,16 +1582,24 @@ describe('XpertChatHandler', () => {
                 (command.entity.id === 'follow-up-1' || command.entity.id === 'follow-up-2')
         ) as ChatMessageUpsertCommand[]
 
-        expect(humanCommands).toHaveLength(2)
-        expect(humanCommands.map((command) => command.entity.id)).toEqual(['follow-up-1', 'follow-up-2'])
+        expect(humanCommands).toHaveLength(1)
+        expect(humanCommands.map((command) => command.entity.id)).toEqual(['follow-up-1'])
         expect(humanCommands.every((command) => command.entity.followUpStatus === 'consumed')).toBe(true)
         expect(humanCommands.every((command) => command.entity.visibleAt instanceof Date)).toBe(true)
+        expect(
+            commands.some(
+                (command) =>
+                    command instanceof ChatMessageUpsertCommand &&
+                    command.entity.id === 'follow-up-2' &&
+                    command.entity.followUpStatus === 'consumed'
+            )
+        ).toBe(false)
 
         const agentCommand = commands.find(
             (command) => command instanceof XpertAgentChatCommand
         ) as XpertAgentChatCommand
         expect(agentCommand.state.human).toEqual({
-            input: 'Please continue\n\nAnd add detail',
+            input: 'Please continue',
             references: [
                 {
                     type: 'quote',
@@ -1450,8 +1610,7 @@ describe('XpertChatHandler', () => {
                 {
                     id: 'file-1'
                 }
-            ],
-            custom: 'latest'
+            ]
         })
 
         const aiPlaceholderCommand = commands.find(
@@ -1462,7 +1621,7 @@ describe('XpertChatHandler', () => {
         ) as ChatMessageUpsertCommand
         expect(aiPlaceholderCommand.entity.parent).toEqual(
             expect.objectContaining({
-                id: 'follow-up-2'
+                id: 'follow-up-1'
             })
         )
 
@@ -1475,8 +1634,8 @@ describe('XpertChatHandler', () => {
                         data: expect.objectContaining({
                             type: 'follow_up_consumed',
                             mode: 'queue',
-                            clientMessageIds: ['client-1', 'client-2'],
-                            messageIds: ['follow-up-1', 'follow-up-2'],
+                            clientMessageIds: ['client-1'],
+                            messageIds: ['follow-up-1'],
                             executionId: 'execution-prev'
                         })
                     })

--- a/packages/server-ai/src/xpert/commands/handlers/chat.handler.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/chat.handler.ts
@@ -52,7 +52,10 @@ import { CreateMemoryStoreCommand } from '../../../shared/commands/create-memory
 import { getDisabledSkillIds } from '../../../shared/agent/tool-preference'
 import { hydrateHumanInput, hydrateSendRequestHumanInput, normalizeReferences } from '../../../shared/agent/human-input'
 import { hasExplicitPlanModeFlag, isPlanModeEnabledFromState } from '../../../shared/agent/plan-mode'
-import { collectPendingFollowUpsByClientMessageId } from '../../../shared/agent/persisted-follow-up'
+import {
+    collectPendingFollowUpsByClientMessageId,
+    findPendingFollowUpByClientMessageId
+} from '../../../shared/agent/persisted-follow-up'
 import { normalizeChatState } from '../../../shared/agent/utils'
 import {
     getRuntimeCapabilitiesFromState,
@@ -202,18 +205,21 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                 throw new BadRequestException('Follow-up input is required')
             }
 
+            const targetMessage = resolveFollowUpTargetMessage(request, conversation.messages)
             const targetExecutionId =
-                request.target?.executionId ??
-                options?.execution?.id ??
-                [...(conversation.messages ?? [])].reverse().find((message) => message.role === 'ai')?.executionId ??
-                null
+                targetMessage?.executionId ?? request.target?.executionId ?? options?.execution?.id ?? null
+            const existingPendingFollowUp = findPendingFollowUpByClientMessageId(
+                conversation.messages,
+                request.message.clientMessageId
+            )
 
             const followUpFileAssets = toFileAssetReferences(followUpInput.files)
             const followUpLegacyAttachments = toLegacyStorageFileAttachments(followUpInput.files)
 
             await this.commandBus.execute(
                 new ChatMessageUpsertCommand({
-                    parent: conversation.messages?.[conversation.messages.length - 1] ?? null,
+                    ...(existingPendingFollowUp?.id ? { id: existingPendingFollowUp.id } : {}),
+                    parent: targetMessage ?? conversation.messages?.[conversation.messages.length - 1] ?? null,
                     role: 'human',
                     content: followUpInput.input,
                     conversationId: conversation.id,
@@ -1421,6 +1427,16 @@ function resolveRetryMessage(request: TXpertChatRetryRequest, messages?: IChatMe
 function resolveResumeTargetMessage(request: TXpertChatResumeRequest, messages?: IChatMessage[] | null) {
     if (request.target.aiMessageId) {
         return messages.find((message) => message.id === request.target.aiMessageId) ?? null
+    }
+    return findLastAiMessage(messages) ?? null
+}
+
+function resolveFollowUpTargetMessage(
+    request: Extract<TChatRequest, { action: 'follow_up' }>,
+    messages?: IChatMessage[] | null
+) {
+    if (request.target?.aiMessageId) {
+        return messages?.find((message) => message.id === request.target?.aiMessageId) ?? null
     }
     return findLastAiMessage(messages) ?? null
 }


### PR DESCRIPTION
## Summary
- Consume only the selected pending follow-up per turn instead of merging all pending items that share a target execution.
- Preserve queued follow-ups for later turns after a steer/queue item is consumed.
- Target steer follow-ups by the selected AI message and update an existing pending queued follow-up by client message id when it is promoted to steer.

## Validation
- `pnpm nx test server-ai --skip-nx-cache --runInBand --testPathPatterns=packages/server-ai/src/shared/agent/persisted-follow-up.spec.ts --testPathPatterns=packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts --testPathPatterns=packages/server-ai/src/xpert/commands/handlers/chat.handler.spec.ts`
- `git diff --check`