### PR TITLE
fix: expose publishAt on SkillPackage contract

### DIFF
--- a/.changeset/fix-publishAt-column.md
+++ b/.changeset/fix-publishAt-column.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/contracts': patch
+---
+
+Add missing `publishAt` to the `ISkillPackage` contract so shared skills published to the organization market expose their published state consistently.

--- a/packages/contracts/src/ai/skill.model.ts
+++ b/packages/contracts/src/ai/skill.model.ts
@@ -194,6 +194,7 @@ export interface ISkillPackage extends IBasePerWorkspaceEntityModel, TSkillPacka
   packagePath?: string
   sharedSkillId?: string
   sharedPackagePath?: string
+  publishAt?: Date
 }
 
 /**


### PR DESCRIPTION
Closed after rechecking the inheritance chain.

`ISkillPackage` already extends `IBasePerWorkspaceEntityModel`, and `IBasePerWorkspaceEntityModel` already declares `publishAt?: Date` on `origin/develop`. `SkillPackage` also already inherits the persisted `publishAt` TypeORM column from `WorkspaceBaseEntity`.

So no code change is needed here. The old PR noise came from the branch base and release commit, not from a missing `publishAt` field.