### PR TITLE
[codex] Prepare agent workspace file actions

### DIFF
--- a/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.spec.ts
+++ b/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.spec.ts
@@ -1,4 +1,8 @@
 import { WorkflowNodeTypeEnum, XpertTypeEnum } from '@xpert-ai/contracts'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { VolumeHandle } from '../../shared/volume'
 import { AgentViewHostDefinition } from './agent-view-host.definition'
 
 describe('AgentViewHostDefinition', () => {
@@ -59,7 +63,12 @@ describe('AgentViewHostDefinition', () => {
                 }
             })
         }
-        const definition = new AgentViewHostDefinition(xpertService as any, {} as any, middlewareRegistry as any)
+        const definition = new AgentViewHostDefinition(
+            xpertService as any,
+            {} as any,
+            middlewareRegistry as any,
+            {} as any
+        )
 
         const resolved = await definition.resolve('agent-host-1')
 
@@ -86,5 +95,73 @@ describe('AgentViewHostDefinition', () => {
             }
         })
         expect((resolved?.hostSnapshot as any).agent.key).toBe('Agent_BusinessAssistant')
+    })
+
+    it('uploads workspace file actions into the xpert workspace before provider execution', async () => {
+        const tempRoot = mkdtempSync(join(tmpdir(), 'xpert-view-host-'))
+        const volumeClient = {
+            resolve: jest.fn().mockReturnValue(
+                new VolumeHandle(
+                    {
+                        tenantId: 'tenant-1',
+                        catalog: 'xperts',
+                        xpertId: 'agent-host-1',
+                        isolateByUser: false
+                    },
+                    tempRoot,
+                    tempRoot,
+                    'http://files.example/xperts/agent-host-1'
+                )
+            )
+        }
+        const definition = new AgentViewHostDefinition({} as any, {} as any, {} as any, volumeClient as any)
+
+        try {
+            const expectedFileName = '\u552e\u540e\u6570\u636e\u5206\u6790\u5de5\u5177\u9700\u6c42v0.1.xlsx'
+            const rawMultipartFileName = Buffer.from(expectedFileName, 'utf8').toString('latin1')
+            const prepared = await definition.prepareFileAction(
+                {
+                    tenantId: 'tenant-1',
+                    organizationId: 'org-1',
+                    userId: 'user-1',
+                    hostType: 'agent',
+                    hostId: 'agent-host-1',
+                    slots: []
+                } as any,
+                {
+                    input: {
+                        workspaceUploadPath: 'fdd/documents',
+                        originalFileName: expectedFileName
+                    }
+                } as any,
+                {
+                    originalname: rawMultipartFileName,
+                    buffer: Buffer.from('xlsx-content'),
+                    mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                    size: 12
+                } as any
+            )
+
+            expect(volumeClient.resolve).toHaveBeenCalledWith({
+                tenantId: 'tenant-1',
+                catalog: 'xperts',
+                xpertId: 'agent-host-1',
+                isolateByUser: false
+            })
+            expect(prepared.input).toMatchObject({
+                workspaceUploadPath: 'fdd/documents',
+                workspaceFile: {
+                    workspacePath: `fdd/documents/${expectedFileName}`,
+                    filePath: `fdd/documents/${expectedFileName}`,
+                    originalName: expectedFileName,
+                    name: expectedFileName,
+                    mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                    size: 12
+                }
+            })
+            expect(readFileSync(join(tempRoot, 'fdd/documents', expectedFileName), 'utf8')).toBe('xlsx-content')
+        } finally {
+            rmSync(tempRoot, { recursive: true, force: true })
+        }
     })
 })

--- a/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.ts
+++ b/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.ts
@@ -7,16 +7,25 @@ import {
     normalizeMiddlewareProvider,
     type TXpertTeamNode,
     TXpertFeatures,
+    XpertResolvedViewHostContext,
+    XpertViewActionRequest,
     XpertTypeEnum,
     XpertViewHostCapabilities,
     XpertViewHostState,
     XpertViewSlot
 } from '@xpert-ai/contracts'
 import { AgentMiddlewareRegistry } from '@xpert-ai/plugin-sdk'
-import { RequestContext, ViewHostDefinition, ViewHostDefinitionContract } from '@xpert-ai/server-core'
-import { Injectable } from '@nestjs/common'
+import {
+    RequestContext,
+    ViewExtensionFileActionFile,
+    ViewHostDefinition,
+    ViewHostDefinitionContract
+} from '@xpert-ai/server-core'
+import { normalizeUploadedFileName } from '@xpert-ai/server-common'
+import { Inject, Injectable } from '@nestjs/common'
 import { XpertService } from '../../xpert/xpert.service'
 import { PublishedXpertAccessService } from '../../xpert/published-xpert-access.service'
