### PR TITLE
fix: prevent feature toggle layout clipping

### DIFF
--- a/apps/cloud/src/app/@shared/features/feature-toggle/feature-toggle.component.html
+++ b/apps/cloud/src/app/@shared/features/feature-toggle/feature-toggle.component.html
@@ -4,7 +4,8 @@
 
 <ng-template #featureRow let-feature>
   <div
-    class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-divider-regular px-4 py-3 last:border-b-0 md:grid-cols-[minmax(160px,0.75fr)_minmax(220px,1fr)_auto_auto]"
+    data-feature-row
+    class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-divider-regular px-4 py-3 last:border-b-0 md:grid-cols-[minmax(160px,0.75fr)_minmax(0,1fr)_auto_auto]"
   >
     <div class="flex min-w-0 items-center gap-3">
       <span
@@ -146,7 +147,7 @@
       }
     </div>
 
-    <div data-feature-groups-grid class="columns-1 gap-4 xl:columns-2 2xl:columns-3">
+    <div data-feature-groups-grid class="columns-xl gap-4">
       @for (group of visibleFeatureGroups(features); track $index) {
         <z-card
           data-feature-group-card

--- a/apps/cloud/src/app/@shared/features/feature-toggle/feature-toggle.component.spec.ts
+++ b/apps/cloud/src/app/@shared/features/feature-toggle/feature-toggle.component.spec.ts
@@ -957,8 +957,12 @@ describe('FeatureToggleComponent', () => {
 
     expect(element.querySelector('[data-feature-summary]')).not.toBeNull()
     expect(element.querySelector('[data-feature-home-section]')).toBeNull()
-    expect(element.querySelector('[data-feature-groups-grid]')?.className).toContain('columns-1')
-    expect(element.querySelector('[data-feature-groups-grid]')?.className).toContain('2xl:columns-3')
+    const groupsGridClass = element.querySelector('[data-feature-groups-grid]')?.className ?? ''
+    expect(groupsGridClass).toContain('columns-xl')
+    expect(groupsGridClass).not.toContain('2xl:columns-3')
+
+    const featureRowClass = element.querySelector('[data-feature-row]')?.className ?? ''
+    expect(featureRowClass).toContain('minmax(0,1fr)')
     expect(element.querySelector('[data-feature-group-id="FEATURE_HOME"]')).not.toBeNull()
     expect(element.querySelector('[data-feature-group-id="FEATURE_ORGANIZATION"] z-card-content')).toBeNull()
     expect(element.querySelector('[data-feature-group-card]')?.className).toContain('break-inside-avoid')


### PR DESCRIPTION
## What changed

- Changed the feature management card masonry layout to use a width-based `columns-xl` utility instead of viewport-forced `2xl:columns-3`.
- Allowed the feature row description column to shrink with `minmax(0,1fr)` so status badges and checkboxes stay inside the card.
- Updated the feature toggle component spec to guard against restoring the forced three-column layout.

## Root cause

The feature management page enabled three columns based on viewport width, while the real content width was smaller after shell/sidebar spacing. Child row columns also had a fixed minimum width, so controls could be pushed outside the card and then clipped by the page body's hidden horizontal overflow.

## Validation

- `pnpm exec jest --config apps/cloud/jest.config.ts --runTestsByPath apps/cloud/src/app/@shared/features/feature-toggle/feature-toggle.component.spec.ts --runInBand`
- `git diff --check origin/develop...HEAD`