### PR TITLE
fix: avoid selecting recent chats on task routes

### DIFF
--- a/apps/cloud/src/app/features/menus.spec.ts
+++ b/apps/cloud/src/app/features/menus.spec.ts
@@ -76,6 +76,7 @@ describe('getFeatureMenus', () => {
     expect(chat?.expanded).toBe(true)
     expect(chat?.children?.map((item) => item.link)).toEqual(['/chat', '/chat/tasks'])
     expect(chat?.children?.map((item) => item.title)).toEqual(['最近会话', '任务'])
+    expect(chat?.children?.[0]?.data?.inactivePathPrefixes).toEqual(['/chat/tasks'])
   })
 
   it('adds MCP Monitor beside Plugins for super admins', () => {

--- a/apps/cloud/src/app/features/menus.ts
+++ b/apps/cloud/src/app/features/menus.ts
@@ -227,7 +227,8 @@ export function getFeatureMenus(scopeLevel: RequestScopeLevel, _org: IOrganizati
           pathMatch: 'prefix',
           data: {
             translationKey: 'Recent Chats',
-            activePathPrefixes: ['/chat/c']
+            activePathPrefixes: ['/chat/c'],
+            inactivePathPrefixes: ['/chat/tasks']
           }
         },
         {


### PR DESCRIPTION
## Summary
- Prevent the Recent Chats sidebar child item from staying active on `/chat/tasks` routes.
- Add a focused menu metadata regression assertion for the inactive task-route prefix.

## Root cause
Both chat sidebar child items used prefix matching, so `/chat/tasks/...` matched both `/chat` and `/chat/tasks`.

## Validation
- `pnpm nx test cloud --runInBand --testPathPatterns=apps/cloud/src/app/features/menus.spec.ts`