### PR TITLE
[codex] Lock tenant onboard after initialization

### DIFF
--- a/packages/server/src/tenant/tenant.controller.ts
+++ b/packages/server/src/tenant/tenant.controller.ts
@@ -168,8 +168,9 @@ export class TenantController extends CrudController<Tenant> {
 	@HttpCode(HttpStatus.CREATED)
 	@Post('onboard')
 	async onboardDefault(@Body() entity: ITenantCreateInput): Promise<Tenant> {
-		const defaultTenant = await this.tenantService.findOneOrFailByWhereOptions({name: entity.name})
-		if (defaultTenant.success) {
+		const tenantCount = await this.tenantService.count()
+		const requestedTenant = await this.tenantService.findOneOrFailByWhereOptions({ name: entity.name })
+		if (tenantCount > 0 || requestedTenant.success) {
 			throw new BadRequestException('Tenant already exists');
 		}
 		const preparedEntity = await this.tenantService.prepareTenantCreateInput(entity)


### PR DESCRIPTION
## Summary

This PR prevents the public tenant onboard endpoint from creating tenants after the instance has already been initialized.

`POST /api/tenant/onboard` remains available for the first-time setup path, but it now checks whether any tenant already exists before continuing. If the tenant table is no longer empty, the endpoint returns `Tenant already exists` and does not create another tenant.

The existing same-name check is preserved for the empty-database path. Installer or operator flows that run `node main.js --command seedModule --name Tenant --tenant <name>` are not affected because that command runs through the CLI seed path and does not go through `TenantController.onboardDefault()`.

## Validation

- `pnpm nx build server`