### PR TITLE
fix: sync chat trigger parameters to preview

### DIFF
--- a/apps/cloud/src/app/features/xpert/draft/editable-draft.util.ts
+++ b/apps/cloud/src/app/features/xpert/draft/editable-draft.util.ts
@@ -2,6 +2,7 @@ import { omit } from 'lodash-es'
 import { normalizeMiddlewareNodes, type IXpert, type TXpertTeamDraft } from '@xpert-ai/contracts'
 import { ToConnectionViewModelHandler } from '../studio/domain/connection/map/to-connection-view-model.handler'
 import { ToNodeViewModelHandler } from '../studio/domain/node/map/to-view-model.handler'
+import { applyChatTriggerInputParametersToDraft } from './xpert-draft-trigger.util'
 
 export function buildEditableXpertDraft(xpert: IXpert): TXpertTeamDraft {
   const baseTeam = {
@@ -10,7 +11,7 @@ export function buildEditableXpertDraft(xpert: IXpert): TXpertTeamDraft {
   }
 
   if (xpert.draft) {
-    return {
+    return applyChatTriggerInputParametersToDraft({
       team: {
         ...baseTeam,
         ...(xpert.draft.team ?? {}),
@@ -20,12 +21,12 @@ export function buildEditableXpertDraft(xpert: IXpert): TXpertTeamDraft {
         xpert.draft.nodes ?? xpert.graph?.nodes ?? new ToNodeViewModelHandler(xpert).handle().nodes
       ),
       connections: xpert.draft.connections ?? xpert.graph?.connections ?? new ToConnectionViewModelHandler(xpert).handle()
-    }
+    })
   }
 
-  return {
+  return applyChatTriggerInputParametersToDraft({
     team: baseTeam,
     nodes: normalizeMiddlewareNodes(xpert.graph?.nodes ?? new ToNodeViewModelHandler(xpert).handle().nodes),
     connections: xpert.graph?.connections ?? new ToConnectionViewModelHandler(xpert).handle()
-  } as TXpertTeamDraft
+  } as TXpertTeamDraft)
 }

--- a/apps/cloud/src/app/features/xpert/draft/xpert-draft-trigger.util.spec.ts
+++ b/apps/cloud/src/app/features/xpert/draft/xpert-draft-trigger.util.spec.ts
@@ -1,6 +1,9 @@
-import { TXpertTeamDraft, WorkflowNodeTypeEnum } from '@xpert-ai/contracts'
+import { IWFNTrigger, TXpertTeamDraft, WorkflowNodeTypeEnum, XpertParameterTypeEnum } from '@xpert-ai/contracts'
 import { WorkflowTriggerProviderOption } from './workflow-trigger-provider-option'
 import {
+  applyChatTriggerInputParametersToDraft,
+  createChatTriggerInputParameters,
+  deriveChatTriggerInputParametersFromDraft,
   readTriggerEditorItemsFromDraft,
   upsertTriggerEditorItemsIntoDraft,
   XPERT_DRAFT_PRIMARY_AGENT_NODE_MISSING,
@@ -87,7 +90,170 @@ function createTriggerItem(
   }
 }
 
+function addChatTriggerParameter(draft: TXpertTeamDraft) {
+  const chatTriggerNode = draft.nodes.find((node) => node.key === 'trigger-chat')
+  if (
+    !chatTriggerNode ||
+    chatTriggerNode.type !== 'workflow' ||
+    chatTriggerNode.entity.type !== WorkflowNodeTypeEnum.TRIGGER
+  ) {
+    throw new Error('Chat trigger node missing')
+  }
+
+  const chatTrigger = chatTriggerNode.entity as IWFNTrigger
+  chatTriggerNode.entity = {
+    ...chatTrigger,
+    parameters: [
+      {
+        type: XpertParameterTypeEnum.TEXT,
+        name: 'topic'
+      }
+    ]
+  }
+}
+
 describe('xpert draft trigger util', () => {
+  it('creates chat trigger input parameters as a channel object group', () => {
+    expect(
+      createChatTriggerInputParameters('trigger-chat', [
+        {
+          type: XpertParameterTypeEnum.TEXT,
+          name: 'topic'
+        }
+      ])
+    ).toEqual([
+      {
+        type: XpertParameterTypeEnum.OBJECT,
+        name: 'trigger-chat_channel',
+        optional: true,
+        item: [
+          {
+            type: XpertParameterTypeEnum.TEXT,
+            name: 'topic'
+          }
+        ]
+      }
+    ])
+  })
+
+  it('derives chat trigger input parameters from draft', () => {
+    const draft = createDraft()
+    addChatTriggerParameter(draft)
+
+    expect(deriveChatTriggerInputParametersFromDraft(draft)).toEqual([
+      {
+        type: XpertParameterTypeEnum.OBJECT,
+        name: 'trigger-chat_channel',
+        optional: true,
+        item: [
+          {
+            type: XpertParameterTypeEnum.TEXT,
+            name: 'topic'
+          }
+        ]
+      }
+    ])
+  })
+
+  it('uses chat trigger parameters to overwrite existing team agent config parameters', () => {
+    const draft = createDraft({
+      team: {
+        id: 'xpert-1',
+        agent: {
+          key: 'agent-1'
+        },
+        agentConfig: {
+          parameters: [
+            {
+              type: XpertParameterTypeEnum.TEXT,
+              name: 'agentParam'
+            }
+          ]
+        }
+      } as TXpertTeamDraft['team']
+    })
+    addChatTriggerParameter(draft)
+
+    expect(applyChatTriggerInputParametersToDraft(draft).team.agentConfig?.parameters).toEqual([
+      {
+        type: XpertParameterTypeEnum.OBJECT,
+        name: 'trigger-chat_channel',
+        optional: true,
+        item: [
+          {
+            type: XpertParameterTypeEnum.TEXT,
+            name: 'topic'
+          }
+        ]
+      }
+    ])
+  })
+
+  it('removes stale chat trigger input parameters when chat trigger has no parameters', () => {
+    const draft = createDraft({
+      team: {
+        id: 'xpert-1',
+        agent: {
+          key: 'agent-1'
+        },
+        agentConfig: {
+          parameters: [
+            {
+              type: XpertParameterTypeEnum.OBJECT,
+              name: 'trigger-chat_channel',
+              optional: true,
+              item: [
+                {
+                  type: XpertParameterTypeEnum.TEXT,
+                  name: 'topic'
+                }
+              ]
+            }
+          ]
+        }
+      } as TXpertTeamDraft['team']
+    })
+
+    expect(applyChatTriggerInputParametersToDraft(draft).team.agentConfig?.parameters).toBeNull()
+  })
+
+  it('keeps non-trigger input parameters when removing stale chat trigger parameters', () => {
+    const draft = createDraft({
+      team: {
+        id: 'xpert-1',
+        agent: {
+          key: 'agent-1'
+        },
+        agentConfig: {
+          parameters: [
+            {
+              type: XpertParameterTypeEnum.TEXT,
+              name: 'agentParam'
+            },
+            {
+              type: XpertParameterTypeEnum.OBJECT,
+              name: 'trigger-chat_channel',
+              optional: true,
+              item: [
+                {
+                  type: XpertParameterTypeEnum.TEXT,
+                  name: 'topic'
+                }
+              ]
+            }
+          ]
+        }
+      } as TXpertTeamDraft['team']
+    })
+
+    expect(applyChatTriggerInputParametersToDraft(draft).team.agentConfig?.parameters).toEqual([
+      {
+        type: XpertParameterTypeEnum.TEXT,
+        name: 'agentParam'
+      }
+    ])
+  })
+
   it('reads non-chat trigger editor items from draft', () => {
     const draft = createDraft()
 

--- a/apps/cloud/src/app/features/xpert/draft/xpert-draft-trigger.util.ts
+++ b/apps/cloud/src/app/features/xpert/draft/xpert-draft-trigger.util.ts
@@ -1,9 +1,12 @@
 import {
+  channelName,
   IWFNTrigger,
+  TXpertParameter,
   TXpertTeamConnection,
   TXpertTeamDraft,
   TXpertTeamNode,
-  WorkflowNodeTypeEnum
+  WorkflowNodeTypeEnum,
+  XpertParameterTypeEnum
 } from '@xpert-ai/contracts'
 import { WorkflowTriggerProviderOption } from './workflow-trigger-provider-option'
 
@@ -28,7 +31,7 @@ export function readTriggerEditorItemsFromDraft(
     .filter(isWorkflowTriggerNode)
     .map((node) => {
       const trigger = node.entity as IWFNTrigger
-      const providerName = `${trigger.from ?? 'chat'}`.trim() || 'chat'
+      const providerName = getTriggerProviderName(trigger)
 
       return {
         node,
@@ -112,6 +115,92 @@ export function upsertTriggerEditorItemsIntoDraft(
   }
 }
 
+export function createChatTriggerInputParameters(
+  triggerKey: string | null | undefined,
+  parameters: TXpertParameter[] | null | undefined
+): TXpertParameter[] | null {
+  if (!triggerKey || !parameters?.length) {
+    return null
+  }
+
+  return [
+    {
+      type: XpertParameterTypeEnum.OBJECT,
+      name: channelName(triggerKey),
+      optional: true,
+      item: [...parameters]
+    }
+  ]
+}
+
+export function deriveChatTriggerInputParametersFromDraft(
+  draft: Pick<TXpertTeamDraft, 'nodes'> | null | undefined
+): TXpertParameter[] | null {
+  const chatTrigger = getChatTriggerFromDraft(draft)
+
+  return createChatTriggerInputParameters(chatTrigger?.key, chatTrigger?.parameters)
+}
+
+export function applyChatTriggerInputParametersToDraft(draft: TXpertTeamDraft): TXpertTeamDraft {
+  const chatTrigger = getChatTriggerFromDraft(draft)
+  const parameters = createChatTriggerInputParameters(chatTrigger?.key, chatTrigger?.parameters)
+
+  if (!parameters?.length) {
+    const currentParameters = draft.team.agentConfig?.parameters
+    const nextParameters = removeChatTriggerInputParameters(currentParameters, chatTrigger?.key)
+
+    if (nextParameters === currentParameters || (!currentParameters && !nextParameters)) {
+      return draft
+    }
+
+    return {
+      ...draft,
+      team: {
+        ...draft.team,
+        agentConfig: {
+          ...(draft.team.agentConfig ?? {}),
+          parameters: nextParameters
+        }
+      }
+    }
+  }
+
+  return {
+    ...draft,
+    team: {
+      ...draft.team,
+      agentConfig: {
+        ...(draft.team.agentConfig ?? {}),
+        parameters
+      }
+    }
+  }
+}
+
+function getChatTriggerFromDraft(draft: Pick<TXpertTeamDraft, 'nodes'> | null | undefined) {
+  return draft?.nodes.find(isChatTriggerNode)?.entity as IWFNTrigger | undefined
+}
+
+function removeChatTriggerInputParameters(
+  parameters: TXpertParameter[] | null | undefined,
+  triggerKey: string | null | undefined
+): TXpertParameter[] | null {
+  if (!parameters?.length) {
+    return null
+  }
+
+  if (!triggerKey) {
+    return parameters
+  }
+
+  const groupName = channelName(triggerKey)
+  const nextParameters = parameters.filter(
+    (parameter) => !(parameter.type === XpertParameterTypeEnum.OBJECT && parameter.name === groupName)
+  )
+
+  return nextParameters.length ? nextParameters : null
+}
+
 export function getPrimaryAgentNodeFromDraft(draft: TXpertTeamDraft): TXpertTeamNode<'agent'> | null {
   const primaryAgentKey = draft.team?.agent?.key
   if (!primaryAgentKey) {
@@ -127,6 +216,14 @@ export function getPrimaryAgentNodeFromDraft(draft: TXpertTeamDraft): TXpertTeam
 
 function isWorkflowTriggerNode(node: TXpertTeamNode): node is TXpertTeamNode<'workflow'> {
   return node.type === 'workflow' && node.entity.type === WorkflowNodeTypeEnum.TRIGGER
+}
+
+function isChatTriggerNode(node: TXpertTeamNode): node is TXpertTeamNode<'workflow'> {
+  return isWorkflowTriggerNode(node) && getTriggerProviderName(node.entity as IWFNTrigger) === 'chat'
+}
+
+function getTriggerProviderName(trigger: IWFNTrigger) {
+  return `${trigger.from ?? 'chat'}`.trim() || 'chat'
 }
 
 function getNewTriggerNodePosition(

--- a/apps/cloud/src/app/features/xpert/studio/domain/xpert-api.service.ts
+++ b/apps/cloud/src/app/features/xpert/studio/domain/xpert-api.service.ts
@@ -64,7 +64,7 @@ import { CreateTeamHandler, CreateTeamRequest, ExpandTeamRequest, ExpandTeamHand
 import { genAgentKey, genWorkflowKey, injectGetXpertsByWorkspace, injectGetXpertTeam } from '../../utils'
 import { CreateWorkflowNodeRequest, CreateWorkflowNodeHandler, UpdateWorkflowNodeHandler, UpdateWorkflowNodeRequest } from './workflow'
 import { XpertService } from '../../xpert/xpert.service'
-import { buildEditableXpertDraft } from '../../draft/index'
+import { buildEditableXpertDraft, deriveChatTriggerInputParametersFromDraft } from '../../draft/index'
 
 const SaveDraftDebounceTime = 1 // s
 
@@ -300,10 +300,17 @@ export class XpertStudioApiService {
 
   public initRole(xpert: IXpert) {
     this.team.set(xpert)
+    const draft = buildEditableXpertDraft(xpert)
+    const chatTriggerParameters = deriveChatTriggerInputParametersFromDraft(draft)
+    const persistedAgentConfigParameters = xpert.draft?.team?.agentConfig?.parameters ?? xpert.agentConfig?.parameters
 
     this.store.update(() => ({
-      draft: buildEditableXpertDraft(xpert)
+      draft
     }))
+
+    if (chatTriggerParameters?.length && !isEqual(chatTriggerParameters, persistedAgentConfigParameters)) {
+      this.unsaved.set(true)
+    }
 
     this.#reload.next(EReloadReason.INIT)
   }

--- a/apps/cloud/src/app/features/xpert/studio/panel/workflow/trigger/trigger.component.ts
+++ b/apps/cloud/src/app/features/xpert/studio/panel/workflow/trigger/trigger.component.ts
@@ -7,7 +7,6 @@ import { attrModel, linkedModel } from '@xpert-ai/ocap-angular/core'
 import { TranslateModule } from '@ngx-translate/core'
 import {
   AiModelTypeEnum,
-  channelName,
   IWFNTrigger,
   IWorkflowNode,
   WorkflowNodeTypeEnum,
@@ -21,6 +20,7 @@ import { XpertStudioComponent } from '../../../studio.component'
 import { XpertWorkflowBaseComponent } from '../workflow-base.component'
 import { JSONSchemaFormComponent } from '@cloud/app/@shared/forms'
 import { ZardTooltipImports } from '@xpert-ai/headless-ui'
+import { createChatTriggerInputParameters } from '../../../../draft'
 
 @Component({
   selector: 'xpert-workflow-trigger',
@@ -78,23 +78,8 @@ export class XpertWorkflowTriggerComponent extends XpertWorkflowBaseComponent {
         }
       })
       if (from === 'chat') {
-        const hasParameters = !!value?.length
-        const groupName = triggerKey ? channelName(triggerKey) : null
-        this.studioService.agentConfig.update((state) => {
-          return {
-            ...(state ?? {}),
-            parameters:
-              hasParameters && groupName
-                ? [
-                    {
-                      type: XpertParameterTypeEnum.OBJECT,
-                      name: groupName,
-                      optional: true,
-                      item: value
-                    }
-                  ]
-                : null
-          }
+        this.studioService.updateXpertAgentConfig({
+          parameters: createChatTriggerInputParameters(triggerKey, value)
         })
       }
     }


### PR DESCRIPTION
## Summary

- Derive agent input parameters from chat trigger parameters when building editable Xpert drafts.
- Reuse the shared chat trigger parameter group builder from the trigger editor update path.
- Mark the studio as unsaved when persisted agent config parameters do not match derived chat trigger parameters.
- Cover create, derive, overwrite, stale-removal, and non-trigger preservation cases with focused unit tests.

## Root Cause

Preview input parameters are driven by `team.agentConfig.parameters`, while chat trigger parameters were stored on the trigger node and were not consistently propagated to the agent config. When a chat trigger defined parameters, the preview could still see empty or stale agent parameters instead of the trigger-defined parameter group.

## Validation

- `git diff origin/develop --check`
- `pnpm nx test cloud --runInBand --testPathPatterns=xpert-draft-trigger.util.spec.ts --skip-nx-cache`
