### PR TITLE
[codex] promote model providers route and assistant filters

### DIFF
--- a/apps/cloud/src/app/@shared/chat/install-project/install.component.html
+++ b/apps/cloud/src/app/@shared/chat/install-project/install.component.html
@@ -35,7 +35,7 @@
     />
     @if (!copilotModel() && !primaryCopilot()) {
       <a
-        href="/settings/copilot/basic"
+        href="/copilot/basic"
         target="_blank"
         class="text-xs my-1 hover:underline text-primary-400 hover:text-primary-500"
       >

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.html
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.html
@@ -448,7 +448,7 @@
     </div>
 
     <a
-      href="/settings/copilot/basic"
+      href="/copilot/basic"
       target="_blank"
       class="group flex cursor-pointer items-center rounded-b-lg border-t border-divider-subtle bg-components-panel-bg px-4 py-2 text-text-accent"
     >

--- a/apps/cloud/src/app/@shared/copilot/enable-model/enable.component.html
+++ b/apps/cloud/src/app/@shared/copilot/enable-model/enable.component.html
@@ -1,5 +1,5 @@
 <button type="button" class="btn px-3 py-2 rounded-2xl border border-input-border"
-  routerLink="/settings/copilot/basic"
+  routerLink="/copilot/basic"
 >
   @if (copilotEnabled()) {
     {{ 'PAC.Copilot.EnablePrimaryDefaultModel' | translate: {Default: 'Enable primary default model'} }}

--- a/apps/cloud/src/app/features/chat/project/manage/manage.component.html
+++ b/apps/cloud/src/app/features/chat/project/manage/manage.component.html
@@ -17,7 +17,7 @@
     (ngModelChange)="saveProject()"
   />
   @if (!copilotModel() && !primaryCopilot()) {
-    <a href="/settings/copilot/basic" target="_blank" class="text-xs my-1 hover:underline text-primary-400 hover:text-primary-500">
+    <a href="/copilot/basic" target="_blank" class="text-xs my-1 hover:underline text-primary-400 hover:text-primary-500">
       {{ 'PAC.XProject.GlobalModelConfig' | translate: {Default: 'Global model config'} }}
     </a>
   }

--- a/apps/cloud/src/app/features/features-routing.module.spec.ts
+++ b/apps/cloud/src/app/features/features-routing.module.spec.ts
@@ -72,4 +72,12 @@ describe('features routing', () => {
     expect(route?.data?.scopeContext).toBe('dual-scope')
     expect(route?.data?.permissions?.only).toEqual(['SUPER_ADMIN'])
   })
+
+  it('mounts model providers at the top-level /copilot route', () => {
+    const route = children.find((item) => item.path === 'copilot')
+
+    expect(route?.loadChildren).toEqual(expect.any(Function))
+    expect(route?.data?.title).toBe('Model Providers')
+    expect(route?.data?.scopeContext).toBe('dual-scope')
+  })
 })

--- a/apps/cloud/src/app/features/features-routing.module.ts
+++ b/apps/cloud/src/app/features/features-routing.module.ts
@@ -104,6 +104,15 @@ export const routes: Routes = [
           }
         }
       },
+      {
+        path: 'copilot',
+        loadChildren: () => import('./setting/copilot/routing').then((m) => m.default),
+        canActivate: [authGuard],
+        data: {
+          title: 'Model Providers',
+          scopeContext: 'dual-scope'
+        }
+      },
 
       // BI Routers
       // {

--- a/apps/cloud/src/app/features/menus.spec.ts
+++ b/apps/cloud/src/app/features/menus.spec.ts
@@ -98,8 +98,7 @@ describe('getFeatureMenus', () => {
 
   it('promotes model providers to the management menu with the original copilot gate', () => {
     const menus = getFeatureMenus(RequestScopeLevel.ORGANIZATION, null)
-    const modelProviders = menus.find((item) => item.link === '/settings/copilot/basic')
-    const settings = menus.find((item) => item.link === '/settings')
+    const modelProviders = menus.find((item) => item.link === '/copilot/basic')
 
     expect(modelProviders).toMatchObject({
       title: 'Model Providers',
@@ -111,8 +110,7 @@ describe('getFeatureMenus', () => {
     expect(modelProviders?.data?.translationKey).toBe('AI Copilot')
     expect(modelProviders?.data?.featureKey).toBe(AiFeatureEnum.FEATURE_COPILOT)
     expect(modelProviders?.data?.permissionKeys).toEqual([AIPermissionsEnum.COPILOT_EDIT])
-    expect(modelProviders?.data?.activePathPrefixes).toEqual(['/settings/copilot'])
-    expect(settings?.data?.inactivePathPrefixes).toEqual(['/settings/copilot'])
+    expect(modelProviders?.data?.activePathPrefixes).toEqual(['/copilot'])
   })
 
   it('points the Data parent menu at the first visible child menu', () => {

--- a/apps/cloud/src/app/features/menus.ts
+++ b/apps/cloud/src/app/features/menus.ts
@@ -394,8 +394,7 @@ export function getFeatureMenus(scopeLevel: RequestScopeLevel, _org: IOrganizati
       admin: true,
       scopeContext: 'dual-scope',
       data: {
-        translationKey: 'Settings',
-        inactivePathPrefixes: ['/settings/copilot']
+        translationKey: 'Settings'
       }
     },
     {
@@ -424,7 +423,7 @@ export function getFeatureMenus(scopeLevel: RequestScopeLevel, _org: IOrganizati
     {
       title: 'Model Providers',
       icon: 'psychology',
-      link: '/settings/copilot/basic',
+      link: '/copilot/basic',
       pathMatch: 'prefix',
       admin: true,
       scopeContext: 'dual-scope',
@@ -432,7 +431,7 @@ export function getFeatureMenus(scopeLevel: RequestScopeLevel, _org: IOrganizati
         translationKey: 'AI Copilot',
         featureKey: AiFeatureEnum.FEATURE_COPILOT,
         permissionKeys: [AIPermissionsEnum.COPILOT_EDIT],
-        activePathPrefixes: ['/settings/copilot']
+        activePathPrefixes: ['/copilot']
       }
     }
   ]

--- a/apps/cloud/src/app/features/setting/copilot/routing.spec.ts
+++ b/apps/cloud/src/app/features/setting/copilot/routing.spec.ts
@@ -34,14 +34,14 @@ describe('copilot setting routes', () => {
     const children = copilotRoute?.children ?? []
     const monitoringRoutes = ['usages', 'users', 'overview'].map((path) => children.find((route) => route.path === path))
 
-    expect(featureGate).toHaveBeenCalledWith(['FEATURE_COPILOT_MONITORING'], ['/settings/copilot/basic'])
+    expect(featureGate).toHaveBeenCalledWith(['FEATURE_COPILOT_MONITORING'], ['/copilot/basic'])
     monitoringRoutes.forEach((route) => {
       expect(route).toEqual(
         expect.objectContaining({
           canActivate: expect.arrayContaining([
             {
               featureKeys: ['FEATURE_COPILOT_MONITORING'],
-              redirectCommands: ['/settings/copilot/basic']
+              redirectCommands: ['/copilot/basic']
             }
           ])
         })

--- a/apps/cloud/src/app/features/setting/copilot/routing.ts
+++ b/apps/cloud/src/app/features/setting/copilot/routing.ts
@@ -10,7 +10,7 @@ export default [
     component: CopilotComponent,
     canActivate: [NgxPermissionsGuard],
     data: {
-      title: 'Settings / Copilot',
+      title: 'Model Providers',
       permissions: {
         only: [AIPermissionsEnum.COPILOT_EDIT],
         redirectTo: '/settings'
@@ -28,17 +28,17 @@ export default [
       },
       {
         path: 'usages',
-        canActivate: [featureGate([AiFeatureEnum.FEATURE_COPILOT_MONITORING], ['/settings/copilot/basic'])],
+        canActivate: [featureGate([AiFeatureEnum.FEATURE_COPILOT_MONITORING], ['/copilot/basic'])],
         loadComponent: () => import('./usages/usages.component').then((m) => m.CopilotUsagesComponent)
       },
       {
         path: 'users',
-        canActivate: [featureGate([AiFeatureEnum.FEATURE_COPILOT_MONITORING], ['/settings/copilot/basic'])],
+        canActivate: [featureGate([AiFeatureEnum.FEATURE_COPILOT_MONITORING], ['/copilot/basic'])],
         loadComponent: () => import('./users/users.component').then((m) => m.CopilotUsersComponent)
       },
       {
         path: 'overview',
-        canActivate: [featureGate([AiFeatureEnum.FEATURE_COPILOT_MONITORING], ['/settings/copilot/basic'])],
+        canActivate: [featureGate([AiFeatureEnum.FEATURE_COPILOT_MONITORING], ['/copilot/basic'])],
         loadComponent: () => import('./overview/overview.component').then((m) => m.CopilotOverviewComponent)
       }
     ]

--- a/apps/cloud/src/app/features/setting/setting-routing.module.ts
+++ b/apps/cloud/src/app/features/setting/setting-routing.module.ts
@@ -213,9 +213,39 @@ const routes: Routes = [
       },
       {
         path: 'copilot',
-        loadChildren: () => import('./copilot/routing').then((m) => m.default),
+        children: [
+          {
+            path: '',
+            redirectTo: '/copilot',
+            pathMatch: 'full'
+          },
+          {
+            path: 'basic',
+            redirectTo: '/copilot/basic',
+            pathMatch: 'full'
+          },
+          {
+            path: 'usages',
+            redirectTo: '/copilot/usages',
+            pathMatch: 'full'
+          },
+          {
+            path: 'users',
+            redirectTo: '/copilot/users',
+            pathMatch: 'full'
+          },
+          {
+            path: 'overview',
+            redirectTo: '/copilot/overview',
+            pathMatch: 'full'
+          },
+          {
+            path: '**',
+            redirectTo: '/copilot'
+          }
+        ],
         data: {
-          title: 'settings/copilot',
+          title: 'copilot',
           scopeContext: 'dual-scope'
         }
       },

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.html
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.html
@@ -35,14 +35,18 @@
         </label>
 
         <div class="cloud-sidebar-assistants__filters" role="list">
-          @for (categoryItem of categories; track categoryItem.value) {
+          @for (categoryItem of categories(); track categoryItem.value) {
             <button
               type="button"
               class="cloud-sidebar-assistants__filter"
-              [class.is-active]="category() === categoryItem.value"
+              [class.is-active]="activeCategory() === categoryItem.value"
               (click)="selectCategory(categoryItem.value)"
             >
-              {{ categoryItem.labelKey | translate: { Default: categoryItem.labelDefault } }}
+              @if (categoryItem.labelKey) {
+                {{ categoryItem.labelKey | translate: { Default: categoryItem.labelDefault } }}
+              } @else {
+                {{ categoryItem.labelDefault }}
+              }
             </button>
           }
         </div>
@@ -150,7 +154,7 @@
             </div>
           </li>
         } @empty {
-          @if (!collapsed() && (query() || category() !== 'all')) {
+          @if (!collapsed() && !showClawXpertEntry() && (query() || activeCategory() !== 'all')) {
             <li class="cloud-sidebar-assistants__empty">
               {{ 'PAC.Assistant.EmptySearch' | translate: { Default: 'No matching assistants.' } }}
             </li>

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.scss
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.scss
@@ -144,15 +144,11 @@
 
 .cloud-sidebar-assistants__filters {
   display: flex;
+  flex-wrap: wrap;
   min-width: 0;
   gap: 0.45rem;
-  overflow-x: auto;
+  overflow-x: visible;
   padding: 0.1rem 0 0.15rem;
-  scrollbar-width: none;
-}
-
-.cloud-sidebar-assistants__filters::-webkit-scrollbar {
-  display: none;
 }
 
 .cloud-sidebar-assistants__filter {

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.spec.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.spec.ts
@@ -114,12 +114,70 @@ describe('cloud sidebar assistants helpers', () => {
 
   it('filters assistants by label or description', () => {
     const items = [
-      xpert({ id: 'office', title: 'Office Assistant', description: 'Word and sheets' }),
-      xpert({ id: 'tools', title: 'MCP Tools', description: 'Workspace calls' })
+      xpert({ id: 'documents', title: 'Documents Assistant', description: 'Word and sheets' }),
+      xpert({ id: 'tools', title: 'Tool Runner', description: 'Workspace calls' })
     ]
 
-    expect(filterAssistantXperts(items, 'sheet').map((item) => item.id)).toEqual(['office'])
-    expect(filterAssistantXperts(items, 'mcp').map((item) => item.id)).toEqual(['tools'])
+    expect(filterAssistantXperts(items, 'sheet').map((item) => item.id)).toEqual(['documents'])
+    expect(filterAssistantXperts(items, 'tool').map((item) => item.id)).toEqual(['tools'])
+  })
+
+  it('matches assistant categories from tag names instead of label or description keywords', () => {
+    const items = [
+      xpert({ id: 'finance', title: 'General Assistant', tags: [{ name: 'Finance' }] }),
+      xpert({ id: 'support', title: 'General Assistant', tags: [{ name: 'Support' }] }),
+      xpert({
+        id: 'untagged',
+        title: 'Finance Support Assistant',
+        description: 'report ticket workflow',
+        tags: []
+      })
+    ]
+
+    expect(filterAssistantXperts(items, '', 'finance').map((item) => item.id)).toEqual(['finance'])
+    expect(filterAssistantXperts(items, '', 'support').map((item) => item.id)).toEqual(['support'])
+  })
+
+  it('does not use tag labels as category identity', () => {
+    const items = [xpert({ id: 'localized-tag', tags: [{ name: 'finance', label: { zh: '财务' } }] })]
+
+    expect(filterAssistantXperts(items, '', 'finance').map((item) => item.id)).toEqual(['localized-tag'])
+    expect(filterAssistantXperts(items, '', '财务')).toEqual([])
+  })
+
+  it('matches exact normalized tag names without aliases', () => {
+    const items = [xpert({ id: 'localized-tag', tags: [{ name: '财务' }] })]
+
+    expect(filterAssistantXperts(items, '', 'finance')).toEqual([])
+    expect(filterAssistantXperts(items, '', '财务').map((item) => item.id)).toEqual(['localized-tag'])
+  })
+
+  it('does not infer categories from titles or descriptions', () => {
+    const items = [
+      xpert({
+        id: 'keyword-only',
+        title: 'Finance Support Assistant',
+        description: 'Handles finance tickets',
+        tags: []
+      })
+    ]
+
+    expect(filterAssistantXperts(items, '', 'finance')).toEqual([])
+    expect(filterAssistantXperts(items, '', 'support')).toEqual([])
+  })
+
+  it('keeps untagged assistants visible only in the all category', () => {
+    const items = [
+      xpert({
+        id: 'untagged',
+        title: 'Finance Support Assistant',
+        description: 'report ticket workflow'
+      })
+    ]
+
+    expect(filterAssistantXperts(items, '', 'all').map((item) => item.id)).toEqual(['untagged'])
+    expect(filterAssistantXperts(items, '', 'finance')).toEqual([])
+    expect(filterAssistantXperts(items, '', 'support')).toEqual([])
   })
 
   it('matches the active assistant route', () => {
@@ -251,6 +309,136 @@ describe('CloudSidebarAssistantsComponent', () => {
 
     expect(names).toEqual(['Personal Assistant', 'Other Assistant'])
     expect(fixture.nativeElement.querySelector('.cloud-sidebar-assistants__subtitle').textContent).toContain('2')
+  })
+
+  it('builds category filters from assistant tags', async () => {
+    assistantBindingService.getAvailableXperts.mockReturnValue(
+      of([
+        {
+          id: 'other-xpert',
+          slug: 'other-assistant',
+          title: 'Other Assistant',
+          latest: true,
+          tags: [{ name: 'Finance' }, { name: 'Support' }],
+          workspaceId: 'workspace-1',
+          workspace: {
+            capabilities: {
+              canRead: true,
+              canRun: true,
+              canWrite: true,
+              canManage: false
+            }
+          }
+        },
+        {
+          id: 'bound-xpert',
+          slug: 'personal-assistant',
+          title: 'Personal Assistant',
+          latest: true,
+          tags: [{ name: 'Team' }],
+          workspaceId: 'workspace-1',
+          workspace: {
+            capabilities: {
+              canRead: true,
+              canRun: true,
+              canWrite: true,
+              canManage: false
+            }
+          }
+        }
+      ])
+    )
+    const fixture = TestBed.createComponent(CloudSidebarAssistantsComponent)
+
+    fixture.detectChanges()
+    await fixture.whenStable()
+    fixture.detectChanges()
+
+    expect(fixture.componentInstance.categories().map((category) => category.value)).toEqual([
+      'all',
+      'team',
+      'finance',
+      'support'
+    ])
+    expect(
+      Array.from(fixture.nativeElement.querySelectorAll('.cloud-sidebar-assistants__filter')).map((item) =>
+        item.textContent.trim()
+      )
+    ).toEqual(['PAC.Assistant.CategoryAll', 'Team', 'Finance', 'Support'])
+  })
+
+  it('keeps the assistant section visible when the selected category no longer exists', async () => {
+    assistantBindingService.get.mockReturnValue(of(null))
+    assistantBindingService.getAvailableXperts.mockReturnValue(of([]))
+    const fixture = TestBed.createComponent(CloudSidebarAssistantsComponent)
+
+    fixture.detectChanges()
+    await fixture.whenStable()
+    fixture.detectChanges()
+
+    fixture.componentInstance.selectCategory('missing-tag')
+    fixture.detectChanges()
+
+    expect(fixture.componentInstance.activeCategory()).toBe('all')
+    expect(fixture.componentInstance.shouldRender()).toBe(true)
+    expect(fixture.nativeElement.querySelector('.cloud-sidebar-assistants')).not.toBeNull()
+    expect(fixture.nativeElement.querySelector('.cloud-sidebar-assistants__filter.is-active').textContent.trim()).toBe(
+      'PAC.Assistant.CategoryAll'
+    )
+  })
+
+  it('does not show the empty state when a tag only matches the pinned ClawXpert assistant', async () => {
+    assistantBindingService.getAvailableXperts.mockReturnValue(
+      of([
+        {
+          id: 'other-xpert',
+          slug: 'other-assistant',
+          title: 'Other Assistant',
+          latest: true,
+          tags: [{ name: 'Finance' }],
+          workspaceId: 'workspace-1',
+          workspace: {
+            capabilities: {
+              canRead: true,
+              canRun: true,
+              canWrite: true,
+              canManage: false
+            }
+          }
+        },
+        {
+          id: 'bound-xpert',
+          slug: 'personal-assistant',
+          title: 'Personal Assistant',
+          latest: true,
+          tags: [{ name: 'Team' }],
+          workspaceId: 'workspace-1',
+          workspace: {
+            capabilities: {
+              canRead: true,
+              canRun: true,
+              canWrite: true,
+              canManage: false
+            }
+          }
+        }
+      ])
+    )
+    const fixture = TestBed.createComponent(CloudSidebarAssistantsComponent)
+
+    fixture.detectChanges()
+    await fixture.whenStable()
+    fixture.detectChanges()
+
+    fixture.componentInstance.selectCategory('team')
+    fixture.detectChanges()
+
+    const names = Array.from(fixture.nativeElement.querySelectorAll('.cloud-sidebar-assistants__name')).map((item) =>
+      item.textContent.trim()
+    )
+
+    expect(names).toEqual(['Personal Assistant'])
+    expect(fixture.nativeElement.querySelector('.cloud-sidebar-assistants__empty')).toBeNull()
   })
 
   it('routes the pinned ClawXpert item to chat and its settings button to configuration', async () => {

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.ts
@@ -22,11 +22,11 @@ import { EmojiAvatarComponent } from '../../@shared/avatar/emoji-avatar/avatar.c
 import { getAssistantRegistryItem } from '../assistant/assistant.registry'
 import {
   type AssistantXpertLike,
-  type AssistantCategory,
   filterAssistantXperts,
   getAssistantDescription,
   getAssistantLabel,
   getAssistantRouteId,
+  getAssistantTagNames,
   isAssistantRouteActive,
   normalizeAssistantXperts
 } from './cloud-sidebar-assistants.utils'
@@ -34,16 +34,15 @@ import {
 export type CloudSidebarAssistantState = {
   items: IXpert[]
   binding: IAssistantBinding | null
-  loading: boolean
 }
 
 const EMPTY_ASSISTANT_STATE: CloudSidebarAssistantState = {
   items: [],
-  binding: null,
-  loading: false
+  binding: null
 }
 
 const CLAWXPERT_FALLBACK_ID = '__clawxpert__'
+const ALL_ASSISTANT_CATEGORY = 'all'
 
 @Component({
   standalone: true,
@@ -59,14 +58,7 @@ export class CloudSidebarAssistantsComponent {
 
   readonly expanded = signal(true)
   readonly query = signal('')
-  readonly category = signal<AssistantCategory>('all')
-  readonly categories: Array<{ value: AssistantCategory; labelKey: string; labelDefault: string }> = [
-    { value: 'all', labelKey: 'PAC.Assistant.CategoryAll', labelDefault: '全部' },
-    { value: 'office', labelKey: 'PAC.Assistant.CategoryOffice', labelDefault: 'Office' },
-    { value: 'data', labelKey: 'PAC.Assistant.CategoryData', labelDefault: '数据' },
-    { value: 'mcp', labelKey: 'PAC.Assistant.CategoryMcp', labelDefault: 'MCP' },
-    { value: 'personal', labelKey: 'PAC.Assistant.CategoryPersonal', labelDefault: '个人' }
-  ]
+  readonly category = signal(ALL_ASSISTANT_CATEGORY)
 
   readonly #assistantBindingService = inject(AssistantBindingService)
   readonly #conversationService = inject(ChatConversationService)
@@ -131,15 +123,10 @@ export class CloudSidebarAssistantsComponent {
             ({ binding, items }) =>
               ({
                 binding,
-                items: normalizeAssistantXperts(items),
-                loading: false
+                items: normalizeAssistantXperts(items)
               }) satisfies CloudSidebarAssistantState
           ),
-          startWith({
-            items: [],
-            binding: null,
-            loading: true
-          } satisfies CloudSidebarAssistantState),
+          startWith(EMPTY_ASSISTANT_STATE),
           catchError(() => of(EMPTY_ASSISTANT_STATE))
         )
       })
@@ -160,8 +147,33 @@ export class CloudSidebarAssistantsComponent {
     const boundId = this.boundXpert()?.id
     return boundId ? this.xperts().filter((xpert) => xpert.id !== boundId) : this.xperts()
   })
+  readonly categories = computed(() => {
+    const categories: Array<{ value: string; labelKey?: string; labelDefault: string }> = [
+      { value: ALL_ASSISTANT_CATEGORY, labelKey: 'PAC.Assistant.CategoryAll', labelDefault: '全部' }
+    ]
+    const seen = new Set<string>([ALL_ASSISTANT_CATEGORY])
+
+    for (const xpert of [this.clawXpertSearchItem(), ...this.xpertsWithoutClawXpert()]) {
+      for (const tag of getAssistantTagNames(xpert)) {
+        const label = tag.trim()
+        const value = label.toLowerCase()
+        if (!label || seen.has(value)) {
+          continue
+        }
+
+        seen.add(value)
+        categories.push({ value, labelDefault: label })
+      }
+    }
+
+    return categories
+  })
+  readonly activeCategory = computed(() => {
+    const category = this.category()
+    return this.categories().some((item) => item.value === category) ? category : ALL_ASSISTANT_CATEGORY
+  })
   readonly filteredXperts = computed(() =>
-    filterAssistantXperts(this.xpertsWithoutClawXpert(), this.query(), this.category())
+    filterAssistantXperts(this.xpertsWithoutClawXpert(), this.query(), this.activeCategory())
   )
   readonly unreadXpertIdsRequest = computed(() => {
     const ids = [this.boundXpert()?.id, ...this.xpertsWithoutClawXpert().map((xpert) => xpert.id)].filter(
@@ -214,14 +226,14 @@ export class CloudSidebarAssistantsComponent {
       slug: boundXpert?.slug ?? 'clawxpert',
       name: boundXpert?.name ?? label,
       title: label,
-      description: [description, 'ClawXpert', 'personal', '个人', '配置'].filter(Boolean).join(' '),
-      tags: [{ name: 'clawxpert' }, { name: 'personal' }, ...(boundXpert?.tags ?? [])]
+      description: [description, 'ClawXpert', '配置'].filter(Boolean).join(' '),
+      tags: boundXpert?.tags ?? []
     }
   })
   readonly showClawXpertEntry = computed(() => {
     return (
       this.request().enabled &&
-      filterAssistantXperts([this.clawXpertSearchItem()], this.query(), this.category()).length > 0
+      filterAssistantXperts([this.clawXpertSearchItem()], this.query(), this.activeCategory()).length > 0
     )
   })
   readonly assistantCount = computed(() => this.xpertsWithoutClawXpert().length + (this.request().enabled ? 1 : 0))
@@ -236,13 +248,10 @@ export class CloudSidebarAssistantsComponent {
       return this.assistantLabel(activeXpert)
     }
 
-    return this.assistantLabel(this.xperts()[0]) || ''
+    const firstXpert = this.xperts()[0]
+    return firstXpert ? this.assistantLabel(firstXpert) : ''
   })
-  readonly shouldRender = computed(() => {
-    const state = this.state()
-
-    return this.request().enabled && (state.loading || state.items.length > 0 || this.showClawXpertEntry())
-  })
+  readonly shouldRender = computed(() => this.request().enabled)
 
   openClawXpert(event: Event) {
     event.stopPropagation()
@@ -366,7 +375,7 @@ export class CloudSidebarAssistantsComponent {
     this.expanded.update((expanded) => !expanded)
   }
 
-  selectCategory(category: AssistantCategory) {
+  selectCategory(category: string) {
     this.category.set(category)
   }
 

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.utils.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.utils.ts
@@ -9,8 +9,6 @@ export interface AssistantXpertLike {
   tags?: Array<{ name?: unknown; label?: unknown }>
 }
 
-export type AssistantCategory = 'all' | 'office' | 'data' | 'mcp' | 'personal'
-
 export function normalizeAssistantXperts<T extends AssistantXpertLike>(
   items: T[] | { items?: T[] } | null | undefined
 ) {
@@ -30,15 +28,16 @@ export function normalizeAssistantXperts<T extends AssistantXpertLike>(
 export function filterAssistantXperts<T extends AssistantXpertLike>(
   items: T[],
   query: string,
-  category: AssistantCategory = 'all'
+  category = 'all'
 ) {
   const keyword = query.trim().toLowerCase()
 
-  return items.filter(
-    (xpert) =>
-      (category === 'all' || assistantMatchesCategory(xpert, category)) &&
-      (!keyword || getAssistantSearchText(xpert).toLowerCase().includes(keyword))
-  )
+  return items.filter((xpert) => {
+    const matchesCategory = category === 'all' || assistantMatchesTag(xpert, category)
+    const matchesKeyword = !keyword || getAssistantSearchText(xpert).toLowerCase().includes(keyword)
+
+    return matchesCategory && matchesKeyword
+  })
 }
 
 export function getAssistantRouteId(xpert: AssistantXpertLike) {
@@ -64,21 +63,9 @@ export function isAssistantRouteActive(url: string, xpert: AssistantXpertLike) {
   return !!routeId && normalizeChatPath(url).startsWith(`/chat/x/${encodeURIComponent(routeId)}/c`)
 }
 
-export function assistantMatchesCategory(xpert: AssistantXpertLike, category: AssistantCategory) {
-  const text = getAssistantSearchText(xpert).toLowerCase()
-
-  switch (category) {
-    case 'office':
-      return /office|docx|word|sheet|excel|ppt|presentation|document|文档|表格|演示/.test(text)
-    case 'data':
-      return /data|bi|chart|echarts|semantic|ontology|model|数据|图表|指标|模型/.test(text)
-    case 'mcp':
-      return /mcp|tool|tools|toolset|工具/.test(text)
-    case 'personal':
-      return /personal|wechat|微信|个人|crm|客户/.test(text)
-    default:
-      return true
-  }
+function assistantMatchesTag(xpert: AssistantXpertLike, tagName: string) {
+  const normalizedTagName = normalizeAssistantTagValue(tagName)
+  return getAssistantTagNames(xpert).some((tag) => normalizeAssistantTagValue(tag) === normalizedTagName)
 }
 
 function getAssistantSearchText(xpert: AssistantXpertLike) {
@@ -86,24 +73,22 @@ function getAssistantSearchText(xpert: AssistantXpertLike) {
     getAssistantLabel(xpert),
     getAssistantDescription(xpert),
     xpert.slug,
-    ...(xpert.tags?.map((tag) => stringifyAssistantTagValue(tag.name) || stringifyAssistantTagValue(tag.label)) ?? [])
+    ...getAssistantTagNames(xpert)
   ]
     .filter(Boolean)
     .join(' ')
 }
 
-function stringifyAssistantTagValue(value: unknown) {
-  if (typeof value === 'string') {
-    return value
-  }
+export function getAssistantTagNames(xpert: AssistantXpertLike) {
+  return (
+    xpert.tags
+      ?.map((tag) => tag.name)
+      .filter((name): name is string => typeof name === 'string' && !!name.trim()) ?? []
+  )
+}
 
-  if (!value || typeof value !== 'object') {
-    return ''
-  }
-
-  return Object.values(value as Record<string, unknown>)
-    .filter((item): item is string => typeof item === 'string')
-    .join(' ')
+function normalizeAssistantTagValue(value: string) {
+  return value.trim().toLowerCase()
 }
 
 function normalizeChatPath(url: string) {

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.component.spec.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.component.spec.ts
@@ -27,7 +27,7 @@ describe('buildCloudSidebarMenuGroups', () => {
       menu({ title: 'Data', link: '/data' }),
       menu({ title: 'MCP Monitor', link: '/operations' }),
       menu({ title: 'Plugins', link: '/plugins' }),
-      menu({ title: 'Model Providers', link: '/settings/copilot/basic', admin: true }),
+      menu({ title: 'Model Providers', link: '/copilot/basic', admin: true }),
       menu({ title: 'Explore', link: '/explore' })
     ])
 
@@ -40,7 +40,7 @@ describe('buildCloudSidebarMenuGroups', () => {
     expect(groups.find((group) => group.key === 'management')?.items.map((item) => item.link)).toEqual([
       '/plugins',
       '/operations',
-      '/settings/copilot/basic',
+      '/copilot/basic',
       '/settings'
     ])
   })

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.utils.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.utils.ts
@@ -9,7 +9,7 @@ export interface CloudSidebarMenuGroup {
   items: CloudMenuItem[]
 }
 
-const MANAGEMENT_MENU_ORDER = ['/plugins', '/operations', '/settings/copilot/basic', '/settings'] as const
+const MANAGEMENT_MENU_ORDER = ['/plugins', '/operations', '/copilot/basic', '/settings'] as const
 
 export function buildCloudSidebarMenuGroups(menus: CloudMenuItem[]): CloudSidebarMenuGroup[] {
   const visibleMenus = (menus ?? []).filter((menu) => !menu.hidden)

--- a/apps/cloud/src/app/xpert/chat-input/chat-input.component.ts
+++ b/apps/cloud/src/app/xpert/chat-input/chat-input.component.ts
@@ -453,7 +453,7 @@ export class ChatInputComponent {
   }
 
   navigateCopilot() {
-    this.#router.navigate(['/settings/copilot'])
+    this.#router.navigate(['/copilot'])
   }
 
   toggleCanvas() {


### PR DESCRIPTION
## Summary

This PR contains two focused UI/navigation fixes:

- Promotes Model Providers out of the Settings child route and mounts it at the top-level `/copilot` route.
- Derives the cloud sidebar assistant filters from assistant tag names instead of fixed keyword categories.

## Root cause

Model Providers had already been promoted visually into the top-level management menu, but the menu item and related entry points still linked to `/settings/copilot/basic`. That meant navigation still entered the Settings shell and displayed the Settings secondary menu.

The assistant sidebar used fixed category values and keyword inference from labels/descriptions. That could classify assistants by display text instead of explicit metadata, and it could not reflect the actual tags returned by available assistant records.

## Fix

- Added a top-level `/copilot` route that reuses the existing Copilot routing/component tree.
- Updated Model Providers menu metadata and model configuration links to point at `/copilot/basic`.
- Kept legacy `/settings/copilot/*` routes as compatibility redirects to the matching `/copilot/*` paths.
- Updated Copilot monitoring feature-gate fallback redirects to `/copilot/basic`.
- Replaced fixed assistant categories with computed filters built from assistant tag names.
- Updated assistant filtering to match exact normalized tag names while keeping keyword search over label, description, slug, and tag names.

## Validation

- `git diff --check origin/develop...HEAD`
- `pnpm exec jest --config apps/cloud/jest.config.ts apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.spec.ts apps/cloud/src/app/features/menus.spec.ts apps/cloud/src/app/features/features-routing.module.spec.ts apps/cloud/src/app/features/setting/copilot/routing.spec.ts apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.component.spec.ts --runInBand`