### PR TITLE
fix: guard custom provider model schema

### DIFF
--- a/apps/cloud/src/app/@shared/copilot/copilot-provider/provider-schema.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-provider/provider-schema.spec.ts
@@ -1,0 +1,35 @@
+import { ConfigurateMethod } from '@xpert-ai/contracts'
+import { canCreateCustomProviderModel } from './provider-schema'
+
+describe('canCreateCustomProviderModel', () => {
+  it('rejects providers without custom model support', () => {
+    expect(
+      canCreateCustomProviderModel({
+        configurate_methods: []
+      })
+    ).toBe(false)
+  })
+
+  it('rejects providers that declare custom models without a model credential schema', () => {
+    expect(
+      canCreateCustomProviderModel({
+        configurate_methods: [ConfigurateMethod.CUSTOMIZABLE_MODEL]
+      })
+    ).toBe(false)
+  })
+
+  it('accepts customizable providers with a complete model credential schema', () => {
+    expect(
+      canCreateCustomProviderModel({
+        configurate_methods: [ConfigurateMethod.CUSTOMIZABLE_MODEL],
+        model_credential_schema: {
+          model: {
+            label: { en_US: 'Model Name' },
+            placeholder: { en_US: 'Enter model name' }
+          },
+          credential_form_schemas: []
+        }
+      })
+    ).toBe(true)
+  })
+})

--- a/apps/cloud/src/app/@shared/copilot/copilot-provider/provider-schema.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-provider/provider-schema.ts
@@ -1,0 +1,13 @@
+import { ConfigurateMethod, IAiProviderEntity } from '@xpert-ai/contracts'
+
+type CustomModelProviderSchema = Partial<Pick<IAiProviderEntity, 'configurate_methods' | 'model_credential_schema'>>
+
+export function canCreateCustomProviderModel(provider: CustomModelProviderSchema | null | undefined) {
+  const modelCredentialSchema = provider?.model_credential_schema
+
+  return (
+    provider?.configurate_methods?.includes(ConfigurateMethod.CUSTOMIZABLE_MODEL) === true &&
+    !!modelCredentialSchema?.model &&
+    Array.isArray(modelCredentialSchema.credential_form_schemas)
+  )
+}

--- a/apps/cloud/src/app/@shared/copilot/copilot-provider/provider.component.html
+++ b/apps/cloud/src/app/@shared/copilot/copilot-provider/provider.component.html
@@ -169,7 +169,7 @@
           </div>
 
           <div class="shrink-0 flex items-center">
-            @if (!readonly()) {
+            @if (!readonly() && canCustomizableModel()) {
               <button
                 type="button"
                 class="btn disabled:btn-disabled btn-secondary btn-small hidden group-hover:flex h-7 mr-2 items-center"

--- a/apps/cloud/src/app/@shared/copilot/copilot-provider/provider.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-provider/provider.component.ts
@@ -20,10 +20,8 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { derivedAsync } from 'ngxtension/derived-async'
 import { BehaviorSubject, EMPTY, switchMap } from 'rxjs'
 import {
-  ConfigurateMethod,
   getErrorMessage,
   ICopilotProviderModel,
-  injectAiProviders,
   injectCopilotProviderService,
   TCopilotTokenUsage,
   ToastrService
@@ -31,6 +29,7 @@ import {
 import { CopilotProviderModelComponent } from '../copilot-provider-model/model.component'
 import { CopilotAiProviderAuthComponent } from '../provider-authorization/authorization.component'
 import { customProviderModelDisplayTags, providerModelDisplayTags } from '../model-tags'
+import { canCreateCustomProviderModel } from './provider-schema'
 
 @Component({
   standalone: true,
@@ -54,14 +53,11 @@ import { customProviderModelDisplayTags, providerModelDisplayTags } from '../mod
   }
 })
 export class CopilotProviderComponent {
-  eConfigurateMethod = ConfigurateMethod
-
   readonly #dialog = inject(Dialog)
   readonly #translate = inject(TranslateService)
   readonly #toastr = inject(ToastrService)
   readonly #i18n = new NgmI18nPipe()
   readonly #copilotProviderService = injectCopilotProviderService()
-  readonly aiProviders = injectAiProviders()
 
   // Inputs
   readonly providerId = input<string>()
@@ -90,11 +86,8 @@ export class CopilotProviderComponent {
   readonly icon = computed(() => this.largeIcon() || this.smallIcon())
   readonly label = computed(() => this.copilotProvider()?.provider?.label)
   readonly supported_model_types = computed(() => this.copilotProvider()?.provider?.supported_model_types)
-  readonly configurate_methods = computed(() => this.copilotProvider()?.provider?.configurate_methods)
-  readonly canCustomizableModel = computed(() =>
-    this.configurate_methods()?.includes(ConfigurateMethod.CUSTOMIZABLE_MODEL)
-  )
   readonly provider_credential_schema = computed(() => this.copilotProvider()?.provider?.provider_credential_schema)
+  readonly canCustomizableModel = computed(() => canCreateCustomProviderModel(this.copilotProvider()?.provider))
 
   readonly #models = derivedAsync(() => {
     return this.showModels()
@@ -176,10 +169,14 @@ export class CopilotProviderComponent {
     if (this.readonly()) {
       return
     }
+    const copilotProvider = this.copilotProvider()
+    if (!copilotProvider || !canCreateCustomProviderModel(copilotProvider.provider)) {
+      return
+    }
     this.#dialog
       .open(CopilotProviderModelComponent, {
         data: {
-          provider: this.copilotProvider(),
+          provider: copilotProvider,
           modelId: null
         }
       })
@@ -197,10 +194,14 @@ export class CopilotProviderComponent {
     if (this.readonly()) {
       return
     }
+    const copilotProvider = this.copilotProvider()
+    if (!copilotProvider || !canCreateCustomProviderModel(copilotProvider.provider)) {
+      return
+    }
     this.#dialog
       .open(CopilotProviderModelComponent, {
         data: {
-          provider: this.copilotProvider(),
+          provider: copilotProvider,
           modelId: model.id
         }
       })


### PR DESCRIPTION
## Summary
- Guard Copilot custom model actions behind both customizable-model support and a complete model credential schema.
- Hide custom model configure actions for providers that cannot safely open the custom model dialog.
- Add focused tests for the provider schema guard.

## Root cause
Providers such as zhipu can lack `model_credential_schema`, but the custom model dialog expects that schema when rendering model fields. The previous check only looked for the customizable model method and could expose an invalid dialog path.

## Validation
- `git diff --check`
- `pnpm -s nx test cloud --testFile=apps/cloud/src/app/@shared/copilot/copilot-provider/provider-schema.spec.ts --runInBand --skip-nx-cache`