### PR TITLE
fix: sync datasource types on bootstrap

### DIFF
--- a/packages/analytics/src/app.service.spec.ts
+++ b/packages/analytics/src/app.service.spec.ts
@@ -1,0 +1,42 @@
+jest.mock('./data-source-type/data-source-type.service', () => ({
+	DataSourceTypeService: class DataSourceTypeService {}
+}))
+
+jest.mock('./model/model.service', () => ({
+	SemanticModelService: class SemanticModelService {}
+}))
+
+import { Test } from '@nestjs/testing'
+import { DataSourceTypeService } from './data-source-type/data-source-type.service'
+import { AnalyticsService } from './app.service'
+import { SemanticModelService } from './model/model.service'
+
+describe('AnalyticsService', () => {
+	it('syncs plugin datasource types during application bootstrap', async () => {
+		const dataSourceTypeService = {
+			syncAllTenants: jest.fn()
+		}
+		const modelService = {
+			seedIfEmpty: jest.fn()
+		}
+		const testingModule = await Test.createTestingModule({
+			providers: [
+				AnalyticsService,
+				{
+					provide: DataSourceTypeService,
+					useValue: dataSourceTypeService
+				},
+				{
+					provide: SemanticModelService,
+					useValue: modelService
+				}
+			]
+		}).compile()
+		const service = testingModule.get(AnalyticsService)
+
+		await service.seedDBIfEmpty()
+
+		expect(dataSourceTypeService.syncAllTenants).toHaveBeenCalled()
+		expect(modelService.seedIfEmpty).toHaveBeenCalled()
+	})
+})

--- a/packages/analytics/src/app.service.ts
+++ b/packages/analytics/src/app.service.ts
@@ -1,7 +1,7 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import * as chalk from 'chalk';
-import { DataSourceTypeService } from './data-source-type/data-source-type.service';
-import { SemanticModelService } from './model/model.service';
+import { forwardRef, Inject, Injectable } from '@nestjs/common'
+import * as chalk from 'chalk'
+import { DataSourceTypeService } from './data-source-type/data-source-type.service'
+import { SemanticModelService } from './model/model.service'
 
 @Injectable()
 export class AnalyticsService {
@@ -17,17 +17,18 @@ export class AnalyticsService {
 		// if (this.count === 0) {
 		// await this.dsTypeService.seed()
 		// }
+		await this.dsTypeService.syncAllTenants()
 		await this.modelService.seedIfEmpty()
 	}
 
 	constructor(
 		// private readonly commandBus: CommandBus,
-		
+
 		@Inject(forwardRef(() => DataSourceTypeService))
 		private readonly dsTypeService: DataSourceTypeService,
 
 		@Inject(forwardRef(() => SemanticModelService))
-		private readonly modelService: SemanticModelService,
+		private readonly modelService: SemanticModelService
 	) {}
 
 	getHello(): string {

--- a/packages/analytics/src/data-source-type/data-source-type.service.spec.ts
+++ b/packages/analytics/src/data-source-type/data-source-type.service.spec.ts
@@ -1,0 +1,224 @@
+import { Test } from '@nestjs/testing'
+import { getEntityManagerToken, getRepositoryToken } from '@nestjs/typeorm'
+import { DataSourceProtocolEnum, DataSourceSyntaxEnum } from '@xpert-ai/contracts'
+import { DataSourceStrategyRegistry, DBQueryRunner } from '@xpert-ai/plugin-sdk'
+import { TenantCreatedEvent } from '@xpert-ai/server-core'
+import { DataSourceType } from './data-source-type.entity'
+import { DataSourceTypeService } from './data-source-type.service'
+
+jest.mock('@xpert-ai/adapter', () => {
+	class BuiltinRunner {
+		readonly name = 'Builtin'
+		readonly type = 'builtin'
+		readonly syntax = 'sql'
+		readonly protocol = 'sql'
+		readonly configurationSchema = {}
+	}
+
+	return {
+		QUERY_RUNNERS: {
+			builtin: BuiltinRunner
+		}
+	}
+})
+
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+	DataSourceStrategyRegistry: class DataSourceStrategyRegistry {}
+}))
+
+jest.mock('@xpert-ai/server-core', () => {
+	class TenantBaseEntity {
+		id?: string
+		tenantId?: string
+	}
+
+	class Tenant {
+		id?: string
+	}
+
+	class TenantCreatedEvent {
+		constructor(
+			public readonly tenantId: string,
+			public readonly tenantName: string
+		) {}
+	}
+
+	class TenantAwareCrudService<T> {
+		protected readonly repository: {
+			create: (entity: Partial<T>) => Partial<T>
+			save: (entity: Partial<T>) => Promise<Partial<T>>
+			update?: (id: string, entity: Partial<T>) => Promise<unknown>
+		}
+
+		constructor(repository: {
+			create: (entity: Partial<T>) => Partial<T>
+			save: (entity: Partial<T>) => Promise<Partial<T>>
+			update?: (id: string, entity: Partial<T>) => Promise<unknown>
+		}) {
+			this.repository = repository
+		}
+
+		async create(entity: Partial<T>) {
+			return this.repository.save(this.repository.create(entity))
+		}
+
+		async update(id: string, entity: Partial<T>) {
+			return this.repository.update?.(id, entity)
+		}
+	}
+
+	return {
+		RequestContext: {
+			currentTenantId: jest.fn(() => 'tenant-1')
+		},
+		Tenant,
+		TenantAwareCrudService,
+		TenantBaseEntity,
+		TenantCreatedEvent
+	}
+})
+
+jest.mock('./data-source-type.entity', () => ({
+	DataSourceType: class DataSourceType {}
+}))
+
+class PluginMySQLRunner {
+	readonly name = 'MySQL'
+	readonly type = 'mysql'
+	readonly syntax = DataSourceSyntaxEnum.SQL
+	readonly protocol = DataSourceProtocolEnum.SQL
+	readonly configurationSchema = {
+		type: 'object',
+		properties: {
+			host: { type: 'string' }
+		}
+	}
+}
+
+describe('DataSourceTypeService', () => {
+	const savedDataSourceTypes: Array<Partial<DataSourceType>> = []
+	const repository = {
+		findOne: jest.fn(),
+		create: jest.fn((entity: Partial<DataSourceType>) => entity),
+		save: jest.fn(async (entity: Partial<DataSourceType>) => {
+			savedDataSourceTypes.push(entity)
+			return entity
+		}),
+		update: jest.fn()
+	}
+	const entityManager = {
+		find: jest.fn()
+	}
+	const pluginStrategy = {
+		type: 'mysql',
+		name: 'MySQL Data Source',
+		create: jest.fn(),
+		getClassType: jest.fn(() => PluginMySQLRunner)
+	}
+	const dataSourceStrategyRegistry = {
+		list: jest.fn(() => [pluginStrategy])
+	}
+
+	let service: DataSourceTypeService
+
+	beforeEach(async () => {
+		jest.clearAllMocks()
+		savedDataSourceTypes.length = 0
+		repository.findOne.mockResolvedValue(null)
+		entityManager.find.mockResolvedValue([{ id: 'tenant-1' }, { id: 'tenant-2' }])
+
+		const testingModule = await Test.createTestingModule({
+			providers: [
+				DataSourceTypeService,
+				{
+					provide: getRepositoryToken(DataSourceType),
+					useValue: repository
+				},
+				{
+					provide: getEntityManagerToken(),
+					useValue: entityManager
+				},
+				{
+					provide: DataSourceStrategyRegistry,
+					useValue: dataSourceStrategyRegistry
+				}
+			]
+		}).compile()
+
+		service = testingModule.get(DataSourceTypeService)
+		service.log = jest.fn()
+	})
+
+	it('syncs plugin datasource strategies when a tenant is created', async () => {
+		await service.handleTenantCreatedEvent(new TenantCreatedEvent('tenant-1', 'Tenant 1'))
+
+		expect(savedDataSourceTypes).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tenantId: 'tenant-1',
+					name: 'MySQL',
+					type: 'mysql',
+					protocol: DataSourceProtocolEnum.SQL,
+					syntax: DataSourceSyntaxEnum.SQL
+				})
+			])
+		)
+	})
+
+	it('syncs plugin datasource strategies for existing tenants', async () => {
+		await service.syncAllTenants()
+
+		expect(savedDataSourceTypes).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tenantId: 'tenant-1',
+					name: 'MySQL',
+					type: 'mysql'
+				}),
+				expect.objectContaining({
+					tenantId: 'tenant-2',
+					name: 'MySQL',
+					type: 'mysql'
+				})
+			])
+		)
+	})
+
+	it('does not update an existing datasource type when configuration is unchanged', async () => {
+		const configuration = {
+			type: 'object',
+			properties: {
+				host: { type: 'string' }
+			}
+		}
+		repository.findOne.mockResolvedValue({
+			id: 'datasource-type-1',
+			configuration
+		})
+
+		await service.upsertDataSourceType('tenant-1', new PluginMySQLRunner() as unknown as DBQueryRunner)
+
+		expect(repository.update).not.toHaveBeenCalled()
+	})
+
+	it('updates an existing datasource type when configuration changes', async () => {
+		repository.findOne.mockResolvedValue({
+			id: 'datasource-type-1',
+			configuration: {
+				type: 'object',
+				properties: {}
+			}
+		})
+
+		await service.upsertDataSourceType('tenant-1', new PluginMySQLRunner() as unknown as DBQueryRunner)
+
+		expect(repository.update).toHaveBeenCalledWith('datasource-type-1', {
+			configuration: {
+				type: 'object',
+				properties: {
+					host: { type: 'string' }
+				}
+			}
+		})
+	})
+})

--- a/packages/analytics/src/data-source-type/data-source-type.service.ts
+++ b/packages/analytics/src/data-source-type/data-source-type.service.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from 'node:util'
 import { DataSourceProtocolEnum, DataSourceSyntaxEnum } from '@xpert-ai/contracts'
 import { environment as env } from '@xpert-ai/server-config'
 import { RequestContext, Tenant, TenantAwareCrudService, TenantCreatedEvent } from '@xpert-ai/server-core'
@@ -9,7 +10,6 @@ import { DataSourceStrategyRegistry, DBQueryRunner } from '@xpert-ai/plugin-sdk'
 import chalk from 'chalk'
 import { EntityManager, Repository } from 'typeorm'
 import { DataSourceType } from './data-source-type.entity'
-import { seedDefaultDataSourceTypes } from './data-source-type.seed'
 
 @Injectable()
 export class DataSourceTypeService extends TenantAwareCrudService<DataSourceType> {
@@ -23,7 +23,7 @@ export class DataSourceTypeService extends TenantAwareCrudService<DataSourceType
 		@InjectRepository(DataSourceType)
 		dsTypeRepository: Repository<DataSourceType>,
 		@InjectEntityManager()
-		private entityManager: EntityManager,
+		private entityManager: EntityManager
 	) {
 		super(dsTypeRepository)
 	}
@@ -32,12 +32,22 @@ export class DataSourceTypeService extends TenantAwareCrudService<DataSourceType
 	async handleTenantCreatedEvent(event: TenantCreatedEvent) {
 		this.logger.debug('Tenant Created Event: seed dataSource types')
 		const { tenantId } = event
-		const tenant = await this.entityManager.findOne(Tenant, {where: { id: tenantId }})
-		await seedDefaultDataSourceTypes(this.entityManager.connection, tenant)
+		await this.syncForTenant(tenantId)
 	}
 
 	async sync() {
 		const tenantId = RequestContext.currentTenantId()
+		await this.syncForTenant(tenantId)
+	}
+
+	async syncAllTenants() {
+		const tenants = await this.entityManager.find(Tenant)
+		for (const tenant of tenants) {
+			await this.syncForTenant(tenant.id)
+		}
+	}
+
+	async syncForTenant(tenantId: string) {
 		this.log(
 			chalk.magenta(
 				`🌱 SEEDING DATA SOURCE TYPES ${
@@ -78,6 +88,10 @@ export class DataSourceTypeService extends TenantAwareCrudService<DataSourceType
 				configuration: queryRunner.configurationSchema
 			})
 		} else {
+			if (isDeepStrictEqual(dataSourceType.configuration, queryRunner.configurationSchema)) {
+				this.log(chalk.gray(`Datasource type '${queryRunner.name}' unchanged for tenant: ${tenantId}`))
+				return dataSourceType
+			}
 			this.log(chalk.blue(`Update datasource type '${queryRunner.name}' for tenant: ${tenantId}`))
 			await this.update(dataSourceType.id, { configuration: queryRunner.configurationSchema } as DataSourceType)
 		}


### PR DESCRIPTION
## Summary
- Sync plugin-backed datasource types during analytics bootstrap.
- Reuse the datasource type sync path for tenant creation and current-tenant sync.
- Avoid rewriting datasource type configuration when the generated configuration is unchanged.

## Root Cause
Datasource strategies loaded from plugins could be available at runtime without corresponding `data_source_type` rows for existing tenants. Analytics bootstrap did not refresh datasource types, and tenant creation still used the older default seed path.

## User Impact
Existing tenants get plugin-backed datasource type rows synced when analytics boots, so datasource options registered by plugins are available without manual repair.

## Validation
- `git diff --check origin/develop...HEAD`
- `pnpm exec jest --config packages/analytics/jest.config.ts --runTestsByPath packages/analytics/src/app.service.spec.ts packages/analytics/src/data-source-type/data-source-type.service.spec.ts --runInBand`