### PR TITLE
fix: clamp model parameter values

### DIFF
--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
@@ -306,6 +306,52 @@ describe('CopilotModelSelectComponent', () => {
     expect(component['cva'].value$()?.options?.max_tokens).toBe(32768)
   }))
 
+  it('does not clamp parameter updates with stale rules while new model rules are loading', fakeAsync(() => {
+    tick(600)
+    fixture.detectChanges()
+
+    component.setModel(copilot, deepseekModel)
+    fixture.detectChanges()
+    tick()
+    fixture.detectChanges()
+
+    deepseekRules$.next([
+      {
+        name: 'max_tokens',
+        type: ParameterType.INT,
+        min: 1,
+        max: 2048,
+        default: 1024
+      }
+    ])
+    tick()
+    fixture.detectChanges()
+
+    component.setModel(copilot, glmModel)
+    fixture.detectChanges()
+    tick()
+    fixture.detectChanges()
+
+    component.updateParameter('max_tokens', 32000)
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()?.options?.max_tokens).toBe(32000)
+
+    glmRules$.next([
+      {
+        name: 'max_tokens',
+        type: ParameterType.INT,
+        min: 1,
+        max: 32768,
+        default: 8192
+      }
+    ])
+    tick()
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()?.options?.max_tokens).toBe(32000)
+  }))
+
   it('clamps persisted numeric options when model parameter rules resolve', fakeAsync(() => {
     tick(600)
     fixture.detectChanges()

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
@@ -279,6 +279,66 @@ describe('CopilotModelSelectComponent', () => {
     })
   }))
 
+  it('clamps numeric parameter updates to the active rule range', fakeAsync(() => {
+    tick(600)
+    fixture.detectChanges()
+
+    component.setModel(copilot, glmModel)
+    fixture.detectChanges()
+    tick()
+    fixture.detectChanges()
+
+    glmRules$.next([
+      {
+        name: 'max_tokens',
+        type: ParameterType.INT,
+        min: 1,
+        max: 32768,
+        default: 8192
+      }
+    ])
+    tick()
+    fixture.detectChanges()
+
+    component.updateParameter('max_tokens', 655361234)
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()?.options?.max_tokens).toBe(32768)
+  }))
+
+  it('clamps persisted numeric options when model parameter rules resolve', fakeAsync(() => {
+    tick(600)
+    fixture.detectChanges()
+
+    component.writeValue({
+      copilotId: copilot.id,
+      model: glmModel.model,
+      modelType: AiModelTypeEnum.LLM,
+      options: {
+        [ModelPropertyKey.CONTEXT_SIZE]: 200000,
+        max_tokens: 655361234
+      }
+    })
+    fixture.detectChanges()
+
+    glmRules$.next([
+      {
+        name: 'max_tokens',
+        type: ParameterType.INT,
+        min: 1,
+        max: 32768,
+        default: 8192
+      }
+    ])
+    tick()
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()?.options).toEqual({
+      [ModelPropertyKey.CONTEXT_SIZE]: 200000,
+      max_tokens: 32768
+    })
+  }))
+
   it('drops stale persisted model identity when switching to a different model', fakeAsync(() => {
     tick(600)
     fixture.detectChanges()

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
@@ -363,7 +363,9 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
     if (!this.cva.value$()) {
       this.initModel(this.copilotId(), this.selectedAiModel())
     }
-    const rule = this.modelParameterRules().find((item) => item.name === name)
+    const rule = this.hasResolvedCurrentModelParameterRules()
+      ? this.modelParameterRules().find((item) => item.name === name)
+      : null
     const nextValue = rule ? this.normalizeParameterValue(value, rule) : value
 
     this.updateValue({

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
@@ -363,12 +363,14 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
     if (!this.cva.value$()) {
       this.initModel(this.copilotId(), this.selectedAiModel())
     }
+    const rule = this.modelParameterRules().find((item) => item.name === name)
+    const nextValue = rule ? this.normalizeParameterValue(value, rule) : value
 
     this.updateValue({
       ...this.cva.value$(),
       options: {
         ...(this.cva.value$().options ?? {}),
-        [name]: value
+        [name]: nextValue
       }
     })
   }
@@ -538,8 +540,11 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
 
       const value = options?.[rule.name]
       if (value !== undefined) {
-        nextOptions[rule.name] = value
-        hasRetainedRuleValue = true
+        const nextValue = this.normalizeParameterValue(value, rule)
+        if (nextValue !== undefined) {
+          nextOptions[rule.name] = nextValue
+          hasRetainedRuleValue = true
+        }
       }
     }
 
@@ -575,6 +580,57 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
     }
     const keys = Object.keys(options).filter((key) => options[key] !== undefined)
     return keys.length === 0 || (keys.length === 1 && keys[0] === ModelPropertyKey.CONTEXT_SIZE)
+  }
+
+  private normalizeParameterValue(value: unknown, rule: ParameterRule) {
+    if (rule.type !== ParameterType.FLOAT && rule.type !== ParameterType.INT) {
+      return value
+    }
+
+    const numericValue = this.parseNumericParameterValue(value, rule.type)
+    if (numericValue === undefined) {
+      return undefined
+    }
+
+    return this.clampNumericParameterValue(numericValue, rule)
+  }
+
+  private parseNumericParameterValue(
+    value: unknown,
+    type: ParameterType.FLOAT | ParameterType.INT
+  ): number | undefined {
+    if (value === '' || value === null || value === undefined) {
+      return undefined
+    }
+
+    let parsed: number
+    if (typeof value === 'number') {
+      parsed = value
+    } else if (typeof value === 'string') {
+      parsed = type === ParameterType.INT ? Number.parseInt(value, 10) : Number.parseFloat(value)
+    } else {
+      return undefined
+    }
+
+    if (!Number.isFinite(parsed)) {
+      return undefined
+    }
+
+    return type === ParameterType.INT ? Math.trunc(parsed) : parsed
+  }
+
+  private clampNumericParameterValue(value: number, rule: ParameterRule) {
+    let nextValue = value
+
+    if (typeof rule.min === 'number' && Number.isFinite(rule.min) && nextValue < rule.min) {
+      nextValue = rule.min
+    }
+
+    if (typeof rule.max === 'number' && Number.isFinite(rule.max) && nextValue > rule.max) {
+      nextValue = rule.max
+    }
+
+    return rule.type === ParameterType.INT ? Math.trunc(nextValue) : nextValue
   }
 
   private getMenuRailBounds(containerWidth: number | null | undefined) {


### PR DESCRIPTION
## Summary
- Clamp numeric copilot model parameter updates to their active parameter rule range.
- Normalize persisted numeric options when parameter rules resolve so stale oversized values are not sent to models.
- Add focused regression coverage for manual updates and persisted options.

## Test Plan
- `git diff origin/develop --check`
- `NODE_PATH=/Users/jiangyimin/Documents/Git/xpert-develop/node_modules PATH=/Users/jiangyimin/Documents/Git/xpert-develop/node_modules/.bin:$PATH node /Users/jiangyimin/Documents/Git/xpert-develop/node_modules/jest/bin/jest.js --config apps/cloud/jest.config.ts --testPathPatterns=apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts --runInBand --transformIgnorePatterns='node_modules/(?!((echarts|zrender|lodash-es|nanoid|marked|@angular/common/locales|@xpert-ai/chatkit-types)(/|$)|.*\.mjs$))'`