### PR TITLE
[codex] Harden FileMemory Dreamer runs

### DIFF
--- a/apps/cloud/src/app/features/xpert/xpert/memory/files/files.component.html
+++ b/apps/cloud/src/app/features/xpert/xpert/memory/files/files.component.html
@@ -1,11 +1,12 @@
 <div class="flex h-full min-h-0 flex-col gap-3">
-  <div class="grid gap-3 rounded-lg border border-divider-regular bg-components-card-bg p-3">
-    <div class="flex flex-wrap items-end gap-3">
-      <label class="flex min-w-64 flex-1 flex-col gap-1 text-xs text-text-secondary">
-        <span>{{ 'PAC.Xpert.FileMemoryDreamerXpert' | translate: { Default: 'Dreamer Xpert' } }}</span>
+  <div class="grid gap-2 px-1">
+    <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+      <label class="flex min-w-96 basis-2/5 items-center gap-2 text-base text-text-secondary">
+        <span class="shrink-0">{{ 'PAC.Xpert.FileMemoryDreamerXpert' | translate: { Default: 'Dreamer Xpert' } }}</span>
         <z-select
-          class="w-full"
+          class="min-w-0 flex-1"
           zSize="sm"
+          [zDisabled]="configLoading()"
           [zValue]="dreamerXpertId()"
           [zPlaceholder]="'PAC.Xpert.FileMemoryDreamerXpert' | translate: { Default: 'Dreamer Xpert' }"
           (zSelectionChange)="updateDreamerXpertId($event)"
@@ -23,11 +24,14 @@
         </z-select>
       </label>
 
-      <label class="flex min-w-48 flex-col gap-1 text-xs text-text-secondary">
-        <span>{{ 'PAC.Xpert.FileMemoryDreamerAgentKey' | translate: { Default: 'Dreamer Agent Key' } }}</span>
+      <label class="flex min-w-80 items-center gap-2 text-base text-text-secondary">
+        <span class="shrink-0">{{
+          'PAC.Xpert.FileMemoryDreamerAgentKey' | translate: { Default: 'Dreamer Agent Key' }
+        }}</span>
         <z-select
-          class="w-full"
+          class="min-w-0 flex-1"
           zSize="sm"
+          [zDisabled]="configLoading()"
           [zValue]="dreamerAgentKey()"
           [zPlaceholder]="'PAC.Xpert.FileMemoryDreamerAgentKey' | translate: { Default: 'Dreamer Agent Key' }"
           (zSelectionChange)="updateDreamerAgentKey($event)"
@@ -50,22 +54,6 @@
         zType="secondary"
         zSize="sm"
         type="button"
-        [disabled]="configSaving() || configLoading()"
-        (click)="saveDreamConfig()"
-      >
-        @if (configSaving()) {
-          <i class="ri-loader-4-line mr-1 animate-spin"></i>
-        } @else {
-          <i class="ri-save-3-line mr-1"></i>
-        }
-        <span>{{ 'PAC.ACTIONS.Save' | translate: { Default: 'Save' } }}</span>
-      </button>
-
-      <button
-        z-button
-        zType="secondary"
-        zSize="sm"
-        type="button"
         [disabled]="!dreamerXpertId()"
         (click)="openDreamerStudio()"
       >
@@ -74,42 +62,54 @@
       </button>
     </div>
 
-    <div class="flex flex-wrap items-end gap-3 border-t border-divider-regular pt-3">
-      <z-switch zSize="sm" labelPosition="before" [ngModel]="gateEnabled()" (ngModelChange)="gateEnabled.set($event)">
+    <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+      <z-switch
+        class="text-base"
+        zSize="sm"
+        labelPosition="before"
+        [disabled]="configLoading()"
+        [ngModel]="gateEnabled()"
+        (ngModelChange)="updateGateEnabled($event)"
+      >
         {{ 'PAC.Xpert.FileMemoryEnableDreamGate' | translate: { Default: 'Enable Dream gate' } }}
       </z-switch>
 
-      <label class="flex min-w-36 flex-col gap-1 text-xs text-text-secondary">
-        <span>{{ 'PAC.Xpert.FileMemoryMinInterval' | translate: { Default: 'Min interval' } }}</span>
+      <label class="flex items-center gap-2 text-base text-text-secondary">
+        <span class="shrink-0">{{ 'PAC.Xpert.FileMemoryMinInterval' | translate: { Default: 'Min interval' } }}</span>
         <input
           z-input
           type="number"
           min="0"
-          class="w-full"
+          class="w-28"
+          [disabled]="configLoading()"
           [ngModel]="gateMinIntervalMinutes()"
           (ngModelChange)="updateGateMinIntervalMinutes($event)"
         />
       </label>
 
-      <label class="flex min-w-36 flex-col gap-1 text-xs text-text-secondary">
-        <span>{{ 'PAC.Xpert.FileMemoryNewMemories' | translate: { Default: 'New memories' } }}</span>
+      <label class="flex items-center gap-2 text-base text-text-secondary">
+        <span class="shrink-0">{{ 'PAC.Xpert.FileMemoryNewMemories' | translate: { Default: 'New memories' } }}</span>
         <input
           z-input
           type="number"
           min="0"
-          class="w-full"
+          class="w-28"
+          [disabled]="configLoading()"
           [ngModel]="gateMinNewOrUpdatedMemories()"
           (ngModelChange)="updateGateMinNewOrUpdatedMemories($event)"
         />
       </label>
 
-      <label class="flex min-w-36 flex-col gap-1 text-xs text-text-secondary">
-        <span>{{ 'PAC.Xpert.FileMemoryConversations' | translate: { Default: 'Conversations' } }}</span>
+      <label class="flex items-center gap-2 text-base text-text-secondary">
+        <span class="shrink-0">{{
+          'PAC.Xpert.FileMemoryConversations' | translate: { Default: 'Conversations' }
+        }}</span>
         <input
           z-input
           type="number"
           min="0"
-          class="w-full"
+          class="w-28"
+          [disabled]="configLoading()"
           [ngModel]="gateMinConversationCount()"
           (ngModelChange)="updateGateMinConversationCount($event)"
         />
@@ -137,7 +137,7 @@
           zType="default"
           zSize="sm"
           type="button"
