### PR TITLE
fix: skip subdomain tenant parsing for local hosts

### DIFF
--- a/apps/cloud/src/app/@core/services/tenant-hostname.ts
+++ b/apps/cloud/src/app/@core/services/tenant-hostname.ts
@@ -1,0 +1,35 @@
+export function resolveTenantFromHostname(hostname: string): string | null {
+  const host = hostname.trim()
+  const normalizedHost = host.toLowerCase()
+
+  if (!host || normalizedHost === 'localhost' || isIPv4Hostname(normalizedHost)) {
+    return null
+  }
+
+  const parts = host.split('.')
+  // e.g. foo.app.xpertai.cn => ['foo','app','xpertai','cn']
+  if (parts.length >= 4) {
+    const sub = parts[0]
+    if (sub && sub.toLowerCase() !== 'app') {
+      return sub
+    }
+  }
+
+  return null
+}
+
+function isIPv4Hostname(hostname: string) {
+  const parts = hostname.split('.')
+
+  return (
+    parts.length === 4 &&
+    parts.every((part) => {
+      if (!/^\d+$/.test(part)) {
+        return false
+      }
+
+      const value = Number(part)
+      return value >= 0 && value <= 255
+    })
+  )
+}

--- a/apps/cloud/src/app/@core/services/tenant.service.spec.ts
+++ b/apps/cloud/src/app/@core/services/tenant.service.spec.ts
@@ -1,0 +1,35 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing'
+import { TestBed } from '@angular/core/testing'
+import { resolveTenantFromHostname } from './tenant-hostname'
+import { TenantService } from './tenant.service'
+
+describe('TenantService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    })
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('falls back to localStorage tenant for IPv4 hosts', () => {
+    expect(resolveTenantFromHostname('10.151.251.15')).toBeNull()
+  })
+
+  it('falls back to localStorage tenant for localhost', () => {
+    expect(resolveTenantFromHostname('localhost')).toBeNull()
+  })
+
+  it('keeps tenant subdomain routing for hosted domains', () => {
+    expect(resolveTenantFromHostname('shenzhen.app.xpertai.cn')).toBe('shenzhen')
+  })
+
+  it('uses localStorage when the current host does not resolve to a tenant subdomain', () => {
+    localStorage.setItem('tenant', 'local')
+
+    expect(TestBed.inject(TenantService).getTenant()).toBe('local')
+  })
+})

--- a/apps/cloud/src/app/@core/services/tenant.service.ts
+++ b/apps/cloud/src/app/@core/services/tenant.service.ts
@@ -3,6 +3,7 @@ import { Injectable, inject } from '@angular/core'
 import { API_PREFIX } from '@xpert-ai/cloud/state'
 import { catchError, firstValueFrom, map, of, shareReplay } from 'rxjs'
 import { ITenant, ITenantCreateInput, ITenantSetting } from '../types'
+import { resolveTenantFromHostname } from './tenant-hostname'
 
 @Injectable({ providedIn: 'root' })
 export class TenantService {
@@ -12,9 +13,9 @@ export class TenantService {
   API_URL = `${API_PREFIX}/tenant`
 
   readonly #isOnboarded = this.http.get(`${this.API_URL}/onboard`).pipe(
-    map((result) => ({tenant: result})),
-    catchError((err) => of({error: err})),
-    shareReplay<{tenant?: ITenant; error?: Error}>(1)
+    map((result) => ({ tenant: result })),
+    catchError((err) => of({ error: err })),
+    shareReplay<{ tenant?: ITenant; error?: Error }>(1)
   )
 
   create(createInput: ITenantCreateInput): Promise<ITenant> {
@@ -53,15 +54,10 @@ export class TenantService {
     }
 
     // 2) subdomain: <tenant>.app.xpertai.cn
-    const host = window.location.hostname
-    const parts = host.split('.')
-    // e.g. foo.app.xpertai.cn => ['foo','app','xpertai','cn']
-    if (parts.length >= 4) {
-      const sub = parts[0]
-      if (sub && sub !== 'app') {
-        this.setTenant(sub)
-        return sub
-      }
+    const sub = resolveTenantFromHostname(window.location.hostname)
+    if (sub) {
+      this.setTenant(sub)
+      return sub
     }
 
     // 3) localStorage fallback


### PR DESCRIPTION
## Summary
- Extract frontend tenant hostname parsing into a focused helper.
- Skip subdomain tenant parsing for IPv4 hosts and localhost so IP-based deployments fall back to localStorage/default.
- Keep hosted tenant subdomain behavior such as `shenzhen.app.xpertai.cn`.

## Root cause
`TenantService.getTenant()` split every hostname by `.` and treated any host with four or more labels as a tenant subdomain. IPv4 hosts like `10.151.251.15` were therefore parsed as tenant `10`.

## Validation
- `pnpm nx test cloud --testFile=apps/cloud/src/app/@core/services/tenant.service.spec.ts --runInBand`

## Notes
Local `git push` from this machine failed because DNS could not resolve `github.com`, so the remote branch was written through the GitHub connector.