### PR TITLE
feat: separate goal act and verify lifecycle

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -91,6 +91,7 @@
                   "zh-hans/guides/datax-metric-management-plugin",
                   "zh-hans/guides/xpert-prometheus-metrics",
                   "zh-hans/guides/chatkit-slash-commands",
+                  "zh-hans/guides/conversation-goal-architecture",
                   "zh-hans/guides/handoff",
                   "zh-hans/guides/icon-schema",
                   "zh-hans/guides/release",

--- a/docs/zh-hans/guides/conversation-goal-architecture.mdx
+++ b/docs/zh-hans/guides/conversation-goal-architecture.mdx
@@ -1,0 +1,383 @@
+# Conversation Goal 流程设计
+
+这篇文档只讲设计，不要求读代码。
+
+当前 V1 已经确定：**Goal 仍然由 Ralph Loop 插件 / middleware 托管**。这次不是把 goal 平台化，也不是做多 provider 控制面重构，而是优化现有 goal 的运行流程。
+
+新的核心流程是：
+
+```text
+User Request
+  -> GoalSpec
+  -> Act <-> Tool
+  -> Verify
+  -> middleware converts lifecycle
+  -> Done or Loop
+```
+
+## 一句话理解
+
+`goal` 仍然是 Ralph Loop 插件提供的长期任务能力。
+
+用户创建 goal 后，系统先把用户的话整理成一份 `GoalSpec`。后续模型先执行工作，也就是 Act；Act 完后不能直接结束目标，必须进入 Verify。Verify 根据证据输出结构化的 `GoalVerification`。最后由 middleware 读取这个验证结果，决定目标是完成、阻塞，还是继续下一轮。
+
+这次设计解决的核心问题是：**模型不再自己一边干活、一边直接改 goal 状态**。
+
+## 和原来有什么区别
+
+| 设计点       | 原来                                | V1                                    |
+| ------------ | ----------------------------------- | ------------------------------------- |
+| Goal 归属    | Ralph Loop 插件托管                 | 仍然是 Ralph Loop 插件托管            |
+| 用户创建目标 | 保存 `objective`                    | 保存 `objective`，同时生成 `GoalSpec` |
+| 模型执行     | 模型执行后可以调用状态工具          | Act 只能执行工作或提出“可能完成”      |
+| 完成判断     | 模型可以直接调用 `update_goal`      | Verify 生成结构化验证结果             |
+| 状态落库     | 模型通过工具触发                    | middleware 统一转换 lifecycle         |
+| ChatKit      | 展示 `objective`                    | 仍展示 `objective`，不暴露 Verify UI  |
+| 改动范围     | goal middleware + ChatKit goal 类型 | 仍是这两个边界，未做平台化重构        |
+
+## 为什么要这样改
+
+原来的问题不是“goal 放在平台还是插件”，而是执行链路里职责混在一起：
+
+- 模型负责干活。
+- 模型又能判断自己是否完成。
+- 模型还能直接调用工具修改 goal 状态。
+
+这样容易出现“自己干活、自己验收、自己盖章”的问题。
+
+V1 把它拆开：
+
+| 阶段       | 负责什么                         | 不负责什么                     |
+| ---------- | -------------------------------- | ------------------------------ |
+| GoalSpec   | 把用户目标整理成可执行规格       | 不改变用户原始目标             |
+| Act        | 执行任务、调用工具、产出工作结果 | 不修改 goal lifecycle          |
+| Verify     | 根据证据判断是否满足目标         | 不做新工作，不调用普通执行工具 |
+| Middleware | 把验证结果转换成状态             | 不伪造执行证据                 |
+
+这样以后即使 Verify 仍然是 LLM 验证，也至少不是同一个 Act 阶段直接改状态。middleware 成为唯一 lifecycle 转换点。
+
+## GoalSpec
+
+`GoalSpec` 是创建或编辑 goal 时生成的目标规格。
+
+它不是给用户看的主展示文本。ChatKit 继续展示 `objective`。`GoalSpec` 主要给 Ralph Loop 的 Act / Verify prompt 使用。
+
+V1 至少保存这些信息：
+
+| 字段           | 作用                         |
+| -------------- | ---------------------------- |
+| 用户原始目标   | 保留用户真实表达             |
+| 可执行目标说明 | 告诉 Act 阶段到底要推进什么  |
+| 成功标准       | 告诉 Verify 阶段什么叫完成   |
+| 约束条件       | 告诉 Act 阶段不要越界        |
+| 验证清单       | 告诉 Verify 阶段要看哪些证据 |
+| 推荐执行方式   | V1 固定为 act_then_verify    |
+
+当前实现里，`GoalSpec` 是服务端根据 `objective` 生成的基础结构化结果，不是任意可执行 verifier 代码。
+
+后续可以把生成逻辑换成 LLM 翻译，但边界不变：
+
+- 必须保留用户原始目标。
+- 不能偷偷扩大目标范围。
+- 不能生成可直接执行的任意 verifier 脚本。
+- 如果目标需要澄清，应该阻塞或询问用户，而不是盲跑。
+
+## Act 阶段
+
+Act 是真正执行任务的阶段。
+
+Act 可以：
+
+- 读取 `GoalSpec`。
+- 调用工具。
+- 修改文件、查询数据、推进任务。
+- 说明“我认为现在可以验证了”。
+- 给 Verify 留下证据。
+
+Act 不可以：
+
+- 把 goal 标记为 `complete`。
+- 把 goal 标记为 `blocked`。
+- 调用 lifecycle 状态变更工具。
+- 因为自己说“完成了”就结束目标。
+
+也就是说，Act 的输出最多是“完成声明”或“工作结果”，不是最终裁决。
+
+## Verify 阶段
+
+Verify 是验收阶段。
+
+Verify 只根据已有信息判断，不做新工作。
+
+Verify 输入包括：
+
+- `GoalSpec`
+- 最近一轮 Act 输出
+- 工具调用结果
+- 已有文件、消息、错误或产物证据
+- middleware 整理出的结构化证据包
+
+Verify 输出固定为结构化 `GoalVerification`。
+
+```json
+{
+  "outcome": "passed",
+  "evidence": ["..."],
+  "reason": "...",
+  "nextAction": "..."
+}
+```
+
+V1 只接受三种 outcome：
+
+| outcome   | 含义                     | middleware 动作               |
+| --------- | ------------------------ | ----------------------------- |
+| `passed`  | 证据满足成功标准         | 转成 `complete`               |
+| `failed`  | 未完成，但还有明确下一步 | 保持 `active`，进入下一轮 Act |
+| `blocked` | 无法继续推进             | 转成 `blocked`                |
+
+`GoalVerification` 必须有有效 `evidence` 和 `reason`。
+
+如果 outcome 是 `failed`，但没有 `nextAction`，middleware 按 `blocked` 处理，避免无限空转。
+
+如果 Verify 输出无法解析为有效 `GoalVerification`，middleware 会重试一次 Verify；第二次仍无效就转 `blocked`。
+
+当前实现会先按严格 JSON 解析。若模型输出的是固定 `GoalVerification` 结构，但因为字符串里的未转义引号等常见格式问题导致 `JSON.parse` 失败，middleware 会尝试按固定字段做容错解析。容错解析成功后，仍然只按 `outcome` 做 lifecycle 转换。
+
+Verify 不能只相信 Act 的自述。
+
+例如 Act 说“我已经检索确认了”，但实际工具结果里 `memory_search` 返回空数组，这不算满足“通过检索确认能找到”的成功标准。即使后面又用 ID 直接 `memory_get` 读到了内容，也不能把它等同于“检索能找到”。这类判断必须看工具证据，而不是看 Act 的总结。
+
+因此 V1 会把最近消息整理成内部证据：
+
+| 证据             | 作用                                 |
+| ---------------- | ------------------------------------ |
+| assistantOutputs | Act 的文字说明，只能作为辅助信息     |
+| toolResults      | 工具名、状态、输出摘要、是否为空结果 |
+| errors           | 执行过程中的错误                     |
+
+Verify prompt 会明确要求：
+
+- `passed` 必须基于工具结果、文件产物或持久化输出等具体证据。
+- 助手自己的“已经完成”声明不能单独作为通过依据。
+- 如果成功标准要求搜索 / 检索确认，而搜索结果为空，不能用按 ID 直接读取替代。
+
+## Middleware 的职责
+
+middleware 是 V1 的生命周期裁决点。
+
+它负责：
+
+- 注入隐藏 goal context。
+- 暴露只读 `get_goal`。
+- 不再暴露模型可直接调用的 `update_goal`。
+- 在 Act 阶段允许工具调用。
+- 在 Verify 阶段关闭普通执行工具。
+- 判断 Act 是否还有未完成 tool calls。
+- 解析 `GoalVerification`。
+- 把 verification outcome 转成 lifecycle status。
+- 执行 `maxIterations` 自动续跑上限。
+- 发 goal 更新事件。
+- 把内部 Verify 调用标记为 hidden / internal，避免把验证 JSON 当成用户可见回答。
+
+它不负责：
+
+- 平台化管理多个 goal provider。
+- 处理插件关闭后已有 goal 的 provider availability。
+- 实现独立 verifier 服务。
+- 提供 GoalSpec 编辑器。
+
+## 状态机
+
+对外持久化状态仍然只有原来的 lifecycle status。
+
+```mermaid
+stateDiagram-v2
+  [*] --> none
+  none --> active: user creates goal + GoalSpec saved
+
+  active --> active: Act calls tools
+  active --> active: Act done, Verify failed with nextAction
+  active --> complete: Verify passed
+  active --> blocked: Verify blocked
+  active --> blocked: Verify failed without nextAction
+  active --> blocked: invalid Verify after retry
+  active --> budget_limited: maxIterations reached before next Act
+
+  active --> paused: user pauses
+  paused --> active: user resumes
+
+  active --> none: user clears
+  paused --> none: user clears
+  complete --> none: user clears
+  blocked --> none: user clears
+  budget_limited --> none: user clears
+```
+
+Act / Verify 只是内部 phase，不是公开 status。
+
+内部可以理解成：
+
+| 公开状态 | 内部 phase | 含义               |
+| -------- | ---------- | ------------------ |
+| `active` | `act`      | 正在推进目标       |
+| `active` | `verify`   | 正在验收上一轮工作 |
+
+对 ChatKit 和 API 来说，goal 仍然是 `active`，直到 middleware 根据 Verify 结果把它转成 `complete`、`blocked` 或 `budget_limited`。
+
+## 什么时候继续，什么时候停止
+
+每轮后按这个顺序判断：
+
+1. 如果没有 conversationId、Plan mode 开启、没有 goal、goal 不是 runnable 状态，停止 goal loop。
+2. 如果最新 AI 消息还有 tool calls，不进入 Verify，等待工具结果。
+3. 如果当前 phase 是 Act 且没有 tool calls，进入 Verify。
+4. 如果当前 phase 是 Verify，解析 `GoalVerification`。
+5. Verify passed，转 `complete`。
+6. Verify blocked，转 `blocked`。
+7. Verify failed 但没有 `nextAction`，转 `blocked`。
+8. Verify failed 且有 `nextAction`，检查 `maxIterations`。
+9. 没超过上限，进入下一轮 Act。
+10. 达到上限，转 `budget_limited`。
+
+注意：Act 阶段不会直接产生终态。即使已经达到 `maxIterations`，也会先进入 Verify，让 Verify 判断上一轮工作是否已经完成。只有 Verify 判断还需要下一轮 Act 时，middleware 才转 `budget_limited`。
+
+## 谁判断完成
+
+V1 的完成判断不是 Act 自己判断。
+
+更准确地说：
+
+| 动作                         | Owner               |
+| ---------------------------- | ------------------- |
+| 提出可能完成                 | Act                 |
+| 根据证据生成验证结果         | Verify              |
+| 把验证结果转换成 goal status | middleware          |
+| 持久化状态                   | server goal service |
+
+Verify 当前仍然可以由 LLM 完成，所以它不是强验证器。但它和 Act 分离，并且输出结构化结果，middleware 再做硬规则转换。
+
+这比“模型执行完直接调用 update_goal”更稳，因为：
+
+- lifecycle 工具不再暴露给 Act。
+- Verify 必须给 evidence 和 reason。
+- failed 没有下一步会 blocked。
+- invalid Verify 有 retry 上限。
+- maxIterations 由 middleware 控制。
+
+## 当前 V1 没做什么
+
+V1 有意不做这些事情：
+
+| 未做事项                     | 原因                              |
+| ---------------------------- | --------------------------------- |
+| 平台托管 goal provider       | 改动面大，当前先保持插件托管      |
+| 多 provider / strategy 抽象  | Ralph Loop 是唯一 V1 strategy     |
+| 独立 verifier 服务           | 第一版先用结构化 LLM Verify       |
+| LLM 生成可执行 verifier 代码 | 安全和越界风险太高                |
+| GoalSpec 编辑器              | ChatKit 暂时只展示 `objective`    |
+| Verify UI                    | 验证阶段是 middleware 内部流程    |
+| provider availability 状态   | 插件关闭后的恢复/灰态留到后续版本 |
+
+## 运行时循环
+
+Act / Verify 分离以后，middleware 不只是追加一条 Verify prompt，还必须让 graph 可靠地进入下一次 model 调用。
+
+这个点很重要：如果只把 `jumpTo: "model"` 放在一次 hook 返回值里，运行时不一定会在下一次路由判断时读到它。结果就是 Verify prompt 已经进入消息历史，但 graph 没有真正回到 model；下一次用户再触发继续时，phase 还可能被重置，导致 verifier JSON 被当成 Act 输出。
+
+V1 的运行时规则是：
+
+| 运行时信息            | 保存位置             | 作用                                     |
+| --------------------- | -------------------- | ---------------------------------------- |
+| `threadGoalPhase`     | agent channel state  | 区分当前是 Act 还是 Verify               |
+| `jumpTo`              | graph state          | 告诉路由节点下一步回 model / tools / end |
+| Verify prompt         | hidden human message | 让下一次 model 执行验证                  |
+| Verify model metadata | `internal: true`     | 隐藏 verifier JSON，不作为普通对话输出   |
+
+这样 Act 结束后进入 Verify 是一个真正的内部循环，而不是等下一次外部请求时碰运气。
+
+## Repo 改动面
+
+### xpert-develop
+
+| 模块            | 改动                                                           |
+| --------------- | -------------------------------------------------------------- |
+| contracts       | `ThreadGoal` 增加可选 `goalSpec`                               |
+| goal entity     | 增加可选 JSON 字段保存 `goalSpec`                              |
+| goal service    | 创建和编辑 objective 时生成 `GoalSpec`，暂停/恢复保留          |
+| goal middleware | 移除模型可见 `update_goal`，增加 Act / Verify phase            |
+| xpert subgraph  | 把内部 `jumpTo` 写入 graph state，保证 Verify 能自动回到 model |
+| Ralph Loop      | 继续作为默认插件 strategy                                      |
+
+持久化 status 没有新增：
+
+- `active`
+- `paused`
+- `complete`
+- `blocked`
+- `budget_limited`
+- `usage_limited`
+
+### chatkit-js
+
+| 模块              | 改动                                     |
+| ----------------- | ---------------------------------------- |
+| chatkit types     | `ThreadGoal` 增加可选 `goalSpec`         |
+| chatkit-ui parser | 解析 goal payload 时透传合法 `goalSpec`  |
+| UI                | 不新增 GoalSpec 编辑器，不新增 Verify UI |
+
+ChatKit 仍然使用现有 `/goal` 行为：
+
+- 创建
+- 查看
+- 编辑
+- 暂停
+- 恢复
+- 清除
+
+展示上仍然以 `objective` 为主。
+
+## 测试清单
+
+V1 需要覆盖这些行为：
+
+| 场景                                         | 期望                                                  |
+| -------------------------------------------- | ----------------------------------------------------- |
+| 创建 goal                                    | 保存 `objective` 和 `goalSpec`                        |
+| 编辑 objective                               | 重新生成 `goalSpec`                                   |
+| 暂停 / 恢复                                  | 保留已有 `goalSpec`                                   |
+| 老 goal 没有 `goalSpec`                      | 仍能使用 `objective` 跑                               |
+| Act phase                                    | 可以调用工具                                          |
+| Act phase                                    | 不能改 goal lifecycle                                 |
+| Act 有 tool calls                            | 不进入 Verify                                         |
+| Act 无 tool calls                            | 进入 Verify                                           |
+| Verify passed                                | 转 `complete`                                         |
+| Verify failed + nextAction                   | 回到 Act                                              |
+| Verify failed 无 nextAction                  | 转 `blocked`                                          |
+| Verify blocked                               | 转 `blocked`                                          |
+| Verify 常见格式错误但字段完整                | 容错解析成功后按 `outcome` 处理                       |
+| Verify 无法解析为有效 `GoalVerification`     | 重试一次                                              |
+| Verify 重试后仍无法解析                      | 转 `blocked`                                          |
+| maxIterations 到达                           | 只有 Verify 需要下一轮 Act 时转 `budget_limited`      |
+| Act 声称完成但工具证据不足                   | Verify 不能 `passed`                                  |
+| 检索工具返回空结果                           | 不能用按 ID 读取替代检索成功                          |
+| Act 后进入 Verify                            | graph state 中的 `jumpTo` 必须能驱动下一次 model 调用 |
+| Plan mode                                    | 不触发 goal loop                                      |
+| paused / complete / blocked / budget_limited | 不自动继续                                            |
+| ChatKit                                      | 现有 `/goal` 行为不变                                 |
+| ChatKit                                      | goal display 仍使用 `objective`                       |
+
+## 设计结论
+
+V1 的设计原则是：
+
+| 原则                      | 含义                                             |
+| ------------------------- | ------------------------------------------------ |
+| 插件托管不变              | Goal 仍由 Ralph Loop middleware 提供             |
+| 先结构化目标              | 用户输入先变成 `GoalSpec`                        |
+| Act 不落状态              | 执行阶段不能 complete / blocked goal             |
+| Verify 输出结构化结果     | 验收必须给 outcome、evidence、reason、nextAction |
+| Middleware 负责 lifecycle | 状态转换集中在 middleware                        |
+| ChatKit 少动              | UI 继续展示 `objective`，不承载 Verify 逻辑      |
+
+这版没有解决所有可插拔问题，但解决了当前最关键的一点：**模型不能再直接控制目标生命周期，goal 的继续 / 结束由 Verify 结果和 middleware 状态机统一决定**。

