### PR TITLE
feat: refine data source settings and model filters

### DIFF
--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.html
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.html
@@ -18,7 +18,7 @@
 <div
   #modelContainer
   #mt="cdkMenuTriggerFor"
-  class="container group/container flex items-center px-1 h-8 rounded-lg border border-divider-regular bg-components-input-bg-normal hover:border-divider-deep"
+  class="model-select-trigger group/container flex w-full items-center px-1 h-8 rounded-lg border border-divider-regular bg-components-input-bg-normal hover:border-divider-deep"
   [cdkMenuTriggerFor]="readonly() ? null : modelsMenu"
   [cdkMenuTriggerData]="{ mt: mt }"
   (cdkMenuOpened)="syncActiveCopilotTab()"
@@ -68,66 +68,64 @@
         <img [src]="copilot.providerWithModels.icon_small | i18n" class="w-4 h-4 mx-1.5" />
       }
 
-      <div class="flex items-center truncate text-[13px] font-medium mr-1.5">
-        <div class="truncate" [title]="_copilotModel()?.model">{{ _copilotModel()?.model }}</div>
-        @if (selectedAiModel(); as model) {
-          @switch (model.model_type) {
-            @case (eModelType.LLM) {
+      @if (selectedAiModel(); as model) {
+        <ng-template #selectedModelTagsPreview>
+          <div class="w-[220px] p-3">
+            <div class="flex min-w-0 items-center gap-2">
+              @if (copilot.providerWithModels.icon_small) {
+                <img [src]="copilot.providerWithModels.icon_small | i18n" class="h-4 w-4 shrink-0" />
+              }
               <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1"
+                class="min-w-0 truncate text-[13px] font-semibold text-text-primary"
+                [title]="_copilotModel()?.model"
               >
-                {{ 'PAC.Copilot.Chat' | translate: { Default: 'Chat' } }}
+                {{ _copilotModel()?.model }}
               </div>
-            }
-            @case (eModelType.RERANK) {
-              <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1"
-              >
-                <i class="ri-sort-number-asc"></i>
-              </div>
-            }
-            @case (eModelType.TEXT_EMBEDDING) {
-              <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1"
-              >
-                <i class="ri-text-block"></i>
-              </div>
-            }
-            @case (eModelType.SPEECH2TEXT) {
-              <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1"
-              >
-                <i class="ri-speech-to-text-line"></i>
-              </div>
-            }
-            @case (eModelType.TTS) {
-              <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1"
-              >
-                <i class="ri-text-to-speech-line"></i>
-              </div>
-            }
-            @default {}
-          }
-          @if (
-            model.features?.includes(eModelFeature.TOOL_CALL) || model.features?.includes(eModelFeature.MULTI_TOOL_CALL)
-          ) {
-            <div
-              class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 w-[18px] justify-center opacity-60"
-            >
-              <i class="ri-hammer-fill"></i>
             </div>
-          }
-          @if (model.features?.includes(eModelFeature.VISION)) {
-            <div
-              class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 w-[18px] justify-center opacity-60"
-            >
-              <i class="ri-eye-fill"></i>
+            <div class="mt-2 flex flex-wrap gap-1">
+              @for (tag of modelDisplayTags(model); track tag.id) {
+                <div
+                  class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap"
+                >
+                  @if (tag.iconClass) {
+                    <i class="mr-0.5 text-[11px] leading-none" [ngClass]="tag.iconClass"></i>
+                  }
+                  {{ tag.defaultText }}
+                </div>
+              }
             </div>
+          </div>
+        </ng-template>
+        <div
+          class="flex min-w-0 flex-1 items-center text-[13px] font-medium mr-1.5"
+          [zTooltip]="showInlineSelectedModelTags(modelContainer) ? null : selectedModelTagsPreview"
+          [zTooltipClass]="
+            showInlineSelectedModelTags(modelContainer)
+              ? ''
+              : 'px-0 py-0 rounded-xl border border-divider-regular bg-components-card-bg text-text-primary shadow-lg [&>span]:hidden'
+          "
+          zPosition="left"
+        >
+          <div class="min-w-0 truncate" [title]="_copilotModel()?.model">{{ _copilotModel()?.model }}</div>
+          @if (showInlineSelectedModelTags(modelContainer)) {
+            @for (tag of modelDisplayTags(model); track tag.id; let first = $first) {
+              <div
+                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 whitespace-nowrap"
+                [class.opacity-60]="!first"
+              >
+                @if (tag.iconClass) {
+                  <i class="mr-0.5 text-[11px] leading-none" [ngClass]="tag.iconClass"></i>
+                }
+                {{ tag.defaultText }}
+              </div>
+            }
           }
-        }
-        <div class="inline-block cursor-help"></div>
-      </div>
+        </div>
+      } @else {
+        <div class="min-w-0 flex-1 truncate text-[13px] font-medium mr-1.5" [title]="_copilotModel()?.model">
+          {{ _copilotModel()?.model }}
+        </div>
+      }
     } @else if (__copilotModel()) {
       <div class="truncate text-sm text-text-warning" [title]="__copilotModel().model">
         {{ 'PAC.Copilot.ChooseRightCopilot' | translate: { Default: 'Please choose right copilot' } }}
@@ -309,6 +307,41 @@
           [ngModelOptions]="{ standalone: true }"
         />
       </div>
+      @if (modelFilterTags().length) {
+        <div class="mt-2 flex min-w-0 items-center gap-1.5 overflow-x-auto">
+          <span class="shrink-0 text-[11px] font-medium text-text-tertiary">
+            {{ 'PAC.Copilot.ModelFilters' | translate: { Default: 'Filters' } }}
+          </span>
+          @for (filter of modelFilterTags(); track filter.id) {
+            <button
+              type="button"
+              [class]="
+                'inline-flex shrink-0 items-center whitespace-nowrap rounded-[5px] border px-1.5 py-0.5 text-[10px] font-medium transition-colors ' +
+                (isModelFilterSelected(filter.id)
+                  ? 'border-primary-500 bg-components-panel-bg text-primary-600'
+                  : 'border-divider-regular bg-components-panel-bg text-text-tertiary hover:border-divider-deep hover:text-text-primary')
+              "
+              (mousedown)="$event.preventDefault(); $event.stopPropagation()"
+              (click)="$event.stopPropagation(); toggleModelFilter(filter.id)"
+            >
+              @if (filter.iconClass) {
+                <i class="mr-0.5 text-[11px] leading-none" [ngClass]="filter.iconClass"></i>
+              }
+              {{ filter.defaultText }}
+            </button>
+          }
+          @if (selectedModelFilters().length) {
+            <button
+              type="button"
+              class="shrink-0 rounded-[5px] px-1.5 py-0.5 text-[10px] font-medium text-text-tertiary hover:bg-hover-bg hover:text-text-primary"
+              (mousedown)="$event.preventDefault(); $event.stopPropagation()"
+              (click)="$event.stopPropagation(); clearModelFilters()"
+            >
+              {{ 'PAC.Copilot.ClearFilters' | translate: { Default: 'Clear' } }}
+            </button>
+          }
+        </div>
+      }
     </div>
 
     <div class="min-h-0 flex-1 overflow-hidden">
@@ -400,7 +433,12 @@
 
                 <ng-container
                   [ngTemplateOutlet]="copilotModels"
-                  [ngTemplateOutletContext]="{ $implicit: copilot, mt: mt }"
+                  [ngTemplateOutletContext]="{
+                    $implicit: copilot,
+                    mt: mt,
+                    menuWidth: menuWidth,
+                    menuRailWidth: menuRailWidth
+                  }"
                 />
               </z-tab>
             }
@@ -420,7 +458,10 @@
   </div>
 </ng-template>
 
-<ng-template #copilotModels let-copilot let-mt="mt">
+<ng-template #copilotModels let-copilot let-mt="mt" let-menuWidth="menuWidth" let-menuRailWidth="menuRailWidth">
+  @let showInlineTags = showInlineModelTags(menuWidth, menuRailWidth);
+  @let visibleModels = getVisibleCopilotModels(copilot);
+
   <div class="sticky top-0 z-10 flex items-center bg-components-card-bg px-4 pb-3 pt-4 text-base font-semibold">
     <div class="min-w-0 text-left">
       <span>{{ copilot.providerWithModels?.label | i18n }}</span>
@@ -435,7 +476,31 @@
     </div>
   </div>
 
