### PR TITLE
fix: preserve xpert workbench new thread

### DIFF
--- a/apps/cloud/src/app/features/chat/routes.spec.ts
+++ b/apps/cloud/src/app/features/chat/routes.spec.ts
@@ -154,13 +154,24 @@ describe('chat routes', () => {
   })
 
   it('routes direct xpert workbench urls to the ChatKit workbench component', () => {
-    const entryRoute = children.find((item) => item.path === 'x/:name/c')
-    const threadRoute = children.find((item) => item.path === 'x/:name/c/:threadId')
+    const route = children.find((item) => item.matcher && item.component === ChatXpertWorkbenchComponent)
+    const entryMatch = route?.matcher?.(
+      [new UrlSegment('x', {}), new UrlSegment('sales', {}), new UrlSegment('c', {})],
+      new UrlSegmentGroup([], {}),
+      {} as Route
+    )
+    const threadMatch = route?.matcher?.(
+      [new UrlSegment('x', {}), new UrlSegment('sales', {}), new UrlSegment('c', {}), new UrlSegment('thread-1', {})],
+      new UrlSegmentGroup([], {}),
+      {} as Route
+    )
 
-    expect(entryRoute?.component).toBe(ChatXpertWorkbenchComponent)
-    expect(entryRoute?.canActivate).toHaveLength(1)
-    expect(threadRoute?.component).toBe(ChatXpertWorkbenchComponent)
-    expect(threadRoute?.canActivate).toHaveLength(1)
+    expect(route?.component).toBe(ChatXpertWorkbenchComponent)
+    expect(route?.canActivate).toHaveLength(1)
+    expect(entryMatch?.posParams?.['name']?.path).toBe('sales')
+    expect(entryMatch?.posParams?.['threadId']).toBeUndefined()
+    expect(threadMatch?.posParams?.['name']?.path).toBe('sales')
+    expect(threadMatch?.posParams?.['threadId']?.path).toBe('thread-1')
   })
 
   it('removes chat project routes from /chat', () => {

--- a/apps/cloud/src/app/features/chat/routes.ts
+++ b/apps/cloud/src/app/features/chat/routes.ts
@@ -90,15 +90,7 @@ export const routes: Routes = [
         }
       },
       {
-        path: 'x/:name/c',
-        component: ChatXpertWorkbenchComponent,
-        canActivate: [featureGate([AiFeatureEnum.FEATURE_XPERT, AiFeatureEnum.FEATURE_XPERT_CLAWXPERT])],
-        data: {
-          title: 'Chat Xpert Workbench'
-        }
-      },
-      {
-        path: 'x/:name/c/:threadId',
+        matcher: xpertWorkbenchConversationMatcher,
         component: ChatXpertWorkbenchComponent,
         canActivate: [featureGate([AiFeatureEnum.FEATURE_XPERT, AiFeatureEnum.FEATURE_XPERT_CLAWXPERT])],
         data: {
@@ -188,6 +180,33 @@ function clawxpertConversationMatcher(segments: UrlSegment[]): UrlMatchResult | 
       consumed: segments,
       posParams: {
         threadId: segments[1]
+      }
+    }
+  }
+
+  return null
+}
+
+function xpertWorkbenchConversationMatcher(segments: UrlSegment[]): UrlMatchResult | null {
+  if (segments[0]?.path !== 'x' || !segments[1]?.path || segments[2]?.path !== 'c') {
+    return null
+  }
+
+  if (segments.length === 3) {
+    return {
+      consumed: segments,
+      posParams: {
+        name: segments[1]
+      }
+    }
+  }
+
+  if (segments.length === 4) {
+    return {
+      consumed: segments,
+      posParams: {
+        name: segments[1],
+        threadId: segments[3]
       }
     }
   }

--- a/apps/cloud/src/app/features/chat/xpert-workbench/xpert-workbench.facade.spec.ts
+++ b/apps/cloud/src/app/features/chat/xpert-workbench/xpert-workbench.facade.spec.ts
@@ -1,7 +1,28 @@
+jest.mock('../../../@core', () => ({
+  AssistantBindingScope: {
+    USER: 'user'
+  },
+  AssistantCode: {
+    CLAWXPERT: 'clawxpert'
+  },
+  AssistantBindingService: class AssistantBindingService {},
+  ChatConversationService: class ChatConversationService {},
+  Store: class Store {},
+  OrderTypeEnum: {
+    DESC: 'DESC'
+  },
+  getErrorMessage: (error: { message?: string } | null | undefined) => error?.message ?? ''
+}))
+
+jest.mock('../../assistant/assistant-chatkit.runtime', () => ({
+  sanitizeAssistantFrameUrl: (url: string | null | undefined) => url ?? null
+}))
+
 import { NavigationEnd, Router } from '@angular/router'
 import { TestBed } from '@angular/core/testing'
 import { Subject, of } from 'rxjs'
 import { TranslateService } from '@ngx-translate/core'
+import type { ChatKitControl } from '@xpert-ai/chatkit-angular'
 import { AssistantBindingService, ChatConversationService, IChatConversation, Store } from '../../../@core'
 import { XpertWorkbenchFacade } from './xpert-workbench.facade'
 
@@ -125,10 +146,7 @@ describe('XpertWorkbenchFacade', () => {
       })
     )
     const facade = TestBed.inject(XpertWorkbenchFacade)