--- a/packages/contracts/src/ai/thread-goal.model.ts
+++ b/packages/contracts/src/ai/thread-goal.model.ts
@@ -3,6 +3,17 @@ import { IBasePerTenantAndOrganizationEntityModel } from '../base-entity.model'
 
 export type { ThreadGoalStatus } from '@xpert-ai/chatkit-types'
 
+export type ThreadGoalSpec = {
+  originalObjective: string
+  executableGoal: string
+  successCriteria: string[]
+  constraints: string[]
+  verificationChecklist: string[]
+  recommendedStrategy: string
+  source: 'system' | 'llm'
+  generatedAt: string
+}
+
 export const THREAD_GOAL_STATUS_VALUES = [
   'active',
   'paused',
@@ -20,6 +31,7 @@ export interface IThreadGoal extends IBasePerTenantAndOrganizationEntityModel {
   conversationId: string
   threadId: string
   objective: string
+  goalSpec?: ThreadGoalSpec | null
   status: ThreadGoalStatus
   tokensUsed: number
   elapsedSeconds: number

--- a/packages/server-ai/src/chat-conversation/goal/conversation-goal.entity.ts
+++ b/packages/server-ai/src/chat-conversation/goal/conversation-goal.entity.ts
@@ -1,4 +1,4 @@
-import { IThreadGoal, ThreadGoalStatus } from '@xpert-ai/contracts'
+import { IThreadGoal, ThreadGoalSpec, ThreadGoalStatus } from '@xpert-ai/contracts'
 import { TenantOrganizationBaseEntity } from '@xpert-ai/server-core'
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
 import { IsNumber, IsOptional, IsString } from 'class-validator'
@@ -31,6 +31,11 @@ export class ChatConversationGoal extends TenantOrganizationBaseEntity implement
     @IsString()
     @Column({ type: 'text' })
     objective: string
+
+    @ApiPropertyOptional({ type: () => Object })
+    @IsOptional()
+    @Column({ type: 'jsonb', nullable: true })
+    goalSpec?: ThreadGoalSpec | null
 
     @ApiProperty({ type: () => String })
     @IsString()

--- a/packages/server-ai/src/chat-conversation/goal/conversation-goal.service.spec.ts
+++ b/packages/server-ai/src/chat-conversation/goal/conversation-goal.service.spec.ts
@@ -59,6 +59,16 @@ describe('ChatConversationGoalService', () => {
         conversationId: 'conversation-1',
         threadId: 'thread-1',
         objective: 'ship feature',
+        goalSpec: {
+            originalObjective: 'ship feature',
+            executableGoal: 'Work toward this goal: ship feature',
+            successCriteria: ['The requested goal is complete: ship feature'],
+            constraints: ['Do not change unrelated behavior unless required by the goal.'],
+            verificationChecklist: ['Verify that the requested goal has been completed.'],
+            recommendedStrategy: 'act_then_verify',
+            source: 'system',
+            generatedAt: '2026-06-11T00:00:00.000Z'
+        },
         status: 'active',
         tokensUsed: 12,
         elapsedSeconds: 3,
@@ -112,6 +122,60 @@ describe('ChatConversationGoalService', () => {
 
         const removedBudgetField = 'token' + 'Budget'
         expect(repository.save.mock.calls[0]?.[0]).not.toHaveProperty(removedBudgetField)
+        expect(repository.save.mock.calls[0]?.[0]).toMatchObject({
+            objective: 'ship feature',
+            goalSpec: expect.objectContaining({
+                originalObjective: 'ship feature',
+                executableGoal: expect.stringContaining('ship feature'),
+                successCriteria: [expect.stringContaining('ship feature')],
+                constraints: expect.any(Array),
+                verificationChecklist: expect.any(Array),
+                recommendedStrategy: 'act_then_verify',
+                source: 'system',
+                generatedAt: expect.any(String)
+            })
+        })
+    })
+
+    it('regenerates the goal spec when the user edits the objective', async () => {
+        const goal = await service.patchGoalFromUser('conversation-1', {
+            objective: 'ship updated feature'
+        })
+
+        expect(repository.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: 'goal-1',
+                objective: 'ship updated feature',
+                goalSpec: expect.objectContaining({
+                    originalObjective: 'ship updated feature',
+                    executableGoal: expect.stringContaining('ship updated feature')
+                })
+            })
+        )
+        expect(goal).toMatchObject({
+            objective: 'ship updated feature',
+            goalSpec: expect.objectContaining({
+                originalObjective: 'ship updated feature'
+            })
+        })
+    })
+
+    it('preserves the goal spec when the user only changes status', async () => {
+        const goal = await service.patchGoalFromUser('conversation-1', {
+            status: 'paused'
+        })
+
+        expect(repository.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: 'goal-1',
+                status: 'paused'
+            })
+        )
+        expect(repository.save.mock.calls[0]?.[0]).not.toHaveProperty('goalSpec')
+        expect(goal).toMatchObject({
+            status: 'paused',
+            goalSpec: existingGoal.goalSpec
+        })
     })
 
     it('returns the full goal when the model updates the status', async () => {
@@ -128,6 +192,7 @@ describe('ChatConversationGoalService', () => {
             conversationId: 'conversation-1',
             threadId: 'thread-1',
             objective: 'ship feature',
+            goalSpec: existingGoal.goalSpec,
             status: 'complete',
             tokensUsed: 12,
             elapsedSeconds: 3,

--- a/packages/server-ai/src/chat-conversation/goal/conversation-goal.service.ts
+++ b/packages/server-ai/src/chat-conversation/goal/conversation-goal.service.ts
@@ -2,6 +2,7 @@ import {
     ChatMessageEventTypeEnum,
     ChatMessageTypeEnum,
     IThreadGoal,
+    ThreadGoalSpec,
     ThreadGoalModelStatus,
     ThreadGoalUserStatus,
     TThreadGoalPatchRequest,
@@ -54,6 +55,7 @@ export class ChatConversationGoalService extends TenantOrganizationAwareCrudServ
             this.normalizeId(conversationId, 'conversationId')
         )
         const objective = this.normalizeObjective(request.objective)
+        const goalSpec = this.buildGoalSpec(objective)
         const existing = await this.getByConversationId(conversation.id)
         const now = new Date()
         const entity: DeepPartial<ChatConversationGoal> = {
@@ -61,6 +63,7 @@ export class ChatConversationGoalService extends TenantOrganizationAwareCrudServ
             conversationId: conversation.id,
             threadId: conversation.threadId,
             objective,
+            goalSpec,
             status: 'active',
             tokensUsed: 0,
             elapsedSeconds: 0,
@@ -78,12 +81,14 @@ export class ChatConversationGoalService extends TenantOrganizationAwareCrudServ
         const now = new Date()
         const status = request.status ? this.normalizeUserStatus(request.status) : goal.status
         const objective = request.objective === undefined ? goal.objective : this.normalizeObjective(request.objective)
+        const goalSpec = request.objective === undefined ? undefined : this.buildGoalSpec(objective)
         const completedAt = status !== goal.status ? null : (goal.completedAt ?? null)
         const blockedAt = status !== goal.status ? null : (goal.blockedAt ?? null)
         const patch: DeepPartial<ChatConversationGoal> = {
             id: goal.id,
             objective,
             status,
+            ...(goalSpec ? { goalSpec } : {}),
             ...(status !== goal.status
                 ? {
                       statusUpdatedAt: now,
@@ -98,6 +103,7 @@ export class ChatConversationGoalService extends TenantOrganizationAwareCrudServ
             ...goal,
             ...saved,
             objective,
+            ...(goalSpec ? { goalSpec } : {}),
             status,
             ...(status !== goal.status
                 ? {
@@ -236,6 +242,19 @@ export class ChatConversationGoalService extends TenantOrganizationAwareCrudServ
             return Math.floor(value)
         }
         return 0
+    }
+
+    private buildGoalSpec(objective: string): ThreadGoalSpec {
+        return {
+            originalObjective: objective,
+            executableGoal: `Work toward this goal: ${objective}`,
+            successCriteria: [`The requested goal is complete: ${objective}`],
+            constraints: ['Do not change unrelated behavior unless required by the goal.'],
+            verificationChecklist: ['Verify that the requested goal has been completed.'],
+            recommendedStrategy: 'act_then_verify',
+            source: 'system',
+            generatedAt: new Date().toISOString()
+        }
     }
 
     private normalizeUserStatus(status: ThreadGoalUserStatus): ThreadGoalUserStatus {

--- a/packages/server-ai/src/xpert-agent/agent.spec.ts
+++ b/packages/server-ai/src/xpert-agent/agent.spec.ts
@@ -24,6 +24,38 @@ describe('createMapStreamEvents', () => {
         jest.clearAllMocks()
     })
 
+    it('suppresses internal stream events', () => {
+        const subscriber = { next: jest.fn() }
+        const mapStreamEvent = createMapStreamEvents(
+            logger as unknown as Logger,
+            subscriber as unknown as Subscriber<MessageEvent>,
+            {
+                agent: { key: 'Agent_root' } as unknown as IXpertAgent,
+                unmutes: []
+            }
+        )
+
+        const chunk = mapStreamEvent({
+            event: 'on_chat_model_stream',
+            tags: [],
+            data: {
+                chunk: {
+                    id: 'message-stream-1',
+                    content: '{"outcome":"passed"}',
+                    tool_call_chunks: [],
+                    additional_kwargs: {}
+                }
+            },
+            metadata: {
+                internal: true
+            },
+            run_id: 'langgraph-run-1'
+        })
+
+        expect(chunk).toBeNull()
+        expect(subscriber.next).not.toHaveBeenCalled()
+    })
+
     it('adds execution metadata to streamed text chunks', () => {
         const subscriber = { next: jest.fn() }
         const mapStreamEvent = createMapStreamEvents(

--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
@@ -134,6 +134,7 @@ import { FILE_UNDERSTANDING_MIDDLEWARE_NAME } from '../../../file-understanding/
 
 const XPERT_TITLE_MIDDLEWARE_NODE_KEY = '__xpert_title_middleware__'
 const FILE_UNDERSTANDING_MIDDLEWARE_NODE_KEY = '__file_understanding_middleware__'
+const GRAPH_JUMP_TO_STATE_KEY = '__xpertJumpTo'
 
 @CommandHandler(XpertAgentSubgraphCommand)
 export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubgraphCommand> {
@@ -949,6 +950,10 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
         const workflowNodes = allChannels(graph, agent.key)
         // Collect channels used in the graph
         const SubgraphStateAnnotation = Annotation.Root({
+            [GRAPH_JUMP_TO_STATE_KEY]: Annotation<JumpToTarget | null>({
+                reducer: (a, b) => (b === undefined ? a : b),
+                default: () => null
+            }),
             // Temp parameters
             ...(variables?.reduce((state, schema) => {
                 state[schema.name] = Annotation(stateVariable(schema))
@@ -1155,6 +1160,8 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
                 (<string>config.metadata.langgraph_triggers[0])?.startsWith(START),
                 jsonSchema
             )
+            const channelState = getChannelState(state, agentChannel)
+            const isInternalGoalVerification = readGoalPhaseFromChannelState(channelState) === 'verify'
             // Disable history and new human request then remove history
             const deleteMessages =
                 !enableMessageHistory && humanMessages.length
@@ -1180,8 +1187,17 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
                 systemMessageContent = systemMsg.content
                 const finalMessages = systemMsg ? [systemMsg, ...reqMessages] : reqMessages
                 const scopedSignal = createScopedAbortSignal()
+                const invokeConfig = isInternalGoalVerification
+                    ? {
+                          ...config,
+                          metadata: {
+                              ...(config?.metadata ?? {}),
+                              internal: true
+                          }
+                      }
+                    : config
                 const response = await model
-                    .invoke(finalMessages, { ...config, signal: scopedSignal.signal })
+                    .invoke(finalMessages, { ...invokeConfig, signal: scopedSignal.signal })
                     .finally(() => {
                         scopedSignal.cleanup()
                     })
@@ -1209,6 +1225,7 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
                 const message: AIMessage | object = await wrappedModelHandler(baseRequest)
 
                 const nState: Record<string, any> = {
+                    [GRAPH_JUMP_TO_STATE_KEY]: null,
                     messages: [...humanMessages],
                     [channelName(agentKey)]: {
                         system: systemMessageContent,
@@ -1866,7 +1883,7 @@ function createAgentNavigator(
     jumpTargets?: Partial<Record<JumpToTarget, string>>
 ) {
     return (state: typeof AgentStateAnnotation.State, config) => {
-        const jumpTo = consumeJumpTo(config)
+        const jumpTo = consumeJumpTo(state, config)
         if (jumpTo === 'end') {
             return END
         }
@@ -1941,12 +1958,32 @@ function createAgentNavigator(
     }
 }
 
-function consumeJumpTo(config: RunnableConfig | undefined): JumpToTarget | undefined {
+function consumeJumpTo(state: unknown, config?: RunnableConfig): JumpToTarget | undefined {
+    const stateJumpTo = readStateJumpTo(state)
+    if (stateJumpTo) {
+        return stateJumpTo
+    }
     const jumpTo = (config as { jumpTo?: JumpToTarget } | undefined)?.jumpTo
     if (jumpTo) {
         delete (config as { jumpTo?: JumpToTarget }).jumpTo
     }
     return jumpTo
+}
+
+function readStateJumpTo(state: unknown): JumpToTarget | undefined {
+    if (!state || typeof state !== 'object') {
+        return undefined
+    }
+    const value = Reflect.get(state, GRAPH_JUMP_TO_STATE_KEY)
+    return value === 'model' || value === 'tools' || value === 'end' ? value : undefined
+}
+
+function readGoalPhaseFromChannelState(state: unknown): 'act' | 'verify' | undefined {
+    if (!state || typeof state !== 'object') {
+        return undefined
+    }
+    const value = Reflect.get(state, 'threadGoalPhase')
+    return value === 'act' || value === 'verify' ? value : undefined
 }
 
 function createAfterAgentNavigator(
@@ -2130,13 +2167,16 @@ function createBeforeModelNode(hook: BeforeModelHandler<typeof MessagesAnnotatio
                     ;(config as any).jumpTo = jumpTo
                 }
                 return {
+                    [GRAPH_JUMP_TO_STATE_KEY]: jumpTo ?? null,
                     [agentChannel]: {
                         ...middlewareState,
                         ...partial
                     }
                 }
             }
-            return null
+            return {
+                [GRAPH_JUMP_TO_STATE_KEY]: null
+            }
         }
     })
 }
@@ -2158,6 +2198,7 @@ function createAfterModelNode(
                 return state
             }
             let nextState: Record<string, any> = { ...channelState }
+            let nextJumpTo: JumpToTarget | undefined
             if (hook) {
                 const result = await hook(channelState, config)
                 if (result && typeof result === 'object') {
@@ -2169,13 +2210,19 @@ function createAfterModelNode(
                     if (jumpTo) {
                         ;(config as any) ??= {}
                         ;(config as any).jumpTo = jumpTo
+                        nextJumpTo = jumpTo
                     }
                 }
             }
-            if (isLast) {
-                return writeAgentMemories({ ...state, [agentChannel]: nextState }, memories)
+            const rootState = {
+                ...state,
+                ...(nextJumpTo ? { [GRAPH_JUMP_TO_STATE_KEY]: nextJumpTo } : {}),
+                [agentChannel]: nextState
             }
-            return { ...state, [agentChannel]: nextState }
+            if (isLast) {
+                return writeAgentMemories(rootState, memories)
+            }
+            return rootState
         }
     })
 }
@@ -2202,7 +2249,10 @@ function createAfterAgentNode(
                         ;(config as any) ??= {}
                         ;(config as any).jumpTo = jumpTo
                     }
-                    return partial
+                    return {
+                        ...partial,
+                        ...(jumpTo ? { [GRAPH_JUMP_TO_STATE_KEY]: jumpTo } : {})
+                    }
                 }
             }
             return null

--- a/packages/server-ai/src/xpert-middleware/conversation-goal.middleware.shared.ts
+++ b/packages/server-ai/src/xpert-middleware/conversation-goal.middleware.shared.ts
@@ -4,7 +4,8 @@ import {
     HumanMessage,
     MessageContent,
     SystemMessage,
-    isAIMessage
+    isAIMessage,
+    isToolMessage
 } from '@langchain/core/messages'
 import { tool } from '@langchain/core/tools'
 import { dispatchCustomEvent } from '@langchain/core/callbacks/dispatch'
@@ -14,7 +15,6 @@ import {
     IThreadGoal,
     STATE_VARIABLE_HUMAN,
     TAgentMiddlewareMeta,
-    ThreadGoalModelStatus,
     ThreadGoalStatus,
     createThreadGoalUpdatedEvent,
     isRunnableThreadGoalStatus
@@ -37,12 +37,10 @@ export const conversationGoalStateSchema = z.object({
     threadGoalObjective: z.string().optional(),
     // usage_limited is reserved for future usage-quota enforcement; this middleware does not emit it yet.
     threadGoalStatus: z.enum(['active', 'paused', 'blocked', 'usage_limited', 'budget_limited', 'complete']).optional(),
+    threadGoalPhase: z.enum(['act', 'verify']).optional(),
     threadGoalContinuationCount: z.number().int().min(0).default(0),
+    threadGoalVerificationRetryCount: z.number().int().min(0).default(0),
     threadGoalTurnStartedAt: z.number().optional()
-})
-
-const updateGoalToolSchema = z.object({
-    status: z.string()
 })
 
 export type ConversationGoalMiddlewareConfig = InferInteropZodInput<typeof configSchema>
@@ -126,6 +124,14 @@ function hasToolCalls(message: AIMessage | undefined): boolean {
     return Array.isArray(message?.tool_calls) && message.tool_calls.length > 0
 }
 
+function readGoalPhase(state: unknown): 'act' | 'verify' {
+    if (!state || typeof state !== 'object') {
+        return 'act'
+    }
+    const value = Reflect.get(state, 'threadGoalPhase')
+    return value === 'verify' ? 'verify' : 'act'
+}
+
 function appendHiddenGoalContext(systemMessage: SystemMessage | undefined, goalContext: string): SystemMessage {
     const currentContent =
         typeof systemMessage?.content === 'string' ? systemMessage.content : getMessageText(systemMessage?.content)
@@ -141,35 +147,320 @@ function appendHiddenGoalContext(systemMessage: SystemMessage | undefined, goalC
 function buildGoalContext(goal: {
     objective: string
     status: string
+    goalSpec?: IThreadGoal['goalSpec']
     elapsedSeconds?: number
     continuationCount?: number
 }): string {
+    const goalSpec = goal.goalSpec
+    const executableGoal = goalSpec?.executableGoal?.trim()
+    const successCriteria = goalSpec?.successCriteria?.length
+        ? goalSpec.successCriteria.map((item) => `- ${item}`).join('\n')
+        : '- The user objective is complete.'
+    const constraints = goalSpec?.constraints?.length
+        ? goalSpec.constraints.map((item) => `- ${item}`).join('\n')
+        : '- None.'
+    const verificationChecklist = goalSpec?.verificationChecklist?.length
+        ? goalSpec.verificationChecklist.map((item) => `- ${item}`).join('\n')
+        : '- Verify the user objective is complete.'
+
     return `<goal_context>
 status: ${goal.status}
 objective: ${goal.objective}
+executable_goal: ${executableGoal || goal.objective}
+success_criteria:
+${successCriteria}
+constraints:
+${constraints}
+verification_checklist:
+${verificationChecklist}
 usage:
 - elapsed_seconds: ${goal.elapsedSeconds ?? 0}
 - continuation_count: ${goal.continuationCount ?? 0}
 instructions:
-- Keep working toward the objective until it is complete, blocked, or paused.
+- Act toward the executable goal until there is enough evidence to verify it.
+- Do not mark the goal complete or blocked from the act phase.
 - Use get_goal when you need the latest persisted goal state.
-- Use update_goal with status "complete" only when the objective is fully complete.
-- Use update_goal with status "blocked" only when you cannot make meaningful progress without user input or external changes.
 - Do not pause, resume, clear, or replace the goal; those actions are user-controlled.
 </goal_context>`
 }
 
-function createContinuationMessage(): HumanMessage {
+function createActMessage(nextAction?: string): HumanMessage {
+    const action = nextAction?.trim()
     return new HumanMessage(
-        'Continue working toward the active goal. If the goal is complete, call update_goal with status "complete". If you are blocked, call update_goal with status "blocked". Otherwise make concrete progress and continue.'
+        action
+            ? `Continue working toward the active goal. Next action: ${action}`
+            : 'Continue working toward the active goal. Make concrete progress toward the executable goal. Do not mark the goal complete or blocked from this act phase.'
     )
 }
 
-function normalizeModelStatus(value: string): ThreadGoalModelStatus {
-    if (value !== 'complete' && value !== 'blocked') {
-        throw new Error('update_goal only supports complete or blocked status.')
+type GoalEvidence = {
+    assistantOutputs: string[]
+    toolResults: Array<{
+        name: string
+        status?: string
+        emptyResult?: boolean
+        output: string
+    }>
+    errors: string[]
+}
+
+function truncateEvidenceText(text: string, maxLength = 1200): string {
+    const normalized = text.trim()
+    if (normalized.length <= maxLength) {
+        return normalized
     }
-    return value
+    return `${normalized.slice(0, maxLength)}... [truncated]`
+}
+
+function tryParseJson(value: string): unknown {
+    const trimmed = value.trim()
+    if (!trimmed) {
+        return undefined
+    }
+    try {
+        return JSON.parse(trimmed) as unknown
+    } catch {
+        return undefined
+    }
+}
+
+function isEmptyToolResult(value: unknown): boolean | undefined {
+    if (Array.isArray(value)) {
+        return value.length === 0
+    }
+    if (value && typeof value === 'object') {
+        const items = Reflect.get(value, 'items')
+        if (Array.isArray(items)) {
+            return items.length === 0
+        }
+        const results = Reflect.get(value, 'results')
+        if (Array.isArray(results)) {
+            return results.length === 0
+        }
+    }
+    return undefined
+}
+
+function buildGoalEvidence(messages: BaseMessage[]): GoalEvidence {
+    const evidence: GoalEvidence = {
+        assistantOutputs: [],
+        toolResults: [],
+        errors: []
+    }
+
+    messages.forEach((message) => {
+        if (isToolMessage(message)) {
+            const text = getMessageText(message.content)
+            const parsed = tryParseJson(text)
+            const status =
+                typeof Reflect.get(message, 'status') === 'string' ? Reflect.get(message, 'status') : undefined
+            const name = typeof Reflect.get(message, 'name') === 'string' ? Reflect.get(message, 'name') : 'tool'
+            evidence.toolResults.push({
+                name,
+                ...(status ? { status } : {}),
+                ...(isEmptyToolResult(parsed) !== undefined ? { emptyResult: isEmptyToolResult(parsed) } : {}),
+                output: truncateEvidenceText(text)
+            })
+            return
+        }
+
+        if (isAIMessage(message)) {
+            const text = getMessageText(message.content)
+            if (text) {
+                evidence.assistantOutputs.push(truncateEvidenceText(text, 800))
+            }
+            const error = typeof Reflect.get(message, 'error') === 'string' ? Reflect.get(message, 'error') : ''
+            if (error) {
+                evidence.errors.push(error)
+            }
+        }
+    })
+
+    return evidence
+}
+
+function createVerificationMessage(evidence?: GoalEvidence): HumanMessage {
+    const evidenceJson = evidence ? JSON.stringify(evidence, null, 2) : '{}'
+    return new HumanMessage({
+        content:
+            `Verify the active goal against the goal context. Do not do new work.\n` +
+            `Return only JSON with this shape: {"outcome":"passed"|"failed"|"blocked","evidence":["..."],"reason":"...","nextAction":"..."}.\n` +
+            `Do not wrap the JSON in Markdown. Do not use unescaped double quotes inside string values.\n` +
+            `Use "passed" only when concrete tool results, artifacts, or durable outputs satisfy the success criteria.\n` +
+            `Assistant summaries or claims are not sufficient evidence by themselves.\n` +
+            `If a success criterion requires search/retrieval confirmation and search results are empty, do not treat a direct get/read by id as retrieval success.\n` +
+            `Use "failed" when the goal is not complete and there is a concrete next action. Use "blocked" when progress cannot continue without user input or external changes.\n` +
+            `<goal_evidence_json>\n${evidenceJson}\n</goal_evidence_json>`,
+        additional_kwargs: {
+            hidden: true,
+            internal: true,
+            xpertInternalGoalVerify: true
+        }
+    })
+}
+
+type GoalVerification = {
+    outcome: 'passed' | 'failed' | 'blocked'
+    evidence: string[]
+    reason: string
+    nextAction?: string
+}
+
+function readStringArray(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+        return []
+    }
+    return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+}
+
+function readString(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : ''
+}
+
+function extractGoalVerificationJsonText(text: string): string | null {
+    const jsonText = text.startsWith('{') ? text : text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1)
+    if (!jsonText.startsWith('{') || !jsonText.endsWith('}')) {
+        return null
+    }
+
+    return jsonText
+}
+
+function findGoalVerificationValueStart(text: string, field: keyof GoalVerification): number {
+    const fieldIndex = text.indexOf(`"${field}"`)
+    if (fieldIndex < 0) {
+        return -1
+    }
+    const colonIndex = text.indexOf(':', fieldIndex)
+    if (colonIndex < 0) {
+        return -1
+    }
+
+    let index = colonIndex + 1
+    while (index < text.length && /\s/.test(text[index])) {
+        index += 1
+    }
+    return index
+}
+
+function findNextGoalVerificationField(text: string, startIndex: number): number {
+    const nextField = text.slice(startIndex).search(/\n\s*"(outcome|evidence|reason|nextAction)"\s*:/)
+    if (nextField >= 0) {
+        return startIndex + nextField
+    }
+
+    const objectEnd = text.slice(startIndex).search(/\n\s*}/)
+    if (objectEnd >= 0) {
+        return startIndex + objectEnd
+    }
+
+    return text.length
+}
+
+function trimLooseJsonString(value: string): string {
+    let text = value.trim()
+    if (text.endsWith(',')) {
+        text = text.slice(0, -1).trim()
+    }
+    if (text.startsWith('"')) {
+        text = text.slice(1)
+    }
+    if (text.endsWith('"')) {
+        text = text.slice(0, -1)
+    }
+    return text.replace(/\\"/g, '"').trim()
+}
+
+function readLooseStringField(text: string, field: keyof GoalVerification): string {
+    const valueStart = findGoalVerificationValueStart(text, field)
+    if (valueStart < 0 || text[valueStart] !== '"') {
+        return ''
+    }
+
+    const valueEnd = findNextGoalVerificationField(text, valueStart + 1)
+    return trimLooseJsonString(text.slice(valueStart, valueEnd))
+}
+
+function findLooseArrayEnd(text: string, startIndex: number): number {
+    const arrayEnd = text.slice(startIndex).search(/\n\s*]\s*,?/)
+    return arrayEnd >= 0 ? startIndex + arrayEnd : -1
+}
+
+function readLooseStringArrayField(text: string, field: keyof GoalVerification): string[] {
+    const valueStart = findGoalVerificationValueStart(text, field)
+    if (valueStart < 0 || text[valueStart] !== '[') {
+        return []
+    }
+
+    const arrayEnd = findLooseArrayEnd(text, valueStart + 1)
+    if (arrayEnd < 0) {
+        return []
+    }
+
+    return text
+        .slice(valueStart + 1, arrayEnd)
+        .split('\n')
+        .map((line) => trimLooseJsonString(line))
+        .filter((item) => item.length > 0)
+}
+
+function parseLooseGoalVerification(text: string): GoalVerification | null {
+    const outcome = readLooseStringField(text, 'outcome')
+    if (outcome !== 'passed' && outcome !== 'failed' && outcome !== 'blocked') {
+        return null
+    }
+
+    const evidence = readLooseStringArrayField(text, 'evidence')
+    const reason = readLooseStringField(text, 'reason')
+    if (!evidence.length || !reason) {
+        return null
+    }
+
+    const nextAction = readLooseStringField(text, 'nextAction')
+    return {
+        outcome,
+        evidence,
+        reason,
+        ...(nextAction ? { nextAction } : {})
+    }
+}
+
+function parseGoalVerification(content: MessageContent | unknown): GoalVerification | null {
+    const text = getMessageText(content).trim()
+    if (!text) {
+        return null
+    }
+    const jsonText = extractGoalVerificationJsonText(text)
+    if (!jsonText) {
+        return null
+    }
+
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(jsonText) as unknown
+    } catch {
+        return parseLooseGoalVerification(jsonText)
+    }
+    if (!parsed || typeof parsed !== 'object') {
+        return null
+    }
+
+    const outcome = Reflect.get(parsed, 'outcome')
+    if (outcome !== 'passed' && outcome !== 'failed' && outcome !== 'blocked') {
+        return null
+    }
+    const evidence = readStringArray(Reflect.get(parsed, 'evidence'))
+    const reason = readString(Reflect.get(parsed, 'reason'))
+    if (!evidence.length || !reason) {
+        return null
+    }
+    const nextAction = readString(Reflect.get(parsed, 'nextAction'))
+    return {
+        outcome,
+        evidence,
+        reason,
+        ...(nextAction ? { nextAction } : {})
+    }
 }
 
 async function dispatchGoalUpdated(goal: IThreadGoal | null | undefined) {
@@ -260,24 +551,6 @@ export function buildConversationGoalAgentMiddleware(
                     description: 'Read the current persisted conversation goal.',
                     schema: z.object({})
                 }
-            ),
-            tool(
-                async (input) => {
-                    if (!conversationId) {
-                        throw new Error('update_goal requires a conversationId.')
-                    }
-                    const goal = await goalService.updateGoalFromModel(
-                        conversationId,
-                        normalizeModelStatus(input.status)
-                    )
-                    await dispatchGoalUpdated(goal)
-                    return goal
-                },
-                {
-                    name: 'update_goal',
-                    description: 'Mark the current goal as complete or blocked. Only complete and blocked are allowed.',
-                    schema: updateGoalToolSchema
-                }
             )
         ],
         beforeAgent: {
@@ -293,11 +566,14 @@ export function buildConversationGoalAgentMiddleware(
                     }
                 }
 
+                const currentPhase = readGoalPhase(state)
                 return {
                     threadGoalId: goal.id,
                     threadGoalObjective: goal.objective,
                     threadGoalStatus: goal.status,
+                    threadGoalPhase: isRunnableThreadGoalStatus(goal.status) ? currentPhase : 'act',
                     threadGoalContinuationCount: 0,
+                    threadGoalVerificationRetryCount: 0,
                     ...(isRunnableThreadGoalStatus(goal.status) && !isPlanModeEnabled(state)
                         ? {
                               threadGoalTurnStartedAt: Date.now()
@@ -318,6 +594,7 @@ export function buildConversationGoalAgentMiddleware(
 
             return handler({
                 ...request,
+                ...(readGoalPhase(request.state) === 'verify' ? { tools: [] } : {}),
                 systemMessage: appendHiddenGoalContext(request.systemMessage, buildGoalContext(goal))
             })
         },
@@ -342,6 +619,7 @@ export function buildConversationGoalAgentMiddleware(
                 const latestAiMessage = findLatestAiMessage(messages)
                 if (hasToolCalls(latestAiMessage)) {
                     return {
+                        threadGoalPhase: readGoalPhase(state),
                         threadGoalStatus: goal.status as ThreadGoalStatus
                     }
                 }
@@ -360,20 +638,70 @@ export function buildConversationGoalAgentMiddleware(
                     await dispatchGoalUpdated(usageGoal)
                 }
 
-                const continuationCount = readFiniteNumber(state, 'threadGoalContinuationCount') ?? 0
-                if (continuationCount >= config.maxIterations) {
-                    const budgetGoal = await goalService.markBudgetLimited(conversationId)
-                    await dispatchGoalUpdated(budgetGoal)
+                const phase = readGoalPhase(state)
+                if (phase === 'verify') {
+                    const verification = parseGoalVerification(latestAiMessage?.content)
+                    if (!verification) {
+                        const retryCount = readFiniteNumber(state, 'threadGoalVerificationRetryCount') ?? 0
+                        if (retryCount < 1) {
+                            return {
+                                messages: [createVerificationMessage(buildGoalEvidence(messages))],
+                                threadGoalPhase: 'verify',
+                                threadGoalVerificationRetryCount: retryCount + 1,
+                                threadGoalStatus: 'active',
+                                jumpTo: 'model'
+                            }
+                        }
+                        const blockedGoal = await goalService.updateGoalFromModel(conversationId, 'blocked')
+                        await dispatchGoalUpdated(blockedGoal)
+                        return {
+                            threadGoalStatus: 'blocked'
+                        }
+                    }
+
+                    if (verification.outcome === 'passed') {
+                        const completeGoal = await goalService.updateGoalFromModel(conversationId, 'complete')
+                        await dispatchGoalUpdated(completeGoal)
+                        return {
+                            threadGoalStatus: 'complete'
+                        }
+                    }
+
+                    if (verification.outcome === 'blocked' || !verification.nextAction) {
+                        const blockedGoal = await goalService.updateGoalFromModel(conversationId, 'blocked')
+                        await dispatchGoalUpdated(blockedGoal)
+                        return {
+                            threadGoalStatus: 'blocked'
+                        }
+                    }
+
+                    const continuationCount = readFiniteNumber(state, 'threadGoalContinuationCount') ?? 0
+                    if (continuationCount >= config.maxIterations) {
+                        const budgetGoal = await goalService.markBudgetLimited(conversationId)
+                        await dispatchGoalUpdated(budgetGoal)
+                        return {
+                            threadGoalContinuationCount: continuationCount,
+                            threadGoalStatus: 'budget_limited'
+                        }
+                    }
+
+                    await goalService.incrementContinuation(conversationId)
                     return {
-                        threadGoalContinuationCount: continuationCount,
-                        threadGoalStatus: 'budget_limited'
+                        messages: [createActMessage(verification.nextAction)],
+                        threadGoalContinuationCount: continuationCount + 1,
+                        threadGoalPhase: 'act',
+                        threadGoalVerificationRetryCount: 0,
+                        threadGoalStatus: 'active',
+                        threadGoalTurnStartedAt: Date.now(),
+                        jumpTo: 'model'
                     }
                 }
 
-                await goalService.incrementContinuation(conversationId)
                 return {
-                    messages: [createContinuationMessage()],
-                    threadGoalContinuationCount: continuationCount + 1,
+                    messages: [createVerificationMessage(buildGoalEvidence(messages))],
+                    threadGoalContinuationCount: readFiniteNumber(state, 'threadGoalContinuationCount') ?? 0,
+                    threadGoalPhase: 'verify',
+                    threadGoalVerificationRetryCount: 0,
                     threadGoalStatus: 'active',
                     threadGoalTurnStartedAt: Date.now(),
                     jumpTo: 'model'

--- a/packages/server-ai/src/xpert-middleware/ralph-loop.middleware.spec.ts
+++ b/packages/server-ai/src/xpert-middleware/ralph-loop.middleware.spec.ts
@@ -10,7 +10,7 @@ jest.mock('@langchain/core/callbacks/dispatch', () => ({
     dispatchCustomEvent: jest.fn().mockResolvedValue(undefined)
 }))
 
-import { AIMessage, HumanMessage, SystemMessage } from '@langchain/core/messages'
+import { AIMessage, HumanMessage, SystemMessage, ToolMessage } from '@langchain/core/messages'
 import { dispatchCustomEvent } from '@langchain/core/callbacks/dispatch'
 import {
     CHAT_EVENT_TYPE_THREAD_GOAL_UPDATED,
@@ -30,6 +30,16 @@ type GoalRecord = {
     conversationId: string
     threadId: string
     objective: string
+    goalSpec?: {
+        originalObjective: string
+        executableGoal: string
+        successCriteria: string[]
+        constraints: string[]
+        verificationChecklist: string[]
+        recommendedStrategy: string
+        source: string
+        generatedAt: string
+    }
     status: ThreadGoalStatus
     tokensUsed: number
     elapsedSeconds: number
@@ -133,6 +143,8 @@ async function createRalphLoopAgentMiddleware(goalService = createGoalService())
 type MiddlewareResultSnapshot = {
     messages?: Array<{ content?: unknown }>
     threadGoalContinuationCount?: number
+    threadGoalPhase?: string
+    threadGoalVerificationRetryCount?: number
     threadGoalStatus?: string
     jumpTo?: string
 }
@@ -174,6 +186,20 @@ const activeGoal: GoalRecord = {
     continuationCount: 0
 }
 
+const activeGoalWithSpec: GoalRecord = {
+    ...activeGoal,
+    goalSpec: {
+        originalObjective: 'ship the feature',
+        executableGoal: 'Finish and verify the feature implementation.',
+        successCriteria: ['The feature is implemented.', 'Relevant verification passes.'],
+        constraints: ['Do not change unrelated behavior.'],
+        verificationChecklist: ['Confirm implementation exists.', 'Confirm verification evidence exists.'],
+        recommendedStrategy: 'act_then_verify',
+        source: 'llm',
+        generatedAt: '2026-06-11T00:00:00.000Z'
+    }
+}
+
 describe('RalphLoopMiddleware', () => {
     beforeEach(() => {
         jest.clearAllMocks()
@@ -199,31 +225,15 @@ describe('RalphLoopMiddleware', () => {
         expect(JSON.stringify(strategy.meta)).not.toContain('<promise>DONE</promise>')
     })
 
-    it('exposes only read and terminal update goal tools to the model', async () => {
+    it('exposes only the read goal tool to the model', async () => {
         const goalService = createGoalService(activeGoal)
         const strategy = new RalphLoopMiddleware(goalService as unknown as ChatConversationGoalService)
         const middleware = await Promise.resolve(strategy.createMiddleware({}, createContext()))
         const toolNames = middleware.tools?.map((tool) => tool.name)
 
-        expect(toolNames).toEqual(['get_goal', 'update_goal'])
+        expect(toolNames).toEqual(['get_goal'])
         expect(toolNames).not.toContain('create_goal')
-
-        const updateTool = middleware.tools?.find((tool) => tool.name === 'update_goal')
-        if (!updateTool) {
-            throw new Error('Expected update goal tool.')
-        }
-
-        await expect(updateTool.invoke({ status: 'paused' })).rejects.toThrow('complete or blocked')
-        await expect(updateTool.invoke({ status: 'complete' })).resolves.toMatchObject({
-            status: 'complete'
-        })
-        expect(dispatchCustomEvent).toHaveBeenCalledWith(
-            ChatMessageEventTypeEnum.ON_CHAT_EVENT,
-            expect.objectContaining({
-                type: CHAT_EVENT_TYPE_THREAD_GOAL_UPDATED,
-                goal: expect.objectContaining({ status: 'complete' })
-            })
-        )
+        expect(toolNames).not.toContain('update_goal')
     })
 
     it('injects hidden goal context for active goals', async () => {
@@ -253,6 +263,34 @@ describe('RalphLoopMiddleware', () => {
         expect(String(request.systemMessage.content)).toContain('ship the feature')
         expect(String(request.systemMessage.content)).not.toContain('token_budget')
         expect(String(request.systemMessage.content)).toContain('get_goal')
+        expect(String(request.systemMessage.content)).not.toContain('update_goal')
+    })
+
+    it('injects GoalSpec details when available', async () => {
+        const middleware = await createRalphLoopAgentMiddleware(createGoalService(activeGoalWithSpec))
+        const wrapModelCall = getWrapModelCall(middleware)
+        const handler = jest.fn(async (request: { systemMessage: SystemMessage }) => {
+            void request
+            return new AIMessage('ok')
+        })
+
+        await wrapModelCall(
+            {
+                messages: [new HumanMessage('continue')],
+                systemMessage: new SystemMessage('You are helpful.'),
+                state: {},
+                tools: [],
+                runtime: {}
+            } as never,
+            handler as never
+        )
+
+        const request = handler.mock.calls[0]?.[0]
+        if (!request) {
+            throw new Error('Expected wrapModelCall handler request.')
+        }
+        expect(String(request.systemMessage.content)).toContain('Finish and verify the feature implementation.')
+        expect(String(request.systemMessage.content)).toContain('Confirm verification evidence exists.')
     })
 
     it('does not inject or continue when the goal is paused or the run is in plan mode', async () => {
@@ -279,8 +317,9 @@ describe('RalphLoopMiddleware', () => {
         ).resolves.toBeUndefined()
     })
 
-    it('automatically continues active goals without tool calls', async () => {
-        const middleware = await createRalphLoopAgentMiddleware(createGoalService(activeGoal))
+    it('moves from act to verify when active goals have no pending tool calls', async () => {
+        const goalService = createGoalService(activeGoal)
+        const middleware = await createRalphLoopAgentMiddleware(goalService)
         const afterModel = getAfterModelHook(middleware)
         const result = await afterModel(
             {
@@ -293,12 +332,13 @@ describe('RalphLoopMiddleware', () => {
         const snapshot = result as MiddlewareResultSnapshot
 
         expect(snapshot).toMatchObject({
-            threadGoalContinuationCount: 1,
+            threadGoalPhase: 'verify',
             threadGoalStatus: 'active',
             jumpTo: 'model'
         })
         expect(snapshot.messages?.[0]).toBeInstanceOf(HumanMessage)
-        expect(String(snapshot.messages?.[0]?.content)).toContain('Continue working toward the active goal')
+        expect(String(snapshot.messages?.[0]?.content)).toContain('Verify the active goal')
+        expect(goalService.incrementContinuation).not.toHaveBeenCalled()
         expect(dispatchCustomEvent).toHaveBeenCalledWith(
             ChatMessageEventTypeEnum.ON_CHAT_EVENT,
             expect.objectContaining({
@@ -308,7 +348,256 @@ describe('RalphLoopMiddleware', () => {
         )
     })
 
-    it('stops and marks budget_limited when max iterations are reached', async () => {
+    it('includes structured tool evidence in the verification request', async () => {
+        const goalService = createGoalService(activeGoalWithSpec)
+        const middleware = await createRalphLoopAgentMiddleware(goalService)
+        const afterModel = getAfterModelHook(middleware)
+        const result = await afterModel(
+            {
+                messages: [
+                    new HumanMessage('continue'),
+                    new AIMessage('I wrote the memory and confirmed it.'),
+                    new ToolMessage({
+                        name: 'memory_search',
+                        content: '[]',
+                        tool_call_id: 'search-1'
+                    }),
+                    new ToolMessage({
+                        name: 'memory_get',
+                        content: JSON.stringify({ memoryId: 'mem-1', body: 'stored preference' }),
+                        tool_call_id: 'get-1'
+                    }),
+                    new AIMessage('All conditions are done.')
+                ],
+                threadGoalContinuationCount: 0
+            },
+            {}
+        )
+        const snapshot = result as MiddlewareResultSnapshot
+        const verificationPrompt = String(snapshot.messages?.[0]?.content)
+
+        expect(verificationPrompt).toContain('<goal_evidence_json>')
+        expect(verificationPrompt).toContain('"name": "memory_search"')
+        expect(verificationPrompt).toContain('"emptyResult": true')
+        expect(verificationPrompt).toContain('"name": "memory_get"')
+        expect(verificationPrompt).toContain('Assistant summaries or claims are not sufficient evidence')
+        expect(verificationPrompt).toContain('do not treat a direct get/read by id as retrieval success')
+    })
+
+    it('converts a passed verification into a complete goal', async () => {
+        const goalService = createGoalService(activeGoalWithSpec)
+        const middleware = await createRalphLoopAgentMiddleware(goalService)
+        const afterModel = getAfterModelHook(middleware)
+        const result = await afterModel(
+            {
+                messages: [
+                    new HumanMessage('verify'),
+                    new AIMessage(
+                        JSON.stringify({
+                            outcome: 'passed',
+                            evidence: ['Implementation exists.', 'Verification evidence exists.'],
+                            reason: 'The saved success criteria are satisfied.'
+                        })
+                    )
+                ],
+                threadGoalPhase: 'verify',
+                threadGoalContinuationCount: 0
+            },
+            {}
+        )
+        const snapshot = result as MiddlewareResultSnapshot
+
+        expect(snapshot).toMatchObject({
+            threadGoalStatus: 'complete'
+        })
+        expect(snapshot.jumpTo).toBeUndefined()
+        expect(goalService.updateGoalFromModel).toHaveBeenCalledWith('conversation-1', 'complete')
+        expect(dispatchCustomEvent).toHaveBeenCalledWith(
+            ChatMessageEventTypeEnum.ON_CHAT_EVENT,
+            expect.objectContaining({
+                type: CHAT_EVENT_TYPE_THREAD_GOAL_UPDATED,
+                goal: expect.objectContaining({ status: 'complete' })
+            })
+        )
+    })
+
+    it('converts a passed verification with unescaped evidence quotes into a complete goal', async () => {
+        const goalService = createGoalService(activeGoalWithSpec)
+        const middleware = await createRalphLoopAgentMiddleware(goalService)
+        const afterModel = getAfterModelHook(middleware)
+        const result = await afterModel(
+            {
+                messages: [
+                    new HumanMessage('verify'),
+                    new AIMessage(`{
+  "outcome": "passed",
+  "evidence": [
+    "create_workspace_skill 返回 success，技能名称"请假申请整理助手"，包路径 skill-2，状态 applied",
+    "read_skill_file 成功读取 SKILL.md 完整内容，确认输出格式包含 6 项字段"
+  ],
+  "reason": "工作区技能"请假申请整理助手"已成功创建，SKILL.md 已通过 read_skill_file 读取确认。",
+  "nextAction": "none"
+}`)
+                ],
+                threadGoalPhase: 'verify',
+                threadGoalContinuationCount: 0
+            },
+            {}
+        )
+        const snapshot = result as MiddlewareResultSnapshot
+
+        expect(snapshot).toMatchObject({
+            threadGoalStatus: 'complete'
+        })
+        expect(snapshot.jumpTo).toBeUndefined()
+        expect(goalService.updateGoalFromModel).toHaveBeenCalledWith('conversation-1', 'complete')
+    })
+
+    it('preserves a pending verify phase across the next agent entry', async () => {
+        const goalService = createGoalService(activeGoalWithSpec)
+        const middleware = await createRalphLoopAgentMiddleware(goalService)
+        const beforeAgent = getBeforeAgentHook(middleware)
+        const afterModel = getAfterModelHook(middleware)
+
+        const resumedState = await beforeAgent(
+            {
+                messages: [new HumanMessage('Continue working toward the active goal.')],
+                threadGoalPhase: 'verify',
+                threadGoalStatus: 'active',
+                threadGoalContinuationCount: 0
+            },
+            {}
+        )
+        expect(resumedState).toMatchObject({
+            threadGoalPhase: 'verify',
+            threadGoalStatus: 'active'
+        })
+
+        const result = await afterModel(
+            {
+                messages: [
+                    new HumanMessage('Continue working toward the active goal.'),
+                    new AIMessage(
+                        JSON.stringify({
+                            outcome: 'passed',
+                            evidence: ['The pending verification evidence satisfies the checklist.'],
+                            reason: 'The verifier completed after the previous act phase.'
+                        })
+                    )
+                ],
+                ...(resumedState as Record<string, unknown>)
+            },
+            {}
+        )
+
+        expect(result as MiddlewareResultSnapshot).toMatchObject({
+            threadGoalStatus: 'complete'
+        })
+        expect(goalService.updateGoalFromModel).toHaveBeenCalledWith('conversation-1', 'complete')
+    })
+
+    it('loops from failed verification with a next action back to act', async () => {
+        const goalService = createGoalService(activeGoalWithSpec)
+        const middleware = await createRalphLoopAgentMiddleware(goalService)
+        const afterModel = getAfterModelHook(middleware)
+        const result = await afterModel(
+            {
+                messages: [
+                    new HumanMessage('verify'),
+                    new AIMessage(
+                        JSON.stringify({
+                            outcome: 'failed',
+                            evidence: ['Verification evidence is missing.'],
+                            reason: 'The checklist is not satisfied yet.',
+                            nextAction: 'Collect verification evidence.'
+                        })
+                    )
+                ],
+                threadGoalPhase: 'verify',
+                threadGoalContinuationCount: 0
+            },
+            {}
+        )
+        const snapshot = result as MiddlewareResultSnapshot
+
+        expect(snapshot).toMatchObject({
+            threadGoalContinuationCount: 1,
+            threadGoalPhase: 'act',
+            threadGoalStatus: 'active',
+            jumpTo: 'model'
+        })
+        expect(String(snapshot.messages?.[0]?.content)).toContain('Collect verification evidence.')
+        expect(goalService.incrementContinuation).toHaveBeenCalledWith('conversation-1')
+        expect(goalService.updateGoalFromModel).not.toHaveBeenCalled()
+    })
+
+    it('converts failed verification without a next action into a blocked goal', async () => {
+        const goalService = createGoalService(activeGoalWithSpec)
+        const middleware = await createRalphLoopAgentMiddleware(goalService)
+        const afterModel = getAfterModelHook(middleware)
+        const result = await afterModel(
+            {
+                messages: [
+                    new HumanMessage('verify'),
+                    new AIMessage(
+                        JSON.stringify({
+                            outcome: 'failed',
+                            evidence: ['No next action is available.'],
+                            reason: 'The verifier cannot identify concrete progress.'
+                        })
+                    )
+                ],
+                threadGoalPhase: 'verify',
+                threadGoalContinuationCount: 0
+            },
+            {}
+        )
+        const snapshot = result as MiddlewareResultSnapshot
+
+        expect(snapshot).toMatchObject({
+            threadGoalStatus: 'blocked'
+        })
+        expect(snapshot.jumpTo).toBeUndefined()
+        expect(goalService.updateGoalFromModel).toHaveBeenCalledWith('conversation-1', 'blocked')
+    })
+
+    it('retries invalid verification once before blocking', async () => {
+        const goalService = createGoalService(activeGoalWithSpec)
+        const middleware = await createRalphLoopAgentMiddleware(goalService)
+        const afterModel = getAfterModelHook(middleware)
+
+        const retryResult = await afterModel(
+            {
+                messages: [new HumanMessage('verify'), new AIMessage('not json')],
+                threadGoalPhase: 'verify',
+                threadGoalContinuationCount: 0,
+                threadGoalVerificationRetryCount: 0
+            },
+            {}
+        )
+        expect(retryResult as MiddlewareResultSnapshot).toMatchObject({
+            threadGoalPhase: 'verify',
+            threadGoalVerificationRetryCount: 1,
+            threadGoalStatus: 'active',
+            jumpTo: 'model'
+        })
+
+        const blockedResult = await afterModel(
+            {
+                messages: [new HumanMessage('verify'), new AIMessage('still not json')],
+                threadGoalPhase: 'verify',
+                threadGoalContinuationCount: 0,
+                threadGoalVerificationRetryCount: 1
+            },
+            {}
+        )
+        expect(blockedResult as MiddlewareResultSnapshot).toMatchObject({
+            threadGoalStatus: 'blocked'
+        })
+        expect(goalService.updateGoalFromModel).toHaveBeenCalledWith('conversation-1', 'blocked')
+    })
+
+    it('still verifies act output when max iterations are reached', async () => {
         const goalService = createGoalService(activeGoal)
         const strategy = new RalphLoopMiddleware(goalService as unknown as ChatConversationGoalService)
         const middleware = await Promise.resolve(strategy.createMiddleware({ maxIterations: 2 }, createContext()))
@@ -324,9 +613,44 @@ describe('RalphLoopMiddleware', () => {
         const snapshot = result as MiddlewareResultSnapshot
 
         expect(snapshot).toMatchObject({
+            threadGoalPhase: 'verify',
+            threadGoalStatus: 'active',
+            jumpTo: 'model'
+        })
+        expect(goalService.markBudgetLimited).not.toHaveBeenCalled()
+    })
+
+    it('stops and marks budget_limited when verify needs another act after max iterations', async () => {
+        const goalService = createGoalService(activeGoal)
+        const strategy = new RalphLoopMiddleware(goalService as unknown as ChatConversationGoalService)
+        const middleware = await Promise.resolve(strategy.createMiddleware({ maxIterations: 2 }, createContext()))
+        const afterModel = getAfterModelHook(middleware)
+
+        const result = await afterModel(
+            {
+                messages: [
+                    new HumanMessage('verify'),
+                    new AIMessage(
+                        JSON.stringify({
+                            outcome: 'failed',
+                            evidence: ['More work is still required.'],
+                            reason: 'The goal is not complete.',
+                            nextAction: 'Continue implementation.'
+                        })
+                    )
+                ],
+                threadGoalPhase: 'verify',
+                threadGoalContinuationCount: 2
+            },
+            {}
+        )
+        const snapshot = result as MiddlewareResultSnapshot
+
+        expect(snapshot).toMatchObject({
             threadGoalStatus: 'budget_limited'
         })
         expect(snapshot.jumpTo).toBeUndefined()
         expect(goalService.markBudgetLimited).toHaveBeenCalledWith('conversation-1')
+        expect(goalService.incrementContinuation).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
## Summary

- Keep goal ownership in the Ralph Loop middleware/plugin while separating Act from Verify.
- Add persisted `goalSpec` support and generate a structured goal spec when creating or updating a goal.
- Route lifecycle transitions through middleware-owned `GoalVerification` outcomes instead of letting Act directly mark goals complete or blocked.
- Add the Chinese architecture doc for the V1 plugin-owned Act/Verify flow.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm jest --config packages/server-ai/jest.config.ts --runTestsByPath packages/server-ai/src/chat-conversation/goal/conversation-goal.service.spec.ts packages/server-ai/src/xpert-middleware/ralph-loop.middleware.spec.ts packages/server-ai/src/xpert-agent/agent.spec.ts --runInBand`
- `pnpm nx build server-ai`
- `git diff --check`

## Notes

- This PR targets `develop` and was prepared in a clean worktree from `origin/develop`.
- `ThreadGoalSpec` is defined in the local contract layer so this branch does not require an unpublished chatkit package to compile.