+import { VOLUME_CLIENT, VolumeClient, VolumeSubtreeClient } from '../../shared/volume'
 
 export const AGENT_WORKBENCH_MAIN_SLOT = 'agent.workbench.main'
 export const AGENT_WORKBENCH_FIXED_SLOT = 'agent.workbench.fixed'
@@ -34,7 +43,9 @@ export class AgentViewHostDefinition implements ViewHostDefinitionContract {
     constructor(
         private readonly xpertService: XpertService,
         private readonly publishedXpertAccessService: PublishedXpertAccessService,
-        private readonly agentMiddlewareRegistry: AgentMiddlewareRegistry
+        private readonly agentMiddlewareRegistry: AgentMiddlewareRegistry,
+        @Inject(VOLUME_CLIENT)
+        private readonly volumeClient: VolumeClient
     ) {}
 
     async resolve(hostId: string) {
@@ -79,6 +90,64 @@ export class AgentViewHostDefinition implements ViewHostDefinitionContract {
         } catch {
             return false
         }
+    }
+
+    async prepareFileAction(
+        context: XpertResolvedViewHostContext,
+        request: XpertViewActionRequest,
+        file: ViewExtensionFileActionFile
+    ): Promise<XpertViewActionRequest> {
+        const input = isRecord(request.input) ? request.input : {}
+        const workspaceUploadPath = getNonEmptyString(input.workspaceUploadPath)
+        if (!workspaceUploadPath) {
+            return request
+        }
+
+        const uploadFileName =
+            normalizeWorkspaceUploadFileName(
+                getNonEmptyString(input.originalFileName) ??
+                    getNonEmptyString(input.fileName) ??
+                    getNonEmptyString(input.name) ??
+                    file.originalname
+            ) ?? 'upload'
+        const uploaded = await this.createWorkspaceVolumeClient(context.tenantId, context.hostId).uploadFile(
+            '',
+            workspaceUploadPath,
+            normalizeWorkspaceUploadFile(file, uploadFileName)
+        )
+        const uploadedFileName = normalizeWorkspaceUploadedFileName(uploaded.filePath, uploadFileName)
+
+        return {
+            ...request,
+            input: {
+                ...input,
+                workspaceFile: {
+                    ...uploaded,
+                    workspacePath: uploaded.filePath,
+                    filePath: uploaded.filePath,
+                    fileUrl: uploaded.fileUrl ?? uploaded.url,
+                    url: uploaded.fileUrl ?? uploaded.url,
+                    originalName: uploadedFileName,
+                    name: uploadedFileName,
+                    mimeType: uploaded.mimeType ?? file.mimetype,
+                    size: uploaded.size ?? file.size
+                }
+            }
+        }
+    }
+
+    private createWorkspaceVolumeClient(tenantId: string, xpertId: string) {
+        return new VolumeSubtreeClient(
+            this.volumeClient.resolve({
+                tenantId,
+                catalog: 'xperts',
+                xpertId,
+                isolateByUser: false
+            }),
+            {
+                allowRootWorkspace: true
+            }
+        )
     }
 
     private resolveAgentContext(xpert: IXpert): {
@@ -154,4 +223,46 @@ export class AgentViewHostDefinition implements ViewHostDefinitionContract {
         const agentNode = graph?.nodes?.find((node): node is TXpertTeamNode<'agent'> => node.type === 'agent')
         return agentNode?.key ?? agentNode?.entity?.key ?? null
     }
+}
+
+function normalizeWorkspaceUploadFile(file: ViewExtensionFileActionFile, fileName: string) {
+    return {
+        originalname: fileName,
+        buffer: file.buffer,
+        mimetype: file.mimetype
+    }
+}
+
+function normalizeWorkspaceUploadedFileName(filePath?: string, fallback?: string) {
+    const fileName = getFileNameFromPath(filePath)
+    if (fileName) {
+        return normalizeWorkspaceUploadFileName(fileName) ?? fileName
+    }
+    return normalizeWorkspaceUploadFileName(fallback) ?? 'upload'
+}
+
+function normalizeWorkspaceUploadFileName(fileName?: string) {
+    try {
+        return normalizeUploadedFileName(fileName)
+    } catch {
+        return getNonEmptyString(fileName)
+    }
+}
+
+function getFileNameFromPath(filePath?: string) {
+    const value = getNonEmptyString(filePath)
+    if (!value) {
+        return undefined
+    }
+    const clean = value.split('?')[0].split('#')[0]
+    const segments = clean.split('/').filter(Boolean)
+    return getNonEmptyString(segments[segments.length - 1])
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function getNonEmptyString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined
 }

--- a/packages/server/src/view-extension/host-definition.interface.ts
+++ b/packages/server/src/view-extension/host-definition.interface.ts
@@ -1,4 +1,16 @@
-import { XpertViewHostContext, XpertViewSlot } from '@xpert-ai/contracts'
+import {
+	XpertResolvedViewHostContext,
+	XpertViewActionRequest,
+	XpertViewHostContext,
+	XpertViewSlot
+} from '@xpert-ai/contracts'
+
+export interface ViewExtensionFileActionFile {
+	originalname?: string
+	mimetype?: string
+	size?: number
+	buffer: Buffer
+}
 
 export interface ViewHostResolution {
 	workspaceId?: string | null
@@ -13,4 +25,10 @@ export interface ViewHostDefinitionContract {
 	resolve(hostId: string): Promise<ViewHostResolution | null> | ViewHostResolution | null
 
 	canRead(context: XpertViewHostContext, resolution: ViewHostResolution): Promise<boolean> | boolean
+
+	prepareFileAction?(
+		context: XpertResolvedViewHostContext,
+		request: XpertViewActionRequest,
+		file: ViewExtensionFileActionFile
+	): Promise<XpertViewActionRequest> | XpertViewActionRequest
 }

--- a/packages/server/src/view-extension/view-extension.service.ts
+++ b/packages/server/src/view-extension/view-extension.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common'
-import { ViewExtensionProviderRegistry, XpertViewFileActionFile } from '@xpert-ai/plugin-sdk'
+import { ViewExtensionProviderRegistry } from '@xpert-ai/plugin-sdk'
 import {
 	XpertExtensionViewManifest,
 	XpertRemoteComponentEntry,
@@ -12,6 +12,7 @@ import {
 	XpertViewQuery
 } from '@xpert-ai/contracts'
 import { ViewHostDefinitionRegistry } from './host-definition.registry'
+import { ViewExtensionFileActionFile } from './host-definition.interface'
 import { ViewExtensionPermissionService } from './view-extension.permission.service'
 import { ViewExtensionCacheService } from './view-extension.cache.service'
 import {
@@ -201,7 +202,7 @@ export class ViewExtensionService {
 		viewKey: string,
 		actionKey: string,
 		request: XpertViewActionRequest,
-		file: XpertViewFileActionFile
+		file: ViewExtensionFileActionFile
 	) {
 		const context = await this.resolveHostContext(hostType, hostId)
 		const resolved = await this.resolveProviderManifest(context, viewKey)
@@ -222,8 +223,13 @@ export class ViewExtensionService {
 			throw new NotFoundException(`File action '${actionKey}' is not supported for view '${viewKey}'`)
 		}
 
+		const hostDefinition = this.hostDefinitionRegistry.get(hostType)
+		const preparedRequest = hostDefinition?.prepareFileAction
+			? await Promise.resolve(hostDefinition.prepareFileAction(context, request, file))
+			: request
+
 		const result = await Promise.resolve(
-			resolved.provider.executeViewFileAction(context, resolved.manifestKey, actionKey, request, file)
+			resolved.provider.executeViewFileAction(context, resolved.manifestKey, actionKey, preparedRequest, file)
 		)
 
 		if (result.refresh) {


### PR DESCRIPTION
## Summary

- Adds an optional host-level file action preparation hook for view-extension hosts.
- Uses the agent host hook to upload file-action payloads into the xpert workspace when `workspaceUploadPath` is provided.
- Passes the prepared request to the provider while preserving existing file action routing for hosts without a hook.

## Why

Some agent view-extension file actions need the uploaded file to exist in the xpert workspace before provider execution. The previous service path passed the raw multipart file directly to the provider without a host-specific workspace preparation step.

## Impact

Existing file actions continue to execute unchanged when the host does not implement `prepareFileAction` or when `workspaceUploadPath` is absent. Agent file actions that provide `workspaceUploadPath` now receive a `workspaceFile` payload with workspace path, URL, name, MIME type, and size metadata.

## Validation

- `git diff origin/develop --check`
- `pnpm exec jest --config packages/server-ai/jest.config.ts --runTestsByPath packages/server-ai/src/view-extension/hosts/agent-view-host.definition.spec.ts --runInBand`
- `pnpm exec jest --config packages/server/jest.config.ts --runTestsByPath packages/server/src/view-extension/view-extension.service.spec.ts --runInBand`