### PR TITLE
Support Seedream AIGC plugin adaptation

### DIFF
--- a/apps/cloud/src/app/@shared/forms/json-schema-property/property.component.html
+++ b/apps/cloud/src/app/@shared/forms/json-schema-property/property.component.html
@@ -13,7 +13,7 @@
       </div>
     }
     @if (hasCustomWidget()) {
-      @if (meta().description; as desc) {
+      @if (propertyDescription(); as desc) {
         <i
           class="ri-information-line ml-2 text-text-tertiary hover:text-text-primary opacity-80"
           [zTooltip]="desc | i18n"
@@ -94,7 +94,7 @@
         [variable]="xUi().variable"
         [variables]="variables()"
         [placeholder]="
-          (meta().description || meta().title || '' | i18n) +
+          (placeholderMeta() | i18n) +
           (required() ? '' : '(' + ('PAC.KEY_WORDS.Optional' | translate: { Default: 'Optional' }) + ')')
         "
         [(ngModel)]="value$"
@@ -107,7 +107,7 @@
           class="w-full h-9"
           [selectOptions]="enumOptions()"
           [placeholder]="
-            (meta().description || meta().title || '' | i18n) +
+            (placeholderMeta() | i18n) +
             (required() ? '' : '(' + ('PAC.KEY_WORDS.Optional' | translate: { Default: 'Optional' }) + ')')
           "
           [(ngModel)]="value$"
@@ -123,7 +123,7 @@
                   z-input
                   class="min-h-[160px] resize-y font-mono text-sm"
                   [placeholder]="
-                    (meta().description || meta().title || '' | i18n) +
+                    (placeholderMeta() | i18n) +
                     (required() ? '' : '(' + ('PAC.KEY_WORDS.Optional' | translate: { Default: 'Optional' }) + ')')
                   "
                   type="text"
@@ -139,7 +139,7 @@
                   z-input
                   class="min-h-9 resize-y text-sm"
                   [placeholder]="
-                    (meta().description || meta().title || '' | i18n) +
+                    (placeholderMeta() | i18n) +
                     (required() ? '' : '(' + ('PAC.KEY_WORDS.Optional' | translate: { Default: 'Optional' }) + ')')
                   "
                   type="text"
@@ -155,7 +155,7 @@
                   <xpert-variable-input
                     class="w-full px-2 py-1 text-text-primary border-0 rounded-lg bg-components-input-bg-normal focus:outline-none focus:ring-1 focus:ring-inset focus:ring-components-input-border-active"
                     [placeholder]="
-                      (meta().description || meta().title || '' | i18n) +
+                      (placeholderMeta() | i18n) +
                       (required() ? '' : '(' + ('PAC.KEY_WORDS.Optional' | translate: { Default: 'Optional' }) + ')')
                     "
                     [disabled]="readonly()"
@@ -168,7 +168,7 @@
                   <input
                     z-input
                     [placeholder]="
-                      (meta().description || meta().title || '' | i18n) +
+                      (placeholderMeta() | i18n) +
                       (required() ? '' : '(' + ('PAC.KEY_WORDS.Optional' | translate: { Default: 'Optional' }) + ')')
                     "
                     [type]="xUiInputType()"
@@ -186,7 +186,7 @@
               z-input
               class="min-h-9 resize-y text-sm"
               [placeholder]="
-                (meta().description || meta().title || '' | i18n) +
+                (placeholderMeta() | i18n) +
                 (required() ? '' : '(' + ('PAC.KEY_WORDS.Optional' | translate: { Default: 'Optional' }) + ')')
               "
               type="text"
@@ -201,7 +201,7 @@
             <input
               z-input
               [placeholder]="
-                (meta().description || meta().title || '' | i18n) +
+                (placeholderMeta() | i18n) +
                 (required() ? '' : '(' + ('PAC.KEY_WORDS.Optional' | translate: { Default: 'Optional' }) + ')')
               "
               type="number"
@@ -215,7 +215,7 @@
             <input
               z-input
               [placeholder]="
-                (meta().description || meta().title || '' | i18n) +
+                (placeholderMeta() | i18n) +
                 (required() ? '' : '(' + ('PAC.KEY_WORDS.Optional' | translate: { Default: 'Optional' }) + ')')
               "
               type="number"
@@ -260,10 +260,10 @@
               [ngModelOptions]="{ standalone: true }"
               (ngModelChange)="update($event)"
             >
-              @if (meta().description) {
+              @if (propertyDescription(); as desc) {
                 <i
                   class="ri-information-line ml-2 text-text-tertiary hover:text-text-primary opacity-80"
-                  [zTooltip]="meta().description | i18n"
+                  [zTooltip]="desc | i18n"
                 ></i>
               }
             </z-switch>
@@ -299,7 +299,7 @@
                 <xpert-variable-input
                   class="w-full px-2 py-1 text-text-primary border-0 rounded-lg bg-components-input-bg-normal focus:outline-none focus:ring-1 focus:ring-inset focus:ring-components-input-border-active"
                   [placeholder]="
-                    (meta().description || meta().title || '' | i18n) +
+                    (placeholderMeta() | i18n) +
                     (required() ? '' : '(' + ('PAC.KEY_WORDS.Optional' | translate: { Default: 'Optional' }) + ')')
                   "
                   [disabled]="readonly()"
@@ -312,7 +312,7 @@
                 <input
                   z-input
                   [placeholder]="
-                    (meta().description || meta().title || '' | i18n) +
+                    (placeholderMeta() | i18n) +
                     (required() ? '' : '(' + ('PAC.KEY_WORDS.Optional' | translate: { Default: 'Optional' }) + ')')
                   "
                   [type]="xUiInputType()"

--- a/apps/cloud/src/app/@shared/forms/json-schema-property/property.component.spec.ts
+++ b/apps/cloud/src/app/@shared/forms/json-schema-property/property.component.spec.ts
@@ -3,7 +3,7 @@
  * Shared form changes for `context.model` are easy to regress because the visible behavior only shows up in remote-select params.
  * This test guards the contract that sibling-driven depends resolve from the current model and stay flattened for query serialization.
  */
-import { TestBed } from '@angular/core/testing'
+import { fakeAsync, TestBed, tick } from '@angular/core/testing'
 import { TranslateModule } from '@ngx-translate/core'
 import { JSONSchemaPropertyComponent } from './property.component'
 
@@ -96,4 +96,75 @@ describe('JSONSchemaPropertyComponent', () => {
       index: 3
     })
   })
+
+  it('prefers localized x-ui metadata for labels and descriptions', () => {
+    const fixture = TestBed.createComponent(JSONSchemaPropertyComponent)
+
+    fixture.componentRef.setInput('schema', {
+      type: 'string',
+      title: 'Model version',
+      description: 'Seedream model version.',
+      'x-ui': {
+        title: {
+          en_US: 'Model',
+          zh_Hans: '模型版本'
+        },
+        description: {
+          en_US: 'Select a Seedream model.',
+          zh_Hans: '选择 Seedream 模型。'
+        }
+      }
+    })
+    fixture.detectChanges()
+
+    expect(fixture.componentInstance.label()).toEqual({
+      en_US: 'Model',
+      zh_Hans: '模型版本'
+    })
+    expect(fixture.componentInstance.propertyDescription()).toEqual({
+      en_US: 'Select a Seedream model.',
+      zh_Hans: '选择 Seedream 模型。'
+    })
+  })
+
+  it('localizes x-ui enum labels before passing them to select options', () => {
+    const fixture = TestBed.createComponent(JSONSchemaPropertyComponent)
+
+    fixture.componentRef.setInput('schema', {
+      type: 'boolean',
+      enum: [true, false],
+      'x-ui': {
+        enumLabels: {
+          true: {
+            en_US: 'Enabled',
+            zh_Hans: '启用'
+          },
+          false: {
+            en_US: 'Disabled',
+            zh_Hans: '禁用'
+          }
+        }
+      }
+    })
+    fixture.detectChanges()
+
+    expect(fixture.componentInstance.enumOptions()).toEqual([
+      { label: 'Enabled', value: true },
+      { label: 'Disabled', value: false }
+    ])
+  })
+
+  it('applies schema defaults when the current value is nullish', fakeAsync(() => {
+    const fixture = TestBed.createComponent(JSONSchemaPropertyComponent)
+
+    fixture.componentRef.setInput('schema', {
+      type: 'string',
+      default: '2048x2048'
+    })
+    fixture.detectChanges()
+    tick()
+    tick()
+
+    expect(fixture.componentInstance.value$()).toBe('2048x2048')
+  }))
 })

