### PR TITLE
[codex] Resolve same-origin API URLs

### DIFF
--- a/apps/cloud/src/app/@core/providers/url.spec.ts
+++ b/apps/cloud/src/app/@core/providers/url.spec.ts
@@ -1,4 +1,4 @@
-import { normalizeApiBaseUrl } from './url'
+import { normalizeApiBaseUrl, resolveAbsoluteApiBaseUrl, resolveAbsoluteApiUrl } from './url'
 
 describe('normalizeApiBaseUrl', () => {
   it('treats same-origin sentinels as an empty API base URL', () => {
@@ -9,5 +9,31 @@ describe('normalizeApiBaseUrl', () => {
 
   it('keeps explicit API origins without a trailing slash', () => {
     expect(normalizeApiBaseUrl('https://api.xpertai.cn/')).toBe('https://api.xpertai.cn')
+  })
+})
+
+describe('resolveAbsoluteApiBaseUrl', () => {
+  it('resolves same-origin sentinels to the current browser origin', () => {
+    expect(resolveAbsoluteApiBaseUrl('same-origin')).toBe(window.location.origin)
+    expect(resolveAbsoluteApiBaseUrl('self')).toBe(window.location.origin)
+    expect(resolveAbsoluteApiBaseUrl('/')).toBe(window.location.origin)
+  })
+
+  it('keeps explicit API origins without a trailing slash', () => {
+    expect(resolveAbsoluteApiBaseUrl('https://api.xpertai.cn/')).toBe('https://api.xpertai.cn')
+  })
+
+  it('resolves protocol-relative API origins with the current browser protocol', () => {
+    expect(resolveAbsoluteApiBaseUrl('//api.xpertai.cn/')).toBe(`${window.location.protocol}//api.xpertai.cn`)
+  })
+})
+
+describe('resolveAbsoluteApiUrl', () => {
+  it('resolves same-origin API paths to the current browser origin', () => {
+    expect(resolveAbsoluteApiUrl('/api/ai/', 'same-origin')).toBe(`${window.location.origin}/api/ai/`)
+  })
+
+  it('appends API paths to explicit API origins', () => {
+    expect(resolveAbsoluteApiUrl('/api/ai/', 'https://api.xpertai.cn/')).toBe('https://api.xpertai.cn/api/ai/')
   })
 })

--- a/apps/cloud/src/app/@core/providers/url.ts
+++ b/apps/cloud/src/app/@core/providers/url.ts
@@ -12,6 +12,29 @@ export function normalizeApiBaseUrl(value?: string | null) {
   return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized
 }
 
+export function resolveAbsoluteApiBaseUrl(value?: string | null) {
+  const normalized = normalizeApiBaseUrl(value)
+  if (!normalized) {
+    return getCurrentOrigin()
+  }
+
+  if (normalized.startsWith('//')) {
+    return `${getCurrentProtocol()}${normalized}`
+  }
+
+  if (normalized.startsWith('/')) {
+    return `${getCurrentOrigin()}${normalized}`
+  }
+
+  return normalized
+}
+
+export function resolveAbsoluteApiUrl(path: string, value?: string | null) {
+  const base = resolveAbsoluteApiBaseUrl(value)
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${base}${normalizedPath}`
+}
+
 /**
  * Inject the base url of api server
  * 
@@ -19,4 +42,12 @@ export function normalizeApiBaseUrl(value?: string | null) {
  */
 export function injectApiBaseUrl() {
   return normalizeApiBaseUrl(baseUrl)
+}
+
+function getCurrentOrigin() {
+  return typeof window === 'undefined' ? '' : window.location.origin
+}
+
+function getCurrentProtocol() {
+  return typeof window === 'undefined' ? 'https:' : window.location.protocol
 }

--- a/apps/cloud/src/app/features/assistant/assistant-chatkit.runtime.spec.ts
+++ b/apps/cloud/src/app/features/assistant/assistant-chatkit.runtime.spec.ts
@@ -1,6 +1,7 @@
 import { DOCUMENT } from '@angular/common'
 import { signal } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
+import { environment } from '@cloud/environments/environment'
 import { TranslateService } from '@ngx-translate/core'
 import { createChatKit } from '@xpert-ai/chatkit-angular'
 import { of } from 'rxjs'
@@ -37,7 +38,17 @@ jest.mock('../../@core', () => ({
   },
   Store: class Store {},
   ToastrService: class ToastrService {},
-  getErrorMessage: jest.fn((error?: { message?: string }) => error?.message ?? '')
+  getErrorMessage: jest.fn((error?: { message?: string }) => error?.message ?? ''),
+  resolveAbsoluteApiBaseUrl: jest.fn((value?: string | null) => {
+    const normalized = value?.trim()
+    if (!normalized || ['same-origin', 'self', '/'].includes(normalized.toLowerCase())) {
+      return window.location.origin
+    }
+    if (normalized.startsWith('//')) {
+      return `${window.location.protocol}${normalized.replace(/\/+$/, '')}`
+    }
+    return normalized.replace(/\/+$/, '')
+  })
 }))
 
 jest.mock('@xpert-ai/chatkit-angular', () => ({
@@ -70,8 +81,11 @@ function flushAngularEffects() {
 }
 
 describe('assistant chatkit runtime helpers', () => {
+  const originalApiBaseUrl = environment.API_BASE_URL
+
   beforeEach(() => {
     jest.clearAllMocks()
+    environment.API_BASE_URL = originalApiBaseUrl
   })
 
   afterEach(() => {
@@ -220,6 +234,71 @@ describe('assistant chatkit runtime helpers', () => {
             }
           }
         }
+      })
+    )
+  })
+
+  it('passes an absolute same-origin API URL to ChatKit', () => {
+    environment.API_BASE_URL = 'same-origin'
+    const createChatKitMock = createChatKit as jest.Mock
+    createChatKitMock.mockReturnValue({
+      setOptions: jest.fn()
+    })
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DOCUMENT,
+          useValue: document
+        },
+        {
+          provide: TranslateService,
+          useValue: {
+            currentLang: 'en',
+            instant: (_key: string, params?: { Default?: string }) => params?.Default ?? _key
+          }
+        },
+        {
+          provide: ToastrService,
+          useValue: {
+            error: jest.fn()
+          }
+        },
+        {
+          provide: AppService,
+          useValue: {
+            lang: signal('en'),
+            theme$: signal({ primary: 'light' })
+          }
+        },
+        {
+          provide: Store,
+          useValue: {
+            token: 'token-1',
+            token$: of('token-1'),
+            organizationId: 'org-1',
+            selectOrganizationId: () => of('org-1')
+          }
+        }
+      ]
+    })
+
+    TestBed.runInInjectionContext(() => {
+      injectHostedAssistantChatkitControl({
+        identity: signal('xpert_shared'),
+        assistantId: signal('assistant-1'),
+        frameUrl: signal('/chatkit'),
+        titleKey: 'PAC.Xpert.Assistant',
+        titleDefault: 'Assistant'
+      })
+    })
+    flushAngularEffects()
+
+    expect(createChatKitMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        api: expect.objectContaining({
+          apiUrl: `${window.location.origin}/api/ai`
+        })
       })
     )
   })

--- a/apps/cloud/src/app/features/assistant/assistant-chatkit.runtime.ts
+++ b/apps/cloud/src/app/features/assistant/assistant-chatkit.runtime.ts
@@ -13,7 +13,7 @@ import {
   Store,
   type IResolvedAssistantBinding,
   getErrorMessage,
-  normalizeApiBaseUrl,
+  resolveAbsoluteApiBaseUrl,
   ToastrService
 } from '../../@core'
 import { AppService } from '../../app.service'
@@ -452,8 +452,7 @@ function normalizeRgbColor(value: string) {
 }
 
 function buildAssistantApiUrl(baseUrl?: string | null) {
-  const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
-  return normalizedBaseUrl ? `${normalizedBaseUrl}/api/ai` : '/api/ai'
+  return `${resolveAbsoluteApiBaseUrl(baseUrl)}/api/ai`
 }
 
 function buildAssistantClientSecret(secret: string, organizationId?: string | null): AssistantHostedClientSecret {
@@ -465,23 +464,4 @@ function buildAssistantClientSecret(secret: string, organizationId?: string | nu
     secret,
     organizationId
   }
-}
-
-function normalizeBaseUrl(baseUrl?: string | null) {
-  const apiBaseUrl = normalizeApiBaseUrl(baseUrl)
-  if (!apiBaseUrl) {
-    return ''
-  }
-
-  const normalized = apiBaseUrl.endsWith('/') ? apiBaseUrl.slice(0, -1) : apiBaseUrl
-  if (normalized.startsWith('http')) {
-    return normalized
-  }
-
-  if (normalized.startsWith('//')) {
-    const protocol = typeof window === 'undefined' ? 'https:' : window.location.protocol
-    return `${protocol}${normalized}`
-  }
-
-  return normalized
 }

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-preview.component.spec.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-preview.component.spec.ts
@@ -1,5 +1,6 @@
 jest.mock('../../../@core', () => ({
-  injectApiBaseUrl: () => 'http://localhost:3000',
+  injectApiBaseUrl: () => '',
+  resolveAbsoluteApiBaseUrl: () => 'http://localhost:3000',
   injectToastr: () => ({
     warning: jest.fn()
   })

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-preview.component.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-preview.component.ts
@@ -13,10 +13,11 @@ import {
 } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser'
+import { environment } from '@cloud/environments/environment'
 import { TranslateModule } from '@ngx-translate/core'
 import { ZardButtonComponent, ZardInputDirective, ZardMenuImports } from '@xpert-ai/headless-ui'
 import { TChatElementReference } from '@xpert-ai/contracts'
-import { injectApiBaseUrl, injectToastr } from '../../../@core'
+import { injectToastr, resolveAbsoluteApiBaseUrl } from '../../../@core'
 import {
   createClawXpertManagedServicesBrowserController,
   type ClawXpertManagedServicesBrowserControllerOptions,
@@ -769,7 +770,7 @@ function buildElementReference(context: ElementReferenceContext, element: Elemen
 })
 export class ClawXpertConversationPreviewComponent implements OnDestroy {
   readonly #sanitizer = inject(DomSanitizer)
-  readonly #apiBaseUrl = injectApiBaseUrl()
+  readonly #apiBaseUrl = resolveAbsoluteApiBaseUrl(environment.API_BASE_URL)
   readonly #toastr = injectToastr()
   readonly #document = inject(DOCUMENT)
   #frameCleanup: (() => void) | null = null

--- a/apps/cloud/src/app/features/setting/assistants/assistants.facade.ts
+++ b/apps/cloud/src/app/features/setting/assistants/assistants.facade.ts
@@ -19,7 +19,7 @@ import {
   Store,
   ToastrService,
   getErrorMessage,
-  normalizeApiBaseUrl
+  resolveAbsoluteApiBaseUrl
 } from '../../../@core'
 import { ASSISTANT_REGISTRY, type AssistantRegistryItem } from '../../assistant/assistant.registry'
 
@@ -393,27 +393,7 @@ export class AssistantsSettingsFacade {
 }
 
 function buildAssistantRuntimeApiUrl(baseUrl?: string | null) {
-  const normalizedBaseUrl = normalizeAssistantBaseUrl(baseUrl)
-  return normalizedBaseUrl ? `${normalizedBaseUrl}/api/ai` : '/api/ai'
-}
-
-function normalizeAssistantBaseUrl(baseUrl?: string | null) {
-  const apiBaseUrl = normalizeApiBaseUrl(baseUrl)
-  if (!apiBaseUrl) {
-    return ''
-  }
-
-  const normalized = apiBaseUrl.endsWith('/') ? apiBaseUrl.slice(0, -1) : apiBaseUrl
-  if (normalized.startsWith('http')) {
-    return normalized
-  }
-
-  if (normalized.startsWith('//')) {
-    const protocol = typeof window === 'undefined' ? 'https:' : window.location.protocol
-    return `${protocol}${normalized}`
-  }
-
-  return normalized
+  return `${resolveAbsoluteApiBaseUrl(baseUrl)}/api/ai`
 }
 
 function sanitizeConfiguredFrameUrl(frameUrl?: string | null) {

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/api/api.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/api/api.component.ts
@@ -8,7 +8,16 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router'
 import { OverlayAnimations } from '@xpert-ai/core'
 import { NgmSpinComponent } from '@xpert-ai/ocap-angular/common'
 import { TranslateModule } from '@ngx-translate/core'
-import { ApiKeyBindingType, getErrorMessage, injectApiBaseUrl, injectToastr, routeAnimations, XpertAPIService } from '../../../../../@core'
+import { environment } from '@cloud/environments/environment'
+import {
+  ApiKeyBindingType,
+  getErrorMessage,
+  injectApiBaseUrl,
+  injectToastr,
+  resolveAbsoluteApiUrl,
+  routeAnimations,
+  XpertAPIService
+} from '../../../../../@core'
 import { XpertDevelopApiKeyComponent } from '../../../xpert/develop'
 import { ZardTooltipImports } from '@xpert-ai/headless-ui'
 
@@ -41,7 +50,7 @@ export class XpertKBAPIComponent {
   // Inputs
   readonly id = input<string>('')
 
-  readonly apiUrl = computed(() => this.apiBaseUrl + '/api/ai/')
+  readonly apiUrl = computed(() => resolveAbsoluteApiUrl('/api/ai/', environment.API_BASE_URL))
   readonly small = input<boolean, boolean | string>(false, {
     transform: booleanAttribute
   })

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/knowledgebase.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/knowledgebase.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common'
 import { Component, computed, inject, model, signal } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { ActivatedRoute, Router, RouterModule } from '@angular/router'
+import { environment } from '@cloud/environments/environment'
 import { injectExportXpertDsl, XpertInlineProfileComponent } from '@cloud/app/@shared/xpert'
 import { OverlayAnimation1 } from '@xpert-ai/core'
 import { injectConfirmDelete, NgmCopyComponent, NgmSpinComponent } from '@xpert-ai/ocap-angular/common'
@@ -17,11 +18,11 @@ import { catchError, EMPTY } from 'rxjs'
 import {
   ApiKeyBindingType,
   getErrorMessage,
-  injectApiBaseUrl,
   injectHelpWebsite,
   IXpert,
   KnowledgebaseService,
   KnowledgebaseTypeEnum,
+  resolveAbsoluteApiUrl,
   routeAnimations,
   ToastrService
 } from '../../../../@core'
@@ -61,7 +62,6 @@ export class KnowledgebaseComponent {
   readonly i18nService = injectI18nService()
   readonly exportXpertDsl = injectExportXpertDsl()
   readonly confirmDelete = injectConfirmDelete()
-  readonly apiBaseUrl = injectApiBaseUrl()
   readonly apiHelpUrl = injectHelpWebsite('/docs/ai/knowledge/api/')
 
   readonly #knowledgebase = myRxResource({
@@ -119,7 +119,7 @@ export class KnowledgebaseComponent {
   readonly #loading = signal(false)
   readonly loading = computed(() => this.#loading() || this.#knowledgebase.status() === 'loading')
 
-  readonly apiUrl = computed(() => this.apiBaseUrl + '/api/ai/')
+  readonly apiUrl = computed(() => resolveAbsoluteApiUrl('/api/ai/', environment.API_BASE_URL))
 
   readonly apiEnabled = linkedModel({
     initialValue: null,

--- a/apps/cloud/src/app/features/xpert/xpert/api/api.component.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/api/api.component.ts
@@ -8,12 +8,13 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router'
 import { OverlayAnimations } from '@xpert-ai/core'
 import { NgmSpinComponent } from '@xpert-ai/ocap-angular/common'
 import { TranslateModule } from '@ngx-translate/core'
+import { environment } from '@cloud/environments/environment'
 import {
   ApiKeyBindingType,
   derivedHelpUrl,
   getErrorMessage,
-  injectApiBaseUrl,
   injectToastr,
+  resolveAbsoluteApiUrl,
   routeAnimations,
   TChatApi,
   XpertAPIService
@@ -47,13 +48,12 @@ export class XpertAPIComponent {
   readonly #route = inject(ActivatedRoute)
   readonly #clipboard = inject(Clipboard)
   readonly #dialog = inject(Dialog)
-  readonly apiBaseUrl = injectApiBaseUrl()
   readonly apiReferenceUrl = derivedHelpUrl(() => `/api-reference/aiv1/post-apiaiv1kb`)
 
   readonly xpert = this.xpertComponent.latestXpert
 
   readonly avatar = computed(() => this.xpert()?.avatar)
-  readonly apiUrl = computed(() => this.apiBaseUrl + '/api/ai/')
+  readonly apiUrl = computed(() => resolveAbsoluteApiUrl('/api/ai/', environment.API_BASE_URL))
   readonly api = computed(() => this.xpert()?.api)
   readonly enabledApi = computed(() => !this.api()?.disabled)
   readonly small = input<boolean, boolean | string>(false, {


### PR DESCRIPTION
## Summary

This PR keeps same-origin API routing intact for normal frontend HTTP calls while resolving absolute API URLs where the browser/runtime requires an absolute URL string.

## Problem

When the webapp is configured with `WEBAPP_API_BASE_URL=same-origin`, the normalized API base is intentionally empty so Angular HTTP requests use relative `/api/...` paths through the current host. That works for tenant subdomain routing, but some consumers need an absolute URL:

- ChatKit receives `api.apiUrl` and constructs URLs internally.
- Claw preview uses URL construction for same-origin API proxy handling.
- Assistant and knowledgebase backend service API panels display and copy an endpoint for external use.

Under same-origin mode those places could receive or display relative `/api/ai` / `/api/ai/` values.

## Changes

- Added `resolveAbsoluteApiBaseUrl()` and `resolveAbsoluteApiUrl()` next to the existing `normalizeApiBaseUrl()` helper.
- Preserved `normalizeApiBaseUrl()` behavior so ordinary API requests still use relative same-origin routing.
- Updated ChatKit runtime and assistant settings runtime API URLs to pass absolute current-origin API URLs.
- Updated Claw preview API base resolution for same-origin deployments.
- Updated Assistant and Knowledgebase service API endpoint display/copy values to use absolute URLs.
- Added focused unit coverage for same-origin absolute URL resolution and ChatKit API URL behavior.

## Validation

- `pnpm exec jest --config apps/cloud/jest.config.ts apps/cloud/src/app/@core/providers/url.spec.ts --runInBand`
- `pnpm exec jest --config apps/cloud/jest.config.ts apps/cloud/src/app/features/assistant/assistant-chatkit.runtime.spec.ts apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-preview.component.spec.ts --runInBand`
- `pnpm exec tsc -p apps/cloud/tsconfig.app.json --noEmit --pretty false`
- `git diff --check`

Note: the isolated PR worktree has no `node_modules`, so the local commit hook could not run `prettier`; the checks above were run from the main checkout before publishing the isolated branch.