### PR TITLE
[codex] Support tenant subdomain routing

### DIFF
--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -78,6 +78,7 @@ ENV NODE_OPTIONS=${NODE_OPTIONS:-"--max-old-space-size=12288"}
 ENV NODE_ENV=${NODE_ENV:-production}
 
 ENV API_BASE_URL=${API_BASE_URL:-http://localhost:3000} \
+    WEBAPP_API_BASE_URL=${WEBAPP_API_BASE_URL:-} \
     HOST=${HOST:-0.0.0.0} \
     PORT=${PORT:-80} \
     DEMO=${DEMO:-false}

--- a/.deploy/webapp/entrypoint.prod.sh
+++ b/.deploy/webapp/entrypoint.prod.sh
@@ -2,9 +2,10 @@
 set -ex
 
 # This Entrypoint used when we run Docker container outside of Docker Compose (e.g. in k8s)
+WEBAPP_RUNTIME_API_BASE_URL=${WEBAPP_API_BASE_URL:-$API_BASE_URL}
 
 # In production we should replace some values in generated JS code
-sed -i "s#DOCKER_API_BASE_URL#$API_BASE_URL#g" *.js
+sed -i "s#DOCKER_API_BASE_URL#$WEBAPP_RUNTIME_API_BASE_URL#g" *.js
 sed -i "s#DOCKER_CHATKIT_FRAME_URL#$VITE_CHATKIT_FRAME_URL#g" *.js
 sed -i "s#DOCKER_DEPLOYMENT_TARGET#$DEPLOYMENT_TARGET#g" *.js
 sed -i "s#\"DOCKER_ENABLE_LOCAL_AGENT\"#$ENABLE_LOCAL_AGENT#g" *.js

--- a/apps/cloud/src/app/@core/interceptors/tenant.interceptor.spec.ts
+++ b/apps/cloud/src/app/@core/interceptors/tenant.interceptor.spec.ts
@@ -1,0 +1,43 @@
+import { HttpEventType, HttpHandler, HttpRequest } from '@angular/common/http'
+import { RequestScopeLevel } from '@xpert-ai/contracts'
+import { firstValueFrom, of } from 'rxjs'
+import { Store } from '../services/store.service'
+import { TenantInterceptor } from './tenant.interceptor'
+
+function createNextHandler() {
+  let handledRequest: HttpRequest<unknown> | null = null
+  const handle = jest.fn((request: HttpRequest<unknown>) => {
+    handledRequest = request
+    return of({ type: HttpEventType.Sent })
+  })
+  const next: HttpHandler = { handle }
+
+  return {
+    next,
+    getHandledRequest() {
+      if (!handledRequest) {
+        throw new Error('Expected request to be handled')
+      }
+
+      return handledRequest
+    }
+  }
+}
+
+describe('TenantInterceptor', () => {
+  it('does not add tenant scope headers to password login requests', async () => {
+    const store = {
+      user: { tenantId: 'tenant-1' },
+      activeScope: { level: RequestScopeLevel.ORGANIZATION, organizationId: 'org-1' }
+    } as Store
+    const interceptor = new TenantInterceptor(store)
+    const { next, getHandledRequest } = createNextHandler()
+
+    await firstValueFrom(interceptor.intercept(new HttpRequest('POST', '/api/auth/login'), next))
+
+    const handledRequest = getHandledRequest()
+    expect(handledRequest.headers.has('Tenant-Id')).toBe(false)
+    expect(handledRequest.headers.has('X-Scope-Level')).toBe(false)
+    expect(handledRequest.headers.has('Organization-Id')).toBe(false)
+  })
+})

--- a/apps/cloud/src/app/@core/interceptors/tenant.interceptor.ts
+++ b/apps/cloud/src/app/@core/interceptors/tenant.interceptor.ts
@@ -7,6 +7,7 @@ import { isPublicXpertRequest } from '../utils/public-xpert-request'
 import { Store } from './../services/store.service'
 
 const ANONYMOUS_AUTH_PATHS = new Set([
+  '/api/auth/login',
   '/api/auth/sso/providers',
   '/api/auth/sso/bind/challenge',
   '/api/auth/sso/bind/complete',

--- a/apps/cloud/src/app/@core/interceptors/token.interceptor.spec.ts
+++ b/apps/cloud/src/app/@core/interceptors/token.interceptor.spec.ts
@@ -1,0 +1,41 @@
+import { HttpEventType, HttpHandler, HttpRequest } from '@angular/common/http'
+import { firstValueFrom, of } from 'rxjs'
+import { AuthStrategy } from '../auth'
+import { Store } from '../services/store.service'
+import { TokenInterceptor } from './token.interceptor'
+
+function createNextHandler() {
+  let handledRequest: HttpRequest<unknown> | null = null
+  const handle = jest.fn((request: HttpRequest<unknown>) => {
+    handledRequest = request
+    return of({ type: HttpEventType.Sent })
+  })
+  const next: HttpHandler = { handle }
+
+  return {
+    next,
+    getHandledRequest() {
+      if (!handledRequest) {
+        throw new Error('Expected request to be handled')
+      }
+
+      return handledRequest
+    }
+  }
+}
+
+describe('TokenInterceptor', () => {
+  it('does not add stale authorization headers to password login requests', async () => {
+    const store = {
+      token: 'old-token',
+      refreshToken: 'refresh-token'
+    } as Store
+    const auth = {} as AuthStrategy
+    const interceptor = new TokenInterceptor(store, auth)
+    const { next, getHandledRequest } = createNextHandler()
+
+    await firstValueFrom(interceptor.intercept(new HttpRequest('POST', '/api/auth/login'), next))
+
+    expect(getHandledRequest().headers.has('Authorization')).toBe(false)
+  })
+})

--- a/apps/cloud/src/app/@core/interceptors/token.interceptor.ts
+++ b/apps/cloud/src/app/@core/interceptors/token.interceptor.ts
@@ -5,6 +5,7 @@ import { AuthStrategy } from '../auth'
 import { Store } from '../services/store.service'
 
 const ANONYMOUS_AUTH_PATHS = new Set([
+  '/api/auth/login',
   '/api/auth/sso/providers',
   '/api/auth/sso/bind/challenge',
   '/api/auth/sso/bind/complete',

--- a/apps/cloud/src/app/@core/providers/url.spec.ts
+++ b/apps/cloud/src/app/@core/providers/url.spec.ts
@@ -1,0 +1,13 @@
+import { normalizeApiBaseUrl } from './url'
+
+describe('normalizeApiBaseUrl', () => {
+  it('treats same-origin sentinels as an empty API base URL', () => {
+    expect(normalizeApiBaseUrl('same-origin')).toBe('')
+    expect(normalizeApiBaseUrl('self')).toBe('')
+    expect(normalizeApiBaseUrl('/')).toBe('')
+  })
+
+  it('keeps explicit API origins without a trailing slash', () => {
+    expect(normalizeApiBaseUrl('https://api.xpertai.cn/')).toBe('https://api.xpertai.cn')
+  })
+})

--- a/apps/cloud/src/app/@core/providers/url.ts
+++ b/apps/cloud/src/app/@core/providers/url.ts
@@ -1,6 +1,16 @@
 import { environment } from '../../../environments/environment'
 
 const baseUrl = environment.API_BASE_URL
+const SAME_ORIGIN_API_BASE_URLS = new Set(['same-origin', 'self', '/'])
+
+export function normalizeApiBaseUrl(value?: string | null) {
+  const normalized = value?.trim()
+  if (!normalized || normalized.startsWith('DOCKER_') || SAME_ORIGIN_API_BASE_URLS.has(normalized.toLowerCase())) {
+    return ''
+  }
+
+  return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized
+}
 
 /**
  * Inject the base url of api server
@@ -8,8 +18,5 @@ const baseUrl = environment.API_BASE_URL
  * @returns url
  */
 export function injectApiBaseUrl() {
-  if (!baseUrl) {
-    return ''
-  }
-  return baseUrl?.endsWith('/') ? baseUrl.slice(0, baseUrl.length - 1) : baseUrl
+  return normalizeApiBaseUrl(baseUrl)
 }

--- a/apps/cloud/src/app/@core/utils.spec.ts
+++ b/apps/cloud/src/app/@core/utils.spec.ts
@@ -1,0 +1,11 @@
+import { getWebSocketUrl } from './utils'
+
+describe('getWebSocketUrl', () => {
+  it('uses the current origin for same-origin API base URLs', () => {
+    const expectedProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const expectedOrigin = `${expectedProtocol}//${window.location.host}`
+
+    expect(getWebSocketUrl('')).toBe(expectedOrigin)
+    expect(getWebSocketUrl('same-origin')).toBe(expectedOrigin)
+  })
+})

--- a/apps/cloud/src/app/@core/utils.ts
+++ b/apps/cloud/src/app/@core/utils.ts
@@ -1,4 +1,5 @@
 import { firstValueFrom, Observable } from 'rxjs'
+import { normalizeApiBaseUrl } from './providers/url'
 import { ToastrService } from './services'
 import { getErrorMessage } from './types'
 
@@ -59,5 +60,11 @@ export function isUUID(id: string) {
 }
 
 export function getWebSocketUrl(url: string) {
-  return (window.location.protocol === 'https:' ? 'wss:' : 'ws:') + url.replace('http:', '').replace('https:', '')
+  const normalizedUrl = normalizeApiBaseUrl(url)
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  if (!normalizedUrl) {
+    return `${protocol}//${window.location.host}`
+  }
+
+  return protocol + normalizedUrl.replace('http:', '').replace('https:', '')
 }

--- a/apps/cloud/src/app/app.module.ts
+++ b/apps/cloud/src/app/app.module.ts
@@ -19,6 +19,7 @@ import {
   CoreModule,
   LOCALE_DEFAULT,
   LanguageInterceptor,
+  normalizeApiBaseUrl,
   TenantInterceptor,
   TokenInterceptor,
   UpdateService
@@ -117,7 +118,7 @@ function detectSubjectType(subject) {
     { provide: PureAbility, useExisting: Ability },
     {
       provide: PAC_API_BASE_URL,
-      useValue: environment.API_BASE_URL
+      useValue: normalizeApiBaseUrl(environment.API_BASE_URL)
     },
     provideUiI18nAdapterFactory(
       (i18nService: I18nService): UiI18nAdapter => ({

--- a/apps/cloud/src/app/features/assistant/assistant-chatkit.runtime.ts
+++ b/apps/cloud/src/app/features/assistant/assistant-chatkit.runtime.ts
@@ -12,6 +12,7 @@ import {
   Store,
   type IResolvedAssistantBinding,
   getErrorMessage,
+  normalizeApiBaseUrl,
   ToastrService
 } from '../../@core'
 import { AppService } from '../../app.service'
@@ -462,11 +463,12 @@ function buildAssistantClientSecret(secret: string, organizationId?: string | nu
 }
 
 function normalizeBaseUrl(baseUrl?: string | null) {
-  if (!baseUrl) {
+  const apiBaseUrl = normalizeApiBaseUrl(baseUrl)
+  if (!apiBaseUrl) {
     return ''
   }
 
-  const normalized = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+  const normalized = apiBaseUrl.endsWith('/') ? apiBaseUrl.slice(0, -1) : apiBaseUrl
   if (normalized.startsWith('http')) {
     return normalized
   }

--- a/apps/cloud/src/app/features/setting/assistants/assistants.facade.ts
+++ b/apps/cloud/src/app/features/setting/assistants/assistants.facade.ts
@@ -18,7 +18,8 @@ import {
   RolesEnum,
   Store,
   ToastrService,
-  getErrorMessage
+  getErrorMessage,
+  normalizeApiBaseUrl
 } from '../../../@core'
 import { ASSISTANT_REGISTRY, type AssistantRegistryItem } from '../../assistant/assistant.registry'
 
@@ -397,11 +398,12 @@ function buildAssistantRuntimeApiUrl(baseUrl?: string | null) {
 }
 
 function normalizeAssistantBaseUrl(baseUrl?: string | null) {
-  if (!baseUrl) {
+  const apiBaseUrl = normalizeApiBaseUrl(baseUrl)
+  if (!apiBaseUrl) {
     return ''
   }
 
-  const normalized = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+  const normalized = apiBaseUrl.endsWith('/') ? apiBaseUrl.slice(0, -1) : apiBaseUrl
   if (normalized.startsWith('http')) {
     return normalized
   }

--- a/packages/server/src/auth/auth.service.spec.ts
+++ b/packages/server/src/auth/auth.service.spec.ts
@@ -43,7 +43,33 @@ jest.mock('../organization', () => ({
 	OrganizationService: class OrganizationService {}
 }))
 
+jest.mock('../organization/organization.service', () => ({
+	OrganizationService: class OrganizationService {}
+}))
+
+jest.mock('../core/context', () => ({
+	RequestContext: {
+		currentRequest: jest.fn(() => ({
+			headers: {}
+		})),
+		getScope: jest.fn(() => ({
+			tenantId: null,
+			level: 'tenant',
+			organizationId: null
+		}))
+	},
+	getFirstHeaderValue: jest.fn((value?: string | string[]) => {
+		if (Array.isArray(value)) {
+			return value.map((item) => item?.trim()).find(Boolean)
+		}
+
+		return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+	})
+}))
+
 const { AuthService } = require('./auth.service')
+const { RequestContext } = require('../core/context')
+const bcrypt = require('bcryptjs')
 
 describe('AuthService', () => {
 	let service: InstanceType<typeof AuthService>
@@ -51,6 +77,7 @@ describe('AuthService', () => {
 	const userService = {
 		findOne: jest.fn(),
 		findOneOrFailByOptions: jest.fn(),
+		findOneByOptions: jest.fn(),
 		create: jest.fn(),
 		update: jest.fn()
 	}
@@ -97,6 +124,53 @@ describe('AuthService', () => {
 				name: 'ADMIN'
 			}
 		})
+		userService.findOneByOptions.mockResolvedValue(null)
+	})
+
+	it('limits password login to the current tenant context', async () => {
+		jest.spyOn(RequestContext, 'currentRequest').mockReturnValue({
+			headers: {
+				'tenant-id': 'tenant-1',
+				'organization-id': 'org-1',
+				'x-scope-level': 'tenant'
+			}
+		})
+		userService.findOneByOptions.mockResolvedValue({
+			id: 'user-1',
+			email: 'new.user@example.com',
+			tenantId: 'tenant-1',
+			hash: 'stored-hash'
+		})
+		jest.spyOn(bcrypt, 'compare').mockResolvedValue(true)
+		jest.spyOn(service, 'createToken').mockResolvedValue({
+			token: 'jwt-token',
+			refreshToken: 'refresh-token'
+		})
+		const updateRefreshTokenSpy = jest
+			.spyOn(service, 'updateRefreshToken')
+			.mockResolvedValue(undefined)
+
+		await expect(service.login('New.User@example.com', 'password')).resolves.toEqual({
+			user: expect.objectContaining({
+				id: 'user-1',
+				tenantId: 'tenant-1'
+			}),
+			token: 'jwt-token',
+			refreshToken: 'refresh-token'
+		})
+
+		expect(userService.findOneByOptions).toHaveBeenCalledWith({
+			where: [
+				{ email: 'new.user@example.com', emailVerified: true, tenantId: 'tenant-1' },
+				{ username: 'new.user@example.com', tenantId: 'tenant-1' }
+			],
+			relations: ['role', 'role.rolePermissions', 'employee'],
+			order: {
+				createdAt: 'DESC'
+			}
+		})
+		expect(RequestContext.getScope).not.toHaveBeenCalled()
+		expect(updateRefreshTokenSpy).toHaveBeenCalledWith('user-1', 'refresh-token')
 	})
 
 	it('assigns the tenant default organization when organizationId is not provided', async () => {

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -33,6 +33,7 @@ import { AuthRegisterCommand, AuthTrialCommand } from './commands/index'
 import { PasswordResetCreateCommand, PasswordResetGetCommand } from '../password-reset/commands'
 import { RoleService } from '../role/role.service'
 import { OrganizationService } from '../organization/organization.service'
+import { getFirstHeaderValue, RequestContext } from '../core/context'
 
 
 @Injectable()
@@ -79,11 +80,13 @@ export class AuthService extends SocialAuthService {
 	 */
 	async login(email: string, password: string): Promise<IAuthResponse | null> {
 		const normalizedIdentifier = email?.trim().toLowerCase()
+		const tenantId = this.getLoginTenantId()
+		const tenantFilter = tenantId ? { tenantId } : {}
 		const user = await this.userService.findOneByOptions(
 			{
 				where: [
-					{ email: normalizedIdentifier, emailVerified: true },
-					{ username: normalizedIdentifier }
+					{ email: normalizedIdentifier, emailVerified: true, ...tenantFilter },
+					{ username: normalizedIdentifier, ...tenantFilter }
 				],
 				relations: ['role', 'role.rolePermissions', 'employee'],
 				order: {
@@ -103,6 +106,11 @@ export class AuthService extends SocialAuthService {
 			token,
 			refreshToken
 		};
+	}
+
+	private getLoginTenantId() {
+		const request = RequestContext.currentRequest()
+		return getFirstHeaderValue(request?.headers?.['tenant-id']) ?? null
 	}
 
 	async requestPassword(

--- a/packages/server/src/core/context/anonymous-tenant-context.middleware.spec.ts
+++ b/packages/server/src/core/context/anonymous-tenant-context.middleware.spec.ts
@@ -52,6 +52,23 @@ describe('AnonymousTenantContextMiddleware', () => {
     expect(next).toHaveBeenCalledWith()
   })
 
+  it('injects only tenant headers for password login requests', async () => {
+    const request = {
+      method: 'POST',
+      originalUrl: '/api/auth/login',
+      headers: {}
+    } as any
+    const next = jest.fn()
+
+    await middleware.use(request, {} as any, next)
+
+    expect(resolver.resolve).toHaveBeenCalledWith(request)
+    expect(request.headers['tenant-id']).toBe('tenant-1')
+    expect(request.headers['organization-id']).toBeUndefined()
+    expect(request[ANONYMOUS_TENANT_RESOLUTION_REQUEST_KEY]).toEqual(resolution)
+    expect(next).toHaveBeenCalledWith()
+  })
+
   it('does not resolve tenant context for unrelated routes', async () => {
     const request = {
       method: 'GET',

--- a/packages/server/src/core/context/anonymous-tenant-context.middleware.spec.ts
+++ b/packages/server/src/core/context/anonymous-tenant-context.middleware.spec.ts
@@ -17,6 +17,9 @@ import {
 import { AnonymousTenantContextMiddleware } from './anonymous-tenant-context.middleware'
 
 describe('AnonymousTenantContextMiddleware', () => {
+  type MiddlewareRequest = Parameters<AnonymousTenantContextMiddleware['use']>[0]
+  type MiddlewareResponse = Parameters<AnonymousTenantContextMiddleware['use']>[1]
+
   const resolution: AnonymousTenantResolution = {
     tenant: null,
     tenantId: 'tenant-1',
@@ -32,7 +35,9 @@ describe('AnonymousTenantContextMiddleware', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    middleware = new AnonymousTenantContextMiddleware(resolver as any)
+    middleware = new AnonymousTenantContextMiddleware(
+      resolver as unknown as ConstructorParameters<typeof AnonymousTenantContextMiddleware>[0]
+    )
   })
 
   it('injects tenant headers for supported anonymous login routes', async () => {
@@ -40,10 +45,10 @@ describe('AnonymousTenantContextMiddleware', () => {
       method: 'GET',
       originalUrl: '/api/lark-identity/login/start',
       headers: {}
-    } as any
+    } as MiddlewareRequest
     const next = jest.fn()
 
-    await middleware.use(request, {} as any, next)
+    await middleware.use(request, {} as MiddlewareResponse, next)
 
     expect(resolver.resolve).toHaveBeenCalledWith(request)
     expect(request.headers['tenant-id']).toBe('tenant-1')
@@ -57,10 +62,10 @@ describe('AnonymousTenantContextMiddleware', () => {
       method: 'POST',
       originalUrl: '/api/auth/login',
       headers: {}
-    } as any
+    } as MiddlewareRequest
     const next = jest.fn()
 
-    await middleware.use(request, {} as any, next)
+    await middleware.use(request, {} as MiddlewareResponse, next)
 
     expect(resolver.resolve).toHaveBeenCalledWith(request)
     expect(request.headers['tenant-id']).toBe('tenant-1')
@@ -69,15 +74,37 @@ describe('AnonymousTenantContextMiddleware', () => {
     expect(next).toHaveBeenCalledWith()
   })
 
+  it('does not inject fallback tenant headers for password login requests', async () => {
+    const fallbackResolution = {
+      ...resolution,
+      fallbackApplied: true
+    }
+    resolver.resolve.mockResolvedValueOnce(fallbackResolution)
+    const request = {
+      method: 'POST',
+      originalUrl: '/api/auth/login',
+      headers: {}
+    } as MiddlewareRequest
+    const next = jest.fn()
+
+    await middleware.use(request, {} as MiddlewareResponse, next)
+
+    expect(resolver.resolve).toHaveBeenCalledWith(request)
+    expect(request.headers['tenant-id']).toBeUndefined()
+    expect(request.headers['organization-id']).toBeUndefined()
+    expect(request[ANONYMOUS_TENANT_RESOLUTION_REQUEST_KEY]).toEqual(fallbackResolution)
+    expect(next).toHaveBeenCalledWith()
+  })
+
   it('does not resolve tenant context for unrelated routes', async () => {
     const request = {
       method: 'GET',
       originalUrl: '/api/auth/login',
       headers: {}
-    } as any
+    } as MiddlewareRequest
     const next = jest.fn()
 
-    await middleware.use(request, {} as any, next)
+    await middleware.use(request, {} as MiddlewareResponse, next)
 
     expect(resolver.resolve).not.toHaveBeenCalled()
     expect(request.headers['tenant-id']).toBeUndefined()

--- a/packages/server/src/core/context/anonymous-tenant-context.middleware.ts
+++ b/packages/server/src/core/context/anonymous-tenant-context.middleware.ts
@@ -18,13 +18,14 @@ export class AnonymousTenantContextMiddleware implements NestMiddleware {
 
     try {
       const resolution = await this.anonymousTenantResolver.resolve(req)
+      const isPasswordLoginRequest = this.isPasswordLoginRequest(req)
       req[ANONYMOUS_TENANT_RESOLUTION_REQUEST_KEY] = resolution
 
-      if (resolution.tenantId) {
+      if (resolution.tenantId && (!isPasswordLoginRequest || !resolution.fallbackApplied)) {
         req.headers['tenant-id'] = resolution.tenantId
       }
 
-      if (resolution.organizationId && !this.isPasswordLoginRequest(req)) {
+      if (resolution.organizationId && !isPasswordLoginRequest) {
         req.headers['organization-id'] = resolution.organizationId
       }
 
@@ -58,10 +59,7 @@ export class AnonymousTenantContextMiddleware implements NestMiddleware {
 
   private isPasswordLoginRequest(request: Request) {
     const path = getNormalizedRequestPath(request)
-    return (
-      request.method === 'POST' &&
-      (path === '/api/auth/login' || path === '/auth/login')
-    )
+    return request.method === 'POST' && (path === '/api/auth/login' || path === '/auth/login')
   }
 
   private hasExplicitTenantContext(request: Request) {

--- a/packages/server/src/core/context/anonymous-tenant-context.middleware.ts
+++ b/packages/server/src/core/context/anonymous-tenant-context.middleware.ts
@@ -24,7 +24,7 @@ export class AnonymousTenantContextMiddleware implements NestMiddleware {
         req.headers['tenant-id'] = resolution.tenantId
       }
 
-      if (resolution.organizationId) {
+      if (resolution.organizationId && !this.isPasswordLoginRequest(req)) {
         req.headers['organization-id'] = resolution.organizationId
       }
 
@@ -35,6 +35,10 @@ export class AnonymousTenantContextMiddleware implements NestMiddleware {
   }
 
   private shouldResolve(request: Request) {
+    if (this.isPasswordLoginRequest(request)) {
+      return true
+    }
+
     if (request.method !== 'GET') {
       return false
     }
@@ -50,6 +54,14 @@ export class AnonymousTenantContextMiddleware implements NestMiddleware {
     }
 
     return /^\/(?:api\/)?[^/]+\/login\/start$/.test(path)
+  }
+
+  private isPasswordLoginRequest(request: Request) {
+    const path = getNormalizedRequestPath(request)
+    return (
+      request.method === 'POST' &&
+      (path === '/api/auth/login' || path === '/auth/login')
+    )
   }
 
   private hasExplicitTenantContext(request: Request) {

--- a/packages/server/src/core/context/tenant-domain.utils.spec.ts
+++ b/packages/server/src/core/context/tenant-domain.utils.spec.ts
@@ -36,4 +36,10 @@ describe('tenant-domain utils', () => {
     expect(resolveTenantDomainFromRequest(originOnlyRequest)).toBe('tenant-origin')
     expect(resolveTenantDomainFromRequest(localhostRequest)).toBeNull()
   })
+
+  it('ignores reserved application host labels', () => {
+    expect(resolveTenantDomainFromRequest({ headers: { host: 'app.xpertai.cn' } } as any)).toBeNull()
+    expect(resolveTenantDomainFromRequest({ headers: { host: 'api.xpertai.cn' } } as any)).toBeNull()
+    expect(resolveTenantDomainFromRequest({ headers: { host: 'shenzhen.app.xpertai.cn' } } as any)).toBe('shenzhen')
+  })
 })

--- a/packages/server/src/core/context/tenant-domain.utils.ts
+++ b/packages/server/src/core/context/tenant-domain.utils.ts
@@ -1,5 +1,7 @@
 import { Request } from 'express'
 
+const RESERVED_TENANT_DOMAIN_LABELS = new Set(['app', 'api', 'www'])
+
 function normalizeHeaderValue(value: string) {
   return value
     .split(',')
@@ -65,7 +67,12 @@ export function extractTenantDomainFromHostname(hostname: string | undefined): s
     return null
   }
 
-  return parts[0] || null
+  const tenantDomain = parts[0] || null
+  if (!tenantDomain || RESERVED_TENANT_DOMAIN_LABELS.has(tenantDomain)) {
+    return null
+  }
+
+  return tenantDomain
 }
 
 export function resolveTenantDomainFromRequest(request: Request): string | null {


### PR DESCRIPTION
## What changed

- Resolve tenant context from subdomain hosts such as `shenzhen.app.xpertai.cn` while ignoring reserved app/API host labels.
- Resolve anonymous tenant context for password login without injecting organization scope, and scope password login user lookup by the resolved tenant.
- Treat password login as an anonymous browser request so stale tenant scope and auth headers are not sent to `/api/auth/login`.
- Normalize cloud API and websocket URLs so `same-origin` uses the current browser origin.
- Split the deployed webapp browser API base env from backend `API_BASE_URL` via `WEBAPP_API_BASE_URL`.

## Why

Tenant subdomains must preserve the browser host through `/api` and websocket calls. The old deployed browser runtime used `https://api.xpertai.cn`, so a page loaded from `https://shenzhen.app.xpertai.cn` lost the tenant host when requesting tenant state or logging in.

Password login only needs tenant scope. Sending or injecting organization scope on this anonymous route can conflict with `X-Scope-Level: tenant` and fail before credential validation.

## Deployment requirement

For the deployed webapp container, set:

```env
WEBAPP_API_BASE_URL=same-origin
```

Keep backend `API_BASE_URL` as the public API URL, for example `https://api.xpertai.cn`. Without `WEBAPP_API_BASE_URL=same-origin`, the new image falls back to `API_BASE_URL` and tenant subdomain requests will still leave the subdomain host.

## Validation

- `pnpm exec jest -c apps/cloud/jest.config.ts apps/cloud/src/app/@core/providers/url.spec.ts apps/cloud/src/app/@core/utils.spec.ts apps/cloud/src/app/@core/interceptors/tenant.interceptor.spec.ts apps/cloud/src/app/@core/interceptors/token.interceptor.spec.ts --runInBand`
- `pnpm exec jest -c packages/server/jest.config.ts packages/server/src/auth/auth.service.spec.ts packages/server/src/core/context/anonymous-tenant-context.middleware.spec.ts packages/server/src/core/context/tenant-domain.utils.spec.ts --runInBand --globals '{"ts-jest":{"diagnostics":false}}'`
- `git diff --check origin/develop...HEAD`
- `sh -n .deploy/webapp/entrypoint.prod.sh`

Note: the clean PR worktree reuses the primary checkout dependencies for focused tests. Server diagnostics were disabled because the currently installed `@xpert-ai/chatkit-types@0.3.11` package does not export `ThreadGoalSpec`, which is an existing dependency/type mismatch outside this PR.