-          [disabled]="!xpertId() || dreaming()"
+          [disabled]="!xpertId() || dreaming() || configSaving() || configLoading()"
           (click)="triggerDream()"
         >
           @if (dreaming()) {
@@ -156,7 +156,7 @@
         [rootLabel]="rootLabel()"
         [filesLoader]="loadMemoryFiles"
         [fileLoader]="loadMemoryFile"
-        [fileSaver]="effectiveFileSaver()"
+        [fileSaver]="saveMemoryFile"
         [fileUploader]="effectiveFileUploader()"
         [fileDeleter]="effectiveFileDeleter()"
         [reloadKey]="reloadKey()"
@@ -208,14 +208,19 @@
               <span>
                 {{
                   'PAC.Xpert.FileMemoryFilesCount'
-                    | translate: { Default: 'files {{count
-                }}', count: run.changedFileCount ?? '-' } }}
+                    | translate
+                      : { Default: 'files ' + (run.changedFileCount ?? '-'), count: run.changedFileCount ?? '-' }
+                }}
               </span>
               <span>
                 {{
                   'PAC.Xpert.FileMemoryIssuesCount'
-                    | translate: { Default: 'issues {{count
-                }}', count: run.unresolvedConflictCount ?? '-' } }}
+                    | translate
+                      : {
+                          Default: 'issues ' + (run.unresolvedConflictCount ?? '-'),
+                          count: run.unresolvedConflictCount ?? '-'
+                        }
+                }}
               </span>
             </div>
             @if (run.error) {
@@ -275,12 +280,16 @@
                   <dd>{{ selectedRun().summary.gate.newOrUpdatedMemoryCount }}</dd>
                   <dt>{{ 'PAC.Xpert.FileMemoryConversations' | translate: { Default: 'Conversations' } }}</dt>
                   <dd>{{ selectedRun().summary.gate.conversationCount }}</dd>
-                  <dt>{{ 'PAC.Xpert.FileMemoryElapsed' | translate: { Default: 'Elapsed' } }}</dt>
+                  <dt>{{ 'PAC.Xpert.FileMemoryElapsed' | translate: { Default: 'Since last Dream' } }}</dt>
                   <dd>
                     {{
                       'PAC.Xpert.FileMemoryMinutes'
-                        | translate: { Default: '{{value}}
-                    min', value: selectedRun().summary.gate.elapsedMinutes ?? '-' } }}
+                        | translate
+                          : {
+                              Default: (selectedRun().summary.gate.elapsedMinutes ?? '-') + ' min',
+                              value: selectedRun().summary.gate.elapsedMinutes ?? '-'
+                            }
+                    }}
                   </dd>
                 }
               </dl>

--- a/apps/cloud/src/app/features/xpert/xpert/memory/files/files.component.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/memory/files/files.component.ts
@@ -77,9 +77,6 @@ export class XpertMemoryFilesComponent {
   readonly gateMinConversationCount = signal(1)
   readonly defaultDreamerXpertId = signal('')
   readonly defaultDreamerAgentKey = signal('')
-  readonly defaultGateMinIntervalMinutes = signal(30)
-  readonly defaultGateMinNewOrUpdatedMemories = signal(1)
-  readonly defaultGateMinConversationCount = signal(1)
   readonly dreamerOptions = signal<IXpert[]>([])
   readonly dreamRuns = signal<TFileMemoryDreamRunSummary[]>([])
   readonly selectedRunId = signal<string | null>(null)
@@ -91,6 +88,10 @@ export class XpertMemoryFilesComponent {
     () => this.selectedRun()?.summary ?? this.dreamRuns().find((run) => run.runId === this.selectedRunId())
   )
   #polling?: Subscription
+  #autoSaveTimer?: ReturnType<typeof setTimeout>
+  #configSaveInFlight = false
+  #configSaveDirty = false
+  #configSavePromise?: Promise<void>
 
   readonly loadMemoryFiles: FileWorkbenchFilesLoader = (path?: string) => {
     const xpertId = this.xpertId()
@@ -137,11 +138,6 @@ export class XpertMemoryFilesComponent {
     return this.#fileMemoryAPI.deleteFile(xpertId, path)
   }
 
-  readonly effectiveFileSaver = computed<FileWorkbenchFileSaver | null>(() => {
-    const activePath = this.fileWorkbench()?.activeFilePath()
-    return isManagedMemoryIndexPath(activePath) ? null : this.saveMemoryFile
-  })
-
   readonly effectiveFileDeleter = computed<FileWorkbenchFileDeleter | null>(() => {
     const activePath = this.fileWorkbench()?.activeFilePath()
     return isManagedMemoryIndexPath(activePath) ? null : this.deleteMemoryFile
@@ -164,63 +160,98 @@ export class XpertMemoryFilesComponent {
       this.#polling = interval(5000).subscribe(() => {
         void this.loadDreamRuns(xpertId, true)
       })
-      onCleanup(() => this.#polling?.unsubscribe())
+      onCleanup(() => {
+        this.#polling?.unsubscribe()
+        this.clearDreamConfigAutoSave()
+      })
     })
   }
 
-  triggerDream() {
+  async triggerDream() {
     const xpertId = this.xpertId()
-    if (!xpertId || this.dreaming()) {
+    if (!xpertId || this.dreaming() || this.configSaving() || this.configLoading()) {
       return
     }
 
     this.dreaming.set(true)
-    this.#fileMemoryAPI.triggerDream(xpertId).subscribe({
-      next: (run) => {
-        this.#toastr.success('PAC.Xpert.FileMemoryDreamQueued', {
-          Default: `Dream queued: ${run.runId}`,
-          runId: run.runId
-        })
-        this.selectedRunId.set(run.runId)
-        void this.loadDreamRuns(xpertId)
-      },
-      error: (error) => {
-        this.dreaming.set(false)
-        this.#toastr.error(getErrorMessage(error))
-      },
-      complete: () => {
-        this.dreaming.set(false)
-      }
-    })
-  }
-
-  async saveDreamConfig() {
-    const xpertId = this.xpertId()
-    if (!xpertId) {
-      return
-    }
-    this.configSaving.set(true)
     try {
-      const config = await firstValueFrom(
-        this.#fileMemoryAPI.saveDreamConfig(xpertId, {
-          dreamerXpertId: this.dreamerXpertId(),
-          dreamerAgentKey: this.dreamerAgentKey(),
-          gate: {
-            enabled: this.gateEnabled(),
-            minIntervalMinutes: this.gateMinIntervalMinutes(),
-            minNewOrUpdatedMemories: this.gateMinNewOrUpdatedMemories(),
-            minConversationCount: this.gateMinConversationCount()
-          }
-        })
-      )
-      this.applyDreamConfig(config)
-      this.#toastr.success('PAC.Xpert.FileMemoryDreamConfigSaved', {
-        Default: 'Dreamer config saved'
+      await this.persistDreamConfig(xpertId)
+      const run = await firstValueFrom(this.#fileMemoryAPI.triggerDream(xpertId))
+      this.#toastr.success('PAC.Xpert.FileMemoryDreamQueued', {
+        Default: `Dream queued: ${run.runId}`,
+        runId: run.runId
       })
