### PR TITLE
fix: mark internal goal run messages

### DIFF
--- a/packages/server-ai/src/xpert-middleware/conversation-goal.middleware.shared.ts
+++ b/packages/server-ai/src/xpert-middleware/conversation-goal.middleware.shared.ts
@@ -186,11 +186,16 @@ instructions:
 
 function createActMessage(nextAction?: string): HumanMessage {
     const action = nextAction?.trim()
-    return new HumanMessage(
-        action
+    return new HumanMessage({
+        content: action
             ? `Continue working toward the active goal. Next action: ${action}`
-            : 'Continue working toward the active goal. Make concrete progress toward the executable goal. Do not mark the goal complete or blocked from this act phase.'
-    )
+            : 'Continue working toward the active goal. Make concrete progress toward the executable goal. Do not mark the goal complete or blocked from this act phase.',
+        additional_kwargs: {
+            hidden: true,
+            internal: true,
+            xpertInternalGoalAct: true
+        }
+    })
 }
 
 type GoalEvidence = {

--- a/packages/server-ai/src/xpert-middleware/ralph-loop.middleware.spec.ts
+++ b/packages/server-ai/src/xpert-middleware/ralph-loop.middleware.spec.ts
@@ -141,7 +141,14 @@ async function createRalphLoopAgentMiddleware(goalService = createGoalService())
 }
 
 type MiddlewareResultSnapshot = {
-    messages?: Array<{ content?: unknown }>
+    messages?: Array<{
+        content?: unknown
+        additional_kwargs?: {
+            internal?: unknown
+            xpertInternalGoalAct?: unknown
+            xpertInternalGoalVerify?: unknown
+        }
+    }>
     threadGoalContinuationCount?: number
     threadGoalPhase?: string
     threadGoalVerificationRetryCount?: number
@@ -338,6 +345,10 @@ describe('RalphLoopMiddleware', () => {
         })
         expect(snapshot.messages?.[0]).toBeInstanceOf(HumanMessage)
         expect(String(snapshot.messages?.[0]?.content)).toContain('Verify the active goal')
+        expect(snapshot.messages?.[0]?.additional_kwargs).toMatchObject({
+            internal: true,
+            xpertInternalGoalVerify: true
+        })
         expect(goalService.incrementContinuation).not.toHaveBeenCalled()
         expect(dispatchCustomEvent).toHaveBeenCalledWith(
             ChatMessageEventTypeEnum.ON_CHAT_EVENT,
@@ -527,6 +538,10 @@ describe('RalphLoopMiddleware', () => {
             jumpTo: 'model'
         })
         expect(String(snapshot.messages?.[0]?.content)).toContain('Collect verification evidence.')
+        expect(snapshot.messages?.[0]?.additional_kwargs).toMatchObject({
+            internal: true,
+            xpertInternalGoalAct: true
+        })
         expect(goalService.incrementContinuation).toHaveBeenCalledWith('conversation-1')
         expect(goalService.updateGoalFromModel).not.toHaveBeenCalled()
     })

--- a/packages/server-ai/src/xpert/commands/handlers/chat.handler.spec.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/chat.handler.spec.ts
@@ -22,6 +22,7 @@ import { of, lastValueFrom, toArray } from 'rxjs'
 import { ChatMessageEventTypeEnum, ChatMessageTypeEnum, XpertAgentExecutionStatusEnum } from '@xpert-ai/contracts'
 import { BadRequestException } from '@nestjs/common'
 import { ChatConversationUpsertCommand } from '../../../chat-conversation/commands/upsert.command'
+import type { ChatConversationGoalService } from '../../../chat-conversation/goal'
 import { ChatMessageUpsertCommand } from '../../../chat-message/commands/upsert.command'
 import { CopilotCheckpointGetTupleQuery } from '../../../copilot-checkpoint/queries'
 import { CreateMemoryStoreCommand } from '../../../shared/commands/create-memory-store.command'
@@ -42,6 +43,7 @@ describe('XpertChatHandler', () => {
     }
     let commandBus: { execute: jest.Mock }
     let queryBus: { execute: jest.Mock }
+    let goalService: Pick<ChatConversationGoalService, 'getByConversationId'>
     let redisSseStreamService: { wrapChatStream: jest.Mock }
     let handler: XpertChatHandler
 
@@ -90,6 +92,9 @@ describe('XpertChatHandler', () => {
         queryBus = {
             execute: jest.fn()
         }
+        goalService = {
+            getByConversationId: jest.fn().mockResolvedValue(null)
+        }
         redisSseStreamService = {
             wrapChatStream: jest.fn((stream) => stream)
         }
@@ -99,6 +104,7 @@ describe('XpertChatHandler', () => {
             assistantBindingService as any,
             commandBus as any,
             queryBus as any,
+            goalService as unknown as ChatConversationGoalService,
             redisSseStreamService as any
         )
     })
@@ -267,6 +273,114 @@ describe('XpertChatHandler', () => {
                 }
             }
         })
+    })
+
+    it('persists the active goal objective for marked internal goal runs', async () => {
+        const commands: unknown[] = []
+        goalService.getByConversationId = jest.fn().mockResolvedValue({
+            id: 'goal-1',
+            conversationId: 'conversation-1',
+            objective: '创建一个工作区技能，名字叫“请假申请整理助手”。'
+        })
+        commandBus.execute.mockImplementation(async (command: unknown) => {
+            commands.push(command)
+
+            if (command instanceof CreateMemoryStoreCommand) {
+                return null
+            }
+            if (command instanceof ChatConversationUpsertCommand) {
+                if (!command.entity.id) {
+                    return {
+                        id: 'conversation-1',
+                        threadId: 'thread-1',
+                        messages: [],
+                        status: command.entity.status,
+                        title: 'Continue working toward the active goal.',
+                        options: command.entity.options
+                    }
+                }
+                return {
+                    id: 'conversation-1',
+                    threadId: 'thread-1',
+                    status: command.entity.status,
+                    title: command.entity.title,
+                    error: command.entity.error,
+                    operation: command.entity.operation,
+                    options: command.entity.options
+                }
+            }
+            if (command instanceof XpertAgentExecutionUpsertCommand) {
+                if (command.execution.status === XpertAgentExecutionStatusEnum.RUNNING) {
+                    return {
+                        id: 'execution-1',
+                        threadId: 'thread-1'
+                    }
+                }
+                return command.execution
+            }
+            if (command instanceof ChatMessageUpsertCommand) {
+                if (command.entity.role === 'human') {
+                    return {
+                        id: 'human-1',
+                        ...command.entity
+                    }
+                }
+                if (command.entity.role === 'ai' && command.entity.status === 'thinking') {
+                    return {
+                        id: 'ai-1',
+                        ...command.entity
+                    }
+                }
+                return command.entity
+            }
+            if (command instanceof XpertAgentChatCommand) {
+                return of({
+                    data: {
+                        type: ChatMessageTypeEnum.EVENT,
+                        event: ChatMessageEventTypeEnum.ON_AGENT_END,
+                        data: {
+                            id: 'execution-1',
+                            status: XpertAgentExecutionStatusEnum.SUCCESS
+                        }
+                    }
+                } as MessageEvent)
+            }
+            return null
+        })
+
+        const stream = await handler.execute(
+            new XpertChatCommand(
+                {
+                    action: 'send',
+                    message: {
+                        clientMessageId: 'client-1',
+                        input: {
+                            input: 'Continue working toward the active goal.',
+                            xpertInternalGoalRun: true
+                        }
+                    }
+                },
+                {
+                    xpertId: 'xpert-1'
+                } as XpertChatCommandOptions
+            )
+        )
+
+        await lastValueFrom(stream.pipe(toArray()))
+
+        const humanMessageCommand = commands.find(
+            (command) => command instanceof ChatMessageUpsertCommand && command.entity.role === 'human'
+        ) as ChatMessageUpsertCommand
+        const finalConversationCommand = commands
+            .filter((command) => command instanceof ChatConversationUpsertCommand && command.entity.id)
+            .at(-1) as ChatConversationUpsertCommand
+
+        expect(humanMessageCommand.entity.content).toBe('创建一个工作区技能，名字叫“请假申请整理助手”。')
+        expect(humanMessageCommand.entity.content).not.toBe('Continue working toward the active goal.')
+        expect(humanMessageCommand.entity.thirdPartyMessage).toMatchObject({
+            internalGoalRun: true
+        })
+        expect(finalConversationCommand.entity.title).toBe('创建一个工作区技能，名字叫“请假申请整理助手”。')
     })
 
     it('does not persist ChatKit file attachment ids as FileAsset relations', async () => {

--- a/packages/server-ai/src/xpert/commands/handlers/chat.handler.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/chat.handler.ts
@@ -42,6 +42,7 @@ import { uniq } from 'lodash'
 import { CancelSummaryJobCommand } from '../../../chat-conversation/commands/cancel-summary.command'
 import { ScheduleSummaryJobCommand } from '../../../chat-conversation/commands/schedule-summary.command'
 import { ChatConversationUpsertCommand } from '../../../chat-conversation/commands/upsert.command'
+import { ChatConversationGoalService } from '../../../chat-conversation/goal'
 import { GetChatConversationQuery } from '../../../chat-conversation/queries/conversation-get.query'
 import { ChatMessageUpsertCommand } from '../../../chat-message/commands/upsert.command'
 import { XpertAgentExecutionUpsertCommand } from '../../../xpert-agent-execution/commands'
@@ -71,6 +72,41 @@ import { AttachFileToConversationCommand } from '../../../file-understanding'
 import { applicationMetrics } from '../../../metrics'
 import { applicationTracing } from '../../../tracing'
 
+function readBooleanMarker(container: unknown, property: string): boolean {
+    return !!container && typeof container === 'object' && Reflect.get(container, property) === true
+}
+
+function readObjectProperty(container: unknown, property: string): unknown {
+    if (!container || typeof container !== 'object' || Array.isArray(container)) {
+        return null
+    }
+    return Reflect.get(container, property)
+}
+
+function isInternalGoalRunInput(input: TChatRequestHuman | null | undefined): boolean {
+    const metadata = readObjectProperty(input, 'goalRunMetadata')
+    return (
+        readBooleanMarker(input, 'goalRun') ||
+        readBooleanMarker(input, 'internalGoalRun') ||
+        readBooleanMarker(input, 'xpertInternalGoalRun') ||
+        readBooleanMarker(metadata, 'internal') ||
+        readBooleanMarker(metadata, 'xpertInternalGoalRun')
+    )
+}
+
+function resolveVisibleConversationTitle(
+    conversationTitle: string | null | undefined,
+    executionTitle: string | null | undefined,
+    fallbackInput: string | null | undefined,
+    internalGoalRunInput: string | null | undefined
+) {
+    const existingTitle =
+        internalGoalRunInput?.trim() && conversationTitle?.trim() === internalGoalRunInput.trim()
+            ? null
+            : conversationTitle
+    return existingTitle || executionTitle || shortTitle(fallbackInput || '')
+}
+
 @CommandHandler(XpertChatCommand)
 export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
     readonly #logger = new Logger(XpertChatHandler.name)
@@ -80,6 +116,7 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
         private readonly assistantBindingService: AssistantBindingService,
         private readonly commandBus: CommandBus,
         private readonly queryBus: QueryBus,
+        private readonly goalService: ChatConversationGoalService,
         private readonly redisSseStreamService?: RedisSseStreamService
     ) {}
 
@@ -152,6 +189,7 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
         }
 
         const rawSendInput = request.action === 'send' ? sendInput : null
+        const isGoalRun = isInternalGoalRunInput(rawSendInput)
         const titleInput =
             typeof rawSendInput?.input === 'string' && rawSendInput.input.trim().length > 0
                 ? rawSendInput.input
@@ -309,6 +347,7 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
         let executionId: string
         let checkpointId: string = null
         let queueFollowUpConsumedEvent: TFollowUpConsumedEvent | null = null
+        let goalRunVisibleInput: string | null = null
         const requestedSandboxEnvironmentId = resolveRequestSandboxEnvironmentId(request)
         // Resume continues an interrupted AI turn in place by reusing the existing
         // conversation, target AI message, and execution instead of creating a new run.
@@ -424,6 +463,11 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                 }
             }
 
+            if (isGoalRun) {
+                const goal = await this.goalService.getByConversationId(conversation.id)
+                goalRunVisibleInput = goal?.objective?.trim() || null
+            }
+
             let userMessage: IChatMessage = null
             const persistedPendingFollowUpGroup =
                 request.action === 'send'
@@ -526,6 +570,7 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                     // marked consumed before the execution was created.
                 } else {
                     const persistedInput = rawSendInput ?? input
+                    const visibleInput = isGoalRun ? goalRunVisibleInput : persistedInput?.input
                     const references = normalizeReferences(persistedInput?.references)
                     const persistedRuntimeCapabilities =
                         getRuntimeCapabilitiesFromState(state) ??
@@ -533,8 +578,13 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                     const fileAssets = toFileAssetReferences(persistedInput?.files)
                     const legacyAttachments = toLegacyStorageFileAttachments(persistedInput?.files)
                     const thirdPartyMessage =
-                        persistedRuntimeCapabilities || persistedInput?.commandSource
+                        persistedRuntimeCapabilities || persistedInput?.commandSource || isGoalRun
                             ? {
+                                  ...(isGoalRun
+                                      ? {
+                                            internalGoalRun: true
+                                        }
+                                      : {}),
                                   ...(persistedRuntimeCapabilities
                                       ? {
                                             runtimeCapabilities: persistedRuntimeCapabilities
@@ -550,7 +600,7 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                     const _humanMessage: Partial<IChatMessage> = {
                         parent: conversation.messages[conversation.messages.length - 1],
                         role: 'human',
-                        content: persistedInput?.input,
+                        content: visibleInput,
                         conversationId: conversation.id,
                         ...(references.length
                             ? {
@@ -605,6 +655,7 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
         state = preparedAgentChatState.state
         input = preparedAgentChatState.input
         const runtimeCapabilities = preparedAgentChatState.runtimeCapabilities
+        const visibleConversationTitleInput = isGoalRun ? goalRunVisibleInput : titleInput || input?.input
 
         const stream = new Observable<MessageEvent>((subscriber) => {
             let chatMetricsFinished = false
@@ -629,7 +680,12 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                     event: ChatMessageEventTypeEnum.ON_CONVERSATION_START,
                     data: {
                         id: conversation.id,
-                        title: conversation.title || shortTitle(titleInput || input?.input),
+                        title: resolveVisibleConversationTitle(
+                            conversation.title,
+                            null,
+                            visibleConversationTitleInput,
+                            isGoalRun ? titleInput : null
+                        ),
                         status: conversation.status,
                         createdAt: conversation.createdAt,
                         updatedAt: conversation.updatedAt
@@ -873,10 +929,12 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                                     new ChatConversationUpsertCommand({
                                         id: conversation.id,
                                         status: convStatus,
-                                        title:
-                                            conversation.title ||
-                                            _execution?.title ||
-                                            shortTitle(titleInput || input?.input),
+                                        title: resolveVisibleConversationTitle(
+                                            conversation.title,
+                                            _execution?.title,
+                                            visibleConversationTitleInput,
+                                            isGoalRun ? titleInput : null
+                                        ),
                                         operation,
                                         error: _execution?.error,
                                         options: conversation.options
@@ -947,10 +1005,12 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                                         new ChatConversationUpsertCommand({
                                             id: conversation.id,
                                             status: 'idle',
-                                            title:
-                                                conversation.title ||
-                                                _execution?.title ||
-                                                shortTitle(titleInput || input?.input),
+                                            title: resolveVisibleConversationTitle(
+                                                conversation.title,
+                                                _execution?.title,
+                                                visibleConversationTitleInput,
+                                                isGoalRun ? titleInput : null
+                                            ),
                                             options: conversation.options
                                         })
                                     )

--- a/packages/server-ai/src/xpert/commands/handlers/chat.reference-only.spec.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/chat.reference-only.spec.ts
@@ -20,6 +20,7 @@ jest.mock('@xpert-ai/contracts', () => {
 
 import { lastValueFrom, of, toArray } from 'rxjs'
 import { ChatMessageEventTypeEnum, ChatMessageTypeEnum, XpertAgentExecutionStatusEnum } from '@xpert-ai/contracts'
+import type { ChatConversationGoalService } from '../../../chat-conversation/goal'
 import { ChatConversationUpsertCommand } from '../../../chat-conversation/commands/upsert.command'
 import { ChatMessageUpsertCommand } from '../../../chat-message/commands/upsert.command'
 import { CreateMemoryStoreCommand } from '../../../shared/commands/create-memory-store.command'
@@ -36,6 +37,7 @@ describe('XpertChatHandler reference-only inputs', () => {
     }
     let commandBus: { execute: jest.Mock }
     let queryBus: { execute: jest.Mock }
+    let goalService: Pick<ChatConversationGoalService, 'getByConversationId'>
     let handler: XpertChatHandler
 
     const xpert = {
@@ -69,12 +71,16 @@ describe('XpertChatHandler reference-only inputs', () => {
         queryBus = {
             execute: jest.fn()
         }
+        goalService = {
+            getByConversationId: jest.fn().mockResolvedValue(null)
+        }
 
         handler = new XpertChatHandler(
             xpertService as any,
             assistantBindingService as any,
             commandBus as any,
-            queryBus as any
+            queryBus as any,
+            goalService as unknown as ChatConversationGoalService
         )
     })
 


### PR DESCRIPTION
## Summary

- Mark Ralph Loop act messages with internal goal-run metadata instead of relying on the visible prompt text.
- Persist the active goal objective for marked internal goal runs so conversation logs/titles show the user goal rather than `Continue working toward the active goal.`.
- Cover the goal-run title/message behavior and update affected handler specs for the new goal service dependency.

## Validation

- `pnpm jest --config packages/server-ai/jest.config.ts --runTestsByPath packages/server-ai/src/xpert/commands/handlers/chat.reference-only.spec.ts packages/server-ai/src/xpert/commands/handlers/chat.handler.spec.ts packages/server-ai/src/xpert-middleware/ralph-loop.middleware.spec.ts --runInBand`
- `pnpm nx build server-ai`
- `git diff --check origin/develop...HEAD`

## Notes

- This PR is isolated from the local SMTP, Copilot, and user-management working tree changes.