-    const control = {
-      focusComposer: jest.fn().mockResolvedValue(undefined),
-      setThreadId: jest.fn().mockResolvedValue(undefined)
-    } as any
+    const control = createMockChatKitControl()
 
     await settle()
     await facade.ensureConversationEntry(control)
@@ -145,10 +163,7 @@ describe('XpertWorkbenchFacade', () => {
 
   it('focuses the composer when no latest xpert thread exists', async () => {
     const facade = TestBed.inject(XpertWorkbenchFacade)
-    const control = {
-      focusComposer: jest.fn().mockResolvedValue(undefined),
-      setThreadId: jest.fn().mockResolvedValue(undefined)
-    } as any
+    const control = createMockChatKitControl()
 
     await settle()
     await facade.ensureConversationEntry(control)
@@ -161,7 +176,6 @@ describe('XpertWorkbenchFacade', () => {
     const facade = TestBed.inject(XpertWorkbenchFacade)
 
     await settle()
-    jest.spyOn(Date, 'now').mockReturnValueOnce(1000).mockReturnValue(3001)
     facade.onChatThreadChange('thread-2')
 
     expect(router.navigate).toHaveBeenCalledWith(['/chat/x', 'sales', 'c', 'thread-2'])
@@ -176,6 +190,19 @@ describe('XpertWorkbenchFacade', () => {
   function setRoute(url: string) {
     router.url = url
     routerEvents.next(new NavigationEnd(Date.now(), url, url))
+  }
+
+  function createMockChatKitControl() {
+    return {
+      element: null,
+      setOptions: jest.fn(),
+      focusComposer: jest.fn().mockResolvedValue(undefined),
+      setThreadId: jest.fn().mockResolvedValue(undefined),
+      sendUserMessage: jest.fn().mockResolvedValue(undefined),
+      setComposerValue: jest.fn().mockResolvedValue(undefined),
+      fetchUpdates: jest.fn().mockResolvedValue(undefined),
+      sendCustomAction: jest.fn().mockResolvedValue(undefined)
+    } satisfies ChatKitControl
   }
 })
 

--- a/apps/cloud/src/app/features/chat/xpert-workbench/xpert-workbench.facade.ts
+++ b/apps/cloud/src/app/features/chat/xpert-workbench/xpert-workbench.facade.ts
@@ -25,11 +25,6 @@ export class XpertWorkbenchFacade implements WorkbenchChatFacade {
   #loadRequestId = 0
   #conversationEntryRequestId = 0
   #lastConversationEntryKey: string | null = null
-  #nullThreadChangeGuard: { threadId: string | null; expiresAt: number } = {
-    threadId: null,
-    expiresAt: 0
-  }
-
   readonly #assistantBindingService = inject(AssistantBindingService)
   readonly #conversationService = inject(ChatConversationService)
   readonly #store = inject(Store)
@@ -258,12 +253,7 @@ export class XpertWorkbenchFacade implements WorkbenchChatFacade {
 
     if (threadId) {
       this.suppressAutoResume.set(false)
-      this.armNullThreadChangeGuard(threadId)
       this.navigateToThread(threadId)
-      return
-    }
-
-    if (this.shouldIgnoreNullThreadChange()) {
       return
     }
 
@@ -317,22 +307,6 @@ export class XpertWorkbenchFacade implements WorkbenchChatFacade {
   private isConversationEntryRoute() {
     const slug = this.slug()
     return !!slug && this.currentUrl() === `/chat/x/${encodeURIComponent(slug)}/c`
-  }
-
-  private armNullThreadChangeGuard(threadId: string) {
-    this.#nullThreadChangeGuard = {
-      threadId,
-      expiresAt: Date.now() + 1000
-    }
-  }
-
-  private shouldIgnoreNullThreadChange() {
-    const activeThreadId = this.threadId()
-    if (!activeThreadId) {
-      return false
-    }
-
-    return this.#nullThreadChangeGuard.threadId === activeThreadId && this.#nullThreadChangeGuard.expiresAt > Date.now()
   }
 }
 


### PR DESCRIPTION
## Summary
- Route `/chat/x/:name/c` and `/chat/x/:name/c/:threadId` through one matcher so the workbench component/facade is not recreated when starting a new thread.
- Remove the stale null-thread guard so ChatKit `threadId: null` resets can navigate to the blank conversation entry.
- Update route and facade tests for the matcher and reset flow.

## Validation
- `pnpm jest --config apps/cloud/jest.config.ts --runTestsByPath apps/cloud/src/app/features/chat/routes.spec.ts apps/cloud/src/app/features/chat/xpert-workbench/xpert-workbench.facade.spec.ts --runInBand`