+      this.selectedRunId.set(run.runId)
+      void this.loadDreamRuns(xpertId)
     } catch (error) {
       this.#toastr.error(getErrorMessage(error))
     } finally {
+      this.dreaming.set(false)
+    }
+  }
+
+  private async persistDreamConfig(xpertId: string) {
+    this.clearDreamConfigAutoSave()
+    if (this.#configSaveInFlight) {
+      this.#configSaveDirty = true
+      await this.#configSavePromise
+      return
+    }
+    this.#configSaveInFlight = true
+    this.configSaving.set(true)
+    const savePromise = this.runDreamConfigSave(xpertId)
+    this.#configSavePromise = savePromise
+    try {
+      await savePromise
+    } finally {
+      this.#configSaveInFlight = false
+      this.#configSavePromise = undefined
       this.configSaving.set(false)
+    }
+  }
+
+  private async runDreamConfigSave(xpertId: string) {
+    do {
+      this.#configSaveDirty = false
+      const config = await firstValueFrom(this.#fileMemoryAPI.saveDreamConfig(xpertId, this.buildDreamConfigInput()))
+      if (!this.#configSaveDirty && this.xpertId() === xpertId) {
+        this.applyDreamConfig(config)
+      }
+    } while (this.#configSaveDirty && this.xpertId() === xpertId)
+  }
+
+  private buildDreamConfigInput() {
+    return {
+      dreamerXpertId: this.dreamerXpertId(),
+      dreamerAgentKey: this.dreamerAgentKey(),
+      gate: {
+        enabled: this.gateEnabled(),
+        minIntervalMinutes: this.gateMinIntervalMinutes(),
+        minNewOrUpdatedMemories: this.gateMinNewOrUpdatedMemories(),
+        minConversationCount: this.gateMinConversationCount()
+      }
+    }
+  }
+
+  private scheduleDreamConfigAutoSave() {
+    const xpertId = this.xpertId()
+    if (!xpertId || this.configLoading()) {
+      return
+    }
+    this.#configSaveDirty = true
+    this.clearDreamConfigAutoSave()
+    this.#autoSaveTimer = setTimeout(() => {
+      this.#autoSaveTimer = undefined
+      void this.persistDreamConfig(xpertId).catch((error) => {
+        this.#toastr.error(getErrorMessage(error))
+      })
+    }, 600)
+  }
+
+  private clearDreamConfigAutoSave() {
+    if (this.#autoSaveTimer) {
+      clearTimeout(this.#autoSaveTimer)
+      this.#autoSaveTimer = undefined
     }
   }
 
@@ -233,22 +264,32 @@ export class XpertMemoryFilesComponent {
 
   updateDreamerXpertId(value: ZardSelectValue) {
     this.dreamerXpertId.set(selectValueToString(value))
+    this.scheduleDreamConfigAutoSave()
   }
 
   updateDreamerAgentKey(value: ZardSelectValue) {
     this.dreamerAgentKey.set(selectValueToString(value))
+    this.scheduleDreamConfigAutoSave()
+  }
+
+  updateGateEnabled(value: boolean) {
+    this.gateEnabled.set(value)
+    this.scheduleDreamConfigAutoSave()
   }
 
   updateGateMinIntervalMinutes(value: string | number | null) {
     this.gateMinIntervalMinutes.set(toNonNegativeNumber(value))
+    this.scheduleDreamConfigAutoSave()
   }
 
   updateGateMinNewOrUpdatedMemories(value: string | number | null) {
     this.gateMinNewOrUpdatedMemories.set(toNonNegativeNumber(value))
+    this.scheduleDreamConfigAutoSave()
   }
 
   updateGateMinConversationCount(value: string | number | null) {
     this.gateMinConversationCount.set(toNonNegativeNumber(value))
+    this.scheduleDreamConfigAutoSave()
   }
 
   async selectRun(runId: string) {
@@ -357,9 +398,6 @@ export class XpertMemoryFilesComponent {
       ...defaultGate,
       ...config.gate
     }
-    this.defaultGateMinIntervalMinutes.set(defaultGate.minIntervalMinutes)
-    this.defaultGateMinNewOrUpdatedMemories.set(defaultGate.minNewOrUpdatedMemories)
-    this.defaultGateMinConversationCount.set(defaultGate.minConversationCount)
     this.dreamerXpertId.set(config.dreamerXpertId || config.defaults.dreamerXpertId || '')
     this.dreamerAgentKey.set(config.dreamerAgentKey || config.defaults.dreamerAgentKey || 'FileMemoryDreamer')
     this.gateEnabled.set(gate.enabled)

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -4198,7 +4198,7 @@
       "FileMemoryChanged": "变更",
       "FileMemoryIssues": "问题",
       "FileMemoryGate": "门控",
-      "FileMemoryElapsed": "耗时",
+      "FileMemoryElapsed": "距上次整理",
       "FileMemoryMinutes": "{{value}} 分钟",
       "FileMemoryPreflight": "预检",
       "FileMemoryDreamReport": "整理报告",
@@ -4207,7 +4207,6 @@
       "FileMemoryArtifacts": "产物",
       "FileMemorySelectDreamRun": "选择一个整理运行以查看报告。",
       "FileMemoryDreamQueued": "整理任务已入队：{{runId}}",
-      "FileMemoryDreamConfigSaved": "记忆整理器配置已保存",
       "FileMemoryDreamStatus": {
         "queued": "排队中",
         "running": "运行中",

--- a/packages/server-ai/src/file-memory/dream-prompt.ts
+++ b/packages/server-ai/src/file-memory/dream-prompt.ts
@@ -8,14 +8,18 @@ export const FILE_MEMORY_DREAM_SYSTEM_PROMPT = [
     'Do not create per-user directories.',
     'Do not copy raw chat transcripts into memory.',
     'Use absolute dates.',
-    'Prefer merging into existing topic files over creating duplicates.',
+    'Prefer updating or merging existing topic files over creating duplicates.',
+    'Treat duplicate, contradictory, stale, overly specific, and low-confidence memories as maintenance candidates.',
+    'When facts conflict, keep the better-supported or newer absolute-dated fact and record unresolved ambiguity in the final report.',
     'Update MEMORY.md yourself as a concise navigation index.',
-    'Write a preflight report before editing files, then write a final dream report.'
+    'If no memory file changes are warranted, explain why in the final report instead of returning a generic success note.',
+    'Write output/preflight-report.md before editing files, then write output/dream-report.json after finishing.'
 ].join('\n')
 
 export const FILE_MEMORY_DREAM_PHASES = [
     'Orient: read MEMORY.md, manifest, and topic frontmatter before changing files.',
     'Gather recent signal: prefer recall/get/write/writeback/user correction signals over broad transcript browsing.',
+    'Diagnose: list duplicate, conflict, stale, and no-op candidates in the preflight report before editing.',
     'Consolidate: merge duplicates, repair stale facts, and convert relative dates to absolute dates.',
-    'Prune and index: archive stale content and keep MEMORY.md as a short navigation index.'
+    'Report: keep MEMORY.md as a short navigation index and write a structured final report with changed files, unresolved conflicts, and no-change reasoning.'
 ] as const

--- a/packages/server-ai/src/file-memory/dream.service.spec.ts
+++ b/packages/server-ai/src/file-memory/dream.service.spec.ts
@@ -36,7 +36,16 @@ describe('FileMemoryDreamService', () => {
             )
             await fsPromises.writeFile(
                 path.join(runRoot, 'output/dream-report.json'),
-                JSON.stringify({ dreamDiary: 'Dreamer finished.' }, null, 2),
+                JSON.stringify(
+                    {
+                        status: 'succeeded',
+                        changedFiles: [],
+                        unresolvedConflicts: [],
+                        dreamDiary: 'Dreamer finished.'
+                    },
+                    null,
+                    2
+                ),
                 'utf8'
             )
         })
@@ -94,6 +103,9 @@ describe('FileMemoryDreamService', () => {
         await expect(fsPromises.readFile(path.join(runRoot, 'output/dream-report.json'), 'utf8')).resolves.toContain(
             '"status": "succeeded"'
         )
+        await expect(fsPromises.readFile(path.join(runRoot, 'output/dream-report.json'), 'utf8')).resolves.toContain(
+            '"dreamDiary": "Dreamer finished."'
+        )
         await expect(fsPromises.readFile(path.join(runRoot, 'output/validation.json'), 'utf8')).resolves.toContain(
             '"ok": true'
         )
@@ -110,6 +122,149 @@ describe('FileMemoryDreamService', () => {
         expect(
             detail.artifacts.some((artifact) => artifact.path.endsWith('changed-files.json') && artifact.exists)
         ).toBe(true)
+    })
+
+    it('preserves dreamer report fields while adding host diff and validation results', async () => {
+        const created = await fileMemoryService.writeMemory(xpert, {
+            type: 'project',
+            title: 'Dream Report Merge',
+            summary: 'Dreamer report fields should survive host finalization.',
+            content: 'The Dreamer will update this topic and report why it changed.'
+        })
+        dreamerRun.mockImplementationOnce(async ({ memoryRoot, runRoot }) => {
+            await fsPromises.appendFile(
+                path.join(memoryRoot, created.relativePath),
+                '\nDreamer merged details.\n',
+                'utf8'
+            )
+            await fsPromises.writeFile(
+                path.join(runRoot, 'output/dream-report.json'),
+                JSON.stringify(
+                    {
+                        status: 'partial',
+                        changedFiles: [
+                            {
+                                path: created.relativePath,
+                                changeType: 'updated',
+                                reason: 'Merged duplicate project details into the existing topic.'
+                            }
+                        ],
+                        unresolvedConflicts: [
+                            {
+                                path: created.relativePath,
+                                reason: 'Two source snippets still disagree on the final project name.'
+                            }
+                        ],
+                        dreamDiary: 'Dreamer merged one topic and flagged one unresolved conflict.'
+                    },
+                    null,
+                    2
+                ),
+                'utf8'
+            )
+        })
+
+        const run = await dreamService.triggerDream(xpert, { reason: 'manual' })
+        await (dreamService as unknown as { slots: Map<string, TestDreamSlot> }).slots.get('tenant-1:xpert-1')?.current
+        const detail = await waitForRunStatus(run.runId, 'partial')
+
+        expect(detail.summary.unresolvedConflictCount).toBe(1)
+        expect(detail.report?.dreamDiary).toBe('Dreamer merged one topic and flagged one unresolved conflict.')
+        expect(detail.report?.changedFiles).toEqual([
+            expect.objectContaining({
+                path: created.relativePath,
+                changeType: 'updated',
+                reason: 'Merged duplicate project details into the existing topic.'
+            })
+        ])
+        expect(detail.report?.unresolvedConflicts).toEqual([
+            {
+                path: created.relativePath,
+                reason: 'Two source snippets still disagree on the final project name.'
+            }
+        ])
+    })
+
+    it('preserves skipped dreamer report when no memory files changed', async () => {
+        await fileMemoryService.writeMemory(xpert, {
+            type: 'project',
+            title: 'No Dream Changes',
+            summary: 'Dreamer should be able to report a no-op run.',
+            content: 'The Dreamer scans this topic but does not need to edit it.'
+        })
+        dreamerRun.mockImplementationOnce(async ({ runRoot }) => {
+            await fsPromises.writeFile(
+                path.join(runRoot, 'output/dream-report.json'),
+                JSON.stringify(
+                    {
+                        status: 'skipped',
+                        changedFiles: [],
+                        unresolvedConflicts: [],
+                        dreamDiary: 'Dreamer scanned the memory root and found no warranted memory edits.'
+                    },
+                    null,
+                    2
+                ),
+                'utf8'
+            )
+        })
+
+        const run = await dreamService.triggerDream(xpert, { reason: 'manual' })
+        await (dreamService as unknown as { slots: Map<string, TestDreamSlot> }).slots.get('tenant-1:xpert-1')?.current
+        const detail = await waitForRunStatus(run.runId, 'skipped')
+
+        expect(detail.summary.changedFileCount).toBe(0)
+        expect(detail.summary.unresolvedConflictCount).toBe(0)
+        expect(detail.report?.status).toBe('skipped')
+        expect(detail.report?.dreamDiary).toBe('Dreamer scanned the memory root and found no warranted memory edits.')
+    })
+
+    it('marks run partial when dreamer does not write the final report', async () => {
+        await fileMemoryService.writeMemory(xpert, {
+            type: 'project',
+            title: 'Missing Dream Report',
+            summary: 'A missing Dreamer report should not be treated as a successful run.',
+            content: 'The Dreamer runtime returns without writing output/dream-report.json.'
+        })
+        dreamerRun.mockImplementationOnce(async () => undefined)
+
+        const run = await dreamService.triggerDream(xpert, { reason: 'manual' })
+        await (dreamService as unknown as { slots: Map<string, TestDreamSlot> }).slots.get('tenant-1:xpert-1')?.current
+        const detail = await waitForRunStatus(run.runId, 'partial')
+
+        expect(detail.summary.changedFileCount).toBe(0)
+        expect(detail.summary.unresolvedConflictCount).toBe(1)
+        expect(detail.report?.status).toBe('partial')
+        expect(detail.report?.unresolvedConflicts).toEqual([
+            {
+                reason: 'Dreamer did not write output/dream-report.json.'
+            }
+        ])
+    })
+
+    it('marks run partial when dreamer writes an invalid final report shape', async () => {
+        await fileMemoryService.writeMemory(xpert, {
+            type: 'project',
+            title: 'Invalid Dream Report',
+            summary: 'An incomplete Dreamer report should not be treated as a successful run.',
+            content: 'The Dreamer runtime writes output/dream-report.json without required fields.'
+        })
+        dreamerRun.mockImplementationOnce(async ({ runRoot }) => {
+            await fsPromises.writeFile(path.join(runRoot, 'output/dream-report.json'), '{}\n', 'utf8')
+        })
+
+        const run = await dreamService.triggerDream(xpert, { reason: 'manual' })
+        await (dreamService as unknown as { slots: Map<string, TestDreamSlot> }).slots.get('tenant-1:xpert-1')?.current
+        const detail = await waitForRunStatus(run.runId, 'partial')
+
+        expect(detail.summary.changedFileCount).toBe(0)
+        expect(detail.summary.unresolvedConflictCount).toBe(1)
+        expect(detail.report?.status).toBe('partial')
+        expect(detail.report?.unresolvedConflicts).toEqual([
+            {
+                reason: 'Dreamer wrote output/dream-report.json, but status must be "succeeded", "partial", or "skipped".'
+            }
+        ])
     })
 
     it('coalesces a new trigger when a queued run already exists for the same xpert', async () => {

--- a/packages/server-ai/src/file-memory/dream.service.ts
+++ b/packages/server-ai/src/file-memory/dream.service.ts
@@ -232,9 +232,15 @@ export class FileMemoryDreamService {
                 await this.writePreflightReport(xpert, run.runId, evidence)
                 await this.runDreamer(xpert, run.runId, dreamerConfig)
                 const validation = await this.validateMemoryRoot(xpert)
-                const status = validation.status
                 const changedFiles = await this.diffMemoryRootAgainstBackup(xpert)
-                const report = await this.writeDreamReport(xpert, run.runId, status, validation, changedFiles)
+                const report = await this.writeDreamReport(
+                    xpert,
+                    run.runId,
+                    validation.status,
+                    validation,
+                    changedFiles
+                )
+                const status = report.status
                 await this.writeJson(await this.getOutputPath(xpert, run.runId, 'validation.json'), validation)
                 await this.writeJson(await this.getOutputPath(xpert, run.runId, 'changed-files.json'), changedFiles)
                 await this.appendDreamDiary(xpert, report)
@@ -244,7 +250,7 @@ export class FileMemoryDreamService {
                     startedAt,
                     finishedAt: new Date().toISOString(),
                     changedFileCount: changedFiles.length,
-                    unresolvedConflictCount: validation.issues.length,
+                    unresolvedConflictCount: report.unresolvedConflicts.length,
                     gate
                 })
             } finally {
@@ -602,22 +608,76 @@ export class FileMemoryDreamService {
         validation: DreamValidationResult,
         changedFiles: FileMemoryDreamChangedFile[]
     ) {
+        const dreamerReportResult = await this.readDreamerReport(xpert, runId)
+        const dreamerReport = dreamerReportResult.report
+        const dreamerReportConflicts = dreamerReportResult.conflict ? [dreamerReportResult.conflict] : []
+        const unresolvedConflicts = mergeDreamConflicts(
+            [...dreamerReportConflicts, ...(dreamerReport?.unresolvedConflicts ?? [])],
+            validation.issues.map((issue) => ({
+                path: issue.path,
+                reason: issue.message
+            }))
+        )
+        const dreamerStatus = dreamerReport?.status
+        const mergedChangedFiles = mergeDreamChangedFiles(changedFiles, dreamerReport?.changedFiles ?? [])
+        const reportStatus =
+            status === 'succeeded' && (dreamerStatus === 'partial' || unresolvedConflicts.length > 0)
+                ? 'partial'
+                : status === 'succeeded' && dreamerStatus === 'skipped' && mergedChangedFiles.length === 0
+                  ? 'skipped'
+                  : status
+        const dreamerDiary = dreamerReport?.dreamDiary
         const report: FileMemoryDreamRunReport = {
             runId,
             xpertId: xpert.id,
-            status,
-            changedFiles,
-            unresolvedConflicts: validation.issues.map((issue) => ({
-                path: issue.path,
-                reason: issue.message
-            })),
+            status: reportStatus,
+            changedFiles: mergedChangedFiles,
+            unresolvedConflicts,
             dreamDiary:
-                validation.issues.length === 0
-                    ? `Dream scanned the memory root, prepared evidence, and found ${changedFiles.length} changed file(s).`
-                    : `Dream scanned the memory root, found ${changedFiles.length} changed file(s), and found ${validation.issues.length} issue(s) that need Dreamer or manual repair.`
+                dreamerDiary ??
+                (validation.issues.length === 0
+                    ? `Dream scanned the memory root, prepared evidence, and found ${mergedChangedFiles.length} changed file(s).`
+                    : `Dream scanned the memory root, found ${mergedChangedFiles.length} changed file(s), and found ${validation.issues.length} issue(s) that need Dreamer or manual repair.`)
         }
         await this.writeJson(await this.getOutputPath(xpert, runId, 'dream-report.json'), report)
         return report
+    }
+
+    private async readDreamerReport(
+        xpert: FileMemoryXpertScope,
+        runId: string
+    ): Promise<{
+        report?: ParsedDreamerReport
+        conflict?: FileMemoryDreamRunReport['unresolvedConflicts'][number]
+    }> {
+        const reportPath = await this.getOutputPath(xpert, runId, 'dream-report.json')
+        try {
+            const { report, issue } = parseDreamerReportDraft(await this.readJson<unknown>(reportPath))
+            if (issue) {
+                return {
+                    ...(report ? { report } : {}),
+                    conflict: {
+                        reason: issue
+                    }
+                }
+            }
+            return {
+                report
+            }
+        } catch (error) {
+            const errorCode = getErrorCode(error)
+            const reason =
+                errorCode === 'ENOENT'
+                    ? 'Dreamer did not write output/dream-report.json.'
+                    : `Dreamer did not write a valid output/dream-report.json: ${
+                          error instanceof Error ? error.message : String(error)
+                      }`
+            return {
+                conflict: {
+                    reason
+                }
+            }
+        }
     }
 
     private async appendDreamDiary(xpert: FileMemoryXpertScope, report: FileMemoryDreamRunReport) {
@@ -822,7 +882,17 @@ export class FileMemoryDreamService {
             ``,
             `Use scorecards.json as a prioritization hint, not as the source of truth.`,
             ``,
-            `Write output/preflight-report.md before editing files and output/dream-report.json after finishing.`
+            `## Required Reports`,
+            `- Write output/preflight-report.md before editing files. Include scanned topic/index files, duplicate candidates, conflict candidates, stale candidates, planned edits, and the reason if no edit is warranted.`,
+            `- Write output/dream-report.json after finishing. It must be valid JSON with this shape:`,
+            `  {`,
+            `    "runId": "<run id>",`,
+            `    "xpertId": "<target xpert id>",`,
+            `    "status": "succeeded|partial|skipped",`,
+            `    "changedFiles": [{ "path": "user/example.md", "changeType": "created|updated|archived", "reason": "why this file changed" }],`,
+            `    "unresolvedConflicts": [{ "path": "user/example.md", "reason": "what still conflicts or needs manual review" }],`,
+            `    "dreamDiary": "short human-readable summary"`,
+            `  }`
         ].join('\n')
     }
 
@@ -914,6 +984,184 @@ export class FileMemoryDreamService {
         await fsPromises.mkdir(path.dirname(filePath), { recursive: true })
         await fsPromises.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
     }
+}
+
+type ParsedDreamerReport = {
+    status?: 'succeeded' | 'partial' | 'skipped'
+    changedFiles: FileMemoryDreamChangedFile[]
+    unresolvedConflicts: FileMemoryDreamRunReport['unresolvedConflicts']
+    dreamDiary?: string
+}
+
+type ParsedDreamerField<T> = {
+    value: T
+    issue?: string
+}
+
+function parseDreamerReportDraft(value: unknown): {
+    report?: ParsedDreamerReport
+    issue?: string
+} {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return {
+            issue: 'Dreamer wrote output/dream-report.json, but it was not a JSON object.'
+        }
+    }
+
+    const status = parseDreamerFinalStatus(Reflect.get(value, 'status'))
+    const changedFiles = parseDreamerChangedFiles(Reflect.get(value, 'changedFiles'))
+    const unresolvedConflicts = parseDreamerConflicts(Reflect.get(value, 'unresolvedConflicts'))
+    const dreamDiary = optionalString(Reflect.get(value, 'dreamDiary'))
+    const report: ParsedDreamerReport = {
+        changedFiles: changedFiles.value,
+        unresolvedConflicts: unresolvedConflicts.value
+    }
+    if (status) {
+        report.status = status
+    }
+    if (dreamDiary) {
+        report.dreamDiary = dreamDiary
+    }
+
+    return {
+        report,
+        issue:
+            (!status
+                ? 'Dreamer wrote output/dream-report.json, but status must be "succeeded", "partial", or "skipped".'
+                : undefined) ??
+            changedFiles.issue ??
+            unresolvedConflicts.issue ??
+            (!dreamDiary
+                ? 'Dreamer wrote output/dream-report.json, but dreamDiary must be a non-empty string.'
+                : undefined)
+    }
+}
+
+function parseDreamerChangedFiles(value: unknown): ParsedDreamerField<FileMemoryDreamChangedFile[]> {
+    if (!Array.isArray(value)) {
+        return {
+            value: [],
+            issue: 'Dreamer wrote output/dream-report.json, but changedFiles must be an array.'
+        }
+    }
+
+    const files: FileMemoryDreamChangedFile[] = []
+    for (const [index, item] of value.entries()) {
+        const changedFile = parseDreamerChangedFile(item)
+        if (!changedFile) {
+            return {
+                value: files,
+                issue: `Dreamer wrote output/dream-report.json, but changedFiles[${index}] must include path, changeType, and reason.`
+            }
+        }
+        files.push(changedFile)
+    }
+    return { value: files }
+}
+
+function parseDreamerChangedFile(value: unknown): FileMemoryDreamChangedFile | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined
+    }
+    const path = optionalString(Reflect.get(value, 'path'))
+    const changeType = parseDreamChangedFileType(Reflect.get(value, 'changeType'))
+    const reason = optionalString(Reflect.get(value, 'reason'))
+    if (!path || !changeType || !reason) {
+        return undefined
+    }
+    return {
+        path,
+        changeType,
+        reason
+    }
+}
+
+function mergeDreamChangedFiles(
+    changedFiles: FileMemoryDreamChangedFile[],
+    dreamerChangedFiles: FileMemoryDreamChangedFile[]
+) {
+    return changedFiles.map((changedFile) => {
+        const dreamerMatch = dreamerChangedFiles.find(
+            (candidate) => candidate.path === changedFile.path && candidate.changeType === changedFile.changeType
+        )
+        return dreamerMatch ? { ...changedFile, reason: dreamerMatch.reason } : changedFile
+    })
+}
+
+function parseDreamerConflicts(value: unknown): ParsedDreamerField<FileMemoryDreamRunReport['unresolvedConflicts']> {
+    if (!Array.isArray(value)) {
+        return {
+            value: [],
+            issue: 'Dreamer wrote output/dream-report.json, but unresolvedConflicts must be an array.'
+        }
+    }
+
+    const conflicts: FileMemoryDreamRunReport['unresolvedConflicts'] = []
+    for (const [index, item] of value.entries()) {
+        const conflict = parseDreamerConflict(item)
+        if (!conflict) {
+            return {
+                value: conflicts,
+                issue: `Dreamer wrote output/dream-report.json, but unresolvedConflicts[${index}] must include reason.`
+            }
+        }
+        conflicts.push(conflict)
+    }
+    return { value: conflicts }
+}
+
+function parseDreamerConflict(value: unknown): FileMemoryDreamRunReport['unresolvedConflicts'][number] | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined
+    }
+    const reason = optionalString(Reflect.get(value, 'reason'))
+    if (!reason) {
+        return undefined
+    }
+    const path = optionalString(Reflect.get(value, 'path'))
+    return {
+        ...(path ? { path } : {}),
+        reason
+    }
+}
+
+function mergeDreamConflicts(
+    dreamerConflicts: FileMemoryDreamRunReport['unresolvedConflicts'],
+    validationConflicts: FileMemoryDreamRunReport['unresolvedConflicts']
+) {
+    const merged: FileMemoryDreamRunReport['unresolvedConflicts'] = []
+    for (const conflict of [...dreamerConflicts, ...validationConflicts]) {
+        const key = `${conflict.path ?? ''}\n${conflict.reason}`
+        if (!merged.some((existing) => `${existing.path ?? ''}\n${existing.reason}` === key)) {
+            merged.push(conflict)
+        }
+    }
+    return merged
+}
+
+function parseDreamChangedFileType(value: unknown): FileMemoryDreamChangedFile['changeType'] | undefined {
+    if (value === 'created' || value === 'updated' || value === 'archived') {
+        return value
+    }
+    return undefined
+}
+
+function parseDreamerFinalStatus(value: unknown): 'succeeded' | 'partial' | 'skipped' | undefined {
+    if (value === 'succeeded' || value === 'partial' || value === 'skipped') {
+        return value
+    }
+    return undefined
+}
+
+function optionalString(value: unknown) {
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function getErrorCode(error: unknown) {
+    if (!error || typeof error !== 'object' || !('code' in error)) {
+        return undefined
+    }
+    return typeof error.code === 'string' ? error.code : undefined
 }
 
 function createDreamKey(xpert: FileMemoryXpertScope) {

--- a/packages/server-ai/src/xpert-template/templates.json
+++ b/packages/server-ai/src/xpert-template/templates.json
@@ -1,7 +1,7 @@
 {
     "templates": {
         "en-US": {
-            "categories": ["Agent", "Workflow", "HR", "Programming", "Writing", "Assistant", "Analysis"],
+            "categories": ["Agent", "Workflow", "HR", "Programming", "Writing", "Assistant", "Analysis", "Xpert"],
             "recommendedApps": [
                 {
                     "name": "Smart HR Assistant",
@@ -256,11 +256,41 @@
                     "category": "Assistant",
                     "copyright": null,
                     "privacyPolicy": null
+                },
+                {
+                    "name": "FileMemory Dreamer",
+                    "type": "agent",
+                    "title": "FileMemory Dreamer",
+                    "description": "Background memory maintenance agent for Xpert FileMemory. It reads Dream evidence, merges duplicate memories, resolves conflicts, and writes structured Dream reports.",
+                    "avatar": {
+                        "emoji": {
+                            "id": "robot_face"
+                        },
+                        "background": "rgba(213, 245, 246, 0.8)"
+                    },
+                    "id": "xpert-filememory-dreamer",
+                    "category": "Xpert",
+                    "copyright": null,
+                    "privacyPolicy": null,
+                    "copilotModel": {
+                        "modelType": "llm",
+                        "model": "deepseek-v4-flash"
+                    }
                 }
             ]
         },
         "zh-Hans": {
-            "categories": ["Agent", "Workflow", "Claw", "HR", "Programming", "Writing", "Assistant", "Analysis"],
+            "categories": [
+                "Agent",
+                "Workflow",
+                "Claw",
+                "HR",
+                "Programming",
+                "Writing",
+                "Assistant",
+                "Analysis",
+                "Xpert"
+            ],
             "recommendedApps": [
                 {
                     "name": "Claw Xpert",
@@ -357,6 +387,26 @@
                     "category": "Assistant",
                     "copyright": null,
                     "privacyPolicy": null
+                },
+                {
+                    "name": "FileMemory Dreamer",
+                    "type": "agent",
+                    "title": "FileMemory Dreamer",
+                    "description": "用于 Xpert FileMemory 的后台记忆整理智能体，读取 Dream 证据、合并重复记忆、处理冲突，并输出结构化整理报告。",
+                    "avatar": {
+                        "emoji": {
+                            "id": "robot_face"
+                        },
+                        "background": "rgba(213, 245, 246, 0.8)"
+                    },
+                    "id": "xpert-filememory-dreamer",
+                    "category": "Xpert",
+                    "copyright": null,
+                    "privacyPolicy": null,
+                    "copilotModel": {
+                        "modelType": "llm",
+                        "model": "deepseek-v4-flash"
+                    }
                 },
                 {
                     "name": "Demo - Workflow transform",

--- a/packages/server-ai/src/xpert-template/templates/xpert-filememory-dreamer.yaml
+++ b/packages/server-ai/src/xpert-template/templates/xpert-filememory-dreamer.yaml
@@ -1,0 +1,722 @@
+team:
+    name: FileMemory Dreamer
+    type: agent
+    title: FileMemory Dreamer
+    description: null
+    avatar: null
+    starters: null
+    options:
+        agent:
+            Agent_vlqADhkkrY:
+                position:
+                    x: 260
+                    y: 140
+        position:
+            x: 193
+            y: 76
+        scale: 1
+        workflow:
+            Middleware_FpTj3B1GOP:
+                position:
+                    x: 40
+                    y: 320
+            Middleware_lHUyLJVJo5:
+                position:
+                    x: 360
+                    y: 360
+    agentConfig:
+        recursionLimit: 1000
+    memory: null
+    summarize: null
+    features:
+        attachment:
+            enabled: true
+        sandbox:
+            enabled: true
+            provider: local-shell-sandbox
+    version: '3'
+    agent:
+        key: Agent_vlqADhkkrY
+    copilotModel:
+        copilotId: 94a9c79d-5c8b-4096-9f8d-1cf759237a69
+        referencedId: null
+        modelType: llm
+        model: deepseek-v4-flash
+        options:
+            context_size: 1000000
+            temperature: 0.2
+            maxRetries: 6
+            max_tokens: 4096
+            top_p: 1
+            thinking: true
+            reasoning_effort: high
+    knowledgebases: []
+    toolsets: []
+    tags: []
+nodes:
+    - type: agent
+      key: Agent_vlqADhkkrY
+      position:
+          x: 260
+          y: 140
+      entity:
+          key: Agent_vlqADhkkrY
+          name: null
+          title: null
+          description: null
+          avatar: null
+          prompt: |
+              你是 FileMemory Dreamer，一个后台记忆整理智能体。你的任务不是回答用户，而是维护指定 Xpert 的长期记忆文件。
+
+              你会收到一次整理任务，任务消息中会包含：
+
+              * target Xpert ID
+              * run ID
+              * memory root
+              * run root
+              * evidence path
+              * instructions path
+
+              你必须先读取 instructions path，再读取 evidence path 下的证据文件，然后只在允许范围内整理 memory root 中的记忆文件。
+
+              你的工作原则是：保守、可追溯、少改动。不要为了“整理得更多”而制造无意义修改。
+
+              ---
+
+              ## 一、允许修改的文件范围
+
+              你只能修改这些文件：
+
+              * MEMORY.md
+              * user/*.md
+              * feedback/*.md
+              * project/*.md
+              * reference/*.md
+              * run root/output/preflight-report.md
+              * run root/output/dream-report.json
+
+              你不能修改：
+
+              * .dream/signals/*
+              * .dream/scorecards/*
+              * .dream/runs/*/evidence/*
+              * .dream/config.json
+              * 任何权限目录、用户目录、临时目录、日志文件、原始会话文件
+              * memory root 外的任何文件
+
+              `dream-report.json` 中的 `changedFiles` 只记录长期记忆文件的变更，也就是：
+
+              * MEMORY.md
+              * user/*.md
+              * feedback/*.md
+              * project/*.md
+              * reference/*.md
+
+              不要把 `preflight-report.md` 和 `dream-report.json` 本身计入 `changedFiles`，否则无法区分“真正整理了记忆”和“只是生成运行报告”。
+
+              ---
+
+              ## 二、核心目标
+
+              你的整理目标是让长期记忆更准确、更少重复、更容易检索。
+
+              你必须重点处理：
+
+              1. 重复记忆
+
+                 * 同一事实被多条 topic 重复记录
+                 * 标题不同但内容实质相同
+                 * MEMORY.md 里重复索引同类主题
+                 * 多个 topic 记录了同一用户偏好、同一项目事实、同一路径、同一命令、同一部署状态
+
+              2. 语义冲突
+
+                 * 两条记忆对同一事实给出不同答案
+                 * 新证据与旧记忆不一致
+                 * 用户明确纠正过旧记忆
+                 * 偏好、身份、计划、技术事实、路径、命令、部署信息之间存在矛盾
+                 * MEMORY.md 索引与 topic 正文状态不一致
+                 * topic frontmatter 与正文不一致
+
+              3. 过时记忆
+
+                 * 相对日期没有转成绝对日期
+                 * 临时状态被当成长久规则
+                 * 已被后续对话推翻的内容仍是 active
+                 * 旧路径、旧命令、旧配置仍被索引为当前事实
+                 * “当前、最近、今天、昨天、今年、下一步”等表述没有明确时间边界
+
+              4. 结构问题
+
+                 * MEMORY.md 不是简洁导航索引
+                 * topic 文件 frontmatter 与正文不一致
+                 * 标题过泛、summary 不利于检索
+                 * 记忆应该归类到 user / feedback / project / reference 但放错类型
+                 * archived topic 仍被 MEMORY.md 索引为当前可用记忆
+
+              ---
+
+              ## 三、冲突识别的强制方法
+
+              语义冲突不能只靠标题、summary 或直觉判断。你必须执行“事实声明抽取 → 规范化 → 同键聚类 → 冲突判断”的流程。
+
+              ### 1. 抽取 Claim
+
+              从 MEMORY.md、memory-manifest.json、signals.json、scorecards.json、session-snippets.jsonl，以及候选 topic 文件正文中抽取可比较的事实声明，称为 claim。
+
+              每条 claim 至少包含这些字段，用于你内部分析和 preflight 汇总：
+
+              ```json
+              {
+                "claimKey": "规范化主体::规范化属性",
+                "subject": "事实主体，例如 用户偏好 / Xpert 项目 / 某部署环境 / 某工具 / 某路径",
+                "attribute": "属性，例如 preferred_tool / current_branch / api_base_url / model_cache_behavior / deployment_status",
+                "value": "具体取值",
+                "polarity": "affirmed | negated | deprecated | uncertain",
+                "scope": "适用范围，例如 全局 / 某项目 / 某环境 / 某日期 / 某工具",
+                "temporalScope": "时间范围，例如 current / historical / as_of_2026-06-08 / unknown",
+                "sourcePath": "来源文件路径",
+                "sourceRef": "原有 sourceRefs 或证据引用",
+                "evidenceType": "user_correction | direct_user_statement | topic_memory | signal | scorecard | session_snippet | inferred",
+                "confidence": "high | medium | low"
+              }
+              ```
+
+              不需要把完整 claim ledger 写入长期记忆，但必须在 preflight-report.md 中汇总高风险 claim cluster 和候选冲突。
+
+              ### 2. claimKey 规范化规则
+
+              你必须尽量把同一事实归并到同一个 claimKey。
+
+              规范化时：
+
+              * 去掉标题差异，只保留事实主体和属性
+              * 同义主体要合并，例如：
+
+                * “Xpert 平台”
+                * “xpert”
+                * “自研 Xpert”
+                * “类 Dify 平台”
+                  在上下文明确时可归为同一 subject
+              * 同义属性要合并，例如：
+
+                * “当前分支”
+                * “默认开发分支”
+                * “同步 origin 的目标分支”
+                  可归为 `git.current_or_sync_branch`
+              * 路径、URL、端口、模型名、命令、环境变量、版本号必须保留原值，不要模糊化
+              * 相对时间必须转成绝对时间；不能确定时写 `unknown` 或 `as_of_<证据日期>`
+
+              ### 3. 必须重点检查的高风险 Claim 类型
+
+              以下类型最容易产生记忆冲突，必须优先抽取和对比：
+
+              1. 用户偏好与工作方式
+
+                 * 用户喜欢 / 不喜欢的回答方式
+                 * 是否要主动询问
+                 * 是否要自动换策略
+                 * 是否要每日推送
+                 * 输出格式偏好
+
+              2. 项目当前状态
+
+                 * 当前项目阶段
+                 * 已完成 / 未完成 / 下一步
+                 * 是否仍在增加新功能
+                 * 是否进入运维、回归测试、推广阶段
+
+              3. 技术事实
+
+                 * 项目名、仓库、分支、包管理器、框架版本
+                 * 模型名称、参数、缓存行为
+                 * API 路径、环境变量、配置项
+                 * 命令、脚本、端口、部署路径
+
+              4. 部署与环境
+
+                 * 本地环境
+                 * 现场环境
+                 * 操作系统、CPU 架构、容器名、镜像版本
+                 * HTTP/HTTPS、OIDC、反代、证书、Cookie 配置
+
+              5. 数据流和工具边界
+
+                 * 哪个 Agent 可以做什么
+                 * 哪个 Agent 不能做什么
+                 * 主控 / 子任务 / OCR / 写库 / view_image 的职责边界
+                 * 文件处理流程、RAG 入库流程、Workflow 编排规则
+
+              6. 明确纠正
+
+                 * 用户说“不是”
+                 * 用户说“我不是这个意思”
+                 * 用户说“改成”
+                 * 用户说“不要”
+                 * 用户说“已经不是了”
+                 * 用户说“现在是”
+                 * 用户多次强调同一修正
+
+              ---
+
+              ## 四、语义冲突类型
+
+              你必须按以下类型识别冲突。不要只记录“可能冲突”，要说明冲突类型。
+
+              ### 1. Value Conflict
+
+              同一 claimKey 下出现不同 value，且没有清楚的时间或范围区分。
+
+              示例：
+
+              * 一个 topic 说默认端口是 7890
+              * 另一个 topic 说用户想改成 7897
+              * 如果没有标明前者是历史状态，则冲突
+
+              ### 2. Status Conflict
+
+              同一事项同时被标记为 active、done、deprecated、planned、blocked、current。
+
+              示例：
+
+              * 一个 topic 说某功能“下一步要做”
+              * 另一个 topic 说该功能“已经完成”
+              * MEMORY.md 仍把旧 topic 当成当前索引
+
+              ### 3. Negation Conflict
+
+              新证据明确否定旧记忆。
+
+              示例：
+
+              * 旧记忆：用户希望频繁询问确认
+              * 新证据：用户期望模型失败两次后自行换策略，不频繁询问
+              * 应以用户明确纠正为最高优先级
+
+              ### 4. Temporal Conflict
+
+              相同事实因为时间表述不清导致冲突。
+
+              示例：
+
+              * “最近在做运维和回归测试”
+              * “当前还在开发新功能”
+              * 如果证据时间不同，必须转成：
+
+                * 截至 YYYY-MM-DD 的当前状态
+                * YYYY-MM-DD 前后的历史状态
+
+              ### 5. Scope Conflict
+
+              两个事实看似冲突，但适用范围不同。不能误合并。
+
+              示例：
+
+              * 本地环境使用 macOS ARM
+              * 现场环境使用 CentOS7 x86_64
+              * 这不是冲突，必须在 scope 中区分
+
+              ### 6. Index Conflict
+
+              MEMORY.md 的索引摘要与 topic 正文不一致。
+
+              示例：
+
+              * topic 已 archived
+              * MEMORY.md 仍把它列为 active 当前规则
+
+              ### 7. Frontmatter Conflict
+
+              topic frontmatter 与正文不一致。
+
+              示例：
+
+              * frontmatter status: active
+              * 正文说明“已废弃 / 不再使用 / 被后续推翻”
+
+              ### 8. Duplicate-as-Conflict
+
+              两个 topic 内容高度重复，但一个更旧、一个更新，且旧 topic 缺少更新后的限制条件。
+              这种情况既是重复，也可能导致误召回，必须优先合并或归档旧 topic。
+
+              ---
+
+              ## 五、证据优先级
+
+              处理冲突时必须使用以下优先级，不得凭感觉选择：
+
+              1. 用户明确纠正或否定
+
+                 * 例如“不是”“我不是这个意思”“改成”“不要”“现在是”
+                 * 优先级最高
+
+              2. 用户最新的直接陈述
+
+                 * 明确表达当前偏好、当前状态、当前目标
+
+              3. 具体运行证据
+
+                 * 日志、报错、命令输出、配置片段、文件内容
+                 * 必须保留其适用范围
+
+              4. 现有 active topic 记忆
+
+                 * 仅在没有更高优先级证据推翻时有效
+
+              5. 较旧 topic、旧索引、旧 summary
+
+                 * 可能过时，不能自动当成当前事实
+
+              6. 文件 metadata
+
+                 * CreatedAt / ModifiedAt 只能辅助判断
+                 * 不能仅凭 ModifiedAt 判断内容是新的
+                 * 新上传的旧文档仍可能是旧事实
+
+              如果两个证据优先级相同，且无法判断哪个为真，不要猜。必须把相关 topic 标记为 conflict，或在 dream-report.json 的 unresolvedConflicts 中记录。
+
+              ---
+
+              ## 六、必须执行的流程
+
+              ### 1. 预检
+
+              在做任何长期记忆修改前，必须生成：
+
+              ```text
+              run root/output/preflight-report.md
+              ```
+
+              preflight-report.md 必须包含：
+
+              * run ID
+              * target Xpert ID
+              * memory root
+              * evidence files read
+              * topic files scanned
+              * scanned files count
+              * claim extraction summary
+              * high-risk claim clusters
+              * candidate duplicates
+              * candidate semantic conflicts
+              * candidate stale memories
+              * MEMORY.md index issues
+              * files you expect to edit
+              * any uncertainty or missing evidence
+
+              如果你没有找到任何候选项，也必须写明：
+
+              * scanned files count
+              * 扫描了哪些范围
+              * 为什么没有发现 duplicate / conflict / stale candidate
+              * 为什么判断无需修改长期记忆
+
+              candidate semantic conflicts 必须尽量用表格表达：
+
+              | conflictId | conflictType | claimKey | oldValue | newValue | evidence | proposedAction | confidence |
+              | ---------- | ------------ | -------- | -------- | -------- | -------- | -------------- | ---------- |
+
+              其中：
+
+              * `proposedAction` 可以是 `fix_old_memory`、`archive_old_topic`、`merge_topics`、`mark_conflict`、`no_change_scope_distinct`
+              * `confidence` 可以是 `high`、`medium`、`low`
+
+              不要因为证据不足就省略候选冲突。证据不足时，应记录为 unresolved candidate，而不是假装没有冲突。
+
+              ### 2. 读取证据
+
+              必须读取并综合：
+
+              * MEMORY.md
+              * evidence/memory-manifest.json
+              * evidence/signals.json
+              * evidence/scorecards.json
+              * evidence/session-snippets.jsonl
+              * 所有与候选项相关的 topic 文件正文
+
+              读取顺序：
+
+              1. 先读 instructions path
+              2. 再读 MEMORY.md
+              3. 再读 memory-manifest.json
+              4. 再读 signals.json、scorecards.json、session-snippets.jsonl
+              5. 根据 manifest、MEMORY.md、signals、scorecards 识别候选 topic
+              6. 再读取候选 topic 正文
+              7. 生成 preflight-report.md
+              8. 只有在 preflight-report.md 已生成后，才能修改长期记忆文件
+
+              不要把原始会话大段复制进记忆。只提炼稳定、可复用、长期有价值的信息。
+
+              ### 3. 候选项生成
+
+              你必须用两轮扫描生成候选项。
+
+              #### 第一轮：广扫描
+
+              目标是发现可能有关联的 topic，不做修改。
+
+              根据以下线索聚类：
+
+              * 相同或相近 tags
+              * 相同 sourceRefs
+              * 相同项目名、工具名、模型名、路径、端口、命令
+              * 相同用户偏好类型
+              * 相同环境或部署对象
+              * MEMORY.md 中相邻或重复索引项
+              * signals / scorecards 中提示的高风险项
+              * session snippets 中的明确纠正
+
+              #### 第二轮：深扫描
+
+              对候选 cluster 读取正文，抽取 claim，判断：
+
+              * 是否重复
+              * 是否冲突
+              * 是否只是 scope 不同
+              * 是否只是历史演进
+              * 是否应该合并、归档、标记 conflict，还是不改
+
+              不能只根据文件名或标题判断。
+
+              ### 4. 判断优先级
+
+              优先处理：
+
+              1. 用户明确纠正或否定的记忆
+              2. 会影响未来行为的偏好、路径、命令、权限、部署、数据流、调试结论
+              3. 多处重复且容易误召回的记忆
+              4. MEMORY.md 中会误导导航的索引项
+              5. 低价值、临时、一次性内容
+
+              不要整理：
+
+              * 简单闲聊
+              * 一次性输出
+              * 没有长期价值的临时请求
+              * 不确定且没有证据支持的事实
+              * 只有文件名相似、但正文没有重复或冲突证据的 topic
+
+              ---
+
+              ## 七、修改规则
+
+              ### 1. 合并重复记忆
+
+              合并重复记忆时：
+
+              * 优先保留更准确、更新、更完整的 topic
+              * 将可复用内容合并到保留 topic
+              * 被合并的 topic 应标记为 archived
+              * 如果被合并 topic 确实没有长期价值，可以只从 MEMORY.md 移除索引，但不要无证据删除文件
+              * 不要丢失重要 sourceRefs、tags、createdAt 信息
+              * updatedAt 必须使用当前绝对 ISO 时间
+              * updatedBy 使用 `file_memory_dream`
+              * source 可以保持原值；如果是 Dream 产生的新整理内容，可使用 `dream`
+
+              ### 2. 处理语义冲突
+
+              处理语义冲突时：
+
+              * 如果证据足够明确，直接修正旧记忆
+              * 如果旧事实只是历史状态，不要删除；改写成“历史结论”，并标明截至日期
+              * 如果新事实是当前状态，必须明确写“截至 YYYY-MM-DD”
+              * 如果无法确定哪条为真，不要猜
+              * 将相关 topic 标记为 conflict，或在正文中明确列出冲突点和需要人工确认的问题
+              * dream-report.json 必须记录 unresolvedConflicts
+              * MEMORY.md 中 conflict topic 可以保留索引，但 summary 必须显式标注 `conflict` 或“需要确认”
+
+              冲突修复后，必须检查：
+
+              * MEMORY.md 是否仍索引旧结论
+              * archived topic 是否仍被索引
+              * frontmatter status 是否与正文一致
+              * summary 是否仍表达过时事实
+              * tags 是否需要补充 `conflict`、`deprecated`、`historical`、`merged`
+
+              ### 3. 处理过时内容
+
+              处理过时内容时：
+
+              * 将相对日期改为绝对日期
+              * 把“昨天、今天、最近、今年、下一步、当前”等相对表述转成具体日期或 `截至 YYYY-MM-DD`
+              * 如果只能确定记录时间，明确写“截至 YYYY-MM-DD”
+              * 对已失效内容，归档或改成历史结论
+              * 不要继续把失效内容作为当前规则
+              * 不要仅因为内容旧就归档；必须有新证据、明确过时标记，或长期价值不足的理由
+
+              ### 4. 维护 MEMORY.md
+
+              维护 MEMORY.md 时：
+
+              * MEMORY.md 只能作为导航索引
+              * 不要放长正文
+              * 每条索引应简短说明 topic 的当前价值
+              * 不要索引 archived topic
+              * conflict topic 可以索引，但必须显式标注 `conflict` 或“需要确认”
+              * 不要重复索引多个内容实质相同的 topic
+              * 不要把一次性任务、临时输出、闲聊内容放进 MEMORY.md
+
+              ---
+
+              ## 八、写回前校验
+
+              在写入 dream-report.json 前，必须重新检查本次编辑过的文件：
+
+              1. MEMORY.md 是否只保留导航索引
+              2. MEMORY.md 是否没有 archived topic 索引
+              3. conflict topic 是否在 summary 中明确标注冲突
+              4. topic frontmatter 与正文是否一致
+              5. updatedAt 是否是当前绝对 ISO 时间
+              6. updatedBy 是否为 `file_memory_dream`
+              7. 没有修改允许范围之外的文件
+              8. 没有复制大段原始会话内容
+              9. 没有凭空创造用户偏好、路径、命令、配置、事实
+              10. unresolved conflict 是否已经写入 dream-report.json
+
+              ---
+
+              ## 九、输出要求
+
+              整理结束后必须生成：
+
+              ```text
+              run root/output/dream-report.json
+              ```
+
+              必须是合法 JSON，格式如下：
+
+              ```json
+              {
+                "runId": "<run id>",
+                "xpertId": "<target xpert id>",
+                "status": "succeeded | partial",
+                "changedFiles": [
+                  {
+                    "path": "user/example.md",
+                    "changeType": "created | updated | archived",
+                    "reason": "说明为什么改这个文件"
+                  }
+                ],
+                "unresolvedConflicts": [
+                  {
+                    "path": "user/example.md",
+                    "reason": "说明仍未解决的冲突或不确定性"
+                  }
+                ],
+                "analysis": {
+                  "filesScanned": 0,
+                  "duplicatesFound": 0,
+                  "semanticConflictsFound": 0,
+                  "staleMemoriesFound": 0,
+                  "noChangeReason": "如果 changedFiles 为空，必须解释为什么没有长期记忆改动"
+                },
+                "dreamDiary": "用简短文字总结本次整理做了什么、为什么这么做、还有什么风险"
+              }
+              ```
+
+              规则：
+
+              * `changedFiles` 只记录长期记忆文件改动，不记录 preflight-report.md 和 dream-report.json
+              * 如果没有任何长期记忆文件改动，changedFiles 必须是空数组
+              * 如果 changedFiles 为空，analysis.noChangeReason 不能为空
+              * 如果发现冲突但证据不足以修复，status 必须是 `partial`
+              * 如果有 unresolvedConflicts，status 必须是 `partial`
+              * 如果没有发现任何问题，可以 status 为 `succeeded`，但 noChangeReason 必须说明：
+
+                * 扫描了哪些范围
+                * 为什么判断无需修改长期记忆
+              * 如果只更新了 MEMORY.md 索引，也必须记录在 changedFiles 中
+              * 如果归档 topic，changeType 使用 `archived`
+              * 如果修改 topic 内容或 frontmatter，changeType 使用 `updated`
+              * 如果创建新 topic，changeType 使用 `created`
+
+              ---
+
+              ## 十、严格禁止
+
+              * 禁止编造用户偏好、事实、路径、命令、时间
+              * 禁止根据文件名或标题猜测事实
+              * 禁止把一次性聊天内容升级为长期记忆
+              * 禁止复制大段原始聊天记录
+              * 禁止为了让报告好看而制造无意义改动
+              * 禁止只写“整理完成”但不说明扫描和判断依据
+              * 禁止在没有证据时删除或覆盖记忆
+              * 禁止修改允许范围之外的文件
+              * 禁止把 scope 不同的事实误判为冲突
+              * 禁止把历史演进误判为冲突；应改写为 current / historical
+              * 禁止因为证据不足就隐瞒候选冲突；必须写入 unresolvedConflicts 或 preflight uncertainty
+
+              ---
+
+              ## 十一、工作风格
+
+              你必须保守、可追溯、少改动。
+
+              优先做小而确定的修复：
+
+              * 合并明确重复
+              * 标注明确冲突
+              * 归档明确过时
+              * 修正明确错误
+              * 更新索引以反映真实状态
+
+              当证据不足时，宁可留下 unresolvedConflicts，也不要猜测修复。
+
+              你不是聊天助手。你的最终产物是 memory 文件改动、preflight-report.md、dream-report.json。
+          promptTemplates: null
+          parameters: null
+          outputVariables: null
+          options:
+              vision:
+                  enabled: true
+          copilotModel:
+              copilotId: 94a9c79d-5c8b-4096-9f8d-1cf759237a69
+              referencedId: null
+              modelType: llm
+              model: deepseek-v4-flash
+              options:
+                  context_size: 1000000
+                  temperature: 0.2
+                  maxRetries: 6
+                  max_tokens: 4096
+                  top_p: 1
+                  thinking: false
+                  reasoning_effort: high
+          leaderKey: null
+          collaboratorNames: []
+          toolsetIds: []
+          knowledgebaseIds: []
+      hash: d02ce3ffd9fb5ccfb63b7329a4511ee0847b48991f1415b7cf0957044bdf9fd6
+    - type: workflow
+      key: Middleware_FpTj3B1GOP
+      position:
+          x: 40
+          y: 320
+      entity:
+          type: middleware
+          key: Middleware_FpTj3B1GOP
+          title: 中间件
+          provider: SandboxShell
+          required: true
+      hash: ca7be8ce03b67a62d121d09d43dd07f049034e0f0355fbd92f22c9fa5ef191a8
+    - type: workflow
+      key: Middleware_lHUyLJVJo5
+      position:
+          x: 360
+          y: 360
+      entity:
+          type: middleware
+          key: Middleware_lHUyLJVJo5
+          title: 中间件 3
+          provider: SandboxFile
+          required: true
+      hash: 0877c2e019ef0d2f425dbf3ec56e9ef50aa2a5bdd700b690ee701c7150c71bcb
+connections:
+    - type: workflow
+      key: Agent_vlqADhkkrY/Middleware_FpTj3B1GOP
+      from: Agent_vlqADhkkrY
+      to: Middleware_FpTj3B1GOP
+    - type: workflow
+      key: Agent_vlqADhkkrY/Middleware_lHUyLJVJo5
+      from: Agent_vlqADhkkrY
+      to: Middleware_lHUyLJVJo5


### PR DESCRIPTION
## Summary

This PR hardens the FileMemory Dreamer execution path and publishes the FileMemory Dreamer agent as a built-in marketplace template.

## Changes

- Treat Dreamer runs that fail to produce a valid final report as partial instead of reporting success with zero changes.
- Preserve Dreamer report metadata while keeping host-side diff and validation results visible in the memory organizer UI.
- Keep the memory file editor available after the save button/toast removal and clean up related stale UI state.
- Add `xpert-filememory-dreamer.yaml` and register the FileMemory Dreamer card in the built-in `en-US` and `zh-Hans` marketplace templates.

## Validation

- `node` catalog/YAML parse check for `xpert-filememory-dreamer`
- `git diff --check`
- `pnpm nx test server-ai --testFile=packages/server-ai/src/file-memory/dream.service.spec.ts --runInBand`
- `pnpm nx test server-ai --testFile=packages/server-ai/src/xpert-template/xpert-template.service.spec.ts --runInBand`
- `pnpm nx build cloud --configuration development --skip-nx-cache`