### PR TITLE
Fix workspace file path resolution and ClawXpert sidebar scope

### DIFF
--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.spec.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.spec.ts
@@ -340,7 +340,7 @@ describe('CloudSidebarAssistantsComponent', () => {
 
     expect(names).toEqual(['Other Assistant'])
     expect(fixture.nativeElement.querySelector('.cloud-sidebar-assistants__subtitle').textContent).toContain('1')
-    expect(assistantBindingService.getAvailableXperts).toHaveBeenCalledWith('organization', 'chat_common')
+    expect(assistantBindingService.getAvailableXperts).toHaveBeenCalledWith('user', 'clawxpert')
   })
 
   it('renders the current bound ClawXpert card from the existing expert source', async () => {

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.ts
@@ -133,17 +133,12 @@ export class CloudSidebarAssistantsComponent {
   })
   readonly state = toSignal(
     toObservable(this.request).pipe(
-      switchMap(({ enabled, mode, scopeLevel }) => {
+      switchMap(({ enabled, scopeLevel }) => {
         if (!enabled) {
           return of(EMPTY_ASSISTANT_STATE)
         }
 
-        const systemListScope =
-          mode === 'list'
-            ? scopeLevel === RequestScopeLevel.TENANT
-              ? AssistantBindingScope.TENANT
-              : AssistantBindingScope.ORGANIZATION
-            : null
+        const isTenantListScope = scopeLevel === RequestScopeLevel.TENANT
 
         return merge(
           of(null),
@@ -152,16 +147,15 @@ export class CloudSidebarAssistantsComponent {
           )
         ).pipe(
           switchMap(() => {
-            const binding$ =
-              systemListScope === AssistantBindingScope.TENANT
-                ? of(null)
-                : this.#assistantBindingService
-                    .get(AssistantCode.CLAWXPERT, AssistantBindingScope.USER)
-                    .pipe(catchError(() => of(null)))
+            const binding$ = isTenantListScope
+              ? of(null)
+              : this.#assistantBindingService
+                  .get(AssistantCode.CLAWXPERT, AssistantBindingScope.USER)
+                  .pipe(catchError(() => of(null)))
 
-            const items$ = systemListScope
+            const items$ = isTenantListScope
               ? this.#assistantBindingService
-                  .getAvailableXperts(systemListScope, SYSTEM_ASSISTANT_SCOPE_CODE)
+                  .getAvailableXperts(AssistantBindingScope.TENANT, SYSTEM_ASSISTANT_SCOPE_CODE)
                   .pipe(catchError(() => of([] as IXpert[])))
               : this.#assistantBindingService
                   .getAvailableXperts(AssistantBindingScope.USER, AssistantCode.CLAWXPERT)

--- a/docs/en/guides/file-understanding-architecture.mdx
+++ b/docs/en/guides/file-understanding-architecture.mdx
@@ -362,6 +362,33 @@ Behavior:
 - Let Agents use `file_search` / `file_read` when exact content is needed.
 - Fall back to `LoadFileCommand` for failed parsing or legacy-only files.
 
+`LoadFileCommand` must distinguish two path kinds when it reads original bytes:
+
+- Absolute paths are legacy or already-resolved server-side paths and can be passed directly to LangChain / Node file loaders.
+- Workspace-relative paths, for example `files/wechat/<integrationId>/<messageId>/<fileName>`, must not be opened relative to the process `cwd`. They must be resolved through `FileAsset.metadata.workspace.catalog`, `scopeId`, and `tenantId` / `userId`, then mapped with `VolumeClient.resolve(scope).path(relativePath)`.
+
+Workspace-backed assets should keep this metadata:
+
+```ts
+{
+  source: 'platform.workspace.files',
+  catalog: 'projects' | 'users' | 'knowledges' | 'skills' | 'xperts',
+  scopeId: '<projectId | userId | knowledgeId | rootId | xpertId>',
+  relativePath: 'files/wechat/.../technical-notice.docx',
+  workspacePath: 'files/wechat/.../technical-notice.docx'
+}
+```
+
+The shared resolver lives in:
+
+```text
+packages/server-ai/src/file-understanding/domain/workspace-file.ts
+```
+
+`resolveWorkspaceVolumeScope` / `inferWorkspaceVolumeScope` own the catalog-to-`VolumeScope` mapping. `resolveFileAssetWorkspaceRelativePath` / `resolveFileAssetWorkspaceVolumeScope` read the path and scope from `FileAsset`. `LoadFileHandler`, the workspace file runtime capability, and workspace-backed `FileAsset` creation should reuse these helpers instead of maintaining command-handler-local catalog branches.
+
+With this contract, plugins and external connectors only need to provide a relative path plus catalog/scope metadata. Production does not depend on the API process `cwd` being the workspace root, and messages do not need to persist environment-specific absolute paths such as `/sandbox/...` or `/workspace/...`.
+
 Agent tools and built-in middleware:
 
 ```text

--- a/docs/en/guides/volume-workspace-architecture.mdx
+++ b/docs/en/guides/volume-workspace-architecture.mdx
@@ -416,6 +416,47 @@ For a non-project ClawXpert conversation, `/api/chat-conversation/:id/files` the
 
 The `conversationId` is still used for lookup and permission context, but it is not a filesystem directory segment. Users sharing the same Xpert see the same workspace files.
 
+### Workspace File Relative Path Resolution
+
+Plugins, managed connections, and runtime capabilities should record workspace files as "relative path plus catalog/scope", not as an absolute path from the current process or sandbox.
+
+Standard input shape:
+
+```ts
+{
+  tenantId,
+  userId,
+  catalog: 'projects' | 'users' | 'knowledges' | 'skills' | 'xperts',
+  scopeId,
+  filePath: 'files/wechat/<integrationId>/<messageId>/<fileName>'
+}
+```
+
+The shared resolver lives in:
+
+```text
+packages/server-ai/src/file-understanding/domain/workspace-file.ts
+```
+
+It maps `catalog` / `scopeId` to `VolumeScope` consistently:
+
+| catalog      | Scope fields               | Volume scope output                                     |
+| ------------ | -------------------------- | ------------------------------------------------------- |
+| `projects`   | `projectId` or `scopeId`   | `{ catalog: 'projects', projectId, userId }`            |
+| `xperts`     | `xpertId` or `scopeId`     | `{ catalog: 'xperts', xpertId, userId, isolateByUser }` |
+| `users`      | `scopeId` or `userId`      | `{ catalog: 'users', userId }`                          |
+| `knowledges` | `knowledgeId` or `scopeId` | `{ catalog: 'knowledges', knowledgeId, userId }`        |
+| `skills`     | `rootId` or `scopeId`      | `{ catalog: 'skills', rootId, userId }`                 |
+
+Readers should pass only the relative path to `VolumeHandle.path(relativePath)`:
+
+```ts
+const { volumeScope } = resolveWorkspaceVolumeScope(input, { tenantId, userId })
+const absolutePath = volumeClient.resolve(volumeScope).path(input.filePath)
+```
+
+Do not pass `files/wechat/...` directly to Node `fs.open()`. That path would be resolved against the API process `cwd`, which can produce `ENOENT` in production even when the workspace file panel shows the file. Also do not persist `/workspace/...`, `/sandbox/...`, or local runtime directories as business paths; those are runtime / sandbox mappings and are not portable across deployments.
+
 ### Environment sandboxes
 
 When `sandboxEnvironmentId` exists, the environment sandbox has the highest priority and ignores project context:

--- a/docs/zh-hans/guides/file-understanding-architecture.mdx
+++ b/docs/zh-hans/guides/file-understanding-architecture.mdx
@@ -519,6 +519,33 @@ packages/server-ai/src/shared/commands/handlers/load-file.handler.ts
 
 这保证旧会话可继续使用，同时新链路不会依赖 `StorageFile` 的业务语义。
 
+兼容层读取原始文件时必须区分两类路径：
+
+- 绝对路径：只用于旧链路或本地已解析出的 server-side 文件路径，可以直接交给 LangChain / Node 文件 loader。
+- workspace 相对路径：例如 `files/wechat/<integrationId>/<messageId>/<fileName>`。这类路径不能按进程 `cwd` 读取，必须结合 `FileAsset.metadata.workspace.catalog`、`scopeId` 以及 `tenantId` / `userId` 解析到 `VolumeScope`，再通过 `VolumeClient.resolve(scope).path(relativePath)` 得到 server-side 绝对路径。
+
+`FileAsset.metadata.workspace` 至少应保留：
+
+```ts
+{
+  source: 'platform.workspace.files',
+  catalog: 'projects' | 'users' | 'knowledges' | 'skills' | 'xperts',
+  scopeId: '<projectId | userId | knowledgeId | rootId | xpertId>',
+  relativePath: 'files/wechat/.../技术通知单.docx',
+  workspacePath: 'files/wechat/.../技术通知单.docx'
+}
+```
+
+公共解析逻辑在：
+
+```text
+packages/server-ai/src/file-understanding/domain/workspace-file.ts
+```
+
+其中 `resolveWorkspaceVolumeScope` / `inferWorkspaceVolumeScope` 负责 catalog 到 `VolumeScope` 的统一映射；`resolveFileAssetWorkspaceRelativePath` / `resolveFileAssetWorkspaceVolumeScope` 负责从 `FileAsset` 读取相对路径和 scope。`LoadFileHandler`、workspace file runtime capability 和 workspace-backed `FileAsset` 创建逻辑都应复用这套 helper，不要在各自 command handler 中重复维护 catalog 分支。
+
+这样插件或第三方连接器只需要传递相对路径和 catalog/scope 元数据。生产环境不要求进程 `cwd` 位于 workspace 根目录，也不需要把 `/sandbox/...` 或 `/workspace/...` 这类环境相关绝对路径持久化到消息中。
+
 ### Agent tools 与内置 middleware
 
 工具入口：

--- a/docs/zh-hans/guides/volume-workspace-architecture.mdx
+++ b/docs/zh-hans/guides/volume-workspace-architecture.mdx
@@ -418,6 +418,47 @@ DELETE /api/chat-conversation/:conversationId/file
 
 `conversationId` 仍用于会话定位和权限上下文，但不再作为文件系统目录片段。同一个 Xpert 的多个用户会看到同一份 workspace 文件。
 
+### Workspace 文件相对路径解析
+
+插件、managed connection 和 runtime capability 写入 workspace 文件时，应把文件记录为“相对路径 + catalog/scope”，而不是记录当前进程或 sandbox 里的绝对路径。
+
+标准输入形态：
+
+```ts
+{
+  tenantId,
+  userId,
+  catalog: 'projects' | 'users' | 'knowledges' | 'skills' | 'xperts',
+  scopeId,
+  filePath: 'files/wechat/<integrationId>/<messageId>/<fileName>'
+}
+```
+
+公共解析函数位于：
+
+```text
+packages/server-ai/src/file-understanding/domain/workspace-file.ts
+```
+
+它们负责把 `catalog` / `scopeId` 统一映射为 `VolumeScope`：
+
+| catalog      | scope 字段                 | Volume scope 输出                                       |
+| ------------ | -------------------------- | ------------------------------------------------------- |
+| `projects`   | `projectId` 或 `scopeId`   | `{ catalog: 'projects', projectId, userId }`            |
+| `xperts`     | `xpertId` 或 `scopeId`     | `{ catalog: 'xperts', xpertId, userId, isolateByUser }` |
+| `users`      | `scopeId` 或 `userId`      | `{ catalog: 'users', userId }`                          |
+| `knowledges` | `knowledgeId` 或 `scopeId` | `{ catalog: 'knowledges', knowledgeId, userId }`        |
+| `skills`     | `rootId` 或 `scopeId`      | `{ catalog: 'skills', rootId, userId }`                 |
+
+读取文件时，调用方只应把相对路径交给 `VolumeHandle.path(relativePath)`：
+
+```ts
+const { volumeScope } = resolveWorkspaceVolumeScope(input, { tenantId, userId })
+const absolutePath = volumeClient.resolve(volumeScope).path(input.filePath)
+```
+
+不要把 `files/wechat/...` 直接交给 Node `fs.open()`；那会按 API 进程 `cwd` 解析，在生产环境中容易出现文件存在于 workspace 面板但后端报 `ENOENT` 的情况。也不要把 `/workspace/...`、`/sandbox/...` 或本机 runtime 目录持久化为业务路径；这些路径属于具体 runtime / sandbox 映射，跨部署不可移植。
+
 ### 环境 sandbox
 
 当 `sandboxEnvironmentId` 存在时，环境 sandbox 优先级最高，会忽略项目上下文：

--- a/packages/server-ai/src/file-understanding/commands/handlers/create-workspace-file-asset.handler.ts
+++ b/packages/server-ai/src/file-understanding/commands/handlers/create-workspace-file-asset.handler.ts
@@ -9,15 +9,15 @@ import path from 'node:path'
 import { Repository } from 'typeorm'
 import { ConversationFileLink, FileAsset } from '../../entities'
 import type { FileAssetPurpose, FileParseMode } from '../../domain/types'
-import { VOLUME_CLIENT, VolumeClient, type VolumeScope } from '../../../shared/volume'
+import {
+    isWorkspaceFileCatalog,
+    resolveWorkspaceFileCatalog,
+    resolveWorkspaceVolumeScope,
+    type WorkspaceVolumeScopeResolution
+} from '../../domain/workspace-file'
+import { VOLUME_CLIENT, VolumeClient } from '../../../shared/volume'
 import { CreateWorkspaceFileAssetCommand } from '../create-workspace-file-asset.command'
 import { EnqueueFileParseCommand } from '../enqueue-file-parse.command'
-
-type WorkspaceScopeResolution = {
-    volumeScope: VolumeScope
-    catalog: WorkspaceFileCatalog
-    scopeId?: string
-}
 
 @CommandHandler(CreateWorkspaceFileAssetCommand)
 export class CreateWorkspaceFileAssetHandler implements ICommandHandler<CreateWorkspaceFileAssetCommand> {
@@ -113,96 +113,24 @@ export class CreateWorkspaceFileAssetHandler implements ICommandHandler<CreateWo
         )
     }
 
-    private resolveVolumeScope(input: WorkspaceUnderstandFileInput): WorkspaceScopeResolution {
+    private resolveVolumeScope(input: WorkspaceUnderstandFileInput): WorkspaceVolumeScopeResolution {
         const tenantId = normalizeOptionalString(input.tenantId) ?? RequestContext.currentTenantId()
         if (!tenantId) {
             throw new BadRequestException('tenantId is required for workspace file understanding')
         }
         const userId = normalizeOptionalString(input.userId) ?? RequestContext.currentUserId()
-        const catalog = resolveWorkspaceFileCatalog(input)
-
-        switch (catalog) {
-            case 'projects': {
-                const projectId = normalizeOptionalString(input.projectId) ?? normalizeOptionalString(input.scopeId)
-                if (!projectId) {
-                    throw new BadRequestException('projectId is required for project workspace file understanding')
-                }
-                return {
-                    volumeScope: {
-                        tenantId,
-                        catalog,
-                        projectId,
-                        userId
-                    },
-                    catalog,
-                    scopeId: projectId
-                }
-            }
-            case 'xperts': {
-                const xpertId = normalizeOptionalString(input.xpertId) ?? normalizeOptionalString(input.scopeId)
-                if (!xpertId) {
-                    throw new BadRequestException('xpertId is required for xpert workspace file understanding')
-                }
-                return {
-                    volumeScope: {
-                        tenantId,
-                        catalog,
-                        xpertId,
-                        userId,
-                        isolateByUser: input.isolateByUser ?? false
-                    },
-                    catalog,
-                    scopeId: xpertId
-                }
-            }
-            case 'users': {
-                const targetUserId = normalizeOptionalString(input.scopeId) ?? userId
-                if (!targetUserId) {
-                    throw new BadRequestException('userId is required for user workspace file understanding')
-                }
-                return {
-                    volumeScope: {
-                        tenantId,
-                        catalog,
-                        userId: targetUserId
-                    },
-                    catalog,
-                    scopeId: targetUserId
-                }
-            }
-            case 'knowledges': {
-                const knowledgeId = normalizeOptionalString(input.knowledgeId) ?? normalizeOptionalString(input.scopeId)
-                if (!knowledgeId) {
-                    throw new BadRequestException('knowledgeId is required for knowledge workspace file understanding')
-                }
-                return {
-                    volumeScope: {
-                        tenantId,
-                        catalog,
-                        knowledgeId,
-                        userId
-                    },
-                    catalog,
-                    scopeId: knowledgeId
-                }
-            }
-            case 'skills': {
-                const rootId = normalizeOptionalString(input.rootId) ?? normalizeOptionalString(input.scopeId)
-                if (!rootId) {
-                    throw new BadRequestException('rootId is required for skill workspace file understanding')
-                }
-                return {
-                    volumeScope: {
-                        tenantId,
-                        catalog,
-                        rootId,
-                        userId
-                    },
-                    catalog,
-                    scopeId: rootId
-                }
-            }
+        const catalog = normalizeOptionalString(input.catalog)
+        if (catalog && !isWorkspaceFileCatalog(catalog)) {
+            throw new BadRequestException(`Unsupported workspace file catalog: ${catalog}`)
         }
+
+        const resolved = resolveWorkspaceVolumeScope(input, { tenantId, userId, defaultCatalog: 'users' })
+        if (!resolved) {
+            throw new BadRequestException(
+                resolveWorkspaceVolumeScopeError(input, 'workspace file understanding', 'users')
+            )
+        }
+        return resolved
     }
 }
 
@@ -234,33 +162,6 @@ function buildWorkspaceFileAssetMetadata(
             projectedAt: new Date().toISOString()
         })
     })
-}
-
-function resolveWorkspaceFileCatalog(input: WorkspaceUnderstandFileInput): WorkspaceFileCatalog {
-    const catalog = normalizeOptionalString(input.catalog)
-    if (catalog) {
-        if (isWorkspaceFileCatalog(catalog)) {
-            return catalog
-        }
-        throw new BadRequestException(`Unsupported workspace file catalog: ${catalog}`)
-    }
-    if (normalizeOptionalString(input.projectId)) {
-        return 'projects'
-    }
-    if (normalizeOptionalString(input.knowledgeId)) {
-        return 'knowledges'
-    }
-    if (normalizeOptionalString(input.rootId)) {
-        return 'skills'
-    }
-    if (normalizeOptionalString(input.xpertId)) {
-        return 'xperts'
-    }
-    return 'users'
-}
-
-function isWorkspaceFileCatalog(value: string): value is WorkspaceFileCatalog {
-    return ['projects', 'users', 'knowledges', 'skills', 'xperts'].includes(value)
 }
 
 function resolvePurpose(value: unknown): FileAssetPurpose {
@@ -298,6 +199,28 @@ function normalizeWorkspaceFilePath(value: unknown) {
 
 function normalizeOptionalString(value: unknown) {
     return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function resolveWorkspaceVolumeScopeError(
+    input: WorkspaceUnderstandFileInput,
+    context: string,
+    defaultCatalog?: WorkspaceFileCatalog
+) {
+    const catalog = resolveWorkspaceFileCatalog(input, { defaultCatalog })
+    switch (catalog) {
+        case 'projects':
+            return `projectId is required for project ${context}`
+        case 'xperts':
+            return `xpertId is required for xpert ${context}`
+        case 'users':
+            return `userId is required for user ${context}`
+        case 'knowledges':
+            return `knowledgeId is required for knowledge ${context}`
+        case 'skills':
+            return `rootId is required for skill ${context}`
+        default:
+            return `${context} scope is required`
+    }
 }
 
 function compactRecord<T extends Record<string, unknown>>(record: T): T {

--- a/packages/server-ai/src/file-understanding/domain/workspace-file.spec.ts
+++ b/packages/server-ai/src/file-understanding/domain/workspace-file.spec.ts
@@ -1,0 +1,114 @@
+import {
+    inferFileAssetWorkspaceVolumeScope,
+    inferWorkspaceVolumeScope,
+    resolveFileAssetWorkspaceRelativePath,
+    resolveFileAssetWorkspaceVolumeScope,
+    resolveWorkspaceVolumeScope
+} from './workspace-file'
+
+describe('file-understanding workspace file helpers', () => {
+    it('resolves relative workspace paths from metadata before entity and fallback paths', () => {
+        expect(
+            resolveFileAssetWorkspaceRelativePath(
+                {
+                    workspacePath: 'entity/path.docx',
+                    metadata: {
+                        workspace: {
+                            relativePath: 'metadata/path.docx'
+                        }
+                    }
+                },
+                'fallback/path.docx'
+            )
+        ).toBe('metadata/path.docx')
+    })
+
+    it('normalizes and rejects unsafe relative workspace paths', () => {
+        expect(resolveFileAssetWorkspaceRelativePath(null, './files/wechat/contract.docx')).toBe(
+            'files/wechat/contract.docx'
+        )
+        expect(resolveFileAssetWorkspaceRelativePath(null, '../contract.docx')).toBeNull()
+    })
+
+    it.each([
+        ['projects', 'project-1', { catalog: 'projects', projectId: 'project-1', userId: 'user-1' }],
+        ['xperts', 'xpert-1', { catalog: 'xperts', xpertId: 'xpert-1', userId: 'user-1', isolateByUser: true }],
+        ['users', 'user-scope', { catalog: 'users', userId: 'user-scope' }],
+        ['knowledges', 'knowledge-1', { catalog: 'knowledges', knowledgeId: 'knowledge-1', userId: 'user-1' }],
+        ['skills', 'skill-root-1', { catalog: 'skills', rootId: 'skill-root-1', userId: 'user-1' }]
+    ] as const)('resolves %s volume scopes from workspace metadata', (catalog, scopeId, expectedScope) => {
+        expect(
+            resolveFileAssetWorkspaceVolumeScope(
+                {
+                    tenantId: 'tenant-1',
+                    userId: 'user-1',
+                    metadata: {
+                        workspace: {
+                            catalog,
+                            scopeId,
+                            isolateByUser: true
+                        }
+                    }
+                },
+                {}
+            )
+        ).toMatchObject({
+            tenantId: 'tenant-1',
+            ...expectedScope
+        })
+    })
+
+    it.each([
+        ['projects', 'project-1', { catalog: 'projects', projectId: 'project-1', userId: 'user-1' }],
+        ['xperts', 'xpert-1', { catalog: 'xperts', xpertId: 'xpert-1', userId: 'user-1', isolateByUser: false }],
+        ['users', 'user-scope', { catalog: 'users', userId: 'user-scope' }],
+        ['knowledges', 'knowledge-1', { catalog: 'knowledges', knowledgeId: 'knowledge-1', userId: 'user-1' }],
+        ['skills', 'skill-root-1', { catalog: 'skills', rootId: 'skill-root-1', userId: 'user-1' }]
+    ] as const)('resolves %s volume scopes from generic workspace file input', (catalog, scopeId, expectedScope) => {
+        expect(
+            resolveWorkspaceVolumeScope({
+                tenantId: 'tenant-1',
+                userId: 'user-1',
+                catalog,
+                scopeId
+            })?.volumeScope
+        ).toMatchObject({
+            tenantId: 'tenant-1',
+            ...expectedScope
+        })
+    })
+
+    it('infers project, xpert, and user scopes when workspace metadata is absent', () => {
+        expect(
+            inferFileAssetWorkspaceVolumeScope({ userId: 'user-1', projectId: 'project-1' }, 'tenant-1')
+        ).toMatchObject({
+            tenantId: 'tenant-1',
+            catalog: 'projects',
+            projectId: 'project-1',
+            userId: 'user-1'
+        })
+
+        expect(inferFileAssetWorkspaceVolumeScope({ userId: 'user-1', xpertId: 'xpert-1' }, 'tenant-1')).toMatchObject({
+            tenantId: 'tenant-1',
+            catalog: 'xperts',
+            xpertId: 'xpert-1',
+            userId: 'user-1',
+            isolateByUser: false
+        })
+
+        expect(resolveFileAssetWorkspaceVolumeScope({ userId: 'user-asset' }, { tenantId: 'tenant-1' })).toMatchObject({
+            tenantId: 'tenant-1',
+            catalog: 'users',
+            userId: 'user-asset'
+        })
+    })
+
+    it('keeps user scope inference explicit for generic resolution', () => {
+        expect(resolveWorkspaceVolumeScope({ tenantId: 'tenant-1', userId: 'user-1' })).toBeNull()
+        expect(inferWorkspaceVolumeScope({ userId: 'user-1' }, 'tenant-1')?.volumeScope).toMatchObject({
+            tenantId: 'tenant-1',
+            catalog: 'users',
+            userId: 'user-1'
+        })
+    })
+})

--- a/packages/server-ai/src/file-understanding/domain/workspace-file.ts
+++ b/packages/server-ai/src/file-understanding/domain/workspace-file.ts
@@ -1,0 +1,256 @@
+import type { WorkspaceFileCatalog, WorkspaceFileScope } from '@xpert-ai/plugin-sdk'
+import path from 'node:path'
+import type { VolumeScope } from '../../shared/volume'
+import type { FileAsset } from '../entities'
+
+export type FileAssetWorkspaceScopeDefaults = {
+    tenantId?: string | null
+    userId?: string | null
+}
+
+export type WorkspaceFileVolumeScope = Omit<VolumeScope, 'catalog'> & {
+    catalog: WorkspaceFileCatalog
+}
+
+export type WorkspaceVolumeScopeResolution = {
+    volumeScope: WorkspaceFileVolumeScope
+    catalog: WorkspaceFileCatalog
+    scopeId?: string
+}
+
+export type WorkspaceVolumeScopeOptions = FileAssetWorkspaceScopeDefaults & {
+    defaultCatalog?: WorkspaceFileCatalog | null
+    inferUserScope?: boolean
+}
+
+export function resolveFileAssetWorkspaceRelativePath(
+    fileAsset?: Pick<FileAsset, 'metadata' | 'workspacePath'> | null,
+    fallbackPath?: string | null
+) {
+    const workspaceRecord = readWorkspaceMetadataRecord(fileAsset?.metadata)
+    return (
+        normalizeWorkspaceRelativePath(workspaceRecord?.relativePath) ??
+        normalizeWorkspaceRelativePath(workspaceRecord?.workspacePath) ??
+        normalizeWorkspaceRelativePath(fileAsset?.workspacePath) ??
+        normalizeWorkspaceRelativePath(fallbackPath)
+    )
+}
+
+export function resolveFileAssetWorkspaceVolumeScope(
+    fileAsset?: Pick<FileAsset, 'metadata' | 'tenantId' | 'userId' | 'projectId' | 'xpertId'> | null,
+    defaults: FileAssetWorkspaceScopeDefaults = {}
+): VolumeScope | null {
+    const tenantId = normalizeOptionalString(fileAsset?.tenantId) ?? normalizeOptionalString(defaults.tenantId)
+    if (!tenantId) {
+        return null
+    }
+
+    const workspaceRecord = readWorkspaceMetadataRecord(fileAsset?.metadata)
+    if (!workspaceRecord) {
+        return inferFileAssetWorkspaceVolumeScope(fileAsset, tenantId, defaults)
+    }
+
+    const userId = normalizeOptionalString(fileAsset?.userId) ?? normalizeOptionalString(defaults.userId)
+    const resolved = resolveWorkspaceVolumeScope(
+        {
+            tenantId,
+            userId,
+            catalog: normalizeOptionalString(workspaceRecord.catalog) as WorkspaceFileCatalog | undefined,
+            scopeId: normalizeOptionalString(workspaceRecord.scopeId),
+            isolateByUser: typeof workspaceRecord.isolateByUser === 'boolean' ? workspaceRecord.isolateByUser : false
+        },
+        { tenantId, userId }
+    )
+
+    return resolved?.volumeScope ?? inferFileAssetWorkspaceVolumeScope(fileAsset, tenantId, defaults)
+}
+
+export function inferFileAssetWorkspaceVolumeScope(
+    fileAsset: Pick<FileAsset, 'userId' | 'projectId' | 'xpertId'> | null | undefined,
+    tenantId: string,
+    defaults: Pick<FileAssetWorkspaceScopeDefaults, 'userId'> = {}
+): VolumeScope | null {
+    return inferWorkspaceVolumeScope(fileAsset, tenantId, defaults)?.volumeScope ?? null
+}
+
+export function resolveWorkspaceVolumeScope(
+    input?: WorkspaceFileScope | null,
+    options: WorkspaceVolumeScopeOptions = {}
+): WorkspaceVolumeScopeResolution | null {
+    const tenantId = normalizeOptionalString(input?.tenantId) ?? normalizeOptionalString(options.tenantId)
+    if (!tenantId) {
+        return null
+    }
+
+    const userId = normalizeOptionalString(input?.userId) ?? normalizeOptionalString(options.userId)
+    const catalog = resolveWorkspaceFileCatalog(input, { defaultCatalog: options.defaultCatalog })
+    if (!catalog) {
+        return inferWorkspaceVolumeScope(input, tenantId, {
+            userId,
+            inferUserScope: options.inferUserScope ?? false
+        })
+    }
+
+    const scopeId = normalizeOptionalString(input?.scopeId)
+    switch (catalog) {
+        case 'projects': {
+            const projectId = normalizeOptionalString(input?.projectId) ?? scopeId
+            return projectId
+                ? {
+                      volumeScope: { tenantId, catalog, projectId, userId },
+                      catalog,
+                      scopeId: projectId
+                  }
+                : null
+        }
+        case 'xperts': {
+            const xpertId = normalizeOptionalString(input?.xpertId) ?? scopeId
+            return xpertId
+                ? {
+                      volumeScope: {
+                          tenantId,
+                          catalog,
+                          xpertId,
+                          userId,
+                          isolateByUser: input?.isolateByUser ?? false
+                      },
+                      catalog,
+                      scopeId: xpertId
+                  }
+                : null
+        }
+        case 'users': {
+            const targetUserId = scopeId ?? userId
+            return targetUserId
+                ? {
+                      volumeScope: { tenantId, catalog, userId: targetUserId },
+                      catalog,
+                      scopeId: targetUserId
+                  }
+                : null
+        }
+        case 'knowledges': {
+            const knowledgeId = normalizeOptionalString(input?.knowledgeId) ?? scopeId
+            return knowledgeId
+                ? {
+                      volumeScope: { tenantId, catalog, knowledgeId, userId },
+                      catalog,
+                      scopeId: knowledgeId
+                  }
+                : null
+        }
+        case 'skills': {
+            const rootId = normalizeOptionalString(input?.rootId) ?? scopeId
+            return rootId
+                ? {
+                      volumeScope: { tenantId, catalog, rootId, userId },
+                      catalog,
+                      scopeId: rootId
+                  }
+                : null
+        }
+    }
+}
+
+export function inferWorkspaceVolumeScope(
+    input: Pick<WorkspaceFileScope, 'userId' | 'projectId' | 'knowledgeId' | 'rootId' | 'xpertId'> | null | undefined,
+    tenantId: string,
+    options: Pick<WorkspaceVolumeScopeOptions, 'userId' | 'inferUserScope'> = {}
+): WorkspaceVolumeScopeResolution | null {
+    const userId = normalizeOptionalString(input?.userId) ?? normalizeOptionalString(options.userId)
+    const projectId = normalizeOptionalString(input?.projectId)
+    if (projectId) {
+        return {
+            volumeScope: { tenantId, catalog: 'projects', projectId, userId },
+            catalog: 'projects',
+            scopeId: projectId
+        }
+    }
+
+    const knowledgeId = normalizeOptionalString(input?.knowledgeId)
+    if (knowledgeId) {
+        return {
+            volumeScope: { tenantId, catalog: 'knowledges', knowledgeId, userId },
+            catalog: 'knowledges',
+            scopeId: knowledgeId
+        }
+    }
+
+    const rootId = normalizeOptionalString(input?.rootId)
+    if (rootId) {
+        return {
+            volumeScope: { tenantId, catalog: 'skills', rootId, userId },
+            catalog: 'skills',
+            scopeId: rootId
+        }
+    }
+
+    const xpertId = normalizeOptionalString(input?.xpertId)
+    if (xpertId) {
+        return {
+            volumeScope: { tenantId, catalog: 'xperts', xpertId, userId, isolateByUser: false },
+            catalog: 'xperts',
+            scopeId: xpertId
+        }
+    }
+
+    if (options.inferUserScope !== false && userId) {
+        return {
+            volumeScope: { tenantId, catalog: 'users', userId },
+            catalog: 'users',
+            scopeId: userId
+        }
+    }
+
+    return null
+}
+
+export function resolveWorkspaceFileCatalog(
+    input?: Pick<WorkspaceFileScope, 'catalog' | 'projectId' | 'knowledgeId' | 'rootId' | 'xpertId'> | null,
+    options: Pick<WorkspaceVolumeScopeOptions, 'defaultCatalog'> = {}
+): WorkspaceFileCatalog | null {
+    const catalog = normalizeOptionalString(input?.catalog)
+    if (catalog) {
+        return isWorkspaceFileCatalog(catalog) ? catalog : null
+    }
+    if (normalizeOptionalString(input?.projectId)) {
+        return 'projects'
+    }
+    if (normalizeOptionalString(input?.knowledgeId)) {
+        return 'knowledges'
+    }
+    if (normalizeOptionalString(input?.rootId)) {
+        return 'skills'
+    }
+    if (normalizeOptionalString(input?.xpertId)) {
+        return 'xperts'
+    }
+    return options.defaultCatalog ?? null
+}
+
+export function isWorkspaceFileCatalog(value: string): value is WorkspaceFileCatalog {
+    return ['projects', 'users', 'knowledges', 'skills', 'xperts'].includes(value)
+}
+
+function readWorkspaceMetadataRecord(metadata?: Record<string, unknown>) {
+    const workspace = metadata?.workspace
+    return workspace && typeof workspace === 'object' && !Array.isArray(workspace)
+        ? (workspace as Record<string, unknown>)
+        : null
+}
+
+function normalizeWorkspaceRelativePath(value: unknown) {
+    const raw = normalizeOptionalString(value)
+    if (!raw) {
+        return null
+    }
+    const normalized = path.posix.normalize(raw.replace(/\\/g, '/').replace(/^\/+/, ''))
+    if (!normalized || normalized === '.' || normalized === '..' || normalized.startsWith('../')) {
+        return null
+    }
+    return normalized
+}
+
+function normalizeOptionalString(value: unknown) {
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}

--- a/packages/server-ai/src/file-understanding/index.ts
+++ b/packages/server-ai/src/file-understanding/index.ts
@@ -1,5 +1,6 @@
 export * from './commands'
 export * from './domain/types'
+export * from './domain/workspace-file'
 export * from './entities'
 export * from './file-workspace-projection.service'
 export * from './file-understanding-vector.service'

--- a/packages/server-ai/src/shared/agent/message.spec.ts
+++ b/packages/server-ai/src/shared/agent/message.spec.ts
@@ -1,5 +1,6 @@
 import type { CommandBus, QueryBus } from '@nestjs/cqrs'
 import { GetFileAssetQuery, GetFilePreviewQuery } from '../../file-understanding'
+import { LoadFileCommand } from '../commands'
 import { createHumanMessage } from './message'
 import { ResolvePromptWorkflowInvocationQuery } from './queries/resolve-prompt-workflow-invocation.query'
 import { ListWorkspaceSkillsQuery } from '../../xpert-agent/queries/list-workspace-skills.query'
@@ -405,5 +406,109 @@ describe('createHumanMessage', () => {
         expect(fileCard).toContain('workspacePath: files/wechat/integration-1/uuid-1/msg-1/contract.docx')
         expect(fileCard).toContain('Document summary')
         expect(commandBus.execute).not.toHaveBeenCalled()
+    })
+
+    it('loads workspace-backed FileAsset fallbacks with the relative workspace path', async () => {
+        const workspacePath = 'files/wechat/integration-1/uuid-1/msg-1/contract.docx'
+        const queryBus = {
+            execute: jest.fn().mockImplementation((query) => {
+                if (query instanceof GetFileAssetQuery) {
+                    return {
+                        id: 'file-asset-1',
+                        originalName: 'contract.docx',
+                        mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                        size: 22900,
+                        status: 'uploaded',
+                        capabilities: ['preview', 'workspace'],
+                        workspacePath,
+                        metadata: {
+                            workspace: {
+                                catalog: 'xperts',
+                                scopeId: 'xpert-1',
+                                relativePath: workspacePath,
+                                workspacePath
+                            }
+                        }
+                    }
+                }
+                return null
+            })
+        }
+        const commandBus = {
+            execute: jest.fn().mockResolvedValue([{ pageContent: '合同正文' }])
+        }
+
+        const message = await createHumanMessage(
+            commandBus as unknown as CommandBus,
+            queryBus as unknown as QueryBus,
+            {
+                human: {
+                    input: '提取产品信息',
+                    files: [
+                        {
+                            id: 'file-asset-1',
+                            fileId: 'file-asset-1',
+                            fileAssetId: 'file-asset-1',
+                            filePath: workspacePath,
+                            workspacePath,
+                            originalName: 'contract.docx',
+                            mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                        } as any
+                    ]
+                }
+            },
+            undefined
+        )
+
+        expect(commandBus.execute).toHaveBeenCalledWith(expect.any(LoadFileCommand))
+        const loadCommand = commandBus.execute.mock.calls[0][0] as LoadFileCommand
+        expect(loadCommand.file.filePath).toBe(workspacePath)
+        const fileText = (message.content as Array<{ type: string; text?: string }>)[0].text
+        expect(fileText).toContain(`Attachment File: ${workspacePath}`)
+        expect(fileText).toContain('合同正文')
+    })
+
+    it('does not raw-load a FileAsset when no workspace path is available', async () => {
+        const queryBus = {
+            execute: jest.fn().mockImplementation((query) => {
+                if (query instanceof GetFileAssetQuery) {
+                    return {
+                        id: 'file-asset-1',
+                        originalName: 'contract.docx',
+                        mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                        status: 'uploaded',
+                        capabilities: ['preview', 'workspace']
+                    }
+                }
+                return null
+            })
+        }
+        const commandBus = {
+            execute: jest.fn()
+        }
+
+        const message = await createHumanMessage(
+            commandBus as unknown as CommandBus,
+            queryBus as unknown as QueryBus,
+            {
+                human: {
+                    input: '提取产品信息',
+                    files: [
+                        {
+                            fileId: 'file-asset-1',
+                            fileAssetId: 'file-asset-1',
+                            originalName: 'contract.docx',
+                            mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                        } as any
+                    ]
+                }
+            },
+            undefined
+        )
+
+        expect(commandBus.execute).not.toHaveBeenCalled()
+        const fileCard = (message.content as Array<{ type: string; text?: string }>)[0].text
+        expect(fileCard).toContain('fileId: file-asset-1')
+        expect(fileCard).toContain('status: uploaded')
     })
 })

--- a/packages/server-ai/src/shared/agent/message.ts
+++ b/packages/server-ai/src/shared/agent/message.ts
@@ -5,6 +5,7 @@ import { FileStorage, GetStorageFileQuery } from '@xpert-ai/server-core'
 import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import fs from 'fs'
 import { get } from 'lodash'
+import path from 'path'
 import sharp from 'sharp'
 import {
     FileAsset,
@@ -20,7 +21,8 @@ import { isPromptWorkflowInvocationCandidate } from './prompt-workflow-invocatio
 import { ResolvePromptWorkflowInvocationQuery } from './queries/resolve-prompt-workflow-invocation.query'
 import { buildSelectedRuntimeSkillsPrompt } from './runtime-skills-prompt'
 
-type ResolvedFile = _TFile & {
+type ResolvedFile = Omit<_TFile, 'filePath'> & {
+    filePath?: string
     id?: string
     fileId?: string
     fileAssetId?: string
@@ -87,17 +89,29 @@ async function resolveAttachmentFile(queryBus: QueryBus, file: ResolvedFile): Pr
         }
     }
 
-    const workspacePath = file.workspacePath ?? fileAsset?.workspacePath
+    const localFilePath = file.filePath && path.isAbsolute(file.filePath) ? file.filePath : undefined
+    const workspacePath = file.workspacePath ?? fileAsset?.workspacePath ?? (localFilePath ? undefined : file.filePath)
+    const { filePath: _filePath, ...fileWithoutLocalPath } = file
     if (file.filePath || file.fileUrl || workspacePath) {
         return {
-            ...file,
-            filePath: file.filePath ?? workspacePath,
+            ...fileWithoutLocalPath,
+            ...(localFilePath ? { filePath: localFilePath } : {}),
             fileUrl: file.fileUrl ?? fileAssetUrl(fileAsset),
             mimeType: file.mimeType ?? fileAsset?.mimeType,
             originalName: file.originalName ?? fileAsset?.originalName,
             size: file.size ?? fileAsset?.size,
             workspacePath,
             fileAsset: fileAsset ?? file.fileAsset
+        }
+    }
+
+    if (fileAsset) {
+        return {
+            ...fileWithoutLocalPath,
+            mimeType: file.mimeType ?? fileAsset.mimeType,
+            originalName: file.originalName ?? fileAsset.originalName,
+            size: file.size ?? fileAsset.size,
+            fileAsset
         }
     }
 
@@ -240,11 +254,20 @@ export async function createHumanMessage(
         const fileParts = await Promise.all(
             files.map(async (file) => {
                 if (file.mimeType?.startsWith('image')) {
+                    if (!file.filePath && !file.fileUrl) {
+                        return {
+                            type: 'text',
+                            text: buildFileUnderstandingPrompt(file, null)
+                        }
+                    }
                     return await toImageContentPart(file, attachment)
                 }
 
                 if (file.mimeType?.startsWith('video')) {
                     // Process video files
+                    if (!file.filePath) {
+                        throw new Error('Video file path is required')
+                    }
                     const videoData = await fs.promises.readFile(file.filePath)
                     return {
                         type: 'video_url',
@@ -268,12 +291,29 @@ export async function createHumanMessage(
                     }
                 }
 
+                const loadFilePath = file.filePath ?? file.workspacePath
+                if (file.fileAsset?.id && !loadFilePath) {
+                    return {
+                        type: 'text',
+                        text: buildFileUnderstandingPrompt(file, null)
+                    }
+                }
+
+                if (!loadFilePath) {
+                    return {
+                        type: 'text',
+                        text: `Attachment File: ${formatAttachmentPath(file)}\n<file_content>\nNo local file path available.\n</file_content>`
+                    }
+                }
+
                 // Compatibility fallback for legacy attachments or unsupported
                 // parser states. Ready FileAssets should reach the compact card above.
-                const docs = await commandBus.execute(new LoadFileCommand(file))
+                const docs = await commandBus.execute(
+                    new LoadFileCommand({ ...file, filePath: loadFilePath } as _TFile)
+                )
                 return {
                     type: 'text',
-                    text: `Attachment File: ${file.filePath}\n<file_content>\n${docs?.map((doc) => doc.pageContent).join('\n') || 'No text recognized!'}\n</file_content>`
+                    text: `Attachment File: ${formatAttachmentPath(file)}\n<file_content>\n${docs?.map((doc) => doc.pageContent).join('\n') || 'No text recognized!'}\n</file_content>`
                 }
             })
         )
@@ -291,6 +331,10 @@ export async function createHumanMessage(
     }
 
     return new HumanMessage(finalText)
+}
+
+function formatAttachmentPath(file: ResolvedFile) {
+    return file.workspacePath ?? file.originalName ?? file.filePath ?? file.fileAssetId ?? file.fileId ?? 'attachment'
 }
 
 /**

--- a/packages/server-ai/src/shared/commands/handlers/load-file.handler.spec.ts
+++ b/packages/server-ai/src/shared/commands/handlers/load-file.handler.spec.ts
@@ -1,0 +1,82 @@
+import type { QueryBus } from '@nestjs/cqrs'
+import { Document } from 'langchain/document'
+import { GetFileAssetQuery } from '../../../file-understanding'
+import { VolumeClient, VolumeHandle, type VolumeRootResolution, type VolumeScope } from '../../volume'
+import { LoadFileCommand } from '../load-file.command'
+import { LoadFileHandler } from './load-file.handler'
+
+class TestVolumeClient extends VolumeClient {
+    readonly scopes: VolumeScope[] = []
+
+    resolve(scope: VolumeScope): VolumeHandle {
+        this.scopes.push(scope)
+        const root = `/tmp/workspace-volume/${scope.tenantId}/${scope.catalog}`
+        return new VolumeHandle(scope, root, root, 'https://files.example.test')
+    }
+
+    resolveRoot(_tenantId: string): VolumeRootResolution {
+        return {
+            serverRoot: '/tmp/workspace-volume',
+            hostRoot: '/tmp/workspace-volume'
+        }
+    }
+}
+
+describe('LoadFileHandler', () => {
+    it.each([
+        ['projects', 'project-1', { catalog: 'projects', projectId: 'project-1', userId: 'user-1' }],
+        ['xperts', 'xpert-1', { catalog: 'xperts', xpertId: 'xpert-1', userId: 'user-1', isolateByUser: false }],
+        ['users', 'user-scope', { catalog: 'users', userId: 'user-scope' }],
+        ['knowledges', 'knowledge-1', { catalog: 'knowledges', knowledgeId: 'knowledge-1', userId: 'user-1' }],
+        ['skills', 'skill-root-1', { catalog: 'skills', rootId: 'skill-root-1', userId: 'user-1' }]
+    ] as const)(
+        'resolves %s workspace files from catalog/scope metadata and a relative path',
+        async (catalog, scopeId, expectedScope) => {
+            const relativePath = 'files/wechat/integration-1/uuid-1/msg-1/contract.txt'
+            const queryBus = {
+                execute: jest.fn().mockImplementation((query) => {
+                    if (query instanceof GetFileAssetQuery) {
+                        return {
+                            id: 'file-asset-1',
+                            tenantId: 'tenant-1',
+                            userId: 'user-1',
+                            originalName: 'contract.txt',
+                            mimeType: 'text/plain',
+                            status: 'uploaded',
+                            workspacePath: relativePath,
+                            metadata: {
+                                workspace: {
+                                    catalog,
+                                    scopeId,
+                                    relativePath
+                                }
+                            }
+                        }
+                    }
+                    return null
+                })
+            }
+            const volumeClient = new TestVolumeClient()
+            const handler = new LoadFileHandler(queryBus as unknown as QueryBus, volumeClient)
+            const processText = jest
+                .spyOn(handler, 'processText')
+                .mockResolvedValue([new Document({ pageContent: 'ok' })])
+
+            await expect(
+                handler.execute(
+                    new LoadFileCommand({
+                        fileId: 'file-asset-1',
+                        filePath: relativePath,
+                        mimeType: 'text/plain'
+                    } as any)
+                )
+            ).resolves.toEqual([expect.objectContaining({ pageContent: 'ok' })])
+
+            expect(volumeClient.scopes[0]).toMatchObject({
+                tenantId: 'tenant-1',
+                ...expectedScope
+            })
+            expect(processText).toHaveBeenCalledWith(`/tmp/workspace-volume/tenant-1/${catalog}/${relativePath}`)
+        }
+    )
+})

--- a/packages/server-ai/src/shared/commands/handlers/load-file.handler.ts
+++ b/packages/server-ai/src/shared/commands/handlers/load-file.handler.ts
@@ -2,11 +2,21 @@ import { DocxLoader } from '@langchain/community/document_loaders/fs/docx'
 import { EPubLoader } from '@langchain/community/document_loaders/fs/epub'
 import { PDFLoader } from '@langchain/community/document_loaders/fs/pdf'
 import { PPTXLoader } from '@langchain/community/document_loaders/fs/pptx'
-import { Logger } from '@nestjs/common'
+import { BadRequestException, Inject, Logger } from '@nestjs/common'
 import { CommandHandler, ICommandHandler, QueryBus } from '@nestjs/cqrs'
 import { Document } from 'langchain/document'
 import { TextLoader } from 'langchain/document_loaders/fs/text'
-import { GetFileAssetByStorageFileQuery, GetFileAssetQuery, SearchFileChunksQuery } from '../../../file-understanding'
+import path from 'node:path'
+import { RequestContext } from '@xpert-ai/server-core'
+import {
+    GetFileAssetByStorageFileQuery,
+    GetFileAssetQuery,
+    resolveFileAssetWorkspaceRelativePath,
+    resolveFileAssetWorkspaceVolumeScope,
+    SearchFileChunksQuery
+} from '../../../file-understanding'
+import type { FileAsset } from '../../../file-understanding'
+import { VOLUME_CLIENT, VolumeClient } from '../../volume'
 import { LoadFileCommand } from '../load-file.command'
 
 /**
@@ -18,46 +28,52 @@ import { LoadFileCommand } from '../load-file.command'
 export class LoadFileHandler implements ICommandHandler<LoadFileCommand> {
     readonly #logger = new Logger(LoadFileHandler.name)
 
-    constructor(private readonly queryBus: QueryBus) {}
+    constructor(
+        private readonly queryBus: QueryBus,
+        @Inject(VOLUME_CLIENT)
+        private readonly volumeClient: Pick<VolumeClient, 'resolve'>
+    ) {}
 
     public async execute(command: LoadFileCommand) {
         const { file } = command
-        const understoodDocs = await this.tryLoadFileUnderstandingDocs(file as any)
+        const resolved = await this.resolveFileAsset(file as any)
+        const understoodDocs = await this.tryLoadFileUnderstandingDocs(resolved.fileAsset)
         if (understoodDocs?.length) {
             return understoodDocs
         }
 
-        const type = file.filePath.split('.').pop()
+        const filePath = this.resolveLocalFilePath(file.filePath, resolved.fileAsset)
+        const type = filePath.split('.').pop()
         let data: Document[]
         switch (type.toLowerCase()) {
             case 'md':
             case 'mdx':
             case 'markdown':
-                data = await this.processMarkdown(file.filePath)
+                data = await this.processMarkdown(filePath)
                 break
             case 'pdf':
-                data = await this.processPdf(file.filePath)
+                data = await this.processPdf(filePath)
                 break
             case 'epub':
-                data = await this.processEpub(file.filePath)
+                data = await this.processEpub(filePath)
                 break
             case 'doc':
             case 'docx':
-                data = await this.processDoc(file.filePath)
+                data = await this.processDoc(filePath)
                 break
             case 'pptx':
-                data = await this.processPPT(file.filePath)
+                data = await this.processPPT(filePath)
                 break
             case 'xlsx':
-                data = await this.processExcel(file.filePath)
+                data = await this.processExcel(filePath)
                 break
             case 'odt':
             case 'ods':
             case 'odp':
-                data = await this.processOpenDocument(file.filePath)
+                data = await this.processOpenDocument(filePath)
                 break
             default:
-                data = await this.processText(file.filePath)
+                data = await this.processText(filePath)
                 break
         }
 
@@ -102,7 +118,7 @@ export class LoadFileHandler implements ICommandHandler<LoadFileCommand> {
         return await loader.load()
     }
 
-    private async tryLoadFileUnderstandingDocs(file: {
+    private async resolveFileAsset(file: {
         fileId?: string
         fileAssetId?: string
         storageFileId?: string
@@ -114,6 +130,10 @@ export class LoadFileHandler implements ICommandHandler<LoadFileCommand> {
             : (file.storageFileId ?? file.id)
               ? await this.queryBus.execute(new GetFileAssetByStorageFileQuery(file.storageFileId ?? file.id))
               : null
+        return { fileAsset: (fileAsset ?? null) as FileAsset | null }
+    }
+
+    private async tryLoadFileUnderstandingDocs(fileAsset?: FileAsset | null) {
         if (!fileAsset || !['ready', 'partial'].includes(fileAsset.status)) {
             return null
         }
@@ -135,5 +155,23 @@ export class LoadFileHandler implements ICommandHandler<LoadFileCommand> {
                     }
                 })
         )
+    }
+
+    private resolveLocalFilePath(filePath?: string, fileAsset?: FileAsset | null) {
+        if (filePath && path.isAbsolute(filePath)) {
+            return filePath
+        }
+        const workspacePath = resolveFileAssetWorkspaceRelativePath(fileAsset, filePath)
+        if (!workspacePath) {
+            throw new BadRequestException('Workspace file path is required')
+        }
+        const volumeScope = resolveFileAssetWorkspaceVolumeScope(fileAsset, {
+            tenantId: RequestContext.currentTenantId(),
+            userId: RequestContext.currentUserId()
+        })
+        if (!volumeScope) {
+            throw new BadRequestException('Workspace file catalog/scope is required for relative file access')
+        }
+        return this.volumeClient.resolve(volumeScope).path(workspacePath)
     }
 }

--- a/packages/server-ai/src/shared/runtime/workspace-files-runtime-capability.service.ts
+++ b/packages/server-ai/src/shared/runtime/workspace-files-runtime-capability.service.ts
@@ -11,12 +11,15 @@ import {
     WorkspaceUploadBufferInput
 } from '@xpert-ai/plugin-sdk'
 import { getFileAssetDestination, UploadFileCommand } from '@xpert-ai/server-core'
-import { CreateWorkspaceFileAssetCommand, type FileAsset } from '../../file-understanding'
-import { VOLUME_CLIENT, VolumeClient, VolumeSubtreeClient, type VolumeScope } from '../volume'
-
-type WorkspaceFileVolumeScope = Omit<VolumeScope, 'catalog'> & {
-    catalog: WorkspaceFile['catalog']
-}
+import {
+    CreateWorkspaceFileAssetCommand,
+    isWorkspaceFileCatalog,
+    resolveWorkspaceFileCatalog,
+    resolveWorkspaceVolumeScope,
+    type FileAsset,
+    type WorkspaceVolumeScopeResolution
+} from '../../file-understanding'
+import { VOLUME_CLIENT, VolumeClient, VolumeSubtreeClient } from '../volume'
 
 @Injectable()
 export class WorkspaceFilesRuntimeCapabilityService implements WorkspaceFilesApi {
@@ -156,7 +159,7 @@ export class WorkspaceFilesRuntimeCapabilityService implements WorkspaceFilesApi
     }
 
     private resolveVolumeScope(input: WorkspaceUploadBufferInput | WorkspaceFileReference): {
-        volumeScope: WorkspaceFileVolumeScope
+        volumeScope: WorkspaceVolumeScopeResolution['volumeScope']
         catalog: WorkspaceFile['catalog']
         scopeId?: string
     } {
@@ -165,90 +168,16 @@ export class WorkspaceFilesRuntimeCapabilityService implements WorkspaceFilesApi
             throw new BadRequestException('tenantId is required for workspace file access')
         }
         const userId = normalizeOptionalString(input.userId) ?? RequestContext.currentUserId()
-        const catalog = resolveWorkspaceFileCatalog(input)
-
-        switch (catalog) {
-            case 'projects': {
-                const projectId = normalizeOptionalString(input.projectId) ?? normalizeOptionalString(input.scopeId)
-                if (!projectId) {
-                    throw new BadRequestException('projectId is required for project workspace file access')
-                }
-                return {
-                    volumeScope: {
-                        tenantId,
-                        catalog,
-                        projectId,
-                        userId
-                    },
-                    catalog,
-                    scopeId: projectId
-                }
-            }
-            case 'xperts': {
-                const xpertId = normalizeOptionalString(input.xpertId) ?? normalizeOptionalString(input.scopeId)
-                if (!xpertId) {
-                    throw new BadRequestException('xpertId is required for xpert workspace file access')
-                }
-                return {
-                    volumeScope: {
-                        tenantId,
-                        catalog,
-                        xpertId,
-                        userId,
-                        isolateByUser: input.isolateByUser ?? false
-                    },
-                    catalog,
-                    scopeId: xpertId
-                }
-            }
-            case 'users': {
-                const targetUserId = normalizeOptionalString(input.scopeId) ?? userId
-                if (!targetUserId) {
-                    throw new BadRequestException('userId is required for user workspace file access')
-                }
-                return {
-                    volumeScope: {
-                        tenantId,
-                        catalog,
-                        userId: targetUserId
-                    },
-                    catalog,
-                    scopeId: targetUserId
-                }
-            }
-            case 'knowledges': {
-                const knowledgeId = normalizeOptionalString(input.knowledgeId) ?? normalizeOptionalString(input.scopeId)
-                if (!knowledgeId) {
-                    throw new BadRequestException('knowledgeId is required for knowledge workspace file access')
-                }
-                return {
-                    volumeScope: {
-                        tenantId,
-                        catalog,
-                        knowledgeId,
-                        userId
-                    },
-                    catalog,
-                    scopeId: knowledgeId
-                }
-            }
-            case 'skills': {
-                const rootId = normalizeOptionalString(input.rootId) ?? normalizeOptionalString(input.scopeId)
-                if (!rootId) {
-                    throw new BadRequestException('rootId is required for skill workspace file access')
-                }
-                return {
-                    volumeScope: {
-                        tenantId,
-                        catalog,
-                        rootId,
-                        userId
-                    },
-                    catalog,
-                    scopeId: rootId
-                }
-            }
+        const catalog = normalizeOptionalString(input.catalog)
+        if (catalog && !isWorkspaceFileCatalog(catalog)) {
+            throw new BadRequestException(`Unsupported workspace file catalog: ${catalog}`)
         }
+
+        const resolved = resolveWorkspaceVolumeScope(input, { tenantId, userId })
+        if (!resolved) {
+            throw new BadRequestException(resolveWorkspaceVolumeScopeError(input, 'workspace file access'))
+        }
+        return resolved
     }
 }
 
@@ -269,39 +198,28 @@ function normalizeOptionalString(value: unknown) {
     return typeof value === 'string' && value.trim() ? value.trim() : undefined
 }
 
-function resolveWorkspaceFileCatalog(
-    input: WorkspaceUploadBufferInput | WorkspaceFileReference
-): WorkspaceFile['catalog'] {
-    const catalog = normalizeOptionalString(input.catalog)
-    if (catalog) {
-        if (isWorkspaceFileCatalog(catalog)) {
-            return catalog
-        }
-        throw new BadRequestException(`Unsupported workspace file catalog: ${catalog}`)
-    }
-    if (normalizeOptionalString(input.projectId)) {
-        return 'projects'
-    }
-    if (normalizeOptionalString(input.knowledgeId)) {
-        return 'knowledges'
-    }
-    if (normalizeOptionalString(input.rootId)) {
-        return 'skills'
-    }
-    if (normalizeOptionalString(input.xpertId)) {
-        return 'xperts'
-    }
-    throw new BadRequestException('workspace file catalog is required')
-}
-
-function isWorkspaceFileCatalog(value: string): value is WorkspaceFile['catalog'] {
-    return ['projects', 'users', 'knowledges', 'skills', 'xperts'].includes(value)
-}
-
 function normalizeRequiredWorkspaceFilePath(value: unknown) {
     const normalized = normalizeOptionalString(value)?.replace(/\\/g, '/').replace(/^\/+/, '').replace(/^\.\//, '')
     if (!normalized || normalized === '.' || normalized.split('/').includes('..')) {
         throw new BadRequestException('workspace file path is required')
     }
     return normalized
+}
+
+function resolveWorkspaceVolumeScopeError(input: WorkspaceUploadBufferInput | WorkspaceFileReference, context: string) {
+    const catalog = resolveWorkspaceFileCatalog(input)
+    switch (catalog) {
+        case 'projects':
+            return `projectId is required for project ${context}`
+        case 'xperts':
+            return `xpertId is required for xpert ${context}`
+        case 'users':
+            return `userId is required for user ${context}`
+        case 'knowledges':
+            return `knowledgeId is required for knowledge ${context}`
+        case 'skills':
+            return `rootId is required for skill ${context}`
+        default:
+            return 'workspace file catalog is required'
+    }
 }

--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
@@ -109,8 +109,6 @@ import {
     translate,
     stateVariable,
     createParameters,
-    STATE_VARIABLE_PENDING_FOLLOW_UPS,
-    TPendingFollowUpStateItem,
     TGraphTool,
     TSubAgent,
     TWorkflowGraphNode,


### PR DESCRIPTION
## Summary

- Add shared workspace file helpers to normalize safe relative paths and resolve volume scopes from FileAsset metadata, explicit catalog fields, or legacy IDs.
- Use the resolved workspace path/scope when loading workspace-backed FileAssets so attachments can fall back to volume files without treating relative paths as local absolute paths.
- Query ClawXpert sidebar assistants from the user-scoped ClawXpert list while preserving tenant-scoped system assistant behavior.
- Update the file-understanding and volume workspace architecture docs in English and Chinese.

## Why

Workspace-backed FileAssets could carry relative paths without a reliable, centralized way to resolve the owning workspace volume. That made raw file loading fragile and could fail when an attachment had no storage file but did have workspace metadata. The ClawXpert sidebar also needed to read the user-scoped assistant list so the current bound assistant and normal assistant list stay consistent.

## Testing

- `CI=true ./node_modules/.bin/jest --config packages/server-ai/jest.config.ts --runTestsByPath packages/server-ai/src/file-understanding/domain/workspace-file.spec.ts packages/server-ai/src/shared/agent/message.spec.ts packages/server-ai/src/shared/commands/handlers/load-file.handler.spec.ts --runInBand`
- `CI=true ./node_modules/.bin/jest --config apps/cloud/jest.config.ts --runTestsByPath apps/cloud/src/app/features/sidebar/cloud-sidebar-assistants.component.spec.ts --runInBand`