--- a/apps/cloud/src/app/@shared/forms/json-schema-property/property.component.ts
+++ b/apps/cloud/src/app/@shared/forms/json-schema-property/property.component.ts
@@ -30,6 +30,11 @@ type JsonSchemaTypeWithUi = JsonSchema7Type & {
   'x-ui'?: JsonSchemaUIExtensions
 }
 
+type JsonSchemaPropertyContext = {
+  [key: string]: unknown
+  model?: { [key: string]: unknown }
+}
+
 @Component({
   standalone: true,
   imports: [
@@ -68,7 +73,7 @@ export class JSONSchemaPropertyComponent implements OnInit {
   readonly required = input<boolean, string | boolean>(false, {
     transform: booleanAttribute
   })
-  readonly context = input<Record<string, unknown> | undefined>(undefined)
+  readonly context = input<JsonSchemaPropertyContext | undefined>(undefined)
   readonly arrayItem = input<boolean, string | boolean>(false, {
     transform: booleanAttribute
   })
@@ -89,7 +94,13 @@ export class JSONSchemaPropertyComponent implements OnInit {
   readonly value$ = this.cva.value$
 
   readonly meta = computed(() => this.schema() as JsonSchema7Type)
-  readonly label = computed(() => this.meta()?.title || this.meta()?.description || this.name())
+  // x-ui
+  readonly xUi = computed<JsonSchemaUIExtensions>(() => (this.meta() as JsonSchemaTypeWithUi)?.['x-ui'] || {})
+  readonly xUiTitle = computed(() => this.xUi().title)
+  readonly xUiDescription = computed(() => this.xUi().description)
+  readonly label = computed(() => this.xUiTitle() || this.meta()?.title || this.meta()?.description || this.name())
+  readonly propertyDescription = computed(() => this.xUiDescription() || this.meta()?.description)
+  readonly placeholderMeta = computed(() => this.propertyDescription() || this.xUiTitle() || this.meta()?.title || '')
   readonly stringSchema = computed(() => this.schema() as JsonSchema7StringType)
   readonly arraySchema = computed(() => this.schema() as JsonSchema7ArrayType)
   readonly objectSchema = computed(() => this.schema() as JsonSchema7ObjectType)
@@ -98,11 +109,15 @@ export class JSONSchemaPropertyComponent implements OnInit {
 
   readonly enum = computed(() => this.enumSchema()?.enum)
   readonly enumOptions = computed(() => {
-    const items = this.enum()?.map((value) => ({ label: this.xUi()?.enumLabels?.[value] ?? value, value })) ?? []
+    const enumLabels = this.xUi()?.enumLabels
+    const items = this.enum()?.map((value) => ({
+      label: this.i18n.transform(enumLabels?.[`${value}`] ?? `${value}`),
+      value
+    })) ?? []
     const values = Array.isArray(this.value$()) ? this.value$() : this.value$() != null ? [this.value$()] : []
     values.forEach((element) => {
       if (!items.some((_) => _.value === element)) {
-        items.push({ label: element as string, value: element })
+        items.push({ label: this.i18n.transform(`${element}`), value: element })
       }
     })
     return items
@@ -128,8 +143,6 @@ export class JSONSchemaPropertyComponent implements OnInit {
     return false
   })
 
-  // x-ui
-  readonly xUi = computed<JsonSchemaUIExtensions>(() => (this.meta() as JsonSchemaTypeWithUi)?.['x-ui'] || {})
   readonly xUiComponent = computed(() => this.xUi()?.component)
   readonly xUiInputType = computed(() =>
     ['secretInput', 'password'].includes(this.xUi()?.component) ? 'password' : 'text'
@@ -148,8 +161,8 @@ export class JSONSchemaPropertyComponent implements OnInit {
     () => this.type() === 'object' && !this.hasCustomWidget() && Boolean(this.properties()?.length)
   )
   readonly depends = computed(() =>
-    (this.xUi()?.depends ?? []).reduce((acc: Record<string, unknown>, _) => {
-      const model = (this.context()?.['model'] as Record<string, unknown> | undefined) ?? undefined
+    (this.xUi()?.depends ?? []).reduce((acc: { [key: string]: unknown }, _) => {
+      const model = this.context()?.model
       if (typeof _ === 'string') {
         const value = model?.[_] ?? this.value$()?.[_]
         if (value != null) {
@@ -168,8 +181,8 @@ export class JSONSchemaPropertyComponent implements OnInit {
   constructor() {
     // Waiting NgxControlValueAccessor has been initialized
     setTimeout(() => {
-      if (this.value$() === null && this.default() != null) {
-        // Waiting all controls have been initialized then update the default value, because other's value$() will be undefined (not null) when updated
+      if (this.value$() == null && this.default() != null) {
+        // Wait until sibling controls are initialized so each field can apply its own schema default.
         setTimeout(() => {
           this.value$.set(this.default())
         })

--- a/apps/cloud/src/app/@shared/xpert/tool-parameters/tool-parameters.component.ts
+++ b/apps/cloud/src/app/@shared/xpert/tool-parameters/tool-parameters.component.ts
@@ -1,6 +1,6 @@
 import { booleanAttribute, Component, computed, inject, input } from '@angular/core'
 import { FormsModule } from '@angular/forms'
-import { IXpertTool, JsonSchemaObjectType, TToolParameter, TWorkflowVarGroup } from '@cloud/app/@core'
+import { IXpertTool, JsonSchemaObjectType, JsonSchemaUIExtensions, TToolParameter, TWorkflowVarGroup } from '@cloud/app/@core'
 import { NgmI18nPipe } from '@xpert-ai/ocap-angular/core'
 import { ZardInputDirective } from '@xpert-ai/headless-ui'
 import { TranslateModule } from '@ngx-translate/core'
@@ -8,6 +8,10 @@ import { isNil } from 'lodash-es'
 import { NgxControlValueAccessor } from 'ngxtension/control-value-accessor'
 import { XpertVariableInputComponent } from '../../agent'
 import { JSONSchemaFormComponent } from '../../forms'
+
+type JsonSchemaPropertyWithUi = {
+  'x-ui'?: JsonSchemaUIExtensions
+}
 
 /**
  * Compatible with two schema modes:
@@ -50,7 +54,17 @@ export class XpToolParametersFormComponent {
   readonly schema = computed(() => this.tool()?.schema)
   readonly parameterList = computed<TToolParameter[]>(() => {
     const parameters = this.schema()?.parameters ?? this.tool()?.provider?.parameters
-    return parameters?.filter((_) => isNil(_.visible) || _.visible)
+    const schemaProperties = this.jsonSchema()?.properties ?? {}
+    return parameters
+      ?.filter((_) => isNil(_.visible) || _.visible)
+      .map((parameter) => {
+        const xUi = getJsonSchemaUi(schemaProperties[parameter.name])
+        return {
+          ...parameter,
+          label: xUi?.title ?? parameter.label,
+          placeholder: xUi?.description ?? parameter.placeholder
+        }
+      })
   })
   readonly jsonSchema = computed(() => this.tool()?.schema as JsonSchemaObjectType)
 
@@ -68,4 +82,12 @@ export class XpToolParametersFormComponent {
       [name]: event
     }))
   }
+}
+
+function getJsonSchemaUi(property: unknown): JsonSchemaUIExtensions | undefined {
+  return hasJsonSchemaUi(property) ? property['x-ui'] : undefined
+}
+
+function hasJsonSchemaUi(property: unknown): property is JsonSchemaPropertyWithUi {
+  return typeof property === 'object' && property !== null && 'x-ui' in property
 }

--- a/apps/cloud/src/app/features/setting/integration/integration/configuration.component.html
+++ b/apps/cloud/src/app/features/setting/integration/integration/configuration.component.html
@@ -26,17 +26,23 @@
       <label class="ngm-input-label flex shrink-0 items-center justify-between">
         {{ 'PAC.Integration.Provider' | translate: { Default: 'Provider' } }}
 
-        @if (integrationProvider()?.helpUrl; as helpUrl) {
-          <a
-            [href]="helpUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="group inline-flex items-center text-xs text-primary-400 hover:text-primary-600 hover:underline"
-          >
-            {{ 'PAC.KEY_WORDS.Help' | translate: { Default: 'Help' } }}
-            <i class="ri-book-open-line ml-1 flex items-center justify-center group-hover:hidden"></i>
-            <i class="ri-book-open-fill ml-1 hidden items-center justify-center group-hover:flex"></i>
-          </a>
+        @if (integrationProvider(); as provider) {
+          @if (provider.helpUrl; as helpUrl) {
+            <a
+              [href]="helpUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="group inline-flex items-center text-xs text-primary-400 hover:text-primary-600 hover:underline"
+            >
+              @if (provider.helpLabel) {
+                {{ provider.helpLabel | i18n }}
+              } @else {
+                {{ 'PAC.KEY_WORDS.Help' | translate: { Default: 'Help' } }}
+              }
+              <i class="ri-book-open-line ml-1 flex items-center justify-center group-hover:hidden"></i>
+              <i class="ri-book-open-fill ml-1 hidden items-center justify-center group-hover:flex"></i>
+            </a>
+          }
         }
       </label>
       <ngm-select

--- a/packages/contracts/src/ai/types.ts
+++ b/packages/contracts/src/ai/types.ts
@@ -85,6 +85,14 @@ export const Attachment_Type_Options: TSelectOption<string, TXpertAttachmentType
 
 export type JsonSchemaUIExtensions = {
   /**
+   * Field title used by generic JSON-schema forms.
+   */
+  title?: I18nObject | string
+  /**
+   * Field description used by generic JSON-schema forms.
+   */
+  description?: I18nObject | string
+  /**
    * UI component variant, or custom component name
    */
   component?: 'textarea' | 'select' | 'radio' | 'checkbox' | 'switch' | 'password' | string

--- a/packages/contracts/src/integration.model.ts
+++ b/packages/contracts/src/integration.model.ts
@@ -111,6 +111,7 @@ export type TIntegrationProvider = {
   schema?: TParameterSchema
   features?: IntegrationFeatureEnum[]
   helpUrl?: string
+  helpLabel?: I18nObject
   /**
    * Declarative setup hints consumed by the host integration configuration UI.
    *

--- a/packages/plugin-sdk/src/lib/toolset/strategy.interface.ts
+++ b/packages/plugin-sdk/src/lib/toolset/strategy.interface.ts
@@ -1,7 +1,7 @@
 import { DynamicStructuredTool } from '@langchain/core/tools'
 import { I18nObject, IconDefinition } from '@xpert-ai/contracts'
 import { ZodSchema } from 'zod'
-import { BuiltinToolset } from './builtin'
+import { BuiltinToolset, TBuiltinToolsetParams } from './builtin'
 
 export interface IToolsetStrategy<TConfig = any> {
   /**
@@ -22,7 +22,7 @@ export interface IToolsetStrategy<TConfig = any> {
    */
   validateConfig(config: TConfig): Promise<void>
 
-  create(config: TConfig): Promise<BuiltinToolset>
+  create(config: TConfig, params?: TBuiltinToolsetParams): Promise<BuiltinToolset>
 
   createTools(): DynamicStructuredTool<ZodSchema>[]
 }

--- a/packages/server-ai/src/shared/tools/utils.spec.ts
+++ b/packages/server-ai/src/shared/tools/utils.spec.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+import { JsonSchema7Type } from 'zod-to-json-schema'
+import { ToolSchemaParser } from './utils'
+
+type JsonSchemaWithUi = JsonSchema7Type & {
+	properties?: {
+		size?: JsonSchema7Type & {
+			'x-ui'?: {
+				title?: {
+					en_US: string
+					zh_Hans: string
+				}
+			}
+		}
+	}
+}
+
+describe('ToolSchemaParser', () => {
+	it('passes through plain JSON schema without converting it as Zod', () => {
+		const schema: JsonSchemaWithUi = {
+			type: 'object',
+			properties: {
+				size: {
+					type: 'string',
+					enum: ['2048x2048'],
+					default: '2048x2048',
+					'x-ui': {
+						title: {
+							en_US: 'Image size',
+							zh_Hans: '图像尺寸'
+						}
+					}
+				}
+			}
+		}
+
+		expect(ToolSchemaParser.parseZodToJsonSchema(schema)).toEqual(schema)
+	})
+
+	it('still converts Zod schemas to JSON schema', () => {
+		expect(ToolSchemaParser.parseZodToJsonSchema(z.object({ prompt: z.string() }))).toEqual(
+			expect.objectContaining({
+				type: 'object',
+				properties: expect.objectContaining({
+					prompt: expect.objectContaining({
+						type: 'string'
+					})
+				})
+			})
+		)
+	})
+})

--- a/packages/server-ai/src/shared/tools/utils.ts
+++ b/packages/server-ai/src/shared/tools/utils.ts
@@ -4,8 +4,11 @@ import { zodToJsonSchema } from 'zod-to-json-schema'
 
 export class ToolSchemaParser {
 	static parseZodToJsonSchema(schema: z3.ZodTypeAny | JsonSchema7Type) {
-		const jsonSchema = zodToJsonSchema(schema as any)
-		return jsonSchema
+		if (!isZodSchema(schema)) {
+			return JSON.parse(JSON.stringify(schema))
+		}
+
+		return zodToJsonSchema(schema)
 	}
 
 	static serializeJsonSchema(schema) {
@@ -15,4 +18,8 @@ export class ToolSchemaParser {
 
 export function toolNamePrefix(prefix: string, name: string) {
 	return `${prefix ? prefix + '__' : ''}${name}`
+}
+
+function isZodSchema(schema: z3.ZodTypeAny | JsonSchema7Type): schema is z3.ZodTypeAny {
+	return typeof schema === 'object' && schema !== null && '_def' in schema
 }

--- a/packages/server-ai/src/xpert-tool/xpert-tool.service.spec.ts
+++ b/packages/server-ai/src/xpert-tool/xpert-tool.service.spec.ts
@@ -1,0 +1,105 @@
+import { CommandBus, QueryBus } from '@nestjs/cqrs'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { Test } from '@nestjs/testing'
+import { IBuiltinTool, XpertToolsetCategoryEnum } from '@xpert-ai/contracts'
+import { XpertToolsetService } from '../xpert-toolset'
+import { XpertToolset } from '../xpert-toolset/xpert-toolset.entity'
+import { XpertTool } from './xpert-tool.entity'
+import { XpertToolService } from './xpert-tool.service'
+
+describe('XpertToolService', () => {
+    it('hydrates a persisted builtin tool with the latest provider schema', async () => {
+        const latestSchema = {
+            type: 'object',
+            properties: {
+                prompt: {
+                    type: 'string',
+                    'x-ui': {
+                        title: {
+                            en_US: 'Prompt',
+                            zh_Hans: '提示词'
+                        }
+                    }
+                }
+            }
+        }
+        const latestTool: IBuiltinTool = {
+            identity: {
+                name: 'seedream_text_to_image',
+                author: 'yu rongku',
+                label: {
+                    en_US: 'Seedream text to image'
+                },
+                provider: 'seedream_aigc'
+            },
+            description: {
+                human: {
+                    en_US: 'Generate an image.'
+                },
+                llm: 'Generate an image.'
+            },
+            schema: latestSchema
+        }
+        const queryBus = {
+            execute: jest.fn(async () => [
+                latestTool
+            ])
+        }
+        const testingModule = await Test.createTestingModule({
+            providers: [
+                XpertToolService,
+                {
+                    provide: getRepositoryToken(XpertTool),
+                    useValue: {}
+                },
+                {
+                    provide: XpertToolsetService,
+                    useValue: {}
+                },
+                {
+                    provide: CommandBus,
+                    useValue: {}
+                },
+                {
+                    provide: QueryBus,
+                    useValue: queryBus
+                }
+            ]
+        }).compile()
+        const service = testingModule.get(XpertToolService)
+        const persistedTool = Object.assign(new XpertTool(), {
+            id: 'tool-id',
+            name: 'seedream_text_to_image',
+            disabled: false,
+            description: 'Custom description',
+            schema: {
+                type: 'object',
+                properties: {
+                    sequential_image_generation: {
+                        type: 'string'
+                    }
+                }
+            },
+            toolset: {
+                category: XpertToolsetCategoryEnum.BUILTIN,
+                type: 'seedream_aigc'
+            }
+        })
+        persistedTool.toolset = Object.assign(new XpertToolset(), persistedTool.toolset)
+        jest.spyOn(service, 'findOne').mockResolvedValue(persistedTool)
+
+        const tool = await service.getTool('tool-id')
+
+        expect(tool).toEqual(
+            expect.objectContaining({
+                name: 'seedream_text_to_image',
+                disabled: false,
+                description: 'Custom description',
+                schema: latestSchema,
+                provider: expect.objectContaining({
+                    schema: latestSchema
+                })
+            })
+        )
+    })
+})

--- a/packages/server-ai/src/xpert-tool/xpert-tool.service.ts
+++ b/packages/server-ai/src/xpert-tool/xpert-tool.service.ts
@@ -38,7 +38,16 @@ export class XpertToolService extends TenantOrganizationAwareCrudService<XpertTo
             const toolDetails = await this.queryBus.execute<ListBuiltinToolsQuery, IBuiltinTool[]>(
                 new ListBuiltinToolsQuery(tool.toolset.type, [tool.name])
             )
-            tool.provider = toolDetails[0]
+            const latestTool = toolDetails[0]
+            if (latestTool) {
+                tool.provider = latestTool
+                tool.label ??= latestTool.identity.label
+                tool.description ??=
+                    latestTool.description?.human?.zh_Hans ??
+                    latestTool.description?.human?.en_US ??
+                    latestTool.description?.llm
+                tool.schema = latestTool.schema
+            }
         }
 
         return tool

--- a/packages/server-ai/src/xpert-toolset/commands/handlers/create-toolset.handler.test.ts
+++ b/packages/server-ai/src/xpert-toolset/commands/handlers/create-toolset.handler.test.ts
@@ -1,0 +1,48 @@
+import { CommandBus, QueryBus } from '@nestjs/cqrs'
+import { Test } from '@nestjs/testing'
+import { TBuiltinToolsetParams, ToolsetRegistry } from '@xpert-ai/plugin-sdk'
+import { CreateToolsetCommand } from '../create-toolset.command'
+import { XpertToolset } from '../../xpert-toolset.entity'
+import { CreateToolsetHandler } from './create-toolset.handler'
+
+describe('CreateToolsetHandler', () => {
+	it('passes runtime params to plugin toolset strategies', async () => {
+		const createdToolset = {}
+		const strategy = {
+			create: jest.fn().mockResolvedValue(createdToolset)
+		}
+		const testingModule = await Test.createTestingModule({
+			providers: [
+				CreateToolsetHandler,
+				{
+					provide: CommandBus,
+					useValue: {}
+				},
+				{
+					provide: QueryBus,
+					useValue: {}
+				},
+				{
+					provide: ToolsetRegistry,
+					useValue: { get: jest.fn().mockReturnValue(strategy) }
+				}
+			]
+		}).compile()
+		const handler = testingModule.get(CreateToolsetHandler)
+		const commandBus = testingModule.get(CommandBus)
+		const queryBus = testingModule.get(QueryBus)
+		const toolset = Object.assign(new XpertToolset(), { type: 'seedream_aigc' })
+		const params: TBuiltinToolsetParams = {
+			tenantId: 'tenant-1',
+			xpertId: 'xpert-1',
+			env: {},
+			commandBus,
+			queryBus
+		}
+
+		const result = await handler.execute(new CreateToolsetCommand(toolset, params))
+
+		expect(result).toBe(createdToolset)
+		expect(strategy.create).toHaveBeenCalledWith(toolset, params)
+	})
+})

--- a/packages/server-ai/src/xpert-toolset/commands/handlers/create-toolset.handler.ts
+++ b/packages/server-ai/src/xpert-toolset/commands/handlers/create-toolset.handler.ts
@@ -19,6 +19,6 @@ export class CreateToolsetHandler implements ICommandHandler<CreateToolsetComman
 			return null
 		}
 
-		return strategy.create(command.toolset)
+		return strategy.create(command.toolset, command.params)
 	}
 }

--- a/packages/server-ai/src/xpert-toolset/queries/handlers/list-builtin-tools.handler.ts
+++ b/packages/server-ai/src/xpert-toolset/queries/handlers/list-builtin-tools.handler.ts
@@ -6,10 +6,10 @@ import { IQueryHandler, QueryHandler } from '@nestjs/cqrs'
 import * as fs from 'fs'
 import * as path from 'path'
 import { getPositionMap } from '../../../core/utils'
+import { ToolSchemaParser } from '../../../shared'
 import { getBuiltinToolsetBaseUrl } from '../../provider/builtin'
 import { ListBuiltinToolsQuery } from '../list-builtin-tools.query'
 import { ToolsetRegistry } from '@xpert-ai/plugin-sdk'
-import zodToJsonSchema from 'zod-to-json-schema'
 
 @QueryHandler(ListBuiltinToolsQuery)
 export class ListBuiltinToolsHandler implements IQueryHandler<ListBuiltinToolsQuery> {
@@ -55,7 +55,7 @@ export class ListBuiltinToolsHandler implements IQueryHandler<ListBuiltinToolsQu
 							},
 							llm: tool.description
 						},
-					schema: zodToJsonSchema(tool.schema)
+					schema: ToolSchemaParser.parseZodToJsonSchema(tool.schema)
 				}))
 
 				return builtinTools

--- a/packages/server-ai/src/xpert-toolset/xpert-toolset.controller.ts
+++ b/packages/server-ai/src/xpert-toolset/xpert-toolset.controller.ts
@@ -321,7 +321,8 @@ export class XpertToolsetController extends CrudController<XpertToolset> {
     @Get(':toolsetId/tools')
     async getToolsetTools(@Param('toolsetId') toolsetId: string) {
         const toolset = await this.service.findOne(toolsetId, { relations: ['tools'] })
-        return toolset.tools
+        const [hydrated] = await this.service.afterLoad([toolset])
+        return hydrated.tools
     }
 
     @UseGuards(ToolsetGuard)

--- a/packages/server-ai/src/xpert-toolset/xpert-toolset.service.spec.ts
+++ b/packages/server-ai/src/xpert-toolset/xpert-toolset.service.spec.ts
@@ -1,0 +1,122 @@
+import { CommandBus, QueryBus } from '@nestjs/cqrs'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { Test } from '@nestjs/testing'
+import { I18nService } from 'nestjs-i18n'
+import { IBuiltinTool, XpertToolsetCategoryEnum } from '@xpert-ai/contracts'
+import { ConfigService } from '@xpert-ai/server-config'
+import { ToolsetRegistry } from '@xpert-ai/plugin-sdk'
+import { XpertWorkspaceAccessService } from '../xpert-workspace'
+import { XpertTool } from '../xpert-tool/xpert-tool.entity'
+import { XpertToolset } from './xpert-toolset.entity'
+import { XpertToolsetService } from './xpert-toolset.service'
+
+describe('XpertToolsetService', () => {
+    it('hydrates persisted builtin tools with the latest provider schema', async () => {
+        const latestSchema = {
+            type: 'object',
+            properties: {
+                prompt: {
+                    type: 'string',
+                    'x-ui': {
+                        title: {
+                            en_US: 'Prompt',
+                            zh_Hans: '提示词'
+                        }
+                    }
+                }
+            }
+        }
+        const latestTool: IBuiltinTool = {
+            identity: {
+                name: 'seedream_text_to_image',
+                author: 'yu rongku',
+                label: {
+                    en_US: 'Seedream text to image'
+                },
+                provider: 'seedream_aigc'
+            },
+            description: {
+                human: {
+                    en_US: 'Generate an image.'
+                },
+                llm: 'Generate an image.'
+            },
+            schema: latestSchema
+        }
+        const queryBus = {
+            execute: jest.fn(async (query) => {
+                if (query.constructor.name === 'ListBuiltinToolProvidersQuery') {
+                    return [{ identity: { name: 'seedream_aigc', tags: [] } }]
+                }
+                if (query.constructor.name === 'ListBuiltinToolsQuery') {
+                    return [latestTool]
+                }
+                return null
+            })
+        }
+        const testingModule = await Test.createTestingModule({
+            providers: [
+                XpertToolsetService,
+                {
+                    provide: getRepositoryToken(XpertToolset),
+                    useValue: {}
+                },
+                {
+                    provide: XpertWorkspaceAccessService,
+                    useValue: {}
+                },
+                {
+                    provide: I18nService,
+                    useValue: {}
+                },
+                {
+                    provide: ConfigService,
+                    useValue: {}
+                },
+                {
+                    provide: ToolsetRegistry,
+                    useValue: {}
+                },
+                {
+                    provide: CommandBus,
+                    useValue: {}
+                },
+                {
+                    provide: QueryBus,
+                    useValue: queryBus
+                }
+            ]
+        }).compile()
+        const service = testingModule.get(XpertToolsetService)
+        const toolset = Object.assign(new XpertToolset(), {
+            category: XpertToolsetCategoryEnum.BUILTIN,
+            type: 'seedream_aigc',
+            tools: [
+                Object.assign(new XpertTool(), {
+                    name: 'seedream_text_to_image',
+                    disabled: false,
+                    description: 'Custom description',
+                    schema: {
+                        type: 'object',
+                        properties: {
+                            sequential_image_generation: {
+                                type: 'string'
+                            }
+                        }
+                    }
+                })
+            ]
+        })
+
+        const [hydrated] = await service.afterLoad([toolset])
+
+        expect(hydrated.tools[0]).toEqual(
+            expect.objectContaining({
+                name: 'seedream_text_to_image',
+                disabled: false,
+                description: 'Custom description',
+                schema: latestSchema
+            })
+        )
+    })
+})

--- a/packages/server-ai/src/xpert-toolset/xpert-toolset.service.ts
+++ b/packages/server-ai/src/xpert-toolset/xpert-toolset.service.ts
@@ -6,6 +6,7 @@ import { InjectRepository } from '@nestjs/typeorm'
 import { FindOptionsWhere, IsNull, Not, Repository } from 'typeorm'
 import { XpertToolset } from './xpert-toolset.entity'
 import {
+    IBuiltinTool,
     ITag,
     IUser,
     IXpertToolset,
@@ -18,7 +19,7 @@ import { ToolsetRegistry } from '@xpert-ai/plugin-sdk'
 import { assign } from 'lodash'
 import { XpertWorkspaceAccessService, XpertWorkspaceBaseService } from '../xpert-workspace'
 import { DEFAULT_TOOL_TAG_MAP, defaultToolTags } from './utils/tags'
-import { ListBuiltinToolProvidersQuery } from './queries'
+import { ListBuiltinToolProvidersQuery, ListBuiltinToolsQuery } from './queries'
 import { ToolProviderNotFoundError } from './errors'
 import { TToolsetProviderSchema } from './types'
 import { ToolProviderDTO } from './dto'
@@ -235,7 +236,52 @@ export class XpertToolsetService extends XpertWorkspaceBaseService<XpertToolset>
                 })
         }
 
+        await this.hydrateBuiltinToolSchemas(toolsets)
+
         return toolsets
+    }
+
+    private async hydrateBuiltinToolSchemas(toolsets: IXpertToolset[]) {
+        const builtinNames = Array.from(
+            new Set(
+                toolsets
+                    .filter(
+                        (item) =>
+                            item.category === XpertToolsetCategoryEnum.BUILTIN &&
+                            item.type &&
+                            item.tools?.length
+                    )
+                    .map((item) => item.type)
+            )
+        )
+
+        await Promise.all(
+            builtinNames.map(async (provider) => {
+                const builtinTools = await this.queryBus.execute<ListBuiltinToolsQuery, IBuiltinTool[]>(
+                    new ListBuiltinToolsQuery(provider)
+                )
+                const latestTools = new Map(builtinTools.map((tool) => [tool.identity.name, tool]))
+
+                toolsets
+                    .filter(
+                        (toolset) =>
+                            toolset.category === XpertToolsetCategoryEnum.BUILTIN && toolset.type === provider
+                    )
+                    .forEach((toolset) => {
+                        toolset.tools?.forEach((tool) => {
+                            const latestTool = latestTools.get(tool.name)
+                            if (latestTool) {
+                                tool.label ??= latestTool.identity.label
+                                tool.description ??=
+                                    latestTool.description?.human?.zh_Hans ??
+                                    latestTool.description?.human?.en_US ??
+                                    latestTool.description?.llm
+                                tool.schema = latestTool.schema
+                            }
+                        })
+                    })
+            })
+        )
     }
 
     async translate(key: string, options?: TranslateOptions) {


### PR DESCRIPTION
## What changed

This PR adds the platform-side support needed by the Seedream AIGC builtin plugin without hard-coding Seedream-specific behavior into shared layers.

- Supports localized JSON schema metadata from `x-ui.title`, `x-ui.description`, and localized enum labels in shared schema-driven forms and tool parameter rendering.
- Adds an integration provider `helpLabel` contract and renders the custom help label next to provider help links.
- Hydrates persisted builtin tool records with the latest provider schema when loading toolsets and tool details, including `/tools` responses used by the configuration modal.
- Passes runtime toolset strategy params through the plugin SDK `create()` contract and the server command handler.

## Why

Seedream AIGC exposes richer builtin tool metadata and needs runtime context during toolset creation. Previously, the generic schema form and persisted builtin tool records could miss localized labels/descriptions or current provider schemas, which meant the UI could show incomplete parameters or stale schema data after a builtin toolset was saved.

## Validation

Passed:

- `git diff --check origin/develop..HEAD`
- `./node_modules/.bin/nx test server-ai --testFile=packages/server-ai/src/shared/tools/utils.spec.ts --runInBand`
- `./node_modules/.bin/nx test server-ai --testFile=packages/server-ai/src/xpert-tool/xpert-tool.service.spec.ts --runInBand`
- `./node_modules/.bin/nx test server-ai --testFile=packages/server-ai/src/xpert-toolset/commands/handlers/create-toolset.handler.test.ts --runInBand`
- `./node_modules/.bin/nx test server-ai --testFile=packages/server-ai/src/xpert-toolset/xpert-toolset.service.spec.ts --runInBand`

Not passed due existing test environment blocker:

- `./node_modules/.bin/nx test cloud --testFile=apps/cloud/src/app/@shared/forms/json-schema-property/property.component.spec.ts --runInBand`
- Fails before assertions because Jest does not transform `node_modules/echarts/core.js` ESM import (`Unexpected token 'export'`).