-  @for (item of copilot.providerWithModels?.models; track item.model) {
+  @for (item of visibleModels; track item.model) {
+    <ng-template #modelTagsPreview>
+      <div class="w-[220px] p-3">
+        <div class="flex min-w-0 items-center gap-2">
+          @if (copilot.providerWithModels.icon_small) {
+            <img [src]="copilot.providerWithModels.icon_small | i18n" class="h-4 w-4 shrink-0" />
+          }
+          <div class="min-w-0 truncate text-[13px] font-semibold text-text-primary" [title]="item.model">
+            {{ item.model }}
+          </div>
+        </div>
+        <div class="mt-2 flex flex-wrap gap-1">
+          @for (tag of modelDisplayTags(item); track tag.id) {
+            <div
+              class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap"
+            >
+              @if (tag.iconClass) {
+                <i class="mr-0.5 text-[11px] leading-none" [ngClass]="tag.iconClass"></i>
+              }
+              {{ tag.defaultText }}
+            </div>
+          }
+        </div>
+      </div>
+    </ng-template>
     <button
       type="button"
       class="flex w-full min-w-0 items-center justify-start gap-0.5 rounded-xl px-2.5 py-2 text-left cursor-pointer enabled:hover:bg-hover-bg hover:text-primary-500 disabled:cursor-not-allowed"
@@ -445,7 +510,18 @@
           : ''
       "
       [class.opacity-60]="item.deprecated"
-      [zTooltip]="item.deprecated ? ('PAC.Copilot.Deprecated' | translate: { Default: 'Deprecated' }) : ''"
+      [zTooltip]="
+        item.deprecated
+          ? ('PAC.Copilot.Deprecated' | translate: { Default: 'Deprecated' })
+          : showInlineTags
+            ? null
+            : modelTagsPreview
+      "
+      [zTooltipClass]="
+        item.deprecated || showInlineTags
+          ? ''
+          : 'px-0 py-0 rounded-xl border border-divider-regular bg-components-card-bg text-text-primary shadow-lg [&>span]:hidden'
+      "
       zPosition="left"
       [disabled]="item.deprecated"
       (click)="setModel(copilot, item); mt.close()"
@@ -461,56 +537,17 @@
         customClasses="text-primary-600"
         >{{ item.model }}</span
       >
-      @switch (item.model_type) {
-        @case (eModelType.LLM) {
+      @if (showInlineTags) {
+        @for (tag of modelDisplayTags(item); track tag.id) {
           <div
-            class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
+            class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 whitespace-nowrap opacity-60"
           >
-            {{ 'PAC.Copilot.Chat' | translate: { Default: 'Chat' } }}
+            @if (tag.iconClass) {
+              <i class="mr-0.5 text-[11px] leading-none" [ngClass]="tag.iconClass"></i>
+            }
+            {{ tag.defaultText }}
           </div>
         }
-        @case (eModelType.RERANK) {
-          <div
-            class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
-          >
-            <i class="ri-sort-number-asc"></i>
-          </div>
-        }
-        @case (eModelType.TEXT_EMBEDDING) {
-          <div
-            class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
-          >
-            <i class="ri-text-block"></i>
-          </div>
-        }
-        @case (eModelType.SPEECH2TEXT) {
-          <div
-            class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
-          >
-            <i class="ri-speech-to-text-line"></i>
-          </div>
-        }
-        @case (eModelType.TTS) {
-          <div
-            class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default whitespace-nowrap opacity-60"
-          >
-            <i class="ri-text-to-speech-line"></i>
-          </div>
-        }
-      }
-      @if (item.features?.includes(eModelFeature.TOOL_CALL) || item.features?.includes(eModelFeature.MULTI_TOOL_CALL)) {
-        <div
-          class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 w-[18px] justify-center opacity-60"
-        >
-          <i class="ri-hammer-fill"></i>
-        </div>
-      }
-      @if (item.features?.includes(eModelFeature.VISION)) {
-        <div
-          class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 w-[18px] justify-center opacity-60"
-        >
-          <i class="ri-eye-fill"></i>
-        </div>
       }
     </button>
   }

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.scss
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.scss
@@ -1,16 +1,16 @@
 @reference "../../../../styles/tailwind-reference.css";
 :host {
-  .container {
+  .model-select-trigger {
     @apply cursor-pointer bg-components-input-bg-normal;
   }
   &.status-choose {
-    .container {
+    .model-select-trigger {
       @apply bg-yellow-50 border-yellow-200 hover:border-yellow-300;
     }
   }
 
   &.readonly {
-    .container {
+    .model-select-trigger {
       @apply cursor-default;
     }
   }

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
@@ -3,13 +3,9 @@ import { join } from 'node:path'
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing'
 import { TranslateService } from '@ngx-translate/core'
 import { of, Subject } from 'rxjs'
-import {
-  AiModelTypeEnum,
-  CopilotProviderService,
-  CopilotServerService,
-  ModelPropertyKey,
-  ParameterType
-} from '../../../@core'
+import { AiModelTypeEnum, ModelPropertyKey, ParameterType } from '@xpert-ai/contracts'
+import { CopilotProviderService } from '../../../@core/services/copilot-provider.service'
+import { CopilotServerService } from '../../../@core/services/copilot-server.service'
 import { CopilotModelSelectComponent } from './select.component'
 
 describe('CopilotModelSelectComponent', () => {
@@ -23,6 +19,17 @@ describe('CopilotModelSelectComponent', () => {
     const template = readFileSync(join(__dirname, 'select.component.html'), 'utf8')
 
     expect(template).toContain('[style.max-height.px]="getMenuMaxHeight(modelContainer)"')
+  })
+
+  it('prevents model filter controls from stealing menu focus', () => {
+    const template = readFileSync(join(__dirname, 'select.component.html'), 'utf8')
+
+    expect(template).toMatch(
+      /<button[\s\S]*\(mousedown\)="\$event\.preventDefault\(\); \$event\.stopPropagation\(\)"[\s\S]*\(click\)="\$event\.stopPropagation\(\); toggleModelFilter\(filter\.id\)"/
+    )
+    expect(template).toMatch(
+      /<button[\s\S]*\(mousedown\)="\$event\.preventDefault\(\); \$event\.stopPropagation\(\)"[\s\S]*\(click\)="\$event\.stopPropagation\(\); clearModelFilters\(\)"/
+    )
   })
 
   const copilot = {
@@ -448,6 +455,30 @@ describe('CopilotModelSelectComponent', () => {
 
     expect(component['cva'].value$()?.options).toBeUndefined()
     expect(onChange).not.toHaveBeenCalled()
+  }))
+
+  it('uses AND semantics for model filters while keeping all available filter tags', fakeAsync(() => {
+    tick(600)
+    fixture.detectChanges()
+
+    const contextTags = component.modelFilterTags().filter((tag) => tag.kind === 'context-size')
+    expect(contextTags.map((tag) => tag.defaultText)).toEqual(['64K', '200K', '32K'])
+
+    const context64KTag = contextTags.find((tag) => tag.defaultText === '64K')
+    if (!context64KTag) {
+      throw new Error('Expected 64K context filter')
+    }
+
+    component.toggleModelFilter(context64KTag.id)
+    fixture.detectChanges()
+
+    expect(component.getVisibleCopilotModels(copilot).map((model) => model.model)).toEqual(['deepseek-chat'])
+    expect(
+      component
+        .modelFilterTags()
+        .filter((tag) => tag.kind === 'context-size')
+        .map((tag) => tag.defaultText)
+    ).toEqual(['64K', '200K', '32K'])
   }))
 
   it('drops non-applicable options when switching to a model without parameter rules', fakeAsync(() => {

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
@@ -21,23 +21,21 @@ import { TranslateModule } from '@ngx-translate/core'
 import { NgxControlValueAccessor } from 'ngxtension/control-value-accessor'
 import { derivedAsync } from 'ngxtension/derived-async'
 import { distinctUntilChanged, map, of } from 'rxjs'
-import {
-  AiModelTypeEnum,
-  CopilotServerService,
+import { AiModelTypeEnum, ModelFeature, ModelPropertyKey, ParameterType } from '@xpert-ai/contracts'
+import type {
   I18nObject,
   ICopilot,
   ICopilotModel,
   ICopilotWithProvider,
-  injectCopilotProviderService,
-  ModelPropertyKey,
-  ModelFeature,
   ParameterRule,
-  ParameterType,
   ProviderModel
-} from '../../../@core'
+} from '@xpert-ai/contracts'
+import { injectCopilotProviderService } from '../../../@core/services/copilot-provider.service'
+import { CopilotServerService } from '../../../@core/services/copilot-server.service'
 import { ModelParameterInputComponent } from '../model-parameter-input/input.component'
 import { ZardTabsImports, ZardTooltipImports } from '@xpert-ai/headless-ui'
 import { ZardAlertComponent } from '@xpert-ai/headless-ui/components/alert'
+import { ModelFilterTag, providerModelDisplayTags, providerModelFilterTags } from '../model-tags'
 
 type ModelParameterRulesResourceValue = {
   model: string | undefined
@@ -49,6 +47,8 @@ type ModelParameterRulesResourceValue = {
 const MODEL_MENU_MAX_HEIGHT = 560
 const MODEL_MENU_VIEWPORT_MARGIN = 16
 const MODEL_MENU_TRIGGER_GAP = 8
+const MODEL_INLINE_TAGS_MIN_WIDTH = 720
+const SELECTED_MODEL_INLINE_TAGS_MIN_WIDTH = 520
 
 @Component({
   standalone: true,
@@ -75,10 +75,6 @@ const MODEL_MENU_TRIGGER_GAP = 8
   }
 })
 export class CopilotModelSelectComponent implements ControlValueAccessor {
-  eModelFeature = ModelFeature
-  eModelType = AiModelTypeEnum
-  eParameterType = ParameterType
-
   protected cva = inject<NgxControlValueAccessor<Partial<ICopilotModel> | null>>(NgxControlValueAccessor)
   readonly copilotServer = inject(CopilotServerService)
   readonly copilotProviderService = injectCopilotProviderService()
@@ -107,6 +103,8 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
 
   readonly label = input<string | I18nObject>()
 
+  readonly modelDisplayTags = providerModelDisplayTags
+
   // States
   readonly __copilotModel = computed(() => this.cva.value$() ?? this.copilotModel())
   readonly _copilotModel = computed(() => this.__copilotModel() ?? this.inheritModel())
@@ -130,10 +128,11 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
   readonly activeCopilotTabId = model<string | null>(null)
   readonly railWidth = model<number | null>(null)
   readonly isRailResizing = signal(false)
+  readonly selectedModelFilterIds = signal<string[]>([])
   readonly #searchTerm = debouncedSignal(this.searchTerm, 300)
-  readonly searchedModels = computed(() => {
-    const searchText = this.#searchTerm().trim().toLowerCase()
-    const copilots = this.features()?.length
+  readonly featureFilteredCopilots = computed(() => {
+    const features = this.features()
+    return features?.length
       ? this.copilotWithModels()
           ?.map((_) => {
             return {
@@ -141,13 +140,18 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
               providerWithModels: {
                 ..._.providerWithModels,
                 models: _.providerWithModels.models.filter((m) =>
-                  this.features().every((feature) => m.features?.includes(feature))
+                  features.every((feature) => m.features?.includes(feature))
                 )
               }
             }
           })
           .filter((_) => _.providerWithModels.models.length)
       : this.copilotWithModels()
+  })
+
+  readonly searchedModels = computed(() => {
+    const searchText = this.#searchTerm().trim().toLowerCase()
+    const copilots = this.featureFilteredCopilots()
 
     return searchText
       ? copilots
@@ -172,6 +176,34 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
           })
           .filter(nonBlank)
       : copilots
+  })
+
+  readonly activeSearchedCopilot = computed(() => {
+    const activeCopilotTabId = this.resolvedActiveCopilotTabId()
+    return activeCopilotTabId
+      ? (this.searchedModels()?.find((copilot) => copilot.id === activeCopilotTabId) ?? null)
+      : null
+  })
+
+  readonly activeModelFilterTags = computed(() => {
+    const tags = new Map<string, ModelFilterTag>()
+    for (const model of this.activeSearchedCopilot()?.providerWithModels.models ?? []) {
+      for (const tag of this.getModelFilterTags(model)) {
+        if (!tags.has(tag.id)) {
+          tags.set(tag.id, tag)
+        }
+      }
+    }
+    return Array.from(tags.values())
+  })
+
+  readonly selectedModelFilters = computed(() => {
+    const selectedIds = new Set(this.selectedModelFilterIds())
+    return this.activeModelFilterTags().filter((tag) => selectedIds.has(tag.id))
+  })
+
+  readonly modelFilterTags = computed(() => {
+    return this.activeModelFilterTags()
   })
   readonly activeCopilotTabIndex = computed(() => {
     const copilots = this.searchedModels() ?? []
@@ -275,8 +307,40 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
     }, 100)
   })
 
+  toggleModelFilter(filterId: string) {
+    this.selectedModelFilterIds.update((ids) =>
+      ids.includes(filterId) ? ids.filter((id) => id !== filterId) : [...ids, filterId]
+    )
+  }
+
+  clearModelFilters() {
+    this.selectedModelFilterIds.set([])
+  }
+
+  isModelFilterSelected(filterId: string) {
+    return this.selectedModelFilterIds().includes(filterId)
+  }
+
+  private getModelFilterTags(model: ProviderModel): ModelFilterTag[] {
+    return providerModelFilterTags(model)
+  }
+
+  private matchesModelFilters(model: ProviderModel, filters: ModelFilterTag[]) {
+    const modelTagIds = new Set(this.getModelFilterTags(model).map((tag) => tag.id))
+    return filters.every((filter) => modelTagIds.has(filter.id))
+  }
+
   constructor() {
     this.#destroyRef.onDestroy(() => this.stopRailResize())
+
+    effect(() => {
+      const availableIds = new Set(this.modelFilterTags().map((tag) => tag.id))
+      const selectedIds = this.selectedModelFilterIds()
+      const nextSelectedIds = selectedIds.filter((id) => availableIds.has(id))
+      if (nextSelectedIds.length !== selectedIds.length) {
+        this.selectedModelFilterIds.set(nextSelectedIds)
+      }
+    })
 
     effect(() => {
       const value = this.cva.value$()
@@ -399,12 +463,33 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
   selectCopilotTabByIndex(index: number) {
     const copilot = this.searchedModels()?.[index]
     if (copilot) {
+      if (copilot.id !== this.activeCopilotTabId()) {
+        this.clearModelFilters()
+      }
       this.activeCopilotTabId.set(copilot.id)
     }
   }
 
   getCopilotTabModelCount(copilot: ICopilotWithProvider) {
     return copilot.providerWithModels?.models?.length ?? 0
+  }
+
+  getVisibleCopilotModels(copilot: ICopilotWithProvider) {
+    const models = copilot.providerWithModels?.models ?? []
+    if (copilot.id !== this.resolvedActiveCopilotTabId()) {
+      return models
+    }
+
+    const filters = this.selectedModelFilters()
+    return filters.length ? models.filter((model) => this.matchesModelFilters(model, filters)) : models
+  }
+
+  showInlineModelTags(menuWidth: number | null | undefined, menuRailWidth: number | null | undefined) {
+    return (menuWidth ?? 0) - (menuRailWidth ?? 0) >= MODEL_INLINE_TAGS_MIN_WIDTH
+  }
+
+  showInlineSelectedModelTags(container: HTMLElement | null | undefined) {
+    return (container?.getBoundingClientRect().width ?? 0) >= SELECTED_MODEL_INLINE_TAGS_MIN_WIDTH
   }
 
   getMenuWidth(container: HTMLElement | null | undefined) {

--- a/apps/cloud/src/app/@shared/copilot/copilot-provider/provider.component.html
+++ b/apps/cloud/src/app/@shared/copilot/copilot-provider/provider.component.html
@@ -154,28 +154,16 @@
             <img alt="model-icon" class="w-4 h-4 shrink-0 mr-2" [src]="smallIcon() | i18n" />
           }
 
-          <div class="flex items-center truncate text-[13px] grow text-sm font-normal text-text-primary">
-            <div class="truncate" [title]="model.modelName">{{ model.modelName }}</div>
-
-            <div
-              class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium uppercase text-text-tertiary cursor-default ml-1"
-            >
-              {{ model.modelType }}
-            </div>
-
-            @if (model.modelProperties?.context_size) {
+          <div class="flex min-w-0 items-center overflow-hidden text-[13px] grow text-sm font-normal text-text-primary">
+            <div class="min-w-0 truncate" [title]="model.modelName">{{ model.modelName }}</div>
+            @for (tag of customModelTags(model); track tag.id) {
               <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1"
+                class="flex shrink-0 items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 whitespace-nowrap"
               >
-                {{ model.modelProperties.context_size / 1000 | number: '0.0-0' }}K
-              </div>
-            }
-            <!-- @todo move to plugin -->
-            @if (model.modelProperties?.vision_support === 'support') {
-              <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1"
-              >
-                <i class="ri-eye-fill"></i>
+                @if (tag.iconClass) {
+                  <i class="mr-0.5 text-[11px] leading-none" [ngClass]="tag.iconClass"></i>
+                }
+                {{ tag.defaultText }}
               </div>
             }
           </div>
@@ -204,33 +192,16 @@
         >
           <img alt="model-icon" [src]="smallIcon() | i18n" class="w-4 h-4 shrink-0 mr-2" />
 
-          <div class="flex items-center truncate text-base grow font-normal text-text-primary">
-            <div class="truncate" [title]="model.model">{{ model.model }}</div>
-
-            <div
-              class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium uppercase text-text-tertiary cursor-default ml-1"
-            >
-              {{ model.model_type }}
-            </div>
-            @if (model.model_properties?.mode) {
+          <div class="flex min-w-0 items-center overflow-hidden text-base grow font-normal text-text-primary">
+            <div class="min-w-0 truncate" [title]="model.model">{{ model.model }}</div>
+            @for (tag of builtinModelTags(model); track tag.id) {
               <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium uppercase text-text-tertiary cursor-default ml-1"
+                class="flex shrink-0 items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1 whitespace-nowrap"
               >
-                {{ model.model_properties?.mode }}
-              </div>
-            }
-            @if (model.model_properties?.context_size) {
-              <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1"
-              >
-                {{ model.model_properties.context_size / 1000 | number: '0.0-0' }}K
-              </div>
-            }
-            @if (model.features?.includes(eModelFeature.VISION)) {
-              <div
-                class="flex items-center px-1 h-[18px] rounded-[5px] border border-divider-regular bg-components-panel-bg text-[10px] font-medium text-text-tertiary cursor-default ml-1"
-              >
-                <i class="ri-eye-fill"></i>
+                @if (tag.iconClass) {
+                  <i class="mr-0.5 text-[11px] leading-none" [ngClass]="tag.iconClass"></i>
+                }
+                {{ tag.defaultText }}
               </div>
             }
           </div>

--- a/apps/cloud/src/app/@shared/copilot/copilot-provider/provider.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-provider/provider.component.ts
@@ -25,12 +25,12 @@ import {
   ICopilotProviderModel,
   injectAiProviders,
   injectCopilotProviderService,
-  ModelFeature,
   TCopilotTokenUsage,
   ToastrService
 } from '../../../@core'
 import { CopilotProviderModelComponent } from '../copilot-provider-model/model.component'
 import { CopilotAiProviderAuthComponent } from '../provider-authorization/authorization.component'
+import { customProviderModelDisplayTags, providerModelDisplayTags } from '../model-tags'
 
 @Component({
   standalone: true,
@@ -55,7 +55,6 @@ import { CopilotAiProviderAuthComponent } from '../provider-authorization/author
 })
 export class CopilotProviderComponent {
   eConfigurateMethod = ConfigurateMethod
-  eModelFeature = ModelFeature
 
   readonly #dialog = inject(Dialog)
   readonly #translate = inject(TranslateService)
@@ -121,6 +120,9 @@ export class CopilotProviderComponent {
   })
   readonly usageWarn = computed(() => this.tokenRemain() < 40 && this.tokenRemain() > 1)
   readonly usageError = computed(() => this.tokenRemain() < 1)
+
+  readonly customModelTags = customProviderModelDisplayTags
+  readonly builtinModelTags = providerModelDisplayTags
 
   constructor() {
     effect(() => {

--- a/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.ts
@@ -1,9 +1,8 @@
-
 import { Component, inject, input } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { ZardInputDirective, ZardSliderComponent, ZardSwitchComponent } from '@xpert-ai/headless-ui'
 import { NgxControlValueAccessor } from 'ngxtension/control-value-accessor'
-import { ParameterRule, ParameterType } from '../../../@core'
+import { ParameterRule, ParameterType } from '@xpert-ai/contracts'
 
 /**
  * @todo Use JSON Schema to implement

--- a/apps/cloud/src/app/@shared/copilot/model-tags.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/model-tags.spec.ts
@@ -1,0 +1,29 @@
+import { AiModelTypeEnum, FetchFrom, ModelFeature, ModelPropertyKey, ProviderModel } from '@xpert-ai/contracts'
+import { providerModelDisplayTags, providerModelFilterTags } from './model-tags'
+
+describe('model tag helpers', () => {
+  const model: ProviderModel = {
+    model: 'vision-tool-model',
+    label: {},
+    model_type: AiModelTypeEnum.LLM,
+    fetch_from: FetchFrom.PREDEFINED_MODEL,
+    model_properties: {
+      [ModelPropertyKey.MODE]: 'chat',
+      [ModelPropertyKey.CONTEXT_SIZE]: 128000
+    },
+    features: [ModelFeature.TOOL_CALL, ModelFeature.MULTI_TOOL_CALL, ModelFeature.VISION]
+  }
+
+  it('hides common tool-call feature tags while keeping model and visible capability tags', () => {
+    expect(providerModelDisplayTags(model).map((tag) => tag.defaultText)).toEqual(['LLM', 'CHAT', '128K', 'VISION'])
+  })
+
+  it('excludes common tool-call features from filter tags', () => {
+    expect(providerModelFilterTags(model).map((tag) => tag.id)).toEqual([
+      'model-type:LLM',
+      'model-mode:CHAT',
+      'context-size:128K',
+      'feature:vision'
+    ])
+  })
+})

--- a/apps/cloud/src/app/@shared/copilot/model-tags.ts
+++ b/apps/cloud/src/app/@shared/copilot/model-tags.ts
@@ -1,0 +1,191 @@
+import {
+  AiModelTypeEnum,
+  ICopilotProviderModel,
+  ModelFeature,
+  ModelPropertyKey,
+  ProviderModel
+} from '@xpert-ai/contracts'
+
+export type ModelTag = {
+  id: string
+  defaultText: string
+  iconClass?: string
+  value?: string
+}
+
+export type ModelFilterKind = 'model-type' | 'model-mode' | 'context-size' | 'feature'
+
+export type ModelFilterTag = ModelTag & {
+  kind: ModelFilterKind
+}
+
+const HIDDEN_MODEL_FEATURE_TAGS = new Set<string>([
+  ModelFeature.TOOL_CALL,
+  ModelFeature.MULTI_TOOL_CALL,
+  ModelFeature.AGENT_THOUGHT,
+  ModelFeature.STREAM_TOOL_CALL
+])
+
+const MULTIMODAL_FEATURE_ICON_CLASSES: Record<string, string> = {
+  [ModelFeature.VISION]: 'ri-eye-line',
+  [ModelFeature.VIDEO]: 'ri-video-line',
+  audio: 'ri-volume-up-line',
+  document: 'ri-file-text-line'
+}
+
+export function providerModelDisplayTags(model: ProviderModel | null | undefined): ModelTag[] {
+  return modelTags(
+    model?.model_type,
+    model?.model_properties?.[ModelPropertyKey.MODE],
+    model?.model_properties?.[ModelPropertyKey.CONTEXT_SIZE],
+    model?.features
+  )
+}
+
+export function customProviderModelDisplayTags(model: ICopilotProviderModel | null | undefined): ModelTag[] {
+  return modelTags(
+    model?.modelType,
+    model?.modelProperties?.[ModelPropertyKey.MODE],
+    model?.modelProperties?.[ModelPropertyKey.CONTEXT_SIZE],
+    customModelFeatures(model?.modelProperties)
+  )
+}
+
+export function providerModelFilterTags(model: ProviderModel): ModelFilterTag[] {
+  const tags: ModelFilterTag[] = []
+  const modelTypeTag = textModelTag('model-type', model.model_type)
+  if (modelTypeTag) {
+    tags.push({
+      ...modelTypeTag,
+      kind: 'model-type'
+    })
+  }
+
+  const modeTag = textModelTag('model-mode', model.model_properties?.[ModelPropertyKey.MODE])
+  if (modeTag) {
+    tags.push({
+      ...modeTag,
+      kind: 'model-mode'
+    })
+  }
+
+  const contextTag = contextModelTag(model.model_properties?.[ModelPropertyKey.CONTEXT_SIZE])
+  if (contextTag) {
+    tags.push({
+      ...contextTag,
+      id: `context-size:${contextTag.value ?? contextTag.defaultText}`,
+      kind: 'context-size'
+    })
+  }
+
+  for (const featureTag of modelFeatureTags(model.features)) {
+    tags.push({
+      ...featureTag,
+      id: `feature:${featureTag.id}`,
+      kind: 'feature'
+    })
+  }
+
+  return tags
+}
+
+function modelTags(
+  modelType: AiModelTypeEnum | string | null | undefined,
+  mode: unknown,
+  contextSize: unknown,
+  features: readonly string[] | null | undefined
+): ModelTag[] {
+  return [
+    textModelTag('model-type', modelType),
+    textModelTag('model-mode', mode),
+    contextModelTag(contextSize),
+    ...modelFeatureTags(features)
+  ].filter((tag): tag is ModelTag => !!tag)
+}
+
+function modelFeatureTags(features: readonly string[] | null | undefined): ModelTag[] {
+  const tags: ModelTag[] = []
+  const seen = new Set<string>()
+  for (const feature of features ?? []) {
+    if (HIDDEN_MODEL_FEATURE_TAGS.has(feature)) {
+      continue
+    }
+    if (seen.has(feature)) {
+      continue
+    }
+    seen.add(feature)
+    tags.push({
+      id: feature,
+      defaultText: formatTagText(feature),
+      iconClass: MULTIMODAL_FEATURE_ICON_CLASSES[feature]
+    })
+  }
+  return tags
+}
+
+function customModelFeatures(modelProperties: ICopilotProviderModel['modelProperties'] | null | undefined): string[] {
+  const features: string[] = []
+  if (modelProperties?.vision_support === 'support') {
+    features.push(ModelFeature.VISION)
+  }
+  if (modelProperties?.function_calling_type === 'tool_call') {
+    features.push(ModelFeature.TOOL_CALL)
+  }
+  if (modelProperties?.function_calling_type === 'multi_tool_call') {
+    features.push(ModelFeature.TOOL_CALL)
+    features.push(ModelFeature.MULTI_TOOL_CALL)
+  }
+  if (modelProperties?.agent_though_support === 'supported') {
+    features.push(ModelFeature.AGENT_THOUGHT)
+  }
+  return features
+}
+
+function textModelTag(id: string, value: unknown): ModelTag | null {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null
+  }
+
+  const text = `${value}`.trim()
+  if (!text) {
+    return null
+  }
+
+  const defaultText = formatTagText(text)
+  return { id: `${id}:${defaultText}`, defaultText }
+}
+
+function contextModelTag(value: unknown): ModelTag | null {
+  const contextSize = parseContextSize(value)
+  if (typeof contextSize !== 'number') {
+    return null
+  }
+
+  const text = formatContextSize(contextSize)
+  return {
+    id: ModelPropertyKey.CONTEXT_SIZE,
+    defaultText: text,
+    value: text
+  }
+}
+
+function parseContextSize(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.floor(value)
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10)
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed
+    }
+  }
+  return undefined
+}
+
+function formatContextSize(value: number): string {
+  return `${Math.max(1, Math.round(value / 1000)).toLocaleString('en-US')}K`
+}
+
+function formatTagText(value: string): string {
+  return value.replace(/_/g, '-').toUpperCase()
+}

--- a/apps/cloud/src/app/features/setting/data-sources/creation/creation.component.html
+++ b/apps/cloud/src/app/features/setting/data-sources/creation/creation.component.html
@@ -1,129 +1,196 @@
-<div
-  class="w-[300px] shrink-0 flex flex-col justify-start overflow-auto bg-components-panel-bg text-text-primary group"
->
-  <div
-    class="w-full flex justify-start items-center p-4 mb-4 cursor-move"
-    cdkDrag
-    cdkDragRootElement=".cdk-overlay-pane"
-    cdkDragHandle
-  >
-    <i class="ri-draggable -ml-2 opacity-0 group-hover:opacity-80"></i>
-    <span class="text-xl pointer-events-none">
+<header class="flex shrink-0 items-center border-b border-divider-regular px-6 py-4">
+  <div class="min-w-0 flex-1">
+    <h2 class="truncate text-lg font-semibold">
       {{ 'PAC.ACTIONS.NEW' | translate: { Default: 'New' } }}
       {{ 'PAC.KEY_WORDS.DataSource' | translate: { Default: 'Data Source' } }}
-    </span>
+    </h2>
+    <p class="mt-0.5 truncate text-xs text-text-secondary">
+      {{ 'PAC.MENU.DATA_SOURCES.SelectTypeToCreate' | translate: { Default: 'Select a data source type to create' } }}
+    </p>
   </div>
+</header>
 
-  <form [formGroup]="typeFormGroup" class="flex-1 pl-4 overflow-auto">
-    <ul
-      class="pac-ds-creation__types ngm-nav-list ngm-cdk-listbox"
-      cdkListbox
-      formControlName="type"
-      [cdkListboxMultiple]="false"
-      [cdkListboxCompareWith]="compareFn"
-    >
-      @if (listboxConnectionTypes(); as connectionTypes) {
-        @for (item of connectionTypes; track item.id) {
-          <li [cdkOption]="item" class="ngm-cdk-option rounded-lg mb-1 flex items-center gap-3">
-            <span class="flex items-center gap-3">
-              <img src="assets/images/db-logos/{{ item.type }}.png" width="32" height="32" class="m-0 inline-block" />
-              {{ item.name }}
-            </span>
-          </li>
-        }
-      } @else {
-        <list-content-loader />
+<div class="grid min-h-0 flex-1 overflow-hidden grid-cols-[280px_minmax(0,1fr)]">
+  <aside class="flex min-h-0 min-w-0 flex-col overflow-hidden border-r border-divider-regular bg-components-panel-bg">
+    <div class="flex items-center justify-between gap-3 px-4 py-3">
+      <div class="min-w-0">
+        <h3 class="truncate text-sm font-medium">
+          {{ 'PAC.MENU.DATA_SOURCES.TYPE_SELECTION' | translate: { Default: 'Type Selection' } }}
+        </h3>
+      </div>
+      @if (connectionTypes() !== null) {
+        <z-badge zType="secondary" zShape="pill">{{ connectionTypeOptions().length }}</z-badge>
       }
-    </ul>
-  </form>
-
-  <div class="flex justify-between items-center p-4">
-    <div ngmButtonGroup>
-      <button
-        z-button
-        zType="default"
-
-        [disabled]="loading() || formGroup.pristine || formGroup.invalid"
-        (click)="ping()"
-      >
-        {{ 'PAC.ACTIONS.PING' | translate: { Default: 'Ping' } }}
-      </button>
     </div>
 
-    <div ngmButtonGroup>
-      <button z-button zType="secondary" (click)="onCancel()">
-        {{ 'PAC.ACTIONS.CANCEL' | translate: { Default: 'Cancel' } }}
-      </button>
-      <button
-        z-button
-        zType="default"
-
-        cdkFocusInitial
-        [disabled]="formGroup.pristine || formGroup.invalid"
-        (click)="onSave()"
-      >
-        {{ 'PAC.ACTIONS.CREATE' | translate: { Default: 'Create' } }}
-      </button>
-    </div>
-  </div>
-</div>
-
-<div class="w-[500px] shrink-0 flex flex-col overflow-y-auto">
-  <div class="text-lg sticky top-0 z-10 px-6 py-4 bg-components-card-bg">
-    {{ 'PAC.MENU.DATA_SOURCES.CONFIGURATION' | translate: { Default: 'Configuration' } }}
-  </div>
-
-  @if (dataSourceType(); as type) {
-    <form [formGroup]="formGroup" class="flex flex-col justify-start items-stretch p-6">
-      <div class="flex justify-center items-center text-lg my-2">
-        <img src="assets/images/db-logos/{{ type.type }}.png" width="64" height="64" class="m-0 inline-block" />
-        {{ type.name }}
-      </div>
-
-      <ngm-input
-        [ngClass]="{ 'ngm-input-error': nameCtrl.invalid }"
-        [label]="'PAC.MENU.DATA_SOURCES.NAME' | translate: { Default: 'Name' }"
-        formControlName="name"
-        required
-      >
-        @if (nameCtrl.invalid) {
-          <span ngmError>
-            {{ 'PAC.MENU.DATA_SOURCES.NAME_REQUIRED' | translate: { Default: 'Name Required' } }}
-          </span>
-        }
-      </ngm-input>
-
-      <div class="flex justify-between items-center mx-2 mb-6">
-        @if (enableLocalAgent) {
-          <z-switch formControlName="useLocalAgent" labelPosition="before">
-            {{ 'PAC.MENU.DATA_SOURCES.USE_LOCAL_AGENT' | translate: { Default: 'Use Local Agent' } }}
-          </z-switch>
-        }
-
-        @if (isXmla()) {
-          <div class="flex justify-end items-center gap-2">
-            <div>{{ 'PAC.MENU.DATA_SOURCES.AuthType' | translate: {Default: 'Auth Type'} }}</div>
-            <z-toggle-group formControlName="authType" name="authType" ngmAppearance="outline" displayDensity="compact" color="accent">
-              <z-toggle-group-item [value]="null"
-                [zTooltip]="'PAC.MENU.DATA_SOURCES.AuthType_None_Description' | translate: {Default: 'Unified system authorization, no need for users to provide accounts.'}"
-              >{{ 'PAC.MENU.DATA_SOURCES.AuthType_None' | translate: {Default: 'None'} }}</z-toggle-group-item>
-              <z-toggle-group-item [value]="AuthenticationEnum.BASIC"
-                [zTooltip]="'PAC.MENU.DATA_SOURCES.AuthType_Basic_Description' | translate: {Default: 'Users need to provide an account for authorization.'}"
-              >{{ 'PAC.MENU.DATA_SOURCES.AuthType_Basic' | translate: {Default: 'Basic'} }}</z-toggle-group-item>
-            </z-toggle-group>
-          </div>
-        }
-      </div>
-
-      <formly-form [form]="options" [fields]="fields$ | async" [model]="model" (modelChange)="onModelChange($event)">
-      </formly-form>
+    <form [formGroup]="typeFormGroup" class="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+      @if (connectionTypes() === null) {
+        <div class="flex h-full items-center justify-center gap-2 text-sm text-text-secondary">
+          <z-loader zSize="sm" />
+          <span>{{ 'PAC.KEY_WORDS.Loading' | translate: { Default: 'Loading' } }}</span>
+        </div>
+      } @else {
+        <z-radio-group formControlName="type" class="flex flex-col gap-1">
+          @for (item of connectionTypeOptions(); track item.id) {
+            <z-radio
+              [value]="item.id"
+              [class]="
+                dataSourceType()?.id === item.id
+                  ? 'w-full items-center rounded-lg border border-divider-regular bg-components-card-bg px-3 py-2 text-text-primary shadow-sm'
+                  : 'w-full items-center rounded-lg border border-transparent px-3 py-2 text-text-secondary hover:bg-hover-bg hover:text-text-primary'
+              "
+            >
+              <span class="flex min-w-0 flex-1 items-center gap-3">
+                <img
+                  src="assets/images/db-logos/{{ item.type }}.png"
+                  width="24"
+                  height="24"
+                  class="m-0 inline-block shrink-0"
+                  [alt]="item.name"
+                />
+                <span class="min-w-0 flex-1">
+                  <span class="block truncate text-sm font-medium">{{ item.name }}</span>
+                  <span class="block truncate text-xs text-text-tertiary">{{ item.type }}</span>
+                </span>
+              </span>
+            </z-radio>
+          } @empty {
+            <div class="flex min-h-48 items-center justify-center">
+              <z-empty
+                zIcon="database"
+                [zTitle]="'PAC.MENU.DATA_SOURCES.NoDataSources' | translate: { Default: 'No data sources' }"
+              />
+            </div>
+          }
+        </z-radio-group>
+      }
     </form>
-  } @else {
-    <div class="flex-1 w-full flex flex-col justify-center items-center">
-      <i class="ri-database-2-line text-[3rem]"></i>
-      <span class="text-text-secondary">
-        {{ 'PAC.MENU.DATA_SOURCES.SelectTypeToCreate' | translate: { Default: 'Select a data source type to create' } }}
-      </span>
-    </div>
-  }
+  </aside>
+
+  <section class="flex min-h-0 min-w-0 flex-col overflow-hidden bg-components-card-bg">
+    @if (dataSourceType(); as type) {
+      <form [formGroup]="formGroup" class="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+        <div class="mb-5 flex items-center justify-between gap-4 border-b border-divider-regular pb-4">
+          <div class="flex min-w-0 items-center gap-3">
+            <img
+              src="assets/images/db-logos/{{ type.type }}.png"
+              width="40"
+              height="40"
+              class="m-0 inline-block shrink-0"
+              [alt]="type.name"
+            />
+            <div class="min-w-0">
+              <div class="truncate text-base font-semibold">{{ type.name }}</div>
+              <div class="mt-1 flex items-center gap-2">
+                <z-badge zType="outline" zShape="pill">{{ type.type }}</z-badge>
+                <span class="truncate text-xs text-text-tertiary">{{ type.protocol }}</span>
+              </div>
+            </div>
+          </div>
+          <div class="shrink-0 text-sm font-medium text-text-secondary">
+            {{ 'PAC.MENU.DATA_SOURCES.CONFIGURATION' | translate: { Default: 'Configuration' } }}
+          </div>
+        </div>
+
+        <div class="space-y-5">
+          <z-form-field class="w-full" appearance="fill">
+            <z-form-label [zRequired]="true">
+              {{ 'PAC.MENU.DATA_SOURCES.NAME' | translate: { Default: 'Name' } }}
+            </z-form-label>
+            <input z-input formControlName="name" required [zStatus]="nameCtrl?.invalid ? 'error' : undefined" />
+            @if (nameCtrl?.invalid) {
+              <z-form-message zType="error">
+                {{ 'PAC.MENU.DATA_SOURCES.NAME_REQUIRED' | translate: { Default: 'Name Required' } }}
+              </z-form-message>
+            }
+          </z-form-field>
+
+          @if (enableLocalAgent || isXmla()) {
+            <div class="rounded-lg border border-divider-regular bg-components-panel-bg p-4">
+              <div class="flex flex-wrap items-center justify-between gap-4">
+                @if (enableLocalAgent) {
+                  <z-switch formControlName="useLocalAgent" labelPosition="before">
+                    {{ 'PAC.MENU.DATA_SOURCES.USE_LOCAL_AGENT' | translate: { Default: 'Use Local Agent' } }}
+                  </z-switch>
+                }
+
+                @if (isXmla()) {
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-sm text-text-secondary">
+                      {{ 'PAC.MENU.DATA_SOURCES.AuthType' | translate: { Default: 'Auth Type' } }}
+                    </span>
+                    <z-toggle-group formControlName="authType" name="authType" zType="outline" zSize="sm">
+                      <z-toggle-group-item
+                        [value]="null"
+                        [zTooltip]="
+                          'PAC.MENU.DATA_SOURCES.AuthType_None_Description'
+                            | translate
+                              : { Default: 'Unified system authorization, no need for users to provide accounts.' }
+                        "
+                      >
+                        {{ 'PAC.MENU.DATA_SOURCES.AuthType_None' | translate: { Default: 'None' } }}
+                      </z-toggle-group-item>
+                      <z-toggle-group-item
+                        [value]="AuthenticationEnum.BASIC"
+                        [zTooltip]="
+                          'PAC.MENU.DATA_SOURCES.AuthType_Basic_Description'
+                            | translate: { Default: 'Users need to provide an account for authorization.' }
+                        "
+                      >
+                        {{ 'PAC.MENU.DATA_SOURCES.AuthType_Basic' | translate: { Default: 'Basic' } }}
+                      </z-toggle-group-item>
+                    </z-toggle-group>
+                  </div>
+                }
+              </div>
+            </div>
+          }
+
+          <formly-form [form]="options" [fields]="fields$ | async" [model]="model" />
+        </div>
+      </form>
+    } @else {
+      <div class="flex min-h-0 flex-1 items-center justify-center px-8">
+        <z-empty
+          class="max-w-[280px]"
+          zIcon="database"
+          [zTitle]="
+            'PAC.MENU.DATA_SOURCES.SelectTypeToCreate' | translate: { Default: 'Select a data source type to create' }
+          "
+          [zDescription]="'PAC.MENU.DATA_SOURCES.TYPE_SELECTION' | translate: { Default: 'Type Selection' }"
+        />
+      </div>
+    }
+  </section>
 </div>
+
+<footer
+  class="flex shrink-0 items-center justify-between gap-3 border-t border-divider-regular bg-components-card-bg px-4 py-3"
+>
+  <button
+    z-button
+    zType="outline"
+    type="button"
+    class="min-w-32"
+    [zLoading]="loading()"
+    [disabled]="loading() || formGroup.pristine || formGroup.invalid"
+    (click)="ping()"
+  >
+    {{ 'PAC.ACTIONS.PING' | translate: { Default: 'Ping' } }}
+  </button>
+
+  <div class="flex items-center gap-2">
+    <button z-button zType="secondary" type="button" (click)="onCancel()">
+      {{ 'PAC.ACTIONS.CANCEL' | translate: { Default: 'Cancel' } }}
+    </button>
+    <button
+      z-button
+      zType="default"
+      type="button"
+      [disabled]="formGroup.pristine || formGroup.invalid"
+      (click)="onSave()"
+    >
+      {{ 'PAC.ACTIONS.CREATE' | translate: { Default: 'Create' } }}
+    </button>
+  </div>
+</footer>

--- a/apps/cloud/src/app/features/setting/data-sources/creation/creation.component.scss
+++ b/apps/cloud/src/app/features/setting/data-sources/creation/creation.component.scss
@@ -1,14 +1,4 @@
 @reference "../../../../../styles/tailwind-reference.css";
 :host {
-  display: flex;
-  flex-direction: row;
-  flex: 1;
-  overflow: hidden;
-  max-height: 80vh;
-}
-
-.pac-ds-creation__types {
-  .pac-ds-creation__type-content {
-    @apply -mr-4;
-  }
+  @apply flex h-[80vh] max-h-[80vh] w-[780px] max-w-[calc(100vw-48px)] flex-col overflow-hidden bg-components-card-bg text-text-primary;
 }

--- a/apps/cloud/src/app/features/setting/data-sources/creation/creation.component.ts
+++ b/apps/cloud/src/app/features/setting/data-sources/creation/creation.component.ts
@@ -1,33 +1,29 @@
-import { Component, OnInit, computed, inject, signal } from '@angular/core'
+import { Component, OnInit, computed, effect, inject, signal } from '@angular/core'
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop'
-import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms'
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms'
 import { DataSourceProtocolEnum, DataSourceService, DataSourceTypesService } from '@xpert-ai/cloud/state'
-import { AuthenticationEnum, IDataSource, IDataSourceType } from '@cloud/app/@core/types'
-import { isEmpty, omit } from '@xpert-ai/ocap-core'
+import { AuthenticationEnum, getErrorMessage, IDataSource, IDataSourceType } from '@cloud/app/@core/types'
+import { omit } from '@xpert-ai/ocap-core'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
-import { BehaviorSubject, firstValueFrom, map } from 'rxjs'
-import {
-  LocalAgent,
-  ServerSocketAgent,
-  ToastrService,
-  convertConfigurationSchema,
-  getErrorMessage
-} from '@cloud/app/@core/index'
+import { BehaviorSubject, firstValueFrom, startWith } from 'rxjs'
+import { convertConfigurationSchema } from '@cloud/app/@core/services/configuration-schema.service'
+import { LocalAgent } from '@cloud/app/@core/services/local-agent.service'
+import { ServerSocketAgent } from '@cloud/app/@core/services/server-socket-agent.service'
+import { ToastrService } from '@cloud/app/@core/services/toastr.service'
 import { environment } from '@cloud/environments/environment'
 import { CommonModule } from '@angular/common'
-import { DragDropModule } from '@angular/cdk/drag-drop'
-import { CdkListboxModule } from '@angular/cdk/listbox'
-import { ContentLoaderModule } from '@ngneat/content-loader'
 
-import { NgmInputComponent } from '@xpert-ai/ocap-angular/common'
 import { FormlyModule } from '@ngx-formly/core'
-import { AppearanceDirective, ButtonGroupDirective, DensityDirective } from '@xpert-ai/ocap-angular/core'
-import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog'
 import {
+  Z_MODAL_DATA,
+  ZardBadgeComponent,
   ZardButtonComponent,
-  ZardSwitchComponent,
-  ZardToggleGroupComponent,
-  ZardToggleGroupItemComponent,
+  ZardDialogRef,
+  ZardEmptyComponent,
+  ZardFormImports,
+  ZardIconComponent,
+  ZardInputDirective,
+  ZardLoaderComponent,
   ZardTooltipImports
 } from '@xpert-ai/headless-ui'
 
@@ -35,21 +31,16 @@ import {
   standalone: true,
   imports: [
     CommonModule,
-    DragDropModule,
     TranslateModule,
     FormlyModule,
-    FormsModule,
     ReactiveFormsModule,
-    CdkListboxModule,
+    ZardBadgeComponent,
     ZardButtonComponent,
-    ZardToggleGroupComponent,
-    ZardToggleGroupItemComponent,
-    ContentLoaderModule,
-    NgmInputComponent,
-    ButtonGroupDirective,
-    AppearanceDirective,
-    DensityDirective,
-    ZardSwitchComponent,
+    ZardEmptyComponent,
+    ZardIconComponent,
+    ZardInputDirective,
+    ZardLoaderComponent,
+    ...ZardFormImports,
     ...ZardTooltipImports
   ],
   selector: 'pac-data-source-creation',
@@ -64,8 +55,8 @@ export class PACDataSourceCreationComponent implements OnInit {
   private dataSourceService = inject(DataSourceService)
   private toastrService = inject(ToastrService)
   private translateService = inject(TranslateService)
-  private data: IDataSource = inject(DIALOG_DATA, { optional: true })
-  public dialogRef = inject(DialogRef<Partial<IDataSource>>)
+  private data = inject<IDataSource | null>(Z_MODAL_DATA, { optional: true })
+  public dialogRef = inject<ZardDialogRef<PACDataSourceCreationComponent, Partial<IDataSource>>>(ZardDialogRef)
   private localAgent? = inject(LocalAgent, { optional: true })
   private serverAgent = inject(ServerSocketAgent)
 
@@ -74,25 +65,27 @@ export class PACDataSourceCreationComponent implements OnInit {
   readonly connectionTypes$ = this.typesService.types$.pipe(takeUntilDestroyed())
   readonly connectionTypes = toSignal(this.connectionTypes$, { initialValue: null })
   public typeFormGroup = new FormGroup({
-    type: new FormControl(null, [Validators.required])
+    type: new FormControl<string | null>(null, [Validators.required])
   })
-  // get type(): IDataSourceType {
-  //   return this.typeFormGroup.value?.type?.[0]
-  // }
 
-  readonly dataSourceType = toSignal(this.typeFormGroup.valueChanges.pipe(map((value) => value?.type?.[0])))
-  readonly listboxConnectionTypes = computed(() => {
+  readonly selectedTypeId = toSignal(
+    this.typeFormGroup.controls.type.valueChanges.pipe(startWith(this.typeFormGroup.controls.type.value))
+  )
+  readonly initialDataSourceType = signal<IDataSourceType | null>(null)
+  readonly connectionTypeOptions = computed(() => {
     const types = this.connectionTypes() ?? []
-    const selectedTypes = this.typeFormGroup.value?.type ?? []
+    const selectedType = this.initialDataSourceType()
     const options = [...types]
 
-    selectedTypes.forEach((item) => {
-      if (!options.some((type) => this.compareFn(type, item))) {
-        options.push(item)
-      }
-    })
+    if (selectedType && !options.some((type) => type.id === selectedType.id)) {
+      options.push(selectedType)
+    }
 
     return options
+  })
+  readonly dataSourceType = computed(() => {
+    const selectedTypeId = this.selectedTypeId()
+    return selectedTypeId ? this.connectionTypeOptions().find((type) => type.id === selectedTypeId) : null
   })
 
   formGroup = new FormGroup({
@@ -115,26 +108,24 @@ export class PACDataSourceCreationComponent implements OnInit {
   // Signal States
   readonly isXmla = computed(() => this.dataSourceType()?.protocol === DataSourceProtocolEnum.XMLA)
 
-  private _typeFormGroupSub = this.typeFormGroup.valueChanges.subscribe(({ type }) => {
-    if (!isEmpty(type)) {
+  private _typeFieldsEffect = effect(() => {
+    const type = this.dataSourceType()
+    if (type) {
       const i18n = this.translateService.instant('PAC.DataSources.Schema')
-      this.fields$.next(convertConfigurationSchema(type[0].configuration, i18n))
+      this.fields$.next(convertConfigurationSchema(type.configuration, i18n))
     }
   })
 
   async ngOnInit() {
     if (this.data?.id) {
       const dataSource = await firstValueFrom(this.dataSourceService.getOne(this.data.id))
+      this.initialDataSourceType.set(dataSource.type)
       this.typeFormGroup.patchValue({
-        type: [dataSource.type]
+        type: dataSource.type.id
       })
       this.formGroup.patchValue(omit(dataSource, 'id'))
       this.model = dataSource.options
     }
-  }
-
-  compareFn(a: IDataSourceType, b: IDataSourceType) {
-    return a?.id === b?.id
   }
 
   async onSave() {
@@ -154,8 +145,6 @@ export class PACDataSourceCreationComponent implements OnInit {
   onCancel() {
     this.dialogRef.close()
   }
-
-  onModelChange(event) {}
 
   async ping() {
     const agent = this.formGroup.value.useLocalAgent ? this.localAgent : this.serverAgent

--- a/apps/cloud/src/app/features/setting/data-sources/data-sources.component.html
+++ b/apps/cloud/src/app/features/setting/data-sources/data-sources.component.html
@@ -1,96 +1,209 @@
 <div class="pac-page-header">
-  <div class="pac-page-title">{{ 'PAC.KEY_WORDS.DATA_SOURCES' | translate: {Default: "Data Sources"} }}</div>
-</div>
-
-<div class="w-full flex justify-start p-4">
-  <ngm-search [formControl]="searchControl" />
-</div>
-
-<nav class="grid content-start grid-cols-1 gap-4 px-6 pt-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 grow shrink-0">
-  <ngm-card-create [title]="'PAC.DataSources.CreateDataSource' | translate: {Default: 'Create data source'}"
-    [helpTitle]="'PAC.DataSources.CreateDataSourceHelp' | translate: {Default: 'Learn more about custom data sources'} "
-    helpUrl="/docs/server/datasources/"
-    (create)="create()"
-  />
-  @for (item of dataSources(); track item.id) {
-    <div class="datasource-card group relative col-span-1 border-2 border-solid border-transparent rounded-xl shadow-sm min-h-[160px] flex flex-col transition-all duration-200 ease-in-out cursor-pointer hover:shadow-lg
-            bg-background-default-subtle hover:bg-hover-bg"
-      [ngClass]="routeAnimationsElements"
-      [class.active]="mt.isOpen()"
-      (click)="edit(item)"
-    >
-      <div class="flex pt-[14px] px-[14px] pb-3 h-[66px] items-center gap-3 grow-0 shrink-0">
-        <div class="relative shrink-0 w-20 h-20 rounded-xl overflow-hidden">
-          <img src="assets/images/db-logos/{{item.type?.type}}.png">
-        </div>
-        <div class="grow w-0 py-[1px]">
-          <div class="flex items-center text-base leading-5 font-semibold">
-            <div class="truncate" [title]="item.name">{{ item.name }}</div>
-          </div>
-          <div class="flex items-center text-sm leading-5">
-            <div class="truncate" [title]="item.type?.type">{{ item.type?.type }}</div>
-          </div>
-        </div>
+  <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+    <div class="min-w-0">
+      <div class="pac-page-title">
+        {{ 'PAC.KEY_WORDS.DATA_SOURCES' | translate: { Default: 'Data Sources' } }}
       </div>
-      <div
-        class="grow mb-2 px-[14px] max-h-[72px] text-sm leading-normal line-clamp-2 group-hover:line-clamp-2 group-hover:max-h-[36px]"
-      >
-      </div>
-      <div class="flex items-center shrink-0 mt-1 pt-1 pl-[14px] pr-[6px] pb-[6px] h-[42px]">
-      </div>
-
-      <div
-        class="absolute bottom-1 left-0 right-0 items-center shrink-0 pt-1 pl-[14px] pr-[6px] pb-[6px] h-[42px]
-          hidden group-hover:flex"
-        (click)="$event.stopPropagation();"
-      >
-        <div class="grow flex items-center gap-1 w-0">
-          
-        </div>
-        <div class="shrink-0 mx-1 w-[1px] h-[14px] bg-divider-regular"></div>
-        <div class="shrink-0">
-          <button
-            class="bg-components-input-bg-normal !bg-transparent h-8 w-8 rounded-md border-none active:!bg-black/5 hover:!bg-black/5 dark:bg-neutral-400"
-            type="button"
-            [cdkMenuTriggerFor]="menu"
-            [cdkMenuTriggerData]="{item: item}"
-            #mt="cdkMenuTriggerFor"
-            [class.active]="mt.isOpen()"
-            [attr.active]="mt.isOpen()"
-          >
-            <div class="flex items-center justify-center w-8 h-8 cursor-pointer rounded-md">
-              <i class="ri-more-line"></i>
-            </div>
-          </button>
-        </div>
+      <div class="mt-1 text-sm text-text-tertiary">
+        {{
+          'PAC.DataSources.PageDescription'
+            | translate: { Default: 'Manage database and service connections for analytics.' }
+        }}
       </div>
     </div>
-  }
-</nav>
 
-@if (loading()) {
-  <ngm-spin class="absolute top-0 left-0 w-full h-full" />
-}
+    <div class="flex shrink-0 items-center gap-2">
+      <a
+        z-button
+        zType="secondary"
+        [href]="helpWebsite() + '/docs/server/datasources/'"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <z-icon zType="help_outline"></z-icon>
+        {{ 'PAC.KEY_WORDS.Docs' | translate: { Default: 'Docs' } }}
+      </a>
+    </div>
+  </div>
+</div>
+
+<div class="pac-page-body flex flex-1 flex-col gap-4 p-4">
+  <div
+    class="flex flex-col gap-3 rounded-2xl bg-components-panel-bg px-4 py-3 md:flex-row md:items-center md:justify-between"
+  >
+    <div class="relative min-w-0 flex-1 md:max-w-md">
+      <z-icon zType="search" class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-tertiary" />
+      <input
+        z-input
+        type="text"
+        class="w-full pl-9"
+        [formControl]="searchControl"
+        [placeholder]="'PAC.KEY_WORDS.Search' | translate: { Default: 'Search' }"
+      />
+    </div>
+
+    <div class="flex items-center gap-2 text-sm text-text-tertiary">
+      @if (loading()) {
+        <z-loader zSize="sm" />
+        <span>{{ 'PAC.KEY_WORDS.Loading' | translate: { Default: 'Loading...' } }}</span>
+      } @else {
+        <z-badge zType="secondary" zShape="pill">
+          {{ dataSources().length }}
+          {{ 'PAC.KEY_WORDS.Items' | translate: { Default: 'items' } }}
+        </z-badge>
+      }
+    </div>
+  </div>
+
+  @if (dataSources().length) {
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+      <z-card
+        class="group overflow-hidden border border-dashed border-divider-regular bg-components-card-bg p-0 shadow-none transition-colors hover:bg-hover-bg"
+      >
+        <button
+          type="button"
+          z-button
+          zType="ghost"
+          class="flex min-h-[180px] w-full flex-col items-start justify-between rounded-xl p-4 text-left hover:bg-transparent"
+          (click)="create()"
+        >
+          <span
+            class="flex h-11 w-11 items-center justify-center rounded-xl bg-components-panel-bg text-text-secondary"
+          >
+            <z-icon zType="add"></z-icon>
+          </span>
+
+          <span class="flex w-full flex-col gap-1">
+            <span class="text-base font-semibold text-text-primary">
+              {{ 'PAC.DataSources.CreateDataSource' | translate: { Default: 'Create data source' } }}
+            </span>
+          </span>
+        </button>
+      </z-card>
+
+      @for (item of dataSources(); track item.id) {
+        <z-card
+          class="group relative overflow-hidden border border-divider-regular bg-components-card-bg p-0 shadow-none transition-colors hover:bg-hover-bg"
+          [ngClass]="routeAnimationsElements"
+        >
+          <button
+            type="button"
+            z-button
+            zType="ghost"
+            class="flex min-h-[180px] w-full flex-col items-stretch justify-between rounded-xl p-4 text-left hover:bg-transparent"
+            [attr.aria-label]="('PAC.ACTIONS.Edit' | translate: { Default: 'Edit' }) + ': ' + item.name"
+            (click)="edit(item)"
+          >
+            <span class="flex min-w-0 items-start gap-3 pr-10">
+              <span
+                class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-divider-regular bg-background-default-subtle"
+              >
+                <img
+                  src="assets/images/db-logos/{{ item.type?.type }}.png"
+                  width="40"
+                  height="40"
+                  class="m-0 inline-block"
+                  [alt]="item.type?.type || ('PAC.KEY_WORDS.DataSource' | translate: { Default: 'Data Source' })"
+                />
+              </span>
+
+              <span class="min-w-0 flex-1">
+                <span class="block truncate text-base font-semibold text-text-primary" [title]="item.name">
+                  {{ item.name }}
+                </span>
+
+                <span class="mt-2 flex min-w-0 items-center gap-2">
+                  <z-badge zType="secondary" zShape="pill" class="max-w-full truncate font-mono">
+                    {{ item.type?.type || ('PAC.KEY_WORDS.Unknown' | translate: { Default: 'Unknown' }) }}
+                  </z-badge>
+                </span>
+              </span>
+            </span>
+
+            <span
+              class="mt-5 flex items-center justify-between border-t border-divider-regular pt-3 text-xs font-normal text-text-tertiary"
+            >
+              <span class="inline-flex min-w-0 items-center gap-1.5">
+                <z-icon zType="database" class="shrink-0"></z-icon>
+                <span class="truncate">
+                  {{ 'PAC.KEY_WORDS.DataSource' | translate: { Default: 'Data Source' } }}
+                </span>
+              </span>
+
+              <span class="inline-flex items-center gap-1 text-text-secondary">
+                {{ 'PAC.ACTIONS.Edit' | translate: { Default: 'Edit' } }}
+                <z-icon zType="chevron_right"></z-icon>
+              </span>
+            </span>
+          </button>
+
+          <button
+            type="button"
+            z-button
+            zType="ghost"
+            zSize="icon"
+            zShape="circle"
+            class="absolute right-3 top-3 text-text-tertiary opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+            z-menu
+            [zMenuTriggerFor]="menu"
+            [zMenuTriggerData]="{ item: item }"
+            zPlacement="bottomRight"
+            [attr.aria-label]="'PAC.Chat.MoreActions' | translate: { Default: 'More actions' }"
+            (click)="$event.stopPropagation()"
+          >
+            <z-icon zType="more_vert"></z-icon>
+          </button>
+        </z-card>
+      }
+    </div>
+  } @else if (!loading()) {
+    <div
+      class="flex min-h-64 flex-col items-center justify-center rounded-2xl border border-dashed border-divider-regular bg-components-panel-bg px-6 py-10 text-center"
+    >
+      <z-empty
+        zIcon="database"
+        [zTitle]="
+          searchText()
+            ? ('PAC.DataSources.NoMatchingDataSources' | translate: { Default: 'No matching data sources' })
+            : ('PAC.DataSources.NoDataSources' | translate: { Default: 'No data sources yet' })
+        "
+        [zDescription]="
+          searchText()
+            ? ('PAC.DataSources.TryDifferentSearch' | translate: { Default: 'Try a different search keyword.' })
+            : ('PAC.DataSources.EmptyDescription'
+              | translate: { Default: 'Create a data source to connect your databases and services.' })
+        "
+      >
+        @if (!searchText()) {
+          <button type="button" z-button zType="default" class="mt-4" (click)="create()">
+            <z-icon zType="add"></z-icon>
+            {{ 'PAC.DataSources.CreateDataSource' | translate: { Default: 'Create data source' } }}
+          </button>
+        }
+      </z-empty>
+    </div>
+  }
+</div>
 
 <ng-template #menu let-item="item">
-  <div cdkMenu class="cdk-menu__medium">
-    <button cdkMenuItem (click)="edit(item)">
-      <i class="ri-edit-line mr-1"></i>
+  <div z-menu-content class="p-1">
+    <button type="button" z-menu-item (click)="edit(item)">
+      <z-icon zType="edit" class="mr-2"></z-icon>
       <span>
-        {{ 'PAC.ACTIONS.Edit' | translate: {Default: "Edit"} }}
+        {{ 'PAC.ACTIONS.Edit' | translate: { Default: 'Edit' } }}
       </span>
     </button>
 
-    <button cdkMenuItem (click)="copy(item)">
-      <i class="ri-file-copy-line mr-1"></i>
+    <button type="button" z-menu-item (click)="copy(item)">
+      <z-icon zType="copy" class="mr-2"></z-icon>
       <span>
-        {{ 'PAC.ACTIONS.Copy' | translate: {Default: "Copy"} }}
+        {{ 'PAC.ACTIONS.Copy' | translate: { Default: 'Copy' } }}
       </span>
     </button>
 
-    <button cdkMenuItem class="danger" (click)="remove(item)">
-      <i class="ri-delete-bin-line mr-1"></i>
-      <span>{{ 'PAC.ACTIONS.Delete' | translate: {Default: "Delete"} }}</span>
+    <button type="button" z-menu-item zType="destructive" (click)="remove(item)">
+      <z-icon zType="trash" class="mr-2"></z-icon>
+      <span>{{ 'PAC.ACTIONS.Delete' | translate: { Default: 'Delete' } }}</span>
     </button>
   </div>
 </ng-template>

--- a/apps/cloud/src/app/features/setting/data-sources/data-sources.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/data-sources/data-sources.component.spec.ts
@@ -1,0 +1,127 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { DataSourceService } from '@xpert-ai/cloud/state'
+import { TranslateService } from '@ngx-translate/core'
+import { IDataSource } from '@xpert-ai/contracts'
+import { of } from 'rxjs'
+import { ZardAlertDialogService, ZardDialogService } from '@xpert-ai/headless-ui'
+import { PACDataSourcesComponent } from './data-sources.component'
+import { PACDataSourceCreationComponent } from './creation/creation.component'
+import { PACDataSourceEditComponent } from './edit/edit.component'
+
+describe('PACDataSourcesComponent', () => {
+  const dataSource = {
+    id: 'data-source-1',
+    name: 'Main source',
+    type: {
+      type: 'postgres'
+    }
+  } as IDataSource
+
+  let fixture: ComponentFixture<PACDataSourcesComponent>
+  let component: PACDataSourcesComponent
+  let getAll: jest.Mock
+  let open: jest.Mock
+
+  beforeEach(async () => {
+    getAll = jest.fn(() => of([dataSource]))
+    open = jest.fn(() => ({ closed: of(true) }))
+
+    await TestBed.configureTestingModule({
+      imports: [PACDataSourcesComponent],
+      providers: [
+        {
+          provide: DataSourceService,
+          useValue: {
+            getAll,
+            delete: jest.fn(() => of(null))
+          }
+        },
+        {
+          provide: ZardDialogService,
+          useValue: {
+            open
+          }
+        },
+        {
+          provide: ZardAlertDialogService,
+          useValue: {
+            confirm: jest.fn(() => of(false))
+          }
+        },
+        {
+          provide: TranslateService,
+          useValue: {
+            currentLang: 'en',
+            onLangChange: of({ lang: 'en' }),
+            instant: jest.fn((_key: string, params?: { Default?: string }) => params?.Default ?? _key)
+          }
+        }
+      ]
+    })
+      .overrideComponent(PACDataSourcesComponent, {
+        set: {
+          template: ''
+        }
+      })
+      .compileComponents()
+
+    fixture = TestBed.createComponent(PACDataSourcesComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('opens the creation dialog and refreshes after create succeeds', () => {
+    const callsBeforeCreate = getAll.mock.calls.length
+
+    component.create()
+
+    expect(open).toHaveBeenCalledWith(
+      PACDataSourceCreationComponent,
+      expect.objectContaining({
+        backdropClass: 'xp-overlay-share-sheet',
+        panelClass: ['xp-overlay-pane-share-sheet', '!p-0'],
+        width: 'min(780px, calc(100vw - 48px))',
+        maxWidth: 'calc(100vw - 48px)'
+      })
+    )
+    expect(getAll).toHaveBeenCalledTimes(callsBeforeCreate + 1)
+  })
+
+  it('opens the edit dialog with the selected data source id and refreshes after save succeeds', () => {
+    const callsBeforeEdit = getAll.mock.calls.length
+
+    component.edit(dataSource)
+
+    expect(open).toHaveBeenCalledWith(
+      PACDataSourceEditComponent,
+      expect.objectContaining({
+        data: {
+          id: dataSource.id
+        },
+        backdropClass: 'xp-overlay-share-sheet',
+        panelClass: ['xp-overlay-pane-share-sheet', '!p-0'],
+        width: 'min(560px, calc(100vw - 48px))',
+        maxWidth: 'calc(100vw - 48px)'
+      })
+    )
+    expect(getAll).toHaveBeenCalledTimes(callsBeforeEdit + 1)
+  })
+
+  it('opens the creation dialog with source data when copying and refreshes after create succeeds', () => {
+    const callsBeforeCopy = getAll.mock.calls.length
+
+    component.copy(dataSource)
+
+    expect(open).toHaveBeenCalledWith(
+      PACDataSourceCreationComponent,
+      expect.objectContaining({
+        data: dataSource,
+        backdropClass: 'xp-overlay-share-sheet',
+        panelClass: ['xp-overlay-pane-share-sheet', '!p-0'],
+        width: 'min(780px, calc(100vw - 48px))',
+        maxWidth: 'calc(100vw - 48px)'
+      })
+    )
+    expect(getAll).toHaveBeenCalledTimes(callsBeforeCopy + 1)
+  })
+})

--- a/apps/cloud/src/app/features/setting/data-sources/data-sources.component.ts
+++ b/apps/cloud/src/app/features/setting/data-sources/data-sources.component.ts
@@ -1,31 +1,49 @@
-import { Dialog } from '@angular/cdk/dialog'
-import { CdkMenuModule } from '@angular/cdk/menu'
 import { CommonModule } from '@angular/common'
 import { Component, inject, signal, ViewContainerRef } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
-import { FormControl } from '@angular/forms'
+import { FormControl, ReactiveFormsModule } from '@angular/forms'
 import { DataSourceService } from '@xpert-ai/cloud/state'
-import { injectConfirmDelete, NgmSearchComponent, NgmSpinComponent } from '@xpert-ai/ocap-angular/common'
-import { ContentLoaderModule } from '@ngneat/content-loader'
-import { TranslateModule } from '@ngx-translate/core'
-import { BehaviorSubject } from 'rxjs'
-import { combineLatestWith, debounceTime, map, startWith, switchMap, tap } from 'rxjs/operators'
-import { IDataSource, injectHelpWebsite, ROUTE_ANIMATIONS_ELEMENTS } from '../../../@core/index'
-import { CardCreateComponent } from '../../../@shared/card'
+import { TranslateModule, TranslateService } from '@ngx-translate/core'
+import { BehaviorSubject, EMPTY } from 'rxjs'
+import { combineLatestWith, debounceTime, map, shareReplay, startWith, switchMap, tap } from 'rxjs/operators'
+import { IDataSource } from '@xpert-ai/contracts'
+import { ROUTE_ANIMATIONS_ELEMENTS } from '../../../@core/animations'
+import { injectHelpWebsite } from '../../../@core/providers/website'
 import { PACDataSourceCreationComponent } from './creation/creation.component'
 import { PACDataSourceEditComponent } from './edit/edit.component'
 
-import { ZardDialogService } from '@xpert-ai/headless-ui'
+import {
+  ZardAlertDialogService,
+  ZardBadgeComponent,
+  ZardButtonComponent,
+  ZardCardImports,
+  ZardDialogService,
+  ZardEmptyComponent,
+  ZardIconComponent,
+  ZardInputDirective,
+  ZardLoaderComponent,
+  ZardMenuImports
+} from '@xpert-ai/headless-ui'
+
+const DATA_SOURCE_DIALOG_PANEL_CLASS = ['xp-overlay-pane-share-sheet', '!p-0']
+const DATA_SOURCE_DIALOG_MAX_WIDTH = 'calc(100vw - 48px)'
+const DATA_SOURCE_CREATION_DIALOG_WIDTH = 'min(780px, calc(100vw - 48px))'
+const DATA_SOURCE_EDIT_DIALOG_WIDTH = 'min(560px, calc(100vw - 48px))'
+
 @Component({
   standalone: true,
   imports: [
     CommonModule,
-    CdkMenuModule,
+    ReactiveFormsModule,
     TranslateModule,
-    NgmSearchComponent,
-    ContentLoaderModule,
-    CardCreateComponent,
-    NgmSpinComponent
+    ZardBadgeComponent,
+    ZardButtonComponent,
+    ZardEmptyComponent,
+    ZardIconComponent,
+    ZardInputDirective,
+    ZardLoaderComponent,
+    ...ZardCardImports,
+    ...ZardMenuImports
   ],
   selector: 'pac-data-sources',
   templateUrl: './data-sources.component.html',
@@ -35,36 +53,40 @@ export class PACDataSourcesComponent {
   routeAnimationsElements = ROUTE_ANIMATIONS_ELEMENTS
 
   private readonly dataSource = inject(DataSourceService)
-  private readonly _dialog = inject(ZardDialogService)
-  readonly #dialog = inject(Dialog)
+  readonly #dialog = inject(ZardDialogService)
+  readonly #alertDialog = inject(ZardAlertDialogService)
+  readonly #translate = inject(TranslateService)
   readonly #viewContainerRef = inject(ViewContainerRef)
-  readonly confirmDelete = injectConfirmDelete()
   readonly helpWebsite = injectHelpWebsite()
 
   readonly loading = signal(false)
   private readonly refresh$ = new BehaviorSubject<void>(null)
   readonly searchControl = new FormControl('')
+  readonly search$ = this.searchControl.valueChanges.pipe(
+    debounceTime(300),
+    map((text) => text?.trim().toLowerCase() ?? ''),
+    startWith(''),
+    shareReplay({ bufferSize: 1, refCount: true })
+  )
+  readonly searchText = toSignal(this.search$, { initialValue: '' })
   readonly dataSources = toSignal(
     this.refresh$.pipe(
       tap(() => this.loading.set(true)),
       switchMap(() => this.dataSource.getAll(['type'])),
-      combineLatestWith(
-        this.searchControl.valueChanges.pipe(
-          debounceTime(300),
-          map((text) => text?.toLowerCase()),
-          startWith('')
-        )
-      ),
-      map(([items, search]) => (search ? items.filter((item) => item.name.toLowerCase().includes(search)) : items)),
+      combineLatestWith(this.search$),
+      map(([items, search]) => (search ? items.filter((item) => item.name?.toLowerCase().includes(search)) : items)),
       tap(() => this.loading.set(false))
-    )
+    ),
+    { initialValue: [] }
   )
 
   create() {
     this.#dialog
       .open(PACDataSourceCreationComponent, {
         backdropClass: 'xp-overlay-share-sheet',
-        panelClass: 'xp-overlay-pane-share-sheet'
+        panelClass: DATA_SOURCE_DIALOG_PANEL_CLASS,
+        width: DATA_SOURCE_CREATION_DIALOG_WIDTH,
+        maxWidth: DATA_SOURCE_DIALOG_MAX_WIDTH
       })
       .closed.subscribe({
         next: (result) => {
@@ -83,7 +105,9 @@ export class PACDataSourcesComponent {
         },
         viewContainerRef: this.#viewContainerRef,
         backdropClass: 'xp-overlay-share-sheet',
-        panelClass: 'xp-overlay-pane-share-sheet'
+        panelClass: DATA_SOURCE_DIALOG_PANEL_CLASS,
+        width: DATA_SOURCE_EDIT_DIALOG_WIDTH,
+        maxWidth: DATA_SOURCE_DIALOG_MAX_WIDTH
       })
       .closed.subscribe({
         next: (result) => {
@@ -99,7 +123,9 @@ export class PACDataSourcesComponent {
       .open(PACDataSourceCreationComponent, {
         data,
         backdropClass: 'xp-overlay-share-sheet',
-        panelClass: 'xp-overlay-pane-share-sheet'
+        panelClass: DATA_SOURCE_DIALOG_PANEL_CLASS,
+        width: DATA_SOURCE_CREATION_DIALOG_WIDTH,
+        maxWidth: DATA_SOURCE_DIALOG_MAX_WIDTH
       })
       .closed.subscribe({
         next: (result) => {
@@ -116,14 +142,24 @@ export class PACDataSourcesComponent {
     const currentDataSource = this.dataSources()?.find((item) => item.id === data.id)
     const displayName = currentDataSource?.name || data.name
 
-    this.confirmDelete(
-      {
-        value: displayName,
-        information: ''
-      },
-      this.dataSource.delete(data.id)
-    ).subscribe(() => {
-      this.refresh$.next()
-    })
+    this.#alertDialog
+      .confirm({
+        title: this.#getDeleteTitle(displayName),
+        actionText: this.#translate.instant('COMPONENTS.COMMON.Confirm', { Default: 'Confirm' }),
+        cancelText: this.#translate.instant('COMPONENTS.COMMON.CANCEL', { Default: 'Cancel' }),
+        destructive: true,
+        viewContainerRef: this.#viewContainerRef
+      })
+      .pipe(switchMap((confirm) => (confirm ? this.dataSource.delete(data.id) : EMPTY)))
+      .subscribe(() => {
+        this.refresh$.next()
+      })
+  }
+
+  #getDeleteTitle(value?: string) {
+    const title = this.#translate.instant('COMPONENTS.CONFIRM.DELETE', { Default: 'Confirm Delete' })
+    const name = value == null || value === '' ? null : String(value)
+
+    return name ? `${title} [${name}]?` : `${title}?`
   }
 }

--- a/apps/cloud/src/app/features/setting/data-sources/edit/edit.component.html
+++ b/apps/cloud/src/app/features/setting/data-sources/edit/edit.component.html
@@ -1,91 +1,115 @@
-<header class="px-6 pt-6 cursor-move" cdkDrag cdkDragRootElement=".cdk-overlay-pane" cdkDragHandle>
-  <h4 class="text-xl font-semibold">
-    {{ 'PAC.KEY_WORDS.MODIFY' | translate: { Default: 'Modify' } }}
-    {{ 'PAC.KEY_WORDS.DataSource' | translate: { Default: 'Data Source' } }}
-    {{ nameCtrl.value }}
-  </h4>
+<header class="flex shrink-0 items-center border-b border-divider-regular px-6 py-4">
+  <div class="min-w-0 flex-1">
+    <h2 class="truncate text-lg font-semibold">
+      {{ 'PAC.KEY_WORDS.MODIFY' | translate: { Default: 'Modify' } }}
+      {{ 'PAC.KEY_WORDS.DataSource' | translate: { Default: 'Data Source' } }}
+    </h2>
+    <p class="truncate text-xs text-text-secondary">{{ nameCtrl.value }}</p>
+  </div>
 </header>
 
-<div class="p-6 min-w-[500px] overflow-y-auto">
-  @if (dataSource()?.type) {
-    <div class="flex justify-center items-center text-lg">
-      <img src="assets/images/db-logos/{{ dataSource().type.type }}.png" width="64" height="64" />
-      {{ dataSource().type.name }}
+<main class="min-h-0 w-[560px] flex-1 overflow-y-auto px-6 py-5">
+  @if (dataSource()?.type; as type) {
+    <div class="mb-5 flex items-center gap-4 rounded-lg border border-divider-regular bg-components-panel-bg p-4">
+      <img
+        src="assets/images/db-logos/{{ type.type }}.png"
+        width="48"
+        height="48"
+        class="m-0 inline-block shrink-0"
+        [alt]="type.name"
+      />
+      <div class="min-w-0 flex-1">
+        <div class="truncate text-base font-semibold">{{ type.name }}</div>
+        <div class="mt-1 flex items-center gap-2">
+          <z-badge zType="outline" zShape="pill">{{ type.type }}</z-badge>
+          <span class="truncate text-xs text-text-tertiary">{{ type.protocol }}</span>
+        </div>
+      </div>
     </div>
   }
 
-  <form [formGroup]="formGroup" class="flex flex-col justify-start items-stretch">
-    <ngm-input
-      [ngClass]="{ 'ngm-input-error': nameCtrl.invalid }"
-      [label]="'PAC.MENU.DATA_SOURCES.NAME' | translate: { Default: 'Name' }"
-      formControlName="name"
-      required
-    >
-      @if (nameCtrl.invalid) {
-        <span ngmError>
+  <form [formGroup]="formGroup" class="space-y-5">
+    <z-form-field class="w-full" appearance="fill">
+      <z-form-label [zRequired]="true">
+        {{ 'PAC.MENU.DATA_SOURCES.NAME' | translate: { Default: 'Name' } }}
+      </z-form-label>
+      <input z-input formControlName="name" required [zStatus]="nameCtrl?.invalid ? 'error' : undefined" />
+      @if (nameCtrl?.invalid) {
+        <z-form-message zType="error">
           {{ 'PAC.MENU.DATA_SOURCES.NAME_REQUIRED' | translate: { Default: 'Name Required' } }}
-        </span>
+        </z-form-message>
       }
-    </ngm-input>
+    </z-form-field>
 
-    <div class="flex justify-between items-center mx-2 mb-6">
-      @if (enableLocalAgent) {
-        <z-switch formControlName="useLocalAgent" labelPosition="before">
-          {{ 'PAC.MENU.DATA_SOURCES.USE_LOCAL_AGENT' | translate: { Default: 'Use Local Agent' } }}
-        </z-switch>
-      }
+    @if (enableLocalAgent || isXmla()) {
+      <div class="rounded-lg border border-divider-regular bg-components-panel-bg p-4">
+        <div class="flex flex-wrap items-center justify-between gap-4">
+          @if (enableLocalAgent) {
+            <z-switch formControlName="useLocalAgent" labelPosition="before">
+              {{ 'PAC.MENU.DATA_SOURCES.USE_LOCAL_AGENT' | translate: { Default: 'Use Local Agent' } }}
+            </z-switch>
+          }
 
-      @if (isXmla()) {
-        <div class="flex justify-end items-center gap-2">
-          <label>{{ 'PAC.MENU.DATA_SOURCES.AuthType' | translate: { Default: 'Auth Type' } }}</label>
-          <ngm-radio-select
-            [selectOptions]="[
-              {
-                value: null,
-                label: ('PAC.MENU.DATA_SOURCES.AuthType_None' | translate: { Default: 'None' }),
-                description:
-                  ('PAC.MENU.DATA_SOURCES.AuthType_None_Description'
-                  | translate: { Default: 'Unified system authorization, no need for users to provide accounts.' })
-              },
-              {
-                value: AuthenticationEnum.BASIC,
-                label: ('PAC.MENU.DATA_SOURCES.AuthType_Basic' | translate: { Default: 'Basic' }),
-                description:
-                  ('PAC.MENU.DATA_SOURCES.AuthType_Basic_Description'
-                  | translate: { Default: 'Users need to provide an account for authorization.' })
-              }
-            ]"
-          />
+          @if (isXmla()) {
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="text-sm text-text-secondary">
+                {{ 'PAC.MENU.DATA_SOURCES.AuthType' | translate: { Default: 'Auth Type' } }}
+              </span>
+              <z-toggle-group formControlName="authType" name="authType" zType="outline" zSize="sm">
+                <z-toggle-group-item
+                  [value]="null"
+                  [zTooltip]="
+                    'PAC.MENU.DATA_SOURCES.AuthType_None_Description'
+                      | translate: { Default: 'Unified system authorization, no need for users to provide accounts.' }
+                  "
+                >
+                  {{ 'PAC.MENU.DATA_SOURCES.AuthType_None' | translate: { Default: 'None' } }}
+                </z-toggle-group-item>
+                <z-toggle-group-item
+                  [value]="AuthenticationEnum.BASIC"
+                  [zTooltip]="
+                    'PAC.MENU.DATA_SOURCES.AuthType_Basic_Description'
+                      | translate: { Default: 'Users need to provide an account for authorization.' }
+                  "
+                >
+                  {{ 'PAC.MENU.DATA_SOURCES.AuthType_Basic' | translate: { Default: 'Basic' } }}
+                </z-toggle-group-item>
+              </z-toggle-group>
+            </div>
+          }
         </div>
-      }
-    </div>
+      </div>
+    }
   </form>
 
-  @if (schema$()) {
-    <formly-form [form]="optionsFormGroup" [fields]="schema$()" [model]="model" />
-  } @else {
-    <list-content-loader />
-  }
-</div>
-
-<div class="flex justify-between p-4">
-  <div ngmButtonGroup>
-    <button z-button zType="default" [disabled]="_loading()" (click)="ping()">
-      {{ 'PAC.ACTIONS.PING' | translate: { Default: 'Ping' } }}
-    </button>
+  <div class="mt-5">
+    @if (schema$()) {
+      <formly-form [form]="optionsFormGroup" [fields]="schema$()" [model]="model" />
+    } @else {
+      <div class="flex min-h-48 items-center justify-center gap-2 text-sm text-text-secondary">
+        <z-loader zSize="sm" />
+        <span>{{ 'PAC.KEY_WORDS.Loading' | translate: { Default: 'Loading' } }}</span>
+      </div>
+    }
   </div>
-  <div ngmButtonGroup>
-    <button z-button zType="secondary" (click)="onCancel()">
+</main>
+
+<footer class="flex shrink-0 items-center justify-between gap-3 border-t border-divider-regular px-6 py-4">
+  <button z-button zType="outline" type="button" [zLoading]="_loading()" [disabled]="_loading()" (click)="ping()">
+    {{ 'PAC.ACTIONS.PING' | translate: { Default: 'Ping' } }}
+  </button>
+  <div class="flex items-center gap-2">
+    <button z-button zType="secondary" type="button" (click)="onCancel()">
       {{ 'PAC.ACTIONS.CANCEL' | translate: { Default: 'Cancel' } }}
     </button>
     <button
       z-button
       zType="default"
-
+      type="button"
       [disabled]="!dirty() || formGroup.invalid || _loading()"
       (click)="onSave()"
     >
       {{ 'PAC.ACTIONS.SAVE' | translate: { Default: 'Save' } }}
     </button>
   </div>
-</div>
+</footer>

--- a/apps/cloud/src/app/features/setting/data-sources/edit/edit.component.scss
+++ b/apps/cloud/src/app/features/setting/data-sources/edit/edit.component.scss
@@ -1,11 +1,4 @@
 @reference "../../../../../styles/tailwind-reference.css";
 :host {
-  @apply max-h-[80vh] text-text-primary;
-}
-
-.pac-data-source-creation__stepper-content {
-  max-height: 400px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
+  @apply flex h-[80vh] max-h-[80vh] flex-col overflow-hidden bg-components-card-bg text-text-primary;
 }

--- a/apps/cloud/src/app/features/setting/data-sources/edit/edit.component.ts
+++ b/apps/cloud/src/app/features/setting/data-sources/edit/edit.component.ts
@@ -1,40 +1,32 @@
-import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog'
-import { DragDropModule } from '@angular/cdk/drag-drop'
 import { CommonModule } from '@angular/common'
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  effect,
-  HostBinding,
-  inject,
-  Inject,
-  Optional,
-  signal
-} from '@angular/core'
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms'
-import { ZardButtonComponent, ZardFormImports, ZardInputDirective, ZardTooltipImports } from '@xpert-ai/headless-ui'
+import {
+  Z_MODAL_DATA,
+  ZardBadgeComponent,
+  ZardButtonComponent,
+  ZardDialogRef,
+  ZardFormImports,
+  ZardIconComponent,
+  ZardInputDirective,
+  ZardLoaderComponent,
+  ZardTooltipImports
+} from '@xpert-ai/headless-ui'
 import { environment } from '@cloud/environments/environment'
 import { DataSourceProtocolEnum, DataSourceService, DataSourceTypesService } from '@xpert-ai/cloud/state'
-import { NgmInputComponent, NgmRadioSelectComponent } from '@xpert-ai/ocap-angular/common'
-import { ButtonGroupDirective, myRxResource, NgmDensityDirective } from '@xpert-ai/ocap-angular/core'
+import { myRxResource } from '@xpert-ai/ocap-angular/core'
 import { cloneDeep } from '@xpert-ai/ocap-core'
-import { ContentLoaderModule } from '@ngneat/content-loader'
 import { FormlyModule } from '@ngx-formly/core'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { assign, isEqual, isNil, omitBy } from 'lodash-es'
 import { derivedAsync } from 'ngxtension/derived-async'
 import { firstValueFrom, map, of, startWith } from 'rxjs'
-import {
-  AuthenticationEnum,
-  convertConfigurationSchema,
-  getErrorMessage,
-  IDataSource,
-  LocalAgent,
-  ServerAgent,
-  ToastrService
-} from '../../../../@core'
+import { AuthenticationEnum, getErrorMessage, IDataSource } from '../../../../@core/types'
+import { convertConfigurationSchema } from '../../../../@core/services/configuration-schema.service'
+import { LocalAgent } from '../../../../@core/services/local-agent.service'
+import { ServerAgent } from '../../../../@core/services/server-agent.service'
+import { ToastrService } from '../../../../@core/services/toastr.service'
 
 @Component({
   standalone: true,
@@ -42,17 +34,14 @@ import {
     CommonModule,
     TranslateModule,
     ReactiveFormsModule,
-    DragDropModule,
     ZardInputDirective,
     ...ZardFormImports,
     ...ZardTooltipImports,
+    ZardBadgeComponent,
     ZardButtonComponent,
-    FormlyModule,
-    ContentLoaderModule,
-    ButtonGroupDirective,
-    NgmDensityDirective,
-    NgmInputComponent,
-    NgmRadioSelectComponent
+    ZardIconComponent,
+    ZardLoaderComponent,
+    FormlyModule
   ],
   selector: 'pac-data-source-edit',
   templateUrl: 'edit.component.html',
@@ -62,10 +51,15 @@ import {
 export class PACDataSourceEditComponent {
   AuthenticationEnum = AuthenticationEnum
   enableLocalAgent = environment.enableLocalAgent
-  @HostBinding('class.ngm-dialog-container') isDialogContainer = true
 
   readonly dataSourceTypesAPI = inject(DataSourceTypesService)
   readonly dataSourceService = inject(DataSourceService)
+  private translateService = inject(TranslateService)
+  public dialogRef = inject<ZardDialogRef<PACDataSourceEditComponent, boolean>>(ZardDialogRef)
+  public data = inject<Pick<IDataSource, 'id'>>(Z_MODAL_DATA)
+  private toastrService = inject(ToastrService)
+  private serverAgent = inject(ServerAgent)
+  private localAgent = inject(LocalAgent, { optional: true }) ?? undefined
 
   readonly dataSourceId = signal(this.data?.id)
   readonly _loading = signal(false)
@@ -112,24 +106,15 @@ export class PACDataSourceEditComponent {
   readonly formValue = toSignal(this.optionsFormGroup.valueChanges.pipe(startWith(this.optionsFormGroup.value)))
   readonly dirty = computed(() => !isEqual(this.dataSource()?.options, omitBy(this.formValue(), isNil)))
 
-  constructor(
-    private translateService: TranslateService,
-    public dialogRef: DialogRef<boolean>,
-    @Inject(DIALOG_DATA) public data: Pick<IDataSource, 'id'>,
-    private toastrService: ToastrService,
-    private serverAgent: ServerAgent,
-    @Optional() private localAgent?: LocalAgent
-  ) {
-    effect(
-      () => {
-        const dataSource = this.dataSource()
-        if (dataSource) {
-          this.formGroup.patchValue(dataSource)
-          this.optionsFormGroup.patchValue(dataSource.options)
-          assign(this.model, dataSource.options)
-        }
+  constructor() {
+    effect(() => {
+      const dataSource = this.dataSource()
+      if (dataSource) {
+        this.formGroup.patchValue(dataSource)
+        this.optionsFormGroup.patchValue(dataSource.options)
+        assign(this.model, dataSource.options)
       }
-    )
+    })
   }
 
   onCancel() {
@@ -146,7 +131,7 @@ export class PACDataSourceEditComponent {
       )
       this.toastrService.success('PAC.MESSAGE.Update', { Default: 'Update' })
       this.dialogRef.close(true)
-    } catch (err) {
+    } catch {
       this.toastrService.error('', 'PAC.MESSAGE.Update', { Default: 'Update' })
     }
   }

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -85,8 +85,11 @@
       "ACTION": "Action",
       "BUSINESS_AREA": "Business Area",
       "CACHE": "Cache",
+      "DataSource": "Data Source",
       "DATA_SOURCES": "Data Sources",
+      "Docs": "Docs",
       "INDICATOR": "Indicator",
+      "Items": "items",
       "MODEL_TYPE": "Model Type",
       "MODIFY": "Modify",
       "NEW": "New",
@@ -94,11 +97,14 @@
       "Name": "Name",
       "Description": "Description",
       "NOTIFICATION_DESTINATION": "Notification Destination",
+      "Search": "Search",
+      "Loading": "Loading",
       "Role&Permissions": "Role & Permissions",
       "SEMANTIC_MODEL": "Semantic Model",
       "STORY": "Story",
       "USER": "User",
       "SUCCEED": "Succeed",
+      "Unknown": "Unknown",
       "Middleware": "Middleware",
       "Skills": "Skills",
       "You": "You",
@@ -171,6 +177,7 @@
     "Chat": {
       "QuoteSelection": "Quote selection",
       "RemoveReference": "Remove reference",
+      "MoreActions": "More actions",
       "ContextCompression": "Automatically compressing context",
       "ContextCompressed": "Context automatically compressed",
       "ContextCompressionSkipped": "Context not compressed",
@@ -288,6 +295,21 @@
         "Administration": "Administration",
         "General": "General"
       },
+      "DATA_SOURCES": {
+        "TYPE_SELECTION": "Type Selection",
+        "CONFIGURATION": "Configuration",
+        "NAME": "Name",
+        "NAME_REQUIRED": "Name is required",
+        "USE_LOCAL_AGENT": "Use Local Agent",
+        "DONE": "Done",
+        "AuthType": "Auth Type",
+        "AuthType_None": "None",
+        "AuthType_Basic": "Basic",
+        "AuthType_None_Description": "Unified system authorization, no need for users to provide accounts.",
+        "AuthType_Basic_Description": "Users need to provide an account for authorization.",
+        "SelectTypeToCreate": "Select a data source type to create",
+        "NoDataSources": "No data sources"
+      },
       "USERS": "Users",
       "FEATURES": "Features",
       "Data": "Data",
@@ -314,10 +336,15 @@
       "ADD_USER": "Add User"
     },
     "ACTIONS": {
+      "NEW": "New",
+      "CREATE": "Create",
       "CANCEL": "Cancel",
+      "SAVE": "Save",
+      "PING": "Ping",
       "Close": "Close",
       "Delete": "Delete",
       "Edit": "Edit",
+      "Copy": "Copy",
       "Pause": "Pause",
       "Rename": "Rename",
       "CLEAR": "Clear",
@@ -617,6 +644,20 @@
       "Organization": {
         "OrganizationId": "Organization ID"
       }
+    },
+    "DataSources": {
+      "PageDescription": "Manage database and service connections for analytics.",
+      "CreateDataSource": "Create data source",
+      "CreateDataSourceHelp": "Learn more about custom data sources",
+      "NoMatchingDataSources": "No matching data sources",
+      "NoDataSources": "No data sources yet",
+      "TryDifferentSearch": "Try a different search keyword.",
+      "EmptyDescription": "Create a data source to connect your databases and services."
+    },
+    "Copilot": {
+      "NoMatchingModels": "No matching models",
+      "ModelFilters": "Filters",
+      "ClearFilters": "Clear filters"
     }
   },
   "STORY_DESIGNER": {
@@ -951,6 +992,13 @@
     }
   },
   "COMPONENTS": {
+    "COMMON": {
+      "Confirm": "Confirm",
+      "CANCEL": "Cancel"
+    },
+    "CONFIRM": {
+      "DELETE": "Confirm Delete"
+    },
     "TIME_FILTER": {
       "SET_DATE_RANGE": "Set Date Range for {{property}}"
     },

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -131,8 +131,11 @@
       "ACTION": "Action",
       "BUSINESS_AREA": "Business Area",
       "CACHE": "Cache",
+      "DataSource": "Data Source",
       "DATA_SOURCES": "Data Sources",
+      "Docs": "Docs",
       "INDICATOR": "Indicator",
+      "Items": "items",
       "MODEL_TYPE": "Model Type",
       "MODIFY": "Modify",
       "NEW": "New",
@@ -158,6 +161,7 @@
       "Deprecated": "Deprecated",
       "DeprecatedSuffix": " (Deprecated)",
       "Disabled": "Disabled",
+      "Unknown": "Unknown",
       "EDIT": "Edit",
       "Email": "Email",
       "ID": "Identifier",
@@ -294,6 +298,21 @@
         "Administration": "Administration",
         "General": "General"
       },
+      "DATA_SOURCES": {
+        "TYPE_SELECTION": "Type Selection",
+        "CONFIGURATION": "Configuration",
+        "NAME": "Name",
+        "NAME_REQUIRED": "Name is required",
+        "USE_LOCAL_AGENT": "Use Local Agent",
+        "DONE": "Done",
+        "AuthType": "Auth Type",
+        "AuthType_None": "None",
+        "AuthType_Basic": "Basic",
+        "AuthType_None_Description": "Unified system authorization, no need for users to provide accounts.",
+        "AuthType_Basic_Description": "Users need to provide an account for authorization.",
+        "SelectTypeToCreate": "Select a data source type to create",
+        "NoDataSources": "No data sources"
+      },
       "USERS": "Users",
       "FEATURES": "Features",
       "Data": "Data",
@@ -429,11 +448,14 @@
       "CANCEL": "Cancel",
       "Cancel": "Cancel",
       "Close": "Close",
+      "CREATE": "Create",
       "Delete": "Delete",
       "Edit": "Edit",
+      "Copy": "Copy",
       "INVITE": "Invite",
       "ManageInvites": "Manage Invites",
       "NEW": "New",
+      "PING": "Ping",
       "Pause": "Pause",
       "Remove": "Remove",
       "Rename": "Rename",
@@ -1091,6 +1113,9 @@
       }
     },
     "Copilot": {
+      "NoMatchingModels": "No matching models",
+      "ModelFilters": "Filters",
+      "ClearFilters": "Clear filters",
       "SelectModel": "Select model",
       "AllModels": "All models",
       "AllUsers": "All users"
@@ -1520,6 +1545,15 @@
       "EndTool": "End point tool. The conversation ends when the tool completes.",
       "XpertUserGroups": "Xpert User Groups"
     },
+    "DataSources": {
+      "PageDescription": "Manage database and service connections for analytics.",
+      "CreateDataSource": "Create data source",
+      "CreateDataSourceHelp": "Learn more about custom data sources",
+      "NoMatchingDataSources": "No matching data sources",
+      "NoDataSources": "No data sources yet",
+      "TryDifferentSearch": "Try a different search keyword.",
+      "EmptyDescription": "Create a data source to connect your databases and services."
+    },
     "UserGroup": {
       "Title": "User Groups",
       "Subtitle": "Manage organization-level access groups for published assistants.",
@@ -1780,6 +1814,13 @@
     }
   },
   "COMPONENTS": {
+    "COMMON": {
+      "Confirm": "Confirm",
+      "CANCEL": "Cancel"
+    },
+    "CONFIRM": {
+      "DELETE": "Confirm Delete"
+    },
     "TIME_FILTER": {
       "SET_DATE_RANGE": "Set Date Range for {{property}}"
     },

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -180,14 +180,18 @@
       "Cube": "多维数据集",
       "Tags": "标签",
       "DATA": "数据",
+      "DataSource": "数据源",
       "DATA_SOURCE": "数据源",
       "DATA_SOURCES": "数据源",
+      "Docs": "文档",
       "DELETE": "删除",
       "DIMENSIONS": "维度",
       "DIMENSION": "维度",
       "EDIT": "编辑",
       "EXPORT": "导出",
       "GENERAL": "常规",
+      "Items": "项",
+      "Unknown": "未知",
       "GROUP": "组",
       "HIERARCHY": "层次结构",
       "INDICATOR": "指标",
@@ -330,6 +334,7 @@
     "Chat": {
       "QuoteSelection": "引用选中内容",
       "RemoveReference": "移除引用",
+      "MoreActions": "更多操作",
       "ContextCompression": "正在自动压缩上下文",
       "ContextCompressed": "上下文已自动压缩",
       "ContextCompressionSkipped": "上下文无需压缩",
@@ -609,7 +614,11 @@
         "DONE": "完成",
         "AuthType": "授权方式",
         "AuthType_None": "无",
-        "AuthType_Basic": "基本身份验证"
+        "AuthType_Basic": "基本身份验证",
+        "AuthType_None_Description": "系统统一授权，不需要用户提供账号",
+        "AuthType_Basic_Description": "用户需提供账号进行授权",
+        "SelectTypeToCreate": "选择一个数据源类型进行创建",
+        "NoDataSources": "暂无数据源"
       },
       "Roles": {
         "General": "通用",
@@ -1304,6 +1313,13 @@
       }
     },
     "DataSources": {
+      "PageDescription": "管理用于分析的数据库和服务连接。",
+      "CreateDataSource": "创建数据源",
+      "CreateDataSourceHelp": "了解更多关于自定义数据源的信息",
+      "NoMatchingDataSources": "未找到匹配的数据源",
+      "NoDataSources": "暂无数据源",
+      "TryDifferentSearch": "尝试使用其他搜索关键词。",
+      "EmptyDescription": "创建数据源以连接数据库和服务。",
       "Schema": {
         "Host": "主机",
         "Port": "端口号",
@@ -1599,6 +1615,9 @@
       "Model": "模型",
       "AllModels": "全部模型",
       "AllUsers": "全部用户",
+      "NoMatchingModels": "没有匹配的模型",
+      "ModelFilters": "筛选",
+      "ClearFilters": "清空筛选",
       "Options": "选项",
       "UseSystemPrompt": "使用系统提示",
       "ExamplesOfPrompts": "提示语示例",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -643,6 +643,7 @@
       "DataSource": "数据源",
       "DATA_SOURCE": "数据源",
       "DATA_SOURCES": "数据源",
+      "Docs": "文档",
       "DELETE": "删除",
       "Default": "默认",
       "DIMENSIONS": "维度",
@@ -651,6 +652,8 @@
       "Email": "邮箱",
       "EXPORT": "导出",
       "GENERAL": "常规",
+      "Items": "项",
+      "Unknown": "未知",
       "GROUP": "组",
       "HIERARCHY": "层次结构",
       "INDICATOR": "指标",
@@ -1687,7 +1690,8 @@
         "AuthType_Basic": "基本身份验证",
         "AuthType_None_Description": "系统统一授权，不需要用户提供账号",
         "AuthType_Basic_Description": "用户需提供账号进行授权",
-        "SelectTypeToCreate": "选择一个数据源类型进行创建"
+        "SelectTypeToCreate": "选择一个数据源类型进行创建",
+        "NoDataSources": "暂无数据源"
       },
       "Roles": {
         "General": "通用",
@@ -2688,8 +2692,13 @@
       }
     },
     "DataSources": {
+      "PageDescription": "管理用于分析的数据库和服务连接。",
       "CreateDataSource": "创建数据源",
       "CreateDataSourceHelp": "了解更多关于自定义数据源的信息",
+      "NoMatchingDataSources": "未找到匹配的数据源",
+      "NoDataSources": "暂无数据源",
+      "TryDifferentSearch": "尝试使用其他搜索关键词。",
+      "EmptyDescription": "创建数据源以连接数据库和服务。",
       "Schema": {
         "Host": "主机",
         "Port": "端口号",
@@ -3004,6 +3013,8 @@
       "DescribeYourUseCase": "在左侧描述您的用例",
       "ThePromptPreview": "提示词预览将显示在这里",
       "Chat": "对话",
+      "ModelFilters": "筛选",
+      "ClearFilters": "清空筛选",
       "SelectModel": "选择模型",
       "Parameters": "参数",
       "LoadModelParameterRulesFailed": "加载模型参数失败",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -195,6 +195,7 @@
       "DataSource": "數據源",
       "DATA_SOURCE": "數據源",
       "DATA_SOURCES": "數據源",
+      "Docs": "文檔",
       "DELETE": "刪除",
       "Default": "默認",
       "DIMENSIONS": "維度",
@@ -202,6 +203,8 @@
       "EDIT": "編輯",
       "EXPORT": "導出",
       "GENERAL": "常規",
+      "Items": "項",
+      "Unknown": "未知",
       "GROUP": "組",
       "HIERARCHY": "層次結構",
       "INDICATOR": "指標",
@@ -906,7 +909,8 @@
         "AuthType_Basic": "基本身份驗證",
         "AuthType_None_Description": "系統統一授權，不需要用戶提供賬號",
         "AuthType_Basic_Description": "用戶需提供賬號進行授權",
-        "SelectTypeToCreate": "選擇一個數據源類型進行創建"
+        "SelectTypeToCreate": "選擇一個數據源類型進行創建",
+        "NoDataSources": "暫無數據源"
       },
       "Roles": {
         "General": "通用",
@@ -1876,8 +1880,13 @@
       }
     },
     "DataSources": {
+      "PageDescription": "管理用於分析的數據庫和服務連接。",
       "CreateDataSource": "創建數據源",
       "CreateDataSourceHelp": "了解更多關於自定義數據源的信息",
+      "NoMatchingDataSources": "未找到匹配的數據源",
+      "NoDataSources": "暫無數據源",
+      "TryDifferentSearch": "嘗試使用其他搜索關鍵詞。",
+      "EmptyDescription": "創建數據源以連接數據庫和服務。",
       "Schema": {
         "Host": "主機",
         "Port": "端口號",
@@ -2238,6 +2247,7 @@
       "PromptGenerator": "提示詞生成器",
       "PromptGeneratorDesc": "提示生成器使用配置的模型來優化提示，以獲得更高的質量和更好的結構。請寫出清晰詳細的說明。",
       "NoSupportedAIModelFound": "未找到支持的 AI 模型",
+      "NoMatchingModels": "沒有匹配的模型",
       "TryIt": "試一試",
       "Instructions": "指令",
       "WriteClearInstructions": "寫下清晰、具體的說明。",
@@ -2245,6 +2255,8 @@
       "DescribeYourUseCase": "在左側描述您的用例",
       "ThePromptPreview": "提示詞預覽將顯示在這裏",
       "Chat": "對話",
+      "ModelFilters": "篩選",
+      "ClearFilters": "清空篩選",
       "SelectModel": "選擇模型",
       "Parameters": "參數",
       "Role_primary": "主",
@@ -2354,6 +2366,7 @@
     "Chat": {
       "QuoteSelection": "引用選取內容",
       "RemoveReference": "移除引用",
+      "MoreActions": "更多操作",
       "ContextCompression": "正在自動壓縮上下文",
       "ContextCompressed": "上下文已自動壓縮",
       "ContextCompressionSkipped": "上下文無需壓縮",

--- a/packages/ui/src/lib/components/dialog/dialog.service.spec.ts
+++ b/packages/ui/src/lib/components/dialog/dialog.service.spec.ts
@@ -1,26 +1,24 @@
-import { OverlayModule } from '@angular/cdk/overlay';
-import { Component, InjectionToken, TemplateRef, ViewChild, ViewContainerRef, inject } from '@angular/core';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Overlay, OverlayModule } from '@angular/cdk/overlay'
+import { Component, InjectionToken, TemplateRef, ViewChild, ViewContainerRef, inject } from '@angular/core'
+import { fakeAsync, TestBed, tick } from '@angular/core/testing'
 
-import { UiDialogCloseDirective } from './dialog-close.directive';
-import { ZardDialogRef } from './dialog-ref';
-import { Z_MODAL_DATA } from './dialog.service';
-import { ZardDialogService } from './dialog.service';
+import { UiDialogCloseDirective } from './dialog-close.directive'
+import { ZardDialogRef } from './dialog-ref'
+import { Z_MODAL_DATA } from './dialog.service'
+import { ZardDialogService } from './dialog.service'
 
-const TEST_PARENT_TOKEN = new InjectionToken<string>('TEST_PARENT_TOKEN');
+const TEST_PARENT_TOKEN = new InjectionToken<string>('TEST_PARENT_TOKEN')
 
 @Component({
   standalone: true,
-  template: `
-    <button type="button" data-testid="component-close" (click)="close()"></button>
-  `,
+  template: ` <button type="button" data-testid="component-close" (click)="close()"></button> `
 })
 class TestDialogComponent {
-  private readonly dialogRef = inject(ZardDialogRef<TestDialogComponent, string>);
-  private readonly data = inject<{ result?: string }>(Z_MODAL_DATA, { optional: true });
+  private readonly dialogRef = inject(ZardDialogRef<TestDialogComponent, string>)
+  private readonly data = inject<{ result?: string }>(Z_MODAL_DATA, { optional: true })
 
   close() {
-    this.dialogRef.close(this.data?.result ?? 'component-result');
+    this.dialogRef.close(this.data?.result ?? 'component-result')
   }
 }
 
@@ -30,11 +28,11 @@ class TestDialogComponent {
     <ng-template #dialog let-dialogRef="dialogRef">
       <button type="button" data-testid="template-close" (click)="dialogRef.close('template-result')"></button>
     </ng-template>
-  `,
+  `
 })
 class TestTemplateHostComponent {
   @ViewChild('dialog', { static: true })
-  dialogTemplate!: TemplateRef<{ dialogRef: ZardDialogRef<unknown, string> }>;
+  dialogTemplate!: TemplateRef<{ dialogRef: ZardDialogRef<unknown, string> }>
 }
 
 @Component({
@@ -44,183 +42,203 @@ class TestTemplateHostComponent {
     <ng-template #dialog>
       <button type="button" data-testid="template-directive-close" [xpDialogClose]="'directive-result'"></button>
     </ng-template>
-  `,
+  `
 })
 class TestTemplateDirectiveHostComponent {
   @ViewChild('dialog', { static: true })
-  dialogTemplate!: TemplateRef<unknown>;
+  dialogTemplate!: TemplateRef<unknown>
 }
 
 @Component({
   standalone: true,
-  template: `
-    <button type="button" data-testid="inherit-close" (click)="close()"></button>
-  `,
+  template: ` <button type="button" data-testid="inherit-close" (click)="close()"></button> `
 })
 class TestInheritedInjectorDialogComponent {
-  readonly inherited = inject(TEST_PARENT_TOKEN, { optional: true });
-  private readonly dialogRef = inject(ZardDialogRef<TestInheritedInjectorDialogComponent, string>);
+  readonly inherited = inject(TEST_PARENT_TOKEN, { optional: true })
+  private readonly dialogRef = inject(ZardDialogRef<TestInheritedInjectorDialogComponent, string>)
 
   close() {
-    this.dialogRef.close(this.inherited ?? 'missing');
+    this.dialogRef.close(this.inherited ?? 'missing')
   }
 }
 
 @Component({
   standalone: true,
-  template: `
-    <ng-container #anchor></ng-container>
-  `,
-  providers: [{ provide: TEST_PARENT_TOKEN, useValue: 'from-view-container' }],
+  template: ` <ng-container #anchor></ng-container> `,
+  providers: [{ provide: TEST_PARENT_TOKEN, useValue: 'from-view-container' }]
 })
 class TestInjectorHostComponent {
   @ViewChild('anchor', { static: true, read: ViewContainerRef })
-  viewContainerRef!: ViewContainerRef;
+  viewContainerRef!: ViewContainerRef
 }
 
 describe('ZardDialogService', () => {
   afterEach(() => {
-    document.querySelectorAll('.cdk-overlay-container').forEach((element) => element.remove());
-  });
+    document.querySelectorAll('.cdk-overlay-container').forEach((element) => element.remove())
+  })
 
   it('applies zBackdropClass to the overlay backdrop', fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule, TestDialogComponent],
-    });
+      imports: [OverlayModule, TestDialogComponent]
+    })
 
-    const service = TestBed.inject(ZardDialogService);
+    const service = TestBed.inject(ZardDialogService)
     const ref = service.open(TestDialogComponent, {
-      backdropClass: ['custom-backdrop', 'backdrop-blur-sm-black'],
-    });
+      backdropClass: ['custom-backdrop', 'backdrop-blur-sm-black']
+    })
 
-    tick();
+    tick()
 
-    expect(document.querySelector('.cdk-overlay-backdrop.custom-backdrop.backdrop-blur-sm-black')).not.toBeNull();
+    expect(document.querySelector('.cdk-overlay-backdrop.custom-backdrop.backdrop-blur-sm-black')).not.toBeNull()
 
-    ref.close();
-    tick(150);
-  }));
+    ref.close()
+    tick(150)
+  }))
+
+  it('keeps dialog overlays out of the browser popover top layer', fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [OverlayModule, TestDialogComponent]
+    })
+
+    const overlay = TestBed.inject(Overlay)
+    const createSpy = jest.spyOn(overlay, 'create')
+    const service = TestBed.inject(ZardDialogService)
+
+    const ref = service.open(TestDialogComponent)
+    tick()
+
+    expect(createSpy.mock.calls.at(-1)?.[0]?.usePopover).toBe(false)
+
+    ref.close()
+    tick(150)
+  }))
 
   it('keeps the dialog open when zMaskClosable is disabled', fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule, TestDialogComponent],
-    });
+      imports: [OverlayModule, TestDialogComponent]
+    })
 
-    const service = TestBed.inject(ZardDialogService);
-    let result: string | undefined;
+    const service = TestBed.inject(ZardDialogService)
+    let result: string | undefined
 
     const ref = service.open(TestDialogComponent, {
-      disableClose: true,
-    });
+      disableClose: true
+    })
 
     ref.afterClosed().subscribe((value) => {
-      result = value;
-    });
+      result = value
+    })
 
-    tick();
-    (document.querySelector('.cdk-overlay-backdrop') as HTMLElement).click();
-    tick(200);
+    tick()
+    ;(document.querySelector('.cdk-overlay-backdrop') as HTMLElement).click()
+    tick(200)
 
-    expect(document.querySelector('z-dialog')).not.toBeNull();
-    expect(result).toBeUndefined();
+    expect(document.querySelector('z-dialog')).not.toBeNull()
+    expect(result).toBeUndefined()
 
-    ref.close('manual-close');
-    tick(150);
-    expect(result).toBe('manual-close');
-  }));
+    ref.close('manual-close')
+    tick(150)
+    expect(result).toBe('manual-close')
+  }))
 
   it('emits the component dialog close result', fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule, TestDialogComponent],
-    });
+      imports: [OverlayModule, TestDialogComponent]
+    })
 
-    const service = TestBed.inject(ZardDialogService);
-    let result: string | undefined;
+    const service = TestBed.inject(ZardDialogService)
+    let result: string | undefined
 
     service
       .open(TestDialogComponent, {
-        data: { result: 'component-result' },
+        data: { result: 'component-result' }
       })
       .afterClosed()
       .subscribe((value) => {
-        result = value;
-      });
+        result = value
+      })
 
-    tick();
-    (document.querySelector('[data-testid="component-close"]') as HTMLButtonElement).click();
-    tick(150);
+    tick()
+    ;(document.querySelector('[data-testid="component-close"]') as HTMLButtonElement).click()
+    tick(150)
 
-    expect(result).toBe('component-result');
-  }));
+    expect(result).toBe('component-result')
+  }))
 
   it('emits the template dialog close result', fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule, TestTemplateHostComponent],
-    });
+      imports: [OverlayModule, TestTemplateHostComponent]
+    })
 
-    const fixture = TestBed.createComponent(TestTemplateHostComponent);
-    fixture.detectChanges();
+    const fixture = TestBed.createComponent(TestTemplateHostComponent)
+    fixture.detectChanges()
 
-    const service = TestBed.inject(ZardDialogService);
-    let result: string | undefined;
+    const service = TestBed.inject(ZardDialogService)
+    let result: string | undefined
 
-    service.open(fixture.componentInstance.dialogTemplate).afterClosed().subscribe((value) => {
-      result = value;
-    });
+    service
+      .open(fixture.componentInstance.dialogTemplate)
+      .afterClosed()
+      .subscribe((value) => {
+        result = value
+      })
 
-    tick();
-    (document.querySelector('[data-testid="template-close"]') as HTMLButtonElement).click();
-    tick(150);
+    tick()
+    ;(document.querySelector('[data-testid="template-close"]') as HTMLButtonElement).click()
+    tick(150)
 
-    expect(result).toBe('template-result');
-  }));
+    expect(result).toBe('template-result')
+  }))
 
   it('lets template content close through xpDialogClose', fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule, TestTemplateDirectiveHostComponent],
-    });
+      imports: [OverlayModule, TestTemplateDirectiveHostComponent]
+    })
 
-    const fixture = TestBed.createComponent(TestTemplateDirectiveHostComponent);
-    fixture.detectChanges();
+    const fixture = TestBed.createComponent(TestTemplateDirectiveHostComponent)
+    fixture.detectChanges()
 
-    const service = TestBed.inject(ZardDialogService);
-    let result: string | undefined;
+    const service = TestBed.inject(ZardDialogService)
+    let result: string | undefined
 
-    service.open(fixture.componentInstance.dialogTemplate).afterClosed().subscribe((value) => {
-      result = value;
-    });
+    service
+      .open(fixture.componentInstance.dialogTemplate)
+      .afterClosed()
+      .subscribe((value) => {
+        result = value
+      })
 
-    tick();
-    (document.querySelector('[data-testid="template-directive-close"]') as HTMLButtonElement).click();
-    tick(150);
+    tick()
+    ;(document.querySelector('[data-testid="template-directive-close"]') as HTMLButtonElement).click()
+    tick(150)
 
-    expect(result).toBe('directive-result');
-  }));
+    expect(result).toBe('directive-result')
+  }))
 
   it('inherits providers from the supplied view container injector', fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule, TestInheritedInjectorDialogComponent, TestInjectorHostComponent],
-    });
+      imports: [OverlayModule, TestInheritedInjectorDialogComponent, TestInjectorHostComponent]
+    })
 
-    const fixture = TestBed.createComponent(TestInjectorHostComponent);
-    fixture.detectChanges();
+    const fixture = TestBed.createComponent(TestInjectorHostComponent)
+    fixture.detectChanges()
 
-    const service = TestBed.inject(ZardDialogService);
-    let result: string | undefined;
+    const service = TestBed.inject(ZardDialogService)
+    let result: string | undefined
 
     service
       .open(TestInheritedInjectorDialogComponent, {
-        viewContainerRef: fixture.componentInstance.viewContainerRef,
+        viewContainerRef: fixture.componentInstance.viewContainerRef
       })
       .afterClosed()
       .subscribe((value) => {
-        result = value;
-      });
+        result = value
+      })
 
-    tick();
-    (document.querySelector('[data-testid="inherit-close"]') as HTMLButtonElement).click();
-    tick(150);
+    tick()
+    ;(document.querySelector('[data-testid="inherit-close"]') as HTMLButtonElement).click()
+    tick(150)
 
-    expect(result).toBe('from-view-container');
-  }));
-});
+    expect(result).toBe('from-view-container')
+  }))
+})

--- a/packages/ui/src/lib/components/dialog/dialog.service.ts
+++ b/packages/ui/src/lib/components/dialog/dialog.service.ts
@@ -1,92 +1,84 @@
-import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
-import { type ComponentType, Overlay, OverlayConfig, OverlayRef } from '@angular/cdk/overlay';
-import { ComponentPortal, TemplatePortal } from '@angular/cdk/portal';
-import { isPlatformBrowser } from '@angular/common';
-import {
-  inject,
-  Injectable,
-  InjectionToken,
-  Injector,
-  PLATFORM_ID,
-  TemplateRef,
-  ViewContainerRef,
-} from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog'
+import { type ComponentType, Overlay, OverlayConfig, OverlayRef } from '@angular/cdk/overlay'
+import { ComponentPortal, TemplatePortal } from '@angular/cdk/portal'
+import { isPlatformBrowser } from '@angular/common'
+import { inject, Injectable, InjectionToken, Injector, PLATFORM_ID, TemplateRef, ViewContainerRef } from '@angular/core'
 
-import { ZardDialogRef } from './dialog-ref';
-import { ZardDialogComponent, ZardDialogOptions } from './dialog.component';
+import { ZardDialogRef } from './dialog-ref'
+import { ZardDialogComponent, ZardDialogOptions } from './dialog.component'
 
-type ContentType<T> = ComponentType<T> | TemplateRef<T> | string;
-type CustomClass = string | string[] | undefined;
+type ContentType<T> = ComponentType<T> | TemplateRef<T> | string
+type CustomClass = string | string[] | undefined
 
-export const Z_MODAL_DATA = new InjectionToken<any>('Z_MODAL_DATA');
+export const Z_MODAL_DATA = new InjectionToken<any>('Z_MODAL_DATA')
 
 export interface ZardDialogOpenConfig<U = any> {
-  backdropClass?: CustomClass;
-  data?: U;
-  disableClose?: boolean;
-  height?: string;
-  maxHeight?: string;
-  maxWidth?: string;
-  minHeight?: string;
-  minWidth?: string;
-  panelClass?: CustomClass;
-  viewContainerRef?: ViewContainerRef;
-  width?: string;
+  backdropClass?: CustomClass
+  data?: U
+  disableClose?: boolean
+  height?: string
+  maxHeight?: string
+  maxWidth?: string
+  minHeight?: string
+  minWidth?: string
+  panelClass?: CustomClass
+  viewContainerRef?: ViewContainerRef
+  width?: string
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class ZardDialogService {
-  private overlay = inject(Overlay);
-  private injector = inject(Injector);
-  private platformId = inject(PLATFORM_ID);
+  private overlay = inject(Overlay)
+  private injector = inject(Injector)
+  private platformId = inject(PLATFORM_ID)
 
   create<T, U>(config: ZardDialogOptions<T, U>): ZardDialogRef<T> {
-    return this.createDialog<T, U>(config.zContent as ComponentType<T>, config);
+    return this.createDialog<T, U>(config.zContent as ComponentType<T>, config)
   }
 
   open<T, D = any, R = any>(
     componentOrTemplateRef: ContentType<T>,
-    config: ZardDialogOpenConfig<D> = {},
+    config: ZardDialogOpenConfig<D> = {}
   ): ZardDialogRef<T, R, D> {
-    const zardConfig = new ZardDialogOptions<T, D>();
-    zardConfig.zBackdropClass = config.backdropClass;
-    zardConfig.zClosable = false;
-    zardConfig.zContent = componentOrTemplateRef;
-    zardConfig.zCustomClasses = this.mergeCustomClasses(config.panelClass);
-    zardConfig.zData = config.data;
-    zardConfig.zHeight = config.height;
-    zardConfig.zHideFooter = true;
-    zardConfig.zMaskClosable = !config.disableClose;
-    zardConfig.zMaxHeight = config.maxHeight;
-    zardConfig.zMaxWidth = config.maxWidth;
-    zardConfig.zMinHeight = config.minHeight;
-    zardConfig.zMinWidth = config.minWidth;
-    zardConfig.zViewContainerRef = config.viewContainerRef;
-    zardConfig.zWidth = config.width;
+    const zardConfig = new ZardDialogOptions<T, D>()
+    zardConfig.zBackdropClass = config.backdropClass
+    zardConfig.zClosable = false
+    zardConfig.zContent = componentOrTemplateRef
+    zardConfig.zCustomClasses = this.mergeCustomClasses(config.panelClass)
+    zardConfig.zData = config.data
+    zardConfig.zHeight = config.height
+    zardConfig.zHideFooter = true
+    zardConfig.zMaskClosable = !config.disableClose
+    zardConfig.zMaxHeight = config.maxHeight
+    zardConfig.zMaxWidth = config.maxWidth
+    zardConfig.zMinHeight = config.minHeight
+    zardConfig.zMinWidth = config.minWidth
+    zardConfig.zViewContainerRef = config.viewContainerRef
+    zardConfig.zWidth = config.width
 
-    return this.create<T, D>(zardConfig) as ZardDialogRef<T, R, D>;
+    return this.create<T, D>(zardConfig) as ZardDialogRef<T, R, D>
   }
 
   private createDialog<T, U>(componentOrTemplateRef: ContentType<T>, config: ZardDialogOptions<T, U>) {
-    const overlayRef = this.createOverlay(config);
+    const overlayRef = this.createOverlay(config)
 
     if (!overlayRef) {
       return new ZardDialogRef(
         undefined as unknown as OverlayRef,
         config,
         undefined as unknown as ZardDialogComponent<T, U>,
-        this.platformId,
-      );
+        this.platformId
+      )
     }
 
-    const dialogContainer = this.attachDialogContainer<T, U>(overlayRef, config);
-    const dialogRef = this.attachDialogContent<T, U>(componentOrTemplateRef, dialogContainer, overlayRef, config);
+    const dialogContainer = this.attachDialogContainer<T, U>(overlayRef, config)
+    const dialogRef = this.attachDialogContent<T, U>(componentOrTemplateRef, dialogContainer, overlayRef, config)
 
-    dialogContainer.dialogRef = dialogRef;
+    dialogContainer.dialogRef = dialogRef
 
-    return dialogRef;
+    return dialogRef
   }
 
   private createOverlay<T, U>(config: ZardDialogOptions<T, U>): OverlayRef | undefined {
@@ -95,12 +87,13 @@ export class ZardDialogService {
         backdropClass: config.zBackdropClass,
         hasBackdrop: true,
         positionStrategy: this.overlay.position().global(),
-      });
+        usePopover: false
+      })
 
-      return this.overlay.create(overlayConfig);
+      return this.overlay.create(overlayConfig)
     }
 
-    return undefined;
+    return undefined
   }
 
   private attachDialogContainer<T, U>(overlayRef: OverlayRef, config: ZardDialogOptions<T, U>) {
@@ -108,51 +101,51 @@ export class ZardDialogService {
       parent: this.injector,
       providers: [
         { provide: OverlayRef, useValue: overlayRef },
-        { provide: ZardDialogOptions, useValue: config },
-      ],
-    });
+        { provide: ZardDialogOptions, useValue: config }
+      ]
+    })
 
     const containerPortal = new ComponentPortal<ZardDialogComponent<T, U>>(
       ZardDialogComponent,
       config.zViewContainerRef,
-      injector,
-    );
+      injector
+    )
 
-    const containerRef = overlayRef.attach<ZardDialogComponent<T, U>>(containerPortal);
+    const containerRef = overlayRef.attach<ZardDialogComponent<T, U>>(containerPortal)
 
-    return containerRef.instance;
+    return containerRef.instance
   }
 
   private attachDialogContent<T, U>(
     componentOrTemplateRef: ContentType<T>,
     dialogContainer: ZardDialogComponent<T, U>,
     overlayRef: OverlayRef,
-    config: ZardDialogOptions<T, U>,
+    config: ZardDialogOptions<T, U>
   ) {
-    const dialogRef = new ZardDialogRef<T>(overlayRef, config, dialogContainer, this.platformId);
+    const dialogRef = new ZardDialogRef<T>(overlayRef, config, dialogContainer, this.platformId)
 
     if (componentOrTemplateRef instanceof TemplateRef) {
-      const viewContainerRef = config.zViewContainerRef ?? dialogContainer.getViewContainerRef();
-      const injector = this.createInjector<T, U>(dialogRef, config);
+      const viewContainerRef = config.zViewContainerRef ?? dialogContainer.getViewContainerRef()
+      const injector = this.createInjector<T, U>(dialogRef, config)
       dialogContainer.attachTemplatePortal(
         new TemplatePortal<T>(
           componentOrTemplateRef,
           viewContainerRef,
           {
-            dialogRef,
+            dialogRef
           } as T,
-          injector,
-        ),
-      );
+          injector
+        )
+      )
     } else if (typeof componentOrTemplateRef !== 'string') {
-      const injector = this.createInjector<T, U>(dialogRef, config);
+      const injector = this.createInjector<T, U>(dialogRef, config)
       const contentRef = dialogContainer.attachComponentPortal<T>(
-        new ComponentPortal(componentOrTemplateRef, config.zViewContainerRef, injector),
-      );
-      dialogRef.componentInstance = contentRef.instance;
+        new ComponentPortal(componentOrTemplateRef, config.zViewContainerRef, injector)
+      )
+      dialogRef.componentInstance = contentRef.instance
     }
 
-    return dialogRef;
+    return dialogRef
   }
 
   private createInjector<T, U>(dialogRef: ZardDialogRef<T>, config: ZardDialogOptions<T, U>) {
@@ -162,16 +155,16 @@ export class ZardDialogService {
         { provide: DialogRef, useValue: dialogRef },
         { provide: DIALOG_DATA, useValue: config.zData },
         { provide: ZardDialogRef, useValue: dialogRef },
-        { provide: Z_MODAL_DATA, useValue: config.zData },
-      ],
-    });
+        { provide: Z_MODAL_DATA, useValue: config.zData }
+      ]
+    })
   }
 
   private mergeCustomClasses(panelClass: CustomClass) {
     if (Array.isArray(panelClass)) {
-      return panelClass.filter(Boolean).join(' ');
+      return panelClass.filter(Boolean).join(' ')
     }
 
-    return panelClass ?? undefined;
+    return panelClass ?? undefined
   }
 }

--- a/packages/ui/src/lib/components/radio/radio.component.spec.ts
+++ b/packages/ui/src/lib/components/radio/radio.component.spec.ts
@@ -1,8 +1,8 @@
-import { Component } from '@angular/core';
-import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core'
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms'
+import { TestBed } from '@angular/core/testing'
 
-import { ZardRadioComponent, ZardRadioGroupComponent } from './radio.component';
+import { ZardRadioComponent, ZardRadioGroupComponent } from './radio.component'
 
 @Component({
   imports: [ReactiveFormsModule, ZardRadioGroupComponent, ZardRadioComponent],
@@ -11,14 +11,14 @@ import { ZardRadioComponent, ZardRadioGroupComponent } from './radio.component';
       <z-radio value="github">GitHub</z-radio>
       <z-radio value="aliyun">Aliyun</z-radio>
     </z-radio-group>
-  `,
+  `
 })
 class ReactiveHostComponent {
-  readonly control = new FormControl('github');
-  groupChange: unknown = null;
+  readonly control = new FormControl('github')
+  groupChange: unknown = null
 
   onGroupChange(event: unknown) {
-    this.groupChange = event;
+    this.groupChange = event
   }
 }
 
@@ -29,64 +29,74 @@ class ReactiveHostComponent {
       <z-radio value="public">Public</z-radio>
       <z-radio value="private">Private</z-radio>
     </z-radio-group>
-  `,
+  `
 })
 class NgModelHostComponent {
-  value = 'public';
-  disabled = false;
+  value = 'public'
+  disabled = false
 }
 
 describe('ZardRadioGroupComponent', () => {
   it('syncs reactive form values and emits group changes', async () => {
     const fixture = await TestBed.configureTestingModule({
-      imports: [ReactiveHostComponent],
-    }).createComponent(ReactiveHostComponent);
+      imports: [ReactiveHostComponent]
+    }).createComponent(ReactiveHostComponent)
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    fixture.detectChanges()
+    await fixture.whenStable()
+    fixture.detectChanges()
 
-    const radios = fixture.nativeElement.querySelectorAll('input[type="radio"]') as NodeListOf<HTMLInputElement>;
-    const dots = fixture.nativeElement.querySelectorAll('.z-radio__dot') as NodeListOf<HTMLSpanElement>;
-    const controls = fixture.nativeElement.querySelectorAll('.z-radio__control') as NodeListOf<HTMLSpanElement>;
-    expect(radios[0].checked).toBe(true);
-    expect(radios[1].checked).toBe(false);
-    expect(dots[0].className).toContain('peer-checked:opacity-100');
-    expect(controls[0].className).toContain('peer-checked:border-primary');
-    expect(controls[0].previousElementSibling).toBe(radios[0]);
-    expect(dots[0].previousElementSibling).toBe(controls[0]);
+    const radios = fixture.nativeElement.querySelectorAll('input[type="radio"]') as NodeListOf<HTMLInputElement>
+    const dots = fixture.nativeElement.querySelectorAll('.z-radio__dot') as NodeListOf<HTMLSpanElement>
+    const controls = fixture.nativeElement.querySelectorAll('.z-radio__control') as NodeListOf<HTMLSpanElement>
+    expect(radios[0].checked).toBe(true)
+    expect(radios[1].checked).toBe(false)
+    expect(dots[0].className).toContain('opacity-100')
+    expect(dots[1].className).toContain('opacity-0')
+    expect(dots[0].className).toContain('absolute')
+    expect(dots[0].className).toContain('left-1/2')
+    expect(dots[0].className).toContain('top-1/2')
+    expect(dots[0].className).toContain('-translate-x-1/2')
+    expect(dots[0].className).toContain('-translate-y-1/2')
+    expect(dots[0].className).toContain('m-0')
+    expect(dots[0].className).not.toContain('inset-0')
+    expect(dots[0].className).not.toContain('m-auto')
+    expect(controls[0].className).toContain('peer-checked:border-primary')
+    expect(controls[0].previousElementSibling).toBe(radios[0])
+    expect(dots[0].parentElement).toBe(controls[0])
 
-    radios[1].dispatchEvent(new Event('change', { bubbles: true }));
-    fixture.detectChanges();
+    radios[1].dispatchEvent(new Event('change', { bubbles: true }))
+    fixture.detectChanges()
 
-    expect(fixture.componentInstance.control.value).toBe('aliyun');
-    expect(fixture.componentInstance.groupChange).toEqual({ value: 'aliyun' });
-    expect(radios[1].checked).toBe(true);
-    expect(controls[1].previousElementSibling).toBe(radios[1]);
-    expect(dots[1].previousElementSibling).toBe(controls[1]);
-  });
+    expect(fixture.componentInstance.control.value).toBe('aliyun')
+    expect(fixture.componentInstance.groupChange).toEqual({ value: 'aliyun' })
+    expect(radios[1].checked).toBe(true)
+    expect(dots[1].className).toContain('opacity-100')
+    expect(controls[1].previousElementSibling).toBe(radios[1])
+    expect(dots[1].parentElement).toBe(controls[1])
+  })
 
   it('supports ngModel bindings and disables all child radios from the group', async () => {
     const fixture = await TestBed.configureTestingModule({
-      imports: [NgModelHostComponent],
-    }).createComponent(NgModelHostComponent);
+      imports: [NgModelHostComponent]
+    }).createComponent(NgModelHostComponent)
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    fixture.detectChanges()
+    await fixture.whenStable()
+    fixture.detectChanges()
 
-    const radios = fixture.nativeElement.querySelectorAll('input[type="radio"]') as NodeListOf<HTMLInputElement>;
-    expect(radios[0].checked).toBe(true);
+    const radios = fixture.nativeElement.querySelectorAll('input[type="radio"]') as NodeListOf<HTMLInputElement>
+    expect(radios[0].checked).toBe(true)
 
-    radios[1].dispatchEvent(new Event('change', { bubbles: true }));
-    fixture.detectChanges();
+    radios[1].dispatchEvent(new Event('change', { bubbles: true }))
+    fixture.detectChanges()
 
-    expect(fixture.componentInstance.value).toBe('private');
+    expect(fixture.componentInstance.value).toBe('private')
 
-    fixture.componentInstance.disabled = true;
-    fixture.detectChanges();
+    fixture.componentInstance.disabled = true
+    fixture.detectChanges()
 
-    expect(radios[0].disabled).toBe(true);
-    expect(radios[1].disabled).toBe(true);
-  });
-});
+    expect(radios[0].disabled).toBe(true)
+    expect(radios[1].disabled).toBe(true)
+  })
+})

--- a/packages/ui/src/lib/components/radio/radio.component.ts
+++ b/packages/ui/src/lib/components/radio/radio.component.ts
@@ -10,35 +10,41 @@ import {
   output,
   signal,
   type Signal,
-  ViewEncapsulation,
-} from '@angular/core';
-import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+  ViewEncapsulation
+} from '@angular/core'
+import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms'
 
-import type { ClassValue } from 'clsx';
+import type { ClassValue } from 'clsx'
 
-import { ZardIdDirective } from '@/shared/core';
-import { mergeClasses, noopFn } from '@/shared/utils/merge-classes';
+import { ZardIdDirective } from '@/shared/core'
+import { mergeClasses, noopFn } from '@/shared/utils/merge-classes'
 
-import { radioDotVariants, radioItemVariants, radioLabelVariants, radioVariants, type ZardRadioDensity } from './radio.variants';
+import {
+  radioDotVariants,
+  radioItemVariants,
+  radioLabelVariants,
+  radioVariants,
+  type ZardRadioDensity
+} from './radio.variants'
 
-type OnTouchedType = () => void;
-type OnChangeType = (value: unknown) => void;
-let nextUniqueId = 0;
+type OnTouchedType = () => void
+type OnChangeType = (value: unknown) => void
+let nextUniqueId = 0
 
 export interface ZardRadioGroupChange<T = any> {
-  value: T;
+  value: T
 }
 
 export interface ZardRadioGroupApi {
-  readonly disabled: Signal<boolean>;
-  readonly displayDensity: Signal<ZardRadioDensity>;
-  readonly name: Signal<string>;
-  readonly selectedValue: Signal<unknown>;
-  select(value: unknown): void;
-  touch(): void;
+  readonly disabled: Signal<boolean>
+  readonly displayDensity: Signal<ZardRadioDensity>
+  readonly name: Signal<string>
+  readonly selectedValue: Signal<unknown>
+  select(value: unknown): void
+  touch(): void
 }
 
-export const ZARD_RADIO_GROUP = new InjectionToken<ZardRadioGroupApi>('ZARD_RADIO_GROUP');
+export const ZARD_RADIO_GROUP = new InjectionToken<ZardRadioGroupApi>('ZARD_RADIO_GROUP')
 
 @Component({
   selector: 'z-radio-group, [z-radio-group]',
@@ -47,12 +53,12 @@ export const ZARD_RADIO_GROUP = new InjectionToken<ZardRadioGroupApi>('ZARD_RADI
     {
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => ZardRadioGroupComponent),
-      multi: true,
+      multi: true
     },
     {
       provide: ZARD_RADIO_GROUP,
-      useExisting: forwardRef(() => ZardRadioGroupComponent),
-    },
+      useExisting: forwardRef(() => ZardRadioGroupComponent)
+    }
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
@@ -60,52 +66,52 @@ export const ZARD_RADIO_GROUP = new InjectionToken<ZardRadioGroupApi>('ZARD_RADI
     class: 'z-radio-group',
     role: 'radiogroup',
     '[attr.aria-disabled]': 'disabled()',
-    '[attr.data-density]': 'displayDensity()',
+    '[attr.data-density]': 'displayDensity()'
   },
-  exportAs: 'zRadioGroup',
+  exportAs: 'zRadioGroup'
 })
 export class ZardRadioGroupComponent implements ControlValueAccessor, ZardRadioGroupApi {
-  readonly change = output<ZardRadioGroupChange>();
+  readonly change = output<ZardRadioGroupChange>()
 
-  readonly displayDensity = input<ZardRadioDensity>('default');
-  readonly name = input<string>(`z-radio-group-${nextUniqueId++}`);
-  readonly disabledInput = input(false, { alias: 'disabled', transform: booleanAttribute });
+  readonly displayDensity = input<ZardRadioDensity>('default')
+  readonly name = input<string>(`z-radio-group-${nextUniqueId++}`)
+  readonly disabledInput = input(false, { alias: 'disabled', transform: booleanAttribute })
 
-  readonly disabledByForm = signal(false);
-  readonly disabled = computed(() => this.disabledInput() || this.disabledByForm());
-  readonly selectedValue = signal<unknown>(null);
+  readonly disabledByForm = signal(false)
+  readonly disabled = computed(() => this.disabledInput() || this.disabledByForm())
+  readonly selectedValue = signal<unknown>(null)
 
-  private onChange: OnChangeType = noopFn;
-  private onTouched: OnTouchedType = noopFn;
+  private onChange: OnChangeType = noopFn
+  private onTouched: OnTouchedType = noopFn
 
   writeValue(value: unknown): void {
-    this.selectedValue.set(value);
+    this.selectedValue.set(value)
   }
 
   registerOnChange(fn: OnChangeType): void {
-    this.onChange = fn;
+    this.onChange = fn
   }
 
   registerOnTouched(fn: OnTouchedType): void {
-    this.onTouched = fn;
+    this.onTouched = fn
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.disabledByForm.set(isDisabled);
+    this.disabledByForm.set(isDisabled)
   }
 
   select(value: unknown): void {
     if (this.disabled() || Object.is(this.selectedValue(), value)) {
-      return;
+      return
     }
 
-    this.selectedValue.set(value);
-    this.onChange(value);
-    this.change.emit({ value });
+    this.selectedValue.set(value)
+    this.onChange(value)
+    this.change.emit({ value })
   }
 
   touch(): void {
-    this.onTouched();
+    this.onTouched()
   }
 }
 
@@ -126,8 +132,9 @@ export class ZardRadioGroupComponent implements ControlValueAccessor, ZardRadioG
           (change)="onRadioChange($event)"
           (blur)="onRadioBlur()"
         />
-        <span [class]="classes()"></span>
-        <span [class]="dotClasses()"></span>
+        <span [class]="classes()">
+          <span [class]="dotClasses()"></span>
+        </span>
       </span>
       <span [class]="labelClasses()">
         <ng-content />
@@ -140,56 +147,61 @@ export class ZardRadioGroupComponent implements ControlValueAccessor, ZardRadioG
     class: 'z-radio inline-flex max-w-full align-middle',
     '[attr.data-checked]': 'checked() ? "" : null',
     '[attr.data-density]': 'resolvedDisplayDensity()',
-    '[attr.data-disabled]': 'disabled() ? "" : null',
+    '[attr.data-disabled]': 'disabled() ? "" : null'
   },
-  exportAs: 'zRadio',
+  exportAs: 'zRadio'
 })
 export class ZardRadioComponent {
-  private readonly group = inject(ZARD_RADIO_GROUP, { optional: true });
-  private readonly defaultName = `z-radio-${nextUniqueId++}`;
+  private readonly group = inject(ZARD_RADIO_GROUP, { optional: true })
+  private readonly defaultName = `z-radio-${nextUniqueId++}`
 
-  readonly radioChange = output<unknown>();
+  readonly radioChange = output<unknown>()
 
-  readonly class = input<ClassValue>('');
-  readonly displayDensity = input<ZardRadioDensity>('default');
-  readonly name = input<string>('');
-  readonly value = input<unknown>(null);
-  readonly checkedInput = input(false, { alias: 'checked', transform: booleanAttribute });
-  readonly disabledInput = input(false, { alias: 'disabled', transform: booleanAttribute });
-  readonly zId = input<string>('');
+  readonly class = input<ClassValue>('')
+  readonly displayDensity = input<ZardRadioDensity>('default')
+  readonly name = input<string>('')
+  readonly value = input<unknown>(null)
+  readonly checkedInput = input(false, { alias: 'checked', transform: booleanAttribute })
+  readonly disabledInput = input(false, { alias: 'disabled', transform: booleanAttribute })
+  readonly zId = input<string>('')
 
-  protected readonly resolvedDisplayDensity = computed(() => this.group?.displayDensity() ?? this.displayDensity());
-  protected readonly resolvedName = computed(() => this.group?.name() ?? (this.name() || this.defaultName));
+  protected readonly resolvedDisplayDensity = computed(() => this.group?.displayDensity() ?? this.displayDensity())
+  protected readonly resolvedName = computed(() => this.group?.name() ?? (this.name() || this.defaultName))
   protected readonly checked = computed(() =>
-    this.group ? Object.is(this.group.selectedValue(), this.value()) : this.checkedInput(),
-  );
-  protected readonly disabled = computed(() => this.disabledInput() || (this.group?.disabled() ?? false));
+    this.group ? Object.is(this.group.selectedValue(), this.value()) : this.checkedInput()
+  )
+  protected readonly disabled = computed(() => this.disabledInput() || (this.group?.disabled() ?? false))
 
   protected readonly itemClasses = computed(() =>
     mergeClasses(
       radioItemVariants({ displayDensity: this.resolvedDisplayDensity() }),
       this.disabled() ? 'cursor-not-allowed opacity-70' : 'cursor-pointer',
-      this.class(),
-    ),
-  );
-  protected readonly classes = computed(() => radioVariants({ displayDensity: this.resolvedDisplayDensity() }));
-  protected readonly dotClasses = computed(() => radioDotVariants({ displayDensity: this.resolvedDisplayDensity() }));
+      this.class()
+    )
+  )
+  protected readonly classes = computed(() => radioVariants({ displayDensity: this.resolvedDisplayDensity() }))
+  protected readonly dotClasses = computed(() =>
+    mergeClasses(
+      radioDotVariants({ displayDensity: this.resolvedDisplayDensity() }),
+      this.checked() ? 'opacity-100' : 'opacity-0'
+    )
+  )
   protected readonly labelClasses = computed(() =>
-    radioLabelVariants({ displayDensity: this.resolvedDisplayDensity() }),
-  );
+    radioLabelVariants({ displayDensity: this.resolvedDisplayDensity() })
+  )
 
   onRadioBlur(): void {
-    this.group?.touch();
+    this.group?.touch()
   }
 
   onRadioChange(event: Event): void {
-    event.stopPropagation();
+    event.stopPropagation()
 
     if (this.disabled()) {
-      return;
+      return
     }
 
-    this.group?.select(this.value());
-    this.radioChange.emit(this.value());
+    this.group?.select(this.value())
+    this.radioChange.emit(this.value())
   }
 }

--- a/packages/ui/src/lib/components/radio/radio.variants.ts
+++ b/packages/ui/src/lib/components/radio/radio.variants.ts
@@ -1,19 +1,22 @@
-import { cva } from 'class-variance-authority';
+import { cva } from 'class-variance-authority'
 
-export type ZardRadioDensity = 'default' | 'cosy' | 'compact';
+export type ZardRadioDensity = 'default' | 'cosy' | 'compact'
 
-export const radioItemVariants = cva('z-radio__item relative inline-flex max-w-full select-none items-start gap-2 align-middle', {
-  variants: {
-    displayDensity: {
-      default: 'text-sm',
-      cosy: 'gap-2 text-sm',
-      compact: 'gap-1.5 text-xs',
+export const radioItemVariants = cva(
+  'z-radio__item relative inline-flex max-w-full select-none items-start gap-2 align-middle',
+  {
+    variants: {
+      displayDensity: {
+        default: 'text-sm',
+        cosy: 'gap-2 text-sm',
+        compact: 'gap-1.5 text-xs'
+      }
     },
-  },
-  defaultVariants: {
-    displayDensity: 'default',
-  },
-});
+    defaultVariants: {
+      displayDensity: 'default'
+    }
+  }
+)
 
 export const radioVariants = cva(
   'z-radio__control relative flex shrink-0 items-center justify-center rounded-full border border-input bg-background text-primary shadow-xs transition-[border-color,box-shadow,background-color] peer-checked:border-primary peer-checked:bg-primary/10 peer-focus-visible:border-ring peer-focus-visible:ring-[3px] peer-focus-visible:ring-ring/50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 dark:bg-input/30',
@@ -22,40 +25,43 @@ export const radioVariants = cva(
       displayDensity: {
         default: 'size-4',
         cosy: 'size-4',
-        compact: 'size-3.5',
-      },
+        compact: 'size-3.5'
+      }
     },
     defaultVariants: {
-      displayDensity: 'default',
-    },
-  },
-);
+      displayDensity: 'default'
+    }
+  }
+)
 
 export const radioDotVariants = cva(
-  'z-radio__dot pointer-events-none absolute inset-0 m-auto rounded-full bg-primary opacity-0 transition-opacity peer-checked:opacity-100',
+  'z-radio__dot pointer-events-none absolute left-1/2 top-1/2 m-0 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary transition-opacity',
   {
     variants: {
       displayDensity: {
         default: 'size-2',
         cosy: 'size-2',
-        compact: 'size-1.5',
-      },
+        compact: 'size-1.5'
+      }
     },
     defaultVariants: {
-      displayDensity: 'default',
-    },
-  },
-);
+      displayDensity: 'default'
+    }
+  }
+)
 
-export const radioLabelVariants = cva('z-radio__label min-w-0 empty:hidden peer-disabled:opacity-50 peer-disabled:cursor-not-allowed', {
-  variants: {
-    displayDensity: {
-      default: 'text-sm',
-      cosy: 'text-sm',
-      compact: 'text-xs',
+export const radioLabelVariants = cva(
+  'z-radio__label min-w-0 empty:hidden peer-disabled:opacity-50 peer-disabled:cursor-not-allowed',
+  {
+    variants: {
+      displayDensity: {
+        default: 'text-sm',
+        cosy: 'text-sm',
+        compact: 'text-xs'
+      }
     },
-  },
-  defaultVariants: {
-    displayDensity: 'default',
-  },
-});
+    defaultVariants: {
+      displayDensity: 'default'
+    }
+  }
+)


### PR DESCRIPTION
## Summary
- Refresh the data source settings create, copy, edit, search, empty, loading, and delete flows with Zard dialog/form primitives and updated locale copy.
- Add shared Copilot model tag helpers and hide common tool-call capability tags while keeping visible capability tags such as vision.
- Keep all available model filter tags visible after a filter is selected, while narrowing only the model list.
- Update the shared dialog and radio primitives used by this settings flow, with focused component coverage.

## Root Cause
The data source settings UI still mixed older dialog/form patterns with newer Zard conventions, and create/copy/edit paths did not have focused component coverage. Copilot model/provider tag rendering also duplicated model feature formatting logic, which made tool-call tags appear in multiple places even though most current models support tool calling.

## User Impact
- Data source management has more consistent dialog behavior and component styling.
- Model/provider cards no longer show noisy tool-call tags.
- Model filter chips remain discoverable while selected filters narrow the result list.

## Validation
- `git diff --check origin/develop...HEAD`
- `pnpm nx test cloud --testFile=apps/cloud/src/app/@shared/copilot/model-tags.spec.ts --runInBand`
- `pnpm nx test cloud --testFile=apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts --runInBand`
- `pnpm nx test cloud --testFile=apps/cloud/src/app/features/setting/data-sources/data-sources.component.spec.ts --runInBand`
- `pnpm nx test ui --testFile=packages/ui/src/lib/components/dialog/dialog.service.spec.ts --runInBand`
- `pnpm nx test ui --testFile=packages/ui/src/lib/components/radio/radio.component.spec.ts --runInBand`