### PR TITLE
revert: remove redundant SkillPackage publishAt contract change

### DIFF
--- a/.changeset/fix-publishAt-column.md
+++ b/.changeset/fix-publishAt-column.md
@@ -1,5 +1,0 @@
----
-'@xpert-ai/contracts': patch
----
-
-Add missing `publishAt` to the `ISkillPackage` contract so shared skills published to the organization market expose their published state consistently.

--- a/packages/contracts/src/ai/skill.model.ts
+++ b/packages/contracts/src/ai/skill.model.ts
@@ -194,7 +194,6 @@ export interface ISkillPackage extends IBasePerWorkspaceEntityModel, TSkillPacka
   packagePath?: string
   sharedSkillId?: string
   sharedPackagePath?: string
-  publishAt?: Date
 }
 
 /**


### PR DESCRIPTION
## Summary
- Revert PR #684.
- Remove the redundant `ISkillPackage.publishAt` redeclaration.
- Remove the unnecessary `@xpert-ai/contracts` changeset.

## Root cause
`ISkillPackage` already extends `IBasePerWorkspaceEntityModel`, and `IBasePerWorkspaceEntityModel` already declares `publishAt?: Date`. On the persistence side, `SkillPackage` inherits the `publishAt` TypeORM column from `WorkspaceBaseEntity`.

So no code change is needed for `publishAt`; the earlier PR was based on an incomplete read of the inheritance chain.

## Validation
- `pnpm nx build contracts`
- `git diff --check origin/develop...HEAD`