### PR TITLE
fix: implement server socket ping

### DIFF
--- a/apps/cloud/src/app/@core/services/server-socket-agent.service.spec.ts
+++ b/apps/cloud/src/app/@core/services/server-socket-agent.service.spec.ts
@@ -1,0 +1,145 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { TestBed } from '@angular/core/testing'
+import { DataSourceService, Store } from '@xpert-ai/cloud/state'
+import { DataSourceOptions } from '@xpert-ai/ocap-core'
+import { ZardSheetService } from '@xpert-ai/headless-ui'
+import { BehaviorSubject, Subject } from 'rxjs'
+import { I18nService } from '../../@shared/i18n'
+import { ISemanticModel } from '../types'
+import { PAC_SERVER_DEFAULT_OPTIONS } from '../providers'
+import { ToastrService } from './toastr.service'
+import { AgentService } from './agent.service'
+import { PAC_SERVER_AGENT_DEFAULT_OPTIONS } from './server-agent.service'
+import { ServerSocketAgent } from './server-socket-agent.service'
+
+describe('ServerSocketAgent', () => {
+  let agent: ServerSocketAgent
+  let httpMock: HttpTestingController
+  let connected$: BehaviorSubject<boolean>
+  let disconnected$: Subject<boolean>
+  let socket$: BehaviorSubject<null>
+
+  const storeMock = {
+    selectOrganizationId: jest.fn(() => new BehaviorSubject<string | null>('org-1').asObservable())
+  }
+
+  beforeEach(() => {
+    connected$ = new BehaviorSubject<boolean>(true)
+    disconnected$ = new Subject<boolean>()
+    socket$ = new BehaviorSubject<null>(null)
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        ServerSocketAgent,
+        DataSourceService,
+        {
+          provide: Store,
+          useValue: storeMock
+        },
+        {
+          provide: AgentService,
+          useValue: {
+            connected$: connected$.asObservable(),
+            disconnected$: disconnected$.asObservable(),
+            socket$,
+            connect: jest.fn(),
+            emit: jest.fn(),
+            on: jest.fn()
+          }
+        },
+        {
+          provide: I18nService,
+          useValue: {
+            currentLanguage: 'zh'
+          }
+        },
+        {
+          provide: ToastrService,
+          useValue: {
+            error: jest.fn()
+          }
+        },
+        {
+          provide: ZardSheetService,
+          useValue: {
+            open: jest.fn()
+          }
+        },
+        {
+          provide: PAC_SERVER_AGENT_DEFAULT_OPTIONS,
+          useValue: {
+            modelBaseUrl: '/api/semantic-model'
+          }
+        },
+        {
+          provide: PAC_SERVER_DEFAULT_OPTIONS,
+          useValue: {
+            modelEnv: 'internal'
+          }
+        }
+      ]
+    })
+
+    agent = TestBed.inject(ServerSocketAgent)
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('posts new data source ping requests through the data-source API', async () => {
+    const semanticModel: ISemanticModel & DataSourceOptions = {
+      id: 'model-1',
+      type: 'SQL',
+      dataSource: {
+        name: 'mysql-source'
+      }
+    }
+    const body = {
+      name: 'mysql-source'
+    }
+
+    const resultPromise = agent.request(semanticModel, {
+      url: 'ping',
+      body
+    })
+
+    const request = httpMock.expectOne('/api/data-source/ping')
+    expect(request.request.method).toBe('POST')
+    expect(request.request.body).toBe(body)
+
+    request.flush({ ok: true })
+
+    await expect(resultPromise).resolves.toEqual({ ok: true })
+  })
+
+  it('posts existing data source ping requests through the data-source API', async () => {
+    const semanticModel: ISemanticModel & DataSourceOptions = {
+      id: 'model-1',
+      type: 'SQL',
+      dataSource: {
+        id: 'source-1',
+        name: 'mysql-source'
+      }
+    }
+    const body = {
+      id: 'source-1',
+      name: 'mysql-source'
+    }
+
+    const resultPromise = agent.request(semanticModel, {
+      url: 'ping',
+      body
+    })
+
+    const request = httpMock.expectOne('/api/data-source/source-1/ping')
+    expect(request.request.method).toBe('POST')
+    expect(request.request.body).toBe(body)
+
+    request.flush({ ok: true })
+
+    await expect(resultPromise).resolves.toEqual({ ok: true })
+  })
+})

--- a/apps/cloud/src/app/@core/services/server-socket-agent.service.ts
+++ b/apps/cloud/src/app/@core/services/server-socket-agent.service.ts
@@ -183,20 +183,18 @@ export class ServerSocketAgent extends AbstractAgent implements Agent {
     }
 
     if (options.url === 'ping') {
-      throw new Error('Method not implemented.')
+      url = semanticModel.dataSource?.id
+        ? `${API_DATA_SOURCE}/${semanticModel.dataSource.id}/ping`
+        : `${API_DATA_SOURCE}/ping`
+      method = 'POST'
 
-      // url = semanticModel.dataSource?.id
-      //   ? `${API_DATA_SOURCE}/${semanticModel.dataSource.id}/ping`
-      //   : `${API_DATA_SOURCE}/ping`
-      // method = 'POST'
-
-      // try {
-      //   return await firstValueFrom(this.httpClient.post(url, body, { params }))
-      // } catch (err) {
-      //   const message = getErrorMessage(err)
-      //   this.error$.next(message)
-      //   throw new Error(message)
-      // }
+      try {
+        return await firstValueFrom(this.httpClient.post(url, body, { params }))
+      } catch (err) {
+        const message = getErrorMessage(err)
+        this.error$.next(message)
+        throw new Error(message)
+      }
     } else {
       if (semanticModel.type === 'XMLA') {
         /**


### PR DESCRIPTION
## Summary
- Implement ServerSocketAgent ping by posting to the data-source ping API.
- Cover both new and existing data source ping paths with focused Jest tests.

## Test
- `NODE_PATH=/Users/jiangyimin/Documents/Git/xpert-develop/node_modules /Users/jiangyimin/Documents/Git/xpert-develop/node_modules/.bin/jest -c apps/cloud/jest.config.ts apps/cloud/src/app/@core/services/server-socket-agent.service.spec.ts --runInBand`