### PR TITLE
[codex] Promote plugin navigation

### DIFF
--- a/apps/cloud/src/app/features/features-routing.module.spec.ts
+++ b/apps/cloud/src/app/features/features-routing.module.spec.ts
@@ -5,6 +5,9 @@ jest.mock('../@core', () => ({
     MODELS_EDIT: 'MODELS_EDIT',
     INDICATOR_MARTKET_VIEW: 'INDICATOR_MARTKET_VIEW'
   },
+  AIPermissionsEnum: {
+    XPERT_EDIT: 'XPERT_EDIT'
+  },
   authGuard: jest.fn()
 }))
 
@@ -24,6 +27,7 @@ jest.mock('../app.service', () => ({
   }
 }))
 
+import { NgxPermissionsGuard } from 'ngx-permissions'
 import { routes } from './features-routing.module'
 
 describe('features routing', () => {
@@ -45,5 +49,14 @@ describe('features routing', () => {
   it('mounts the data container at /data and removes the legacy /models route', () => {
     expect(children.some((item) => item.path === 'data')).toBe(true)
     expect(children.some((item) => item.path === 'models')).toBe(false)
+  })
+
+  it('mounts plugins at the top level behind the Xpert edit permission', () => {
+    const route = children.find((item) => item.path === 'plugins')
+
+    expect(route?.loadComponent).toEqual(expect.any(Function))
+    expect(route?.canActivate).toContain(NgxPermissionsGuard)
+    expect(route?.data?.scopeContext).toBe('dual-scope')
+    expect(route?.data?.permissions?.only).toEqual(['XPERT_EDIT'])
   })
 })

--- a/apps/cloud/src/app/features/features-routing.module.ts
+++ b/apps/cloud/src/app/features/features-routing.module.ts
@@ -1,7 +1,7 @@
 import { inject, NgModule } from '@angular/core'
 import { RouterModule, Routes } from '@angular/router'
 import { NgxPermissionsGuard } from 'ngx-permissions'
-import { AnalyticsPermissionsEnum, authGuard } from '../@core'
+import { AIPermissionsEnum, AnalyticsPermissionsEnum, authGuard } from '../@core'
 import { FeaturesComponent } from './features.component'
 import { NotFoundComponent } from '../@shared/not-found'
 import { AppService } from '../app.service'
@@ -76,6 +76,19 @@ export const routes: Routes = [
         data: {
           title: 'Xpert Agent',
           scopeContext: 'dual-scope'
+        }
+      },
+      {
+        path: 'plugins',
+        loadComponent: () => import('./setting/plugins/plugins.component').then((m) => m.PluginsComponent),
+        canActivate: [authGuard, NgxPermissionsGuard],
+        data: {
+          title: 'Plugins',
+          scopeContext: 'dual-scope',
+          permissions: {
+            only: [AIPermissionsEnum.XPERT_EDIT],
+            redirectTo
+          }
         }
       },
 

--- a/apps/cloud/src/app/features/menus.spec.ts
+++ b/apps/cloud/src/app/features/menus.spec.ts
@@ -1,5 +1,5 @@
-import { RequestScopeLevel } from '../@core/types'
-import { getSettingsMenuItems } from './menus'
+import { AiFeatureEnum, AIPermissionsEnum, RequestScopeLevel } from '../@core/types'
+import { getFeatureMenus, getSettingsMenuItems } from './menus'
 
 describe('getSettingsMenuItems', () => {
   it('marks legacy settings menus as deprecated', () => {
@@ -9,5 +9,28 @@ describe('getSettingsMenuItems', () => {
     for (const path of deprecatedPaths) {
       expect(menus.find((item) => item.path === path)?.deprecated).toBe(true)
     }
+  })
+
+  it('removes plugins from the settings menu after promotion', () => {
+    const menus = getSettingsMenuItems(RequestScopeLevel.ORGANIZATION)
+
+    expect(menus.find((item) => item.path === 'plugins')).toBeUndefined()
+  })
+})
+
+describe('getFeatureMenus', () => {
+  it('promotes plugins to the bottom top-level Xpert-gated menu item', () => {
+    const menus = getFeatureMenus(RequestScopeLevel.ORGANIZATION, null)
+    const plugins = menus.find((item) => item.link === '/plugins')
+
+    expect(plugins).toMatchObject({
+      title: 'Plugins',
+      icon: 'ri-puzzle-2-line',
+      pathMatch: 'prefix',
+      scopeContext: 'dual-scope'
+    })
+    expect(menus.at(-1)?.link).toBe('/plugins')
+    expect(plugins?.data?.featureKey).toBe(AiFeatureEnum.FEATURE_XPERT)
+    expect(plugins?.data?.permissionKeys).toEqual([AIPermissionsEnum.XPERT_EDIT])
   })
 })

--- a/apps/cloud/src/app/features/menus.ts
+++ b/apps/cloud/src/app/features/menus.ts
@@ -195,15 +195,6 @@ export function getSettingsMenuItems(scopeLevel: RequestScopeLevel): SettingsMen
       }
     },
     {
-      path: 'plugins',
-      label: 'Plugins',
-      icon: 'extension',
-      scopeContext: 'dual-scope',
-      data: {
-        permissionKeys: [RolesEnum.SUPER_ADMIN, RolesEnum.ADMIN, RolesEnum.TRIAL]
-      }
-    },
-    {
       path: 'tenant',
       label: 'Tenant',
       icon: 'storage',
@@ -410,6 +401,18 @@ export function getFeatureMenus(scopeLevel: RequestScopeLevel, _org: IOrganizati
       data: {
         translationKey: 'Settings',
         featureKey: FeatureEnum.FEATURE_SETTING
+      }
+    },
+    {
+      title: 'Plugins',
+      icon: 'ri-puzzle-2-line',
+      link: '/plugins',
+      pathMatch: 'prefix',
+      scopeContext: 'dual-scope',
+      data: {
+        translationKey: 'Plugins',
+        featureKey: AiFeatureEnum.FEATURE_XPERT,
+        permissionKeys: [AIPermissionsEnum.XPERT_EDIT]
       }
     }
   ]

--- a/apps/cloud/src/app/features/setting/setting-routing.module.ts
+++ b/apps/cloud/src/app/features/setting/setting-routing.module.ts
@@ -7,7 +7,6 @@ import { PACAccountComponent } from './account/account.component'
 import { PACAccountPasswordComponent } from './account/password.component'
 import { PACAccountProfileComponent } from './account/profile.component'
 import { PACSettingComponent } from './settings.component'
-import { PluginsComponent } from './plugins/plugins.component'
 
 const routes: Routes = [
   {
@@ -269,15 +268,10 @@ const routes: Routes = [
       },
       {
         path: 'plugins',
-        component: PluginsComponent,
-        canActivate: [NgxPermissionsGuard],
+        redirectTo: '/plugins',
+        pathMatch: 'full',
         data: {
-          title: 'settings/plugins',
-          scopeContext: 'dual-scope',
-          permissions: {
-            only: [RolesEnum.SUPER_ADMIN, RolesEnum.ADMIN, RolesEnum.TRIAL],
-            redirectTo
-          }
+          title: 'settings/plugins'
         }
       },
       {
@@ -287,7 +281,7 @@ const routes: Routes = [
         data: {
           title: 'settings/skill-repository'
         }
-      },
+      }
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Promote the Plugins entry from the Settings submenu to a top-level navigation item at the bottom of the main menu.

The new top-level menu item and `/plugins` route are both gated by `AIPermissionsEnum.XPERT_EDIT`, which corresponds to the digital expert management permission. The old `/settings/plugins` route now redirects to `/plugins` so existing direct links keep working.

## Root cause

Plugins were still exposed through the Settings second-level menu and used the old role-based Settings menu visibility. After moving Plugins to first-level navigation, both the menu item and the route needed to be controlled by the same digital expert access permission to avoid showing or allowing access without digital expert authority.

## Changes

- Remove Plugins from the Settings child menu.
- Add Plugins as a bottom top-level menu item.
- Add a guarded top-level `/plugins` route using `NgxPermissionsGuard` and `AIPermissionsEnum.XPERT_EDIT`.
- Redirect `/settings/plugins` to `/plugins` for backward compatibility.
- Add focused menu and route tests for the new placement and permission guard.

## Validation

- `NX_SKIP_NX_CACHE=true pnpm nx test cloud --runInBand --testPathPatterns=apps/cloud/src/app/features/menus.spec.ts --testPathPatterns=apps/cloud/src/app/features/features-routing.module.spec.ts`
  - 2 test suites passed
  - 7 tests passed
- `git diff --cached --check -- apps/cloud/src/app/features/features-routing.module.spec.ts apps/cloud/src/app/features/features-routing.module.ts apps/cloud/src/app/features/menus.spec.ts apps/cloud/src/app/features/menus.ts apps/cloud/src/app/features/setting/setting-routing.module.ts`