### PR TITLE
feat: release develop updates

### DIFF
--- a/.changeset/floppy-frogs-ask.md
+++ b/.changeset/floppy-frogs-ask.md
@@ -1,0 +1,7 @@
+---
+'@xpert-ai/plugin-sdk': patch
+'@xpert-ai/contracts': patch
+'@xpert-ai/xpert-ui': patch
+---
+
+handoff messages

--- a/apps/cloud/src/app/@shared/user/forms/basic-info/basic-info-form.component.ts
+++ b/apps/cloud/src/app/@shared/user/forms/basic-info/basic-info-form.component.ts
@@ -1,4 +1,16 @@
-import { DestroyRef, Component, ElementRef, EventEmitter, forwardRef, inject, Input, Output, ViewChild } from '@angular/core'
+import {
+  DestroyRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  forwardRef,
+  inject,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ControlValueAccessor, FormGroup, NG_VALUE_ACCESSOR } from '@angular/forms'
 import { AuthService } from '@xpert-ai/cloud/state'
@@ -25,7 +37,7 @@ import { LANGUAGES, RoleService, Store } from '../../../../@core'
     }
   ]
 })
-export class BasicInfoFormComponent implements ControlValueAccessor {
+export class BasicInfoFormComponent implements ControlValueAccessor, OnChanges {
   eDisplayBehaviour = DisplayBehaviour
 
   readonly #store = inject(Store)
@@ -49,6 +61,7 @@ export class BasicInfoFormComponent implements ControlValueAccessor {
   @Input() public isSuperAdmin = false
   @Input() public createdById: string
   @Input() public selectedTags: ITag[]
+  @Input() public readOnly = false
 
   readonly roleOptions$ = new ReplaySubject<Array<{ key: string; caption: string }>>(1)
   private roles: IRole[] = []
@@ -71,12 +84,19 @@ export class BasicInfoFormComponent implements ControlValueAccessor {
       this.model = obj
     }
     this.syncRoleOptions()
+    this.syncReadOnlyState()
   }
   registerOnChange(fn: any): void {
     this.onChange = fn
   }
   registerOnTouched(fn: any): void {}
   setDisabledState?(isDisabled: boolean): void {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['readOnly']) {
+      this.syncReadOnlyState()
+    }
+  }
 
   ngOnInit() {
     const TRANSLATES = this.#translate.instant('PAC.SHARED.USER_BASIC')
@@ -198,10 +218,11 @@ export class BasicInfoFormComponent implements ControlValueAccessor {
             key: 'roleId',
             type: 'select',
             props: {
+              baseDisabled: !this.isSuperAdmin && !this.isAdmin,
               label: TRANSLATES?.Role ?? 'Role',
               placeholder: '',
               required: true,
-              disabled: !this.isSuperAdmin && !this.isAdmin,
+              disabled: this.readOnly || (!this.isSuperAdmin && !this.isAdmin),
               valueProp: 'id',
               labelProp: 'name',
               options: this.roleOptions$.asObservable(),
@@ -226,10 +247,11 @@ export class BasicInfoFormComponent implements ControlValueAccessor {
             key: 'thirdPartyId',
             type: 'input',
             props: {
+              baseDisabled: !this.isSuperAdmin && !this.isAdmin,
               label: TRANSLATES?.ThirdPartyId ?? 'Third Party Id',
               placeholder: '',
               appearance: 'fill',
-              disabled: !this.isSuperAdmin && !this.isAdmin
+              disabled: this.readOnly || (!this.isSuperAdmin && !this.isAdmin)
             }
           },
           {
@@ -259,6 +281,7 @@ export class BasicInfoFormComponent implements ControlValueAccessor {
         }
       }
     ]
+    this.syncReadOnlyState()
 
     // Emit validity so parent (OnPush) can enable/disable Apply button
     queueMicrotask(() => this.validityChange.emit(this.form.valid))
@@ -269,6 +292,25 @@ export class BasicInfoFormComponent implements ControlValueAccessor {
 
   onFormChange(model: any) {
     this.onChange?.(model)
+  }
+
+  private syncReadOnlyState(fields = this.fields) {
+    for (const field of fields) {
+      const baseDisabled = !!field.props?.['baseDisabled']
+      if (field.props) {
+        field.props.disabled = this.readOnly || baseDisabled
+      }
+      if (field.formControl) {
+        if (this.readOnly || baseDisabled) {
+          field.formControl.disable({ emitEvent: false })
+        } else {
+          field.formControl.enable({ emitEvent: false })
+        }
+      }
+      if (field.fieldGroup) {
+        this.syncReadOnlyState(field.fieldGroup)
+      }
+    }
   }
 
   private syncRoleOptions() {

--- a/apps/cloud/src/app/features/setting/account/billing.component.html
+++ b/apps/cloud/src/app/features/setting/account/billing.component.html
@@ -187,22 +187,22 @@
           <table class="min-w-full text-sm">
             <thead class="border-b border-divider-regular bg-components-panel-bg text-xs text-text-tertiary">
               <tr>
-                <th class="px-4 py-3 text-left font-medium">
+                <th class="whitespace-nowrap px-4 py-3 text-left font-medium">
                   {{ 'PAC.KEY_WORDS.Date' | translate: { Default: 'Date' } }}
                 </th>
-                <th class="px-4 py-3 text-left font-medium">
+                <th class="whitespace-nowrap px-4 py-3 text-left font-medium">
                   {{ 'PAC.Membership.Session' | translate: { Default: 'Session' } }}
                 </th>
-                <th class="px-4 py-3 text-left font-medium">
+                <th class="whitespace-nowrap px-4 py-3 text-left font-medium">
                   {{ 'PAC.Copilot.Model' | translate: { Default: 'Model' } }}
                 </th>
-                <th class="px-4 py-3 text-right font-medium">
+                <th class="whitespace-nowrap px-4 py-3 text-right font-medium">
                   {{ 'PAC.Membership.Calls' | translate: { Default: 'Calls' } }}
                 </th>
-                <th class="px-4 py-3 text-right font-medium">
+                <th class="whitespace-nowrap px-4 py-3 text-right font-medium">
                   {{ 'PAC.Membership.Points' | translate: { Default: 'Points' } }}
                 </th>
-                <th class="px-4 py-3 text-right font-medium">
+                <th class="whitespace-nowrap px-4 py-3 text-right font-medium">
                   {{ 'PAC.Membership.Tokens' | translate: { Default: 'Tokens' } }}
                 </th>
               </tr>
@@ -229,12 +229,21 @@
                       </div>
                     </div>
                   </td>
-                  <td class="px-4 py-3">
-                    <div class="min-w-32 text-text-primary">
-                      {{ shortId(summary.threadId) }}
+                  <td
+                    class="max-w-56 px-4 py-3"
+                    [title]="
+                      conversationLabel(summary) +
+                      ' / ' +
+                      ('PAC.Membership.Xpert' | translate: { Default: 'Xpert' }) +
+                      ' ' +
+                      xpertLabel(summary)
+                    "
+                  >
+                    <div class="truncate text-text-primary">
+                      {{ conversationLabel(summary) }}
                     </div>
-                    <div class="text-xs text-text-tertiary">
-                      {{ 'PAC.Membership.Xpert' | translate: { Default: 'Xpert' } }} {{ shortId(summary.xpertId) }}
+                    <div class="truncate text-xs text-text-tertiary">
+                      {{ 'PAC.Membership.Xpert' | translate: { Default: 'Xpert' } }} {{ xpertLabel(summary) }}
                     </div>
                   </td>
                   <td

--- a/apps/cloud/src/app/features/setting/account/billing.component.ts
+++ b/apps/cloud/src/app/features/setting/account/billing.component.ts
@@ -128,6 +128,18 @@ export class PACAccountBillingComponent implements OnInit {
     return value ? value.slice(0, 8) : '-'
   }
 
+  conversationLabel(summary: IMembershipUsageSummary) {
+    return this.trimmed(summary.conversationTitle) || this.shortId(summary.threadId)
+  }
+
+  xpertLabel(summary: IMembershipUsageSummary) {
+    return this.trimmed(summary.xpertTitle) || this.trimmed(summary.xpertName) || this.shortId(summary.xpertId)
+  }
+
+  private trimmed(value?: string | null) {
+    return value?.trim() || null
+  }
+
   private toDetailsQuery(summary: IMembershipUsageSummary): IMembershipUsageQuery {
     return {
       usageHour: summary.usageHour ?? undefined,

--- a/apps/cloud/src/app/features/setting/copilot/usage-center/usage-center.component.html
+++ b/apps/cloud/src/app/features/setting/copilot/usage-center/usage-center.component.html
@@ -34,7 +34,7 @@
       z-input
       zSize="sm"
       class="w-48"
-      [placeholder]="'PAC.Copilot.UserId' | translate: { Default: 'User ID' }"
+      [placeholder]="userFilterPlaceholder()"
       [(ngModel)]="userFilter"
       (keyup.enter)="reload()"
     />
@@ -126,7 +126,7 @@
                 ? ('PAC.Copilot.Model' | translate: { Default: 'Model' })
                 : dimension() === 'organization'
                   ? ('PAC.KEY_WORDS.Organization' | translate: { Default: 'Organization' })
-                  : ('PAC.KEY_WORDS.User' | translate: { Default: 'User' })
+                  : ('PAC.Copilot.Creator' | translate: { Default: 'Creator' })
             }}
           </th>
           @if (dimension() === 'user') {
@@ -143,7 +143,7 @@
           <th z-table-head class="sticky top-0 z-10 w-32 bg-background-default-subtle p-3">
             {{ 'PAC.KEY_WORDS.TokenUsed' | translate: { Default: 'Token Used' } }}
           </th>
-          @if (dimension() !== 'model') {
+          @if (dimension() === 'organization') {
             <th z-table-head class="sticky top-0 z-10 w-32 bg-background-default-subtle p-3">
               {{ 'PAC.KEY_WORDS.TokenLimit' | translate: { Default: 'Token Limit' } }}
             </th>
@@ -200,11 +200,20 @@
                   <z-icon [zType]="isExpanded(item) ? 'chevron-down' : 'chevron-right'"></z-icon>
                 </button>
                 @if (dimension() === 'user') {
-                  @if (item.user) {
-                    <pac-user-profile-inline class="min-w-0" [user]="item.user" small />
-                  } @else {
-                    <span class="truncate">{{ item.userId || '-' }}</span>
-                  }
+                  <div class="min-w-0">
+                    @if (item.user) {
+                      <pac-user-profile-inline class="min-w-0" [user]="item.user" small />
+                    } @else {
+                      <span class="truncate">{{ item.userId || '-' }}</span>
+                    }
+                    @if (item.runtimeUserCount || item.xpertCount) {
+                      <div class="truncate text-xs text-text-quaternary">
+                        {{ 'PAC.Copilot.RuntimeUsers' | translate: { Default: 'Runtime users' } }}:
+                        {{ item.runtimeUserCount || 0 }} /
+                        {{ 'PAC.Copilot.Xperts' | translate: { Default: 'Xperts' } }}: {{ item.xpertCount || 0 }}
+                      </div>
+                    }
+                  </div>
                 } @else if (dimension() === 'organization') {
                   @if (item.organization) {
                     <pac-org-avatar
@@ -238,7 +247,7 @@
             <td z-table-cell class="px-4 py-2 truncate">{{ item.provider || '-' }}</td>
             <td z-table-cell class="px-4 py-2 truncate">{{ item.model || '-' }}</td>
             <td z-table-cell class="px-4 py-2">{{ item.tokenUsed | number: '0.0-0' }}</td>
-            @if (dimension() !== 'model') {
+            @if (dimension() === 'organization') {
               <td z-table-cell class="px-4 py-2">{{ item.tokenLimit | number: '0.0-0' }}</td>
             }
             <td z-table-cell class="px-4 py-2">{{ item.tokenGrandTotal | number: '0.0-0' }}</td>
@@ -294,7 +303,7 @@
 
           @if (isExpanded(item)) {
             <tr z-table-row class="border-b border-divider-regular bg-background-default-subtle">
-              <td z-table-cell [attr.colspan]="dimension() === 'user' ? 12 : 11" class="p-0">
+              <td z-table-cell [attr.colspan]="dimension() === 'model' ? 10 : 11" class="p-0">
                 <div class="px-12 py-3">
                   @if (isLoadingDetails(item)) {
                     <div class="flex justify-center py-4"><ngm-spin /></div>
@@ -304,6 +313,9 @@
                         <tr z-table-row>
                           <th z-table-head class="w-40 px-3 py-2">
                             {{ 'PAC.Copilot.UsageHour' | translate: { Default: 'Usage Hour' } }}
+                          </th>
+                          <th z-table-head class="w-56 px-3 py-2">
+                            {{ 'PAC.Copilot.RuntimeUser' | translate: { Default: 'Runtime User' } }}
                           </th>
                           <th z-table-head class="w-52 px-3 py-2">
                             {{ 'PAC.KEY_WORDS.Thread' | translate: { Default: 'Thread' } }}
@@ -332,6 +344,13 @@
                         @for (detail of item.details; track detail.id) {
                           <tr z-table-row class="border-t border-divider-regular">
                             <td z-table-cell class="px-3 py-2 truncate">{{ detail.usageHour || '-' }}</td>
+                            <td z-table-cell class="px-3 py-2">
+                              @if (detail.user) {
+                                <pac-user-profile-inline class="min-w-0" [user]="detail.user" small />
+                              } @else {
+                                <span class="truncate" [title]="detail.userId">{{ detail.userId || '-' }}</span>
+                              }
+                            </td>
                             <td z-table-cell class="px-3 py-2 truncate" [title]="detail.threadId">
                               {{ detail.threadId || '-' }}
                             </td>

--- a/apps/cloud/src/app/features/setting/copilot/usage-center/usage-center.component.ts
+++ b/apps/cloud/src/app/features/setting/copilot/usage-center/usage-center.component.ts
@@ -68,7 +68,7 @@ export class CopilotUsageCenterComponent {
     this.languageChange()
 
     return [
-      { value: 'user', label: this.translate.instant('PAC.KEY_WORDS.User', { Default: 'User' }) },
+      { value: 'user', label: this.translate.instant('PAC.Copilot.Creator', { Default: 'Creator' }) },
       {
         value: 'organization',
         label: this.translate.instant('PAC.KEY_WORDS.Organization', { Default: 'Organization' })
@@ -131,6 +131,13 @@ export class CopilotUsageCenterComponent {
   })
   readonly showOrganizationFilter = this.isTenantScope
   readonly canLoadMore = computed(() => !this.loading() && !this.done())
+  readonly userFilterPlaceholder = computed(() => {
+    this.languageChange()
+
+    return this.dimension() === 'user'
+      ? this.translate.instant('PAC.Copilot.CreatorUserId', { Default: 'Creator User ID' })
+      : this.translate.instant('PAC.Copilot.UserId', { Default: 'User ID' })
+  })
   readonly quotaTitle = computed(() => {
     this.languageChange()
 
@@ -294,7 +301,7 @@ export class CopilotUsageCenterComponent {
 
   saveQuota() {
     const item = this.quotaItem()
-    if (!item || item.dimension === 'model') {
+    if (!item || item.dimension !== 'organization') {
       return
     }
 
@@ -341,7 +348,7 @@ export class CopilotUsageCenterComponent {
   }
 
   canManageQuota(item: ICopilotUsageSummary) {
-    return item.dimension === 'user' || item.dimension === 'organization'
+    return item.dimension === 'organization'
   }
 
   usageId(item: ICopilotUsageSummary) {

--- a/apps/cloud/src/app/features/setting/users/edit-user/edit-user.component.html
+++ b/apps/cloud/src/app/features/setting/users/edit-user/edit-user.component.html
@@ -1,88 +1,130 @@
-<div class="pac-page-header px-8 py-4">
-  <div class="min-w-0 flex flex-col">
+<div class="flex flex-col gap-6 px-8 py-5">
+  <div class="flex min-w-0 flex-col gap-4">
     <button
       type="button"
-      class="mb-3 inline-flex w-fit items-center gap-2 text-sm font-medium text-text-secondary transition-colors hover:text-text-primary"
+      class="inline-flex w-fit items-center gap-2 text-sm font-medium text-text-secondary transition-colors hover:text-text-primary"
       (click)="backToList()"
     >
       <i class="ri-arrow-left-line text-base"></i>
       <span>{{ 'PAC.Users.BackToList' | translate: { Default: 'Back to users' } }}</span>
     </button>
 
-    <div class="pac-page-title">
-      {{ user() ? userLabel(user()) : ('PAC.MENU.USERS' | translate: { Default: 'Users' }) }}
-    </div>
-  </div>
-</div>
-
-<div class="px-8 py-4">
-  <div class="text-xl font-semibold pb-2">
-    {{ 'PAC.USERS_PAGE.BASIC' | translate: { Default: 'Basic' } }}
-  </div>
-
-  <pac-user-basic
-    class="border border-solid border-divider-regular rounded-xl p-4"
-    [allowRoleChange]="RolesEnum.ADMIN === me.role.name || RolesEnum.SUPER_ADMIN === me.role.name"
-  />
-</div>
-
-<div class="px-8 py-4">
-  <div class="text-xl font-semibold pb-2">
-    {{ 'PAC.USERS_PAGE.ChangePassword' | translate: { Default: 'Change Password' } }}
-  </div>
-
-  <div class="border border-solid border-divider-regular rounded-xl p-4">
-    <pac-user-change-password-form
-      #password
-      [(ngModel)]="newPassword"
-      class="block max-w-lg m-auto ng-untouched ng-pristine ng-valid"
-    />
-
-    <div class="w-full flex justify-end p-2">
-      <button z-button zType="default" (click)="changePassword()">
-        {{ 'PAC.ACTIONS.SAVE' | translate: { Default: 'Save' } }}
-      </button>
-    </div>
-  </div>
-</div>
-
-<div class="px-8 py-4">
-  <div class="text-xl font-semibold pb-2">
-    {{ 'PAC.MENU.ORGANIZATIONS' | translate: { Default: 'Organizations' } }}
-  </div>
-  <pac-user-organizations class="border border-solid border-divider-regular rounded-xl" />
-</div>
-
-@if (user()?.id) {
-  <div class="px-8 py-4">
-    <div class="text-xl font-semibold pb-2">
-      {{ 'PAC.Membership.UserMembership' | translate: { Default: 'Membership' } }}
-    </div>
-    <pac-user-membership class="block border border-solid border-divider-regular rounded-xl p-4" [userId]="user().id" />
-  </div>
-}
-
-<div class="px-8 py-4">
-  <div class="text-xl font-semibold text-text-destructive pb-2">
-    {{ 'PAC.KEY_WORDS.DangerZone' | translate: { Default: 'Danger zone' } }}
-  </div>
-
-  <div class="border border-solid border-text-destructive rounded-xl flex flex-col">
-    <div class="w-full flex justify-between items-center p-4">
-      <div class="flex flex-col">
-        <div class="font-semibold">
-          {{ 'PAC.USERS_PAGE.DeleteUser' | translate: { Default: 'Delete this user' } }}
+    @if (user(); as currentUser) {
+      <div class="flex min-w-0 flex-col gap-2">
+        <div class="pac-page-title truncate">
+          {{ userLabel(currentUser) }}
         </div>
-        <div>
-          {{ 'PAC.USERS_PAGE.DeleteUserDesc' | translate: { Default: 'Delete this user and its associated data' } }}.
+
+        <div class="flex flex-wrap items-center gap-2 text-sm text-text-tertiary">
+          <z-badge
+            zType="secondary"
+            zShape="pill"
+            [class.text-text-accent]="isTechnicalUser(currentUser)"
+            [class.text-text-primary]="!isTechnicalUser(currentUser)"
+          >
+            {{ userTypeLabelKey(currentUser.type) | translate: { Default: userTypeDefaultLabel(currentUser.type) } }}
+          </z-badge>
+
+          <z-badge
+            zType="secondary"
+            zShape="pill"
+            [class.text-text-tertiary]="currentUser.deletedAt"
+            [class.text-text-success]="!currentUser.deletedAt"
+          >
+            {{ userStatusLabelKey(currentUser) | translate: { Default: userStatusDefaultLabel(currentUser) } }}
+          </z-badge>
+
+          @if (currentUser.role; as role) {
+            <z-badge zType="secondary" zShape="pill" class="uppercase text-text-primary">
+              {{ role.name }}
+            </z-badge>
+          } @else {
+            <z-badge zType="outline" zShape="pill" class="text-text-tertiary">
+              {{ 'PAC.USERS_PAGE.NoRole' | translate: { Default: 'No role' } }}
+            </z-badge>
+          }
         </div>
+
+        @if (isTechnicalUser(currentUser)) {
+          <div class="text-sm text-text-tertiary">
+            {{ 'PAC.Users.TechnicalUserReadonlyHint' | translate: { Default: 'Basic account fields are read-only for technical users.' } }}
+          </div>
+        }
       </div>
-
-      <button type="button" class="btn btn-large danger pressable" (click)="deleteUser()">
-        {{ 'PAC.USERS_PAGE.DeleteUser' | translate: { Default: 'Delete this user' } }}
-      </button>
-    </div>
+    } @else {
+      <div class="pac-page-title">
+        {{ 'PAC.MENU.USERS' | translate: { Default: 'Users' } }}
+      </div>
+    }
   </div>
+
+  @if (user(); as currentUser) {
+    <z-tab-group
+      class="min-h-0"
+      fitInkBarToContent
+      preserveContent
+      [selectedIndex]="activeTabIndex()"
+      (selectedIndexChange)="selectTabByIndex($event)"
+    >
+      <z-tab [label]="'PAC.Users.Tabs.Basic' | translate: { Default: 'Basic information' }" bodyClass="pt-5">
+        <pac-user-basic
+          [allowRoleChange]="RolesEnum.ADMIN === me.role.name || RolesEnum.SUPER_ADMIN === me.role.name"
+          [readOnly]="isTechnicalUser(currentUser)"
+        />
+      </z-tab>
+
+      <z-tab [label]="'PAC.Users.Tabs.Membership' | translate: { Default: 'Membership' }" bodyClass="pt-5">
+        @if (currentUser.id; as userId) {
+          <pac-user-membership class="block" [userId]="userId" />
+        }
+      </z-tab>
+
+      @if (!isTechnicalUser(currentUser)) {
+        <z-tab [label]="'PAC.Users.Tabs.Organizations' | translate: { Default: 'Organizations' }" bodyClass="pt-5">
+          <pac-user-organizations />
+        </z-tab>
+      }
+
+      @if (!isTechnicalUser(currentUser)) {
+        <z-tab [label]="'PAC.Users.Tabs.Security' | translate: { Default: 'Security' }" bodyClass="pt-5">
+          <section class="flex max-w-5xl flex-col gap-8">
+            <div class="max-w-xl">
+              <div class="mb-3 text-base font-semibold">
+                {{ 'PAC.USERS_PAGE.ChangePassword' | translate: { Default: 'Change Password' } }}
+              </div>
+
+              <pac-user-change-password-form
+                #password
+                [(ngModel)]="newPassword"
+                class="block ng-untouched ng-pristine ng-valid"
+              />
+
+              <div class="flex justify-end pt-3">
+                <button z-button zType="default" (click)="changePassword()">
+                  {{ 'PAC.ACTIONS.SAVE' | translate: { Default: 'Save' } }}
+                </button>
+              </div>
+            </div>
+
+            <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div class="min-w-0">
+                <div class="font-semibold text-text-destructive">
+                  {{ 'PAC.USERS_PAGE.DeleteUser' | translate: { Default: 'Delete this user' } }}
+                </div>
+                <div class="text-sm text-text-tertiary">
+                  {{ 'PAC.USERS_PAGE.DeleteUserDesc' | translate: { Default: 'Delete this user and its associated data' } }}.
+                </div>
+              </div>
+
+              <button type="button" class="btn btn-large danger pressable shrink-0" (click)="deleteUser()">
+                {{ 'PAC.USERS_PAGE.DeleteUser' | translate: { Default: 'Delete this user' } }}
+              </button>
+            </div>
+          </section>
+        </z-tab>
+      }
+    </z-tab-group>
+  }
 </div>
 
 @if (loading()) {

--- a/apps/cloud/src/app/features/setting/users/edit-user/edit-user.component.ts
+++ b/apps/cloud/src/app/features/setting/users/edit-user/edit-user.component.ts
@@ -1,10 +1,11 @@
-import { Component, inject, model, signal } from '@angular/core'
+import { Component, computed, effect, inject, model, signal } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
 import { FormsModule } from '@angular/forms'
 
 import { ActivatedRoute, Router } from '@angular/router'
 import { UserChangePasswordFormComponent } from '@cloud/app/@shared/user/forms'
 import { Store, UsersService } from '@xpert-ai/cloud/state'
+import { IUser, UserType } from '@xpert-ai/contracts'
 import { injectConfirmDelete, NgmSpinComponent } from '@xpert-ai/ocap-angular/common'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { userLabel } from 'apps/cloud/src/app/@shared/pipes'
@@ -13,8 +14,17 @@ import { distinctUntilChanged, filter, map, startWith, switchMap } from 'rxjs/op
 import { getErrorMessage, injectToastr, RolesEnum, routeAnimations } from '../../../../@core'
 import { PACUserOrganizationsComponent } from '../organizations/organizations.component'
 import { UserBasicComponent } from '../user-basic/user-basic.component'
-import { ZardButtonComponent } from '@xpert-ai/headless-ui'
+import { ZardBadgeComponent, ZardButtonComponent, ZardTabsImports } from '@xpert-ai/headless-ui'
 import { UserMembershipComponent } from '../user-membership/user-membership.component'
+
+type UserDetailTab = 'basic' | 'membership' | 'organizations' | 'security'
+
+const USER_DETAIL_TABS: Array<{ id: UserDetailTab; regularOnly?: boolean }> = [
+  { id: 'basic' },
+  { id: 'membership' },
+  { id: 'organizations', regularOnly: true },
+  { id: 'security', regularOnly: true }
+]
 
 @Component({
   standalone: true,
@@ -25,7 +35,9 @@ import { UserMembershipComponent } from '../user-membership/user-membership.comp
   imports: [
     FormsModule,
     TranslateModule,
+    ZardBadgeComponent,
     ZardButtonComponent,
+    ...ZardTabsImports,
     NgmSpinComponent,
     UserBasicComponent,
     UserChangePasswordFormComponent,
@@ -59,6 +71,88 @@ export class PACEditUserComponent {
   readonly loading = signal(false)
 
   readonly newPassword = model<{ password: string; confirmPassword: string }>()
+  readonly activeTab = signal<UserDetailTab>('basic')
+  readonly queryTab = toSignal(
+    this.route.queryParamMap.pipe(
+      map((params) => this.normalizeTab(params.get('tab'))),
+      distinctUntilChanged()
+    ),
+    {
+      initialValue: this.normalizeTab(this.route.snapshot.queryParamMap.get('tab'))
+    }
+  )
+  readonly availableTabs = computed(() =>
+    USER_DETAIL_TABS.filter((tab) => !tab.regularOnly || !this.isTechnicalUser(this.user()))
+  )
+  readonly activeTabIndex = computed(() => {
+    const index = this.availableTabs().findIndex((tab) => tab.id === this.activeTab())
+    return index > -1 ? index : 0
+  })
+
+  constructor() {
+    effect(
+      () => {
+        const requestedTab = this.queryTab()
+        const currentUser = this.user()
+        const nextTab = this.isTabAvailable(requestedTab, currentUser) ? requestedTab : 'basic'
+
+        if (this.activeTab() !== nextTab) {
+          this.activeTab.set(nextTab)
+        }
+
+        if (requestedTab !== nextTab) {
+          queueMicrotask(() => this.syncTabQuery(nextTab, true))
+        }
+      },
+      { allowSignalWrites: true }
+    )
+  }
+
+  isTechnicalUser(user?: IUser | null) {
+    return user?.type === UserType.COMMUNICATION
+  }
+
+  userTypeLabelKey(type?: UserType) {
+    return type === UserType.COMMUNICATION ? 'PAC.Users.UserTypes.Technical' : 'PAC.Users.UserTypes.Regular'
+  }
+
+  userTypeDefaultLabel(type?: UserType) {
+    return type === UserType.COMMUNICATION ? 'Technical user' : 'Regular user'
+  }
+
+  userStatusLabelKey(user?: IUser | null) {
+    return user?.deletedAt ? 'PAC.KEY_WORDS.Disabled' : 'PAC.KEY_WORDS.Active'
+  }
+
+  userStatusDefaultLabel(user?: IUser | null) {
+    return user?.deletedAt ? 'Disabled' : 'Active'
+  }
+
+  selectTabByIndex(index: number) {
+    const tab = this.availableTabs()[index]?.id ?? 'basic'
+    this.syncTabQuery(tab)
+  }
+
+  private syncTabQuery(tab: UserDetailTab, replaceUrl = false) {
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { tab },
+      queryParamsHandling: 'merge',
+      replaceUrl
+    })
+  }
+
+  private normalizeTab(value?: string | null): UserDetailTab {
+    return USER_DETAIL_TABS.some((tab) => tab.id === value) ? (value as UserDetailTab) : 'basic'
+  }
+
+  private isTabAvailable(tab: UserDetailTab, user?: IUser | null) {
+    if (!user) {
+      return true
+    }
+
+    return !this.isTechnicalUser(user) || !USER_DETAIL_TABS.find((item) => item.id === tab)?.regularOnly
+  }
 
   backToList() {
     this.router.navigate(['/settings/users'])

--- a/apps/cloud/src/app/features/setting/users/manage-user/manage-user.component.html
+++ b/apps/cloud/src/app/features/setting/users/manage-user/manage-user.component.html
@@ -12,7 +12,21 @@
     />
   </div>
 
-  <div class="flex flex-col gap-2 lg:flex-row lg:items-center">
+  <div class="flex flex-col gap-3 lg:flex-row lg:items-center">
+    <div class="flex flex-wrap items-center gap-1">
+      @for (option of userTypeQuickFilters; track option.value ?? 'all') {
+        <button
+          z-button
+          type="button"
+          zSize="sm"
+          [zType]="isUserTypeQuickFilterActive(option.value) ? 'default' : 'ghost'"
+          (click)="selectUserTypeQuickFilter(option.value)"
+        >
+          {{ option.labelKey | translate: { Default: option.defaultLabel } }}
+        </button>
+      }
+    </div>
+
     <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
       <label class="shrink-0 text-sm text-text-tertiary">
         {{ 'PAC.KEY_WORDS.Role' | translate: { Default: 'Role' } }}
@@ -89,7 +103,7 @@
       {{ 'PAC.KEY_WORDS.Users' | translate: { Default: 'Users' } }}
     </span>
 
-    @if (roles.length || status !== allStatusFilter || organizationIds.length) {
+    @if (roles.length || !isDefaultUserTypeFilter() || status !== allStatusFilter || organizationIds.length) {
       <button z-button zType="ghost" zSize="sm" type="button" (click)="clearFilters()">
         {{ 'PAC.KEY_WORDS.Clear' | translate: { Default: 'Clear' } }}
       </button>
@@ -97,15 +111,15 @@
   </div>
 
   @if (users.length) {
-    <div class="min-h-0 overflow-auto rounded-2xl border border-divider-regular bg-components-card-bg">
+    <div class="min-h-0 overflow-auto rounded-xl border border-divider-regular bg-components-card-bg">
       <table z-table zSize="compact" class="min-w-max text-sm">
         <thead z-table-header class="text-text-secondary">
           <tr z-table-row class="border-b bg-muted/30 hover:bg-muted/30">
-            <th z-table-head scope="col" class="sticky top-0 z-10 w-72 bg-background px-4 whitespace-nowrap">
+            <th z-table-head scope="col" class="sticky top-0 z-10 w-80 bg-background px-4 whitespace-nowrap">
               {{ 'PAC.KEY_WORDS.User' | translate: { Default: 'User' } }}
             </th>
-            <th z-table-head scope="col" class="sticky top-0 z-10 w-44 bg-background px-4 whitespace-nowrap">
-              {{ 'PAC.KEY_WORDS.Username' | translate: { Default: 'Username' } }}
+            <th z-table-head scope="col" class="sticky top-0 z-10 w-40 bg-background px-4 whitespace-nowrap">
+              {{ 'PAC.Users.UserType' | translate: { Default: 'User type' } }}
             </th>
             <th z-table-head scope="col" class="sticky top-0 z-10 w-64 bg-background px-4 whitespace-nowrap">
               {{ 'PAC.KEY_WORDS.ORGANIZATION' | translate: { Default: 'Organization' } }}
@@ -143,13 +157,43 @@
               (click)="openUser(user)"
             >
               <td z-table-cell class="px-4 py-3">
-                <pac-user-profile-inline class="min-w-0" [user]="user" small />
+                <div class="flex min-w-0 items-center gap-3">
+                  <div class="relative h-8 w-8 shrink-0">
+                    <img
+                      class="h-full w-full rounded-full object-cover object-center"
+                      [src]="user.imageUrl || '/assets/images/avatar-default.svg'"
+                      [alt]="userIdentityTitle(user)"
+                    />
+                    @if (user.deletedAt) {
+                      <span class="absolute right-0 bottom-0 h-2 w-2 rounded-full bg-text-tertiary ring ring-components-card-bg"></span>
+                    } @else {
+                      <span class="absolute right-0 bottom-0 h-2 w-2 rounded-full bg-text-success ring ring-components-card-bg"></span>
+                    }
+                  </div>
+
+                  <div class="min-w-0">
+                    <div class="max-w-64 truncate font-medium text-text-primary" [title]="userIdentityTitle(user)">
+                      {{ userIdentityTitle(user) || ('PAC.KEY_WORDS.NotSet' | translate: { Default: 'Not set' }) }}
+                    </div>
+
+                    @if (userIdentitySubtitle(user)) {
+                      <div class="max-w-64 truncate text-xs text-text-tertiary" [title]="userIdentitySubtitle(user)">
+                        {{ userIdentitySubtitle(user) }}
+                      </div>
+                    }
+                  </div>
+                </div>
               </td>
 
-              <td z-table-cell class="px-4 py-3 text-text-secondary">
-                <span class="block max-w-40 truncate" [title]="user.username || ''">
-                  {{ user.username || ('PAC.KEY_WORDS.NotSet' | translate: { Default: 'Not set' }) }}
-                </span>
+              <td z-table-cell class="px-4 py-3">
+                <z-badge
+                  zType="secondary"
+                  zShape="pill"
+                  class="max-w-36 truncate"
+                  [ngClass]="userTypeBadgeClass(user.type)"
+                >
+                  {{ userTypeLabelKey(user.type) | translate: { Default: userTypeDefaultLabel(user.type) } }}
+                </z-badge>
               </td>
 
               <td z-table-cell class="px-4 py-3">
@@ -237,18 +281,20 @@
                       <z-icon zType="edit"></z-icon>
                     </button>
 
-                    <button
-                      z-button
-                      zType="ghost"
-                      zSize="icon"
-                      zShape="circle"
-                      type="button"
-                      class="text-text-destructive"
-                      [attr.aria-label]="'PAC.ACTIONS.Delete' | translate: { Default: 'Delete' }"
-                      (click)="remove(user); $event.stopPropagation()"
-                    >
-                      <z-icon zType="trash"></z-icon>
-                    </button>
+                    @if (!isTechnicalUser(user)) {
+                      <button
+                        z-button
+                        zType="ghost"
+                        zSize="icon"
+                        zShape="circle"
+                        type="button"
+                        class="text-text-destructive"
+                        [attr.aria-label]="'PAC.ACTIONS.Delete' | translate: { Default: 'Delete' }"
+                        (click)="remove(user); $event.stopPropagation()"
+                      >
+                        <z-icon zType="trash"></z-icon>
+                      </button>
+                    }
                   </div>
                 </td>
               }
@@ -259,7 +305,7 @@
     </div>
   } @else {
     <div
-      class="flex min-h-64 flex-col items-center justify-center rounded-2xl border border-dashed border-divider-regular bg-components-panel-bg px-6 py-10 text-center"
+      class="flex min-h-64 flex-col items-center justify-center rounded-xl border border-dashed border-divider-regular bg-components-panel-bg px-6 py-10 text-center"
     >
       <z-icon zType="users" class="text-text-tertiary" zSize="lg"></z-icon>
       <div class="mt-3 text-sm font-medium text-text-primary">

--- a/apps/cloud/src/app/features/setting/users/manage-user/manage-user.component.ts
+++ b/apps/cloud/src/app/features/setting/users/manage-user/manage-user.component.ts
@@ -1,7 +1,14 @@
 import { Component, computed, inject } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
 import { ToastrService, UsersService } from '@xpert-ai/cloud/state'
-import { type IOrganization, type IUser, type IUserOrganization, PermissionsEnum, RolesEnum } from '@xpert-ai/contracts'
+import {
+  type IOrganization,
+  type IUser,
+  type IUserOrganization,
+  PermissionsEnum,
+  RolesEnum,
+  UserType
+} from '@xpert-ai/contracts'
 import { NgmConfirmDeleteService } from '@xpert-ai/ocap-angular/common'
 import {
   DateRelativePipe,
@@ -14,7 +21,6 @@ import {
 } from 'apps/cloud/src/app/@core'
 import { TranslationBaseComponent } from 'apps/cloud/src/app/@shared/language'
 import { userLabel } from 'apps/cloud/src/app/@shared/pipes'
-import { UserProfileInlineComponent } from 'apps/cloud/src/app/@shared/user'
 import { includes } from 'lodash-es'
 import { BehaviorSubject, combineLatest, firstValueFrom, map, shareReplay, switchMap } from 'rxjs'
 import { PACUsersComponent } from '../users.component'
@@ -36,6 +42,22 @@ type UserStatusFilter = 'all' | 'active' | 'disabled'
 type UserTableRow = IUser & {
   displayOrganizations: IOrganization[]
 }
+
+const MANAGED_USER_TYPES = [UserType.USER, UserType.COMMUNICATION]
+const DEFAULT_USER_TYPES = [UserType.USER]
+
+const USER_TYPE_OPTIONS: Array<{ value: UserType; labelKey: string; defaultLabel: string }> = [
+  {
+    value: UserType.USER,
+    labelKey: 'PAC.Users.UserTypes.Regular',
+    defaultLabel: 'Regular user'
+  },
+  {
+    value: UserType.COMMUNICATION,
+    labelKey: 'PAC.Users.UserTypes.Technical',
+    defaultLabel: 'Technical user'
+  }
+]
 
 const USER_STATUS_OPTIONS: Array<{ value: UserStatusFilter; labelKey: string; defaultLabel: string }> = [
   {
@@ -71,7 +93,6 @@ const USER_STATUS_OPTIONS: Array<{ value: UserStatusFilter; labelKey: string; de
     ZardInputDirective,
     ...ZardSelectImports,
     ...ZardTableImports,
-    UserProfileInlineComponent,
     DateRelativePipe
   ]
 })
@@ -95,6 +116,15 @@ export class ManageUserComponent extends TranslationBaseComponent {
   }
 
   private search$ = new BehaviorSubject<string>('')
+  readonly userTypeQuickFilters: Array<{ value: UserType | null; labelKey: string; defaultLabel: string }> = [
+    {
+      value: null,
+      labelKey: 'PAC.KEY_WORDS.All',
+      defaultLabel: 'All'
+    },
+    ...USER_TYPE_OPTIONS
+  ]
+  private userTypes$ = new BehaviorSubject<UserType[]>(DEFAULT_USER_TYPES)
   readonly allStatusFilter: UserStatusFilter = 'all'
   readonly statusOptions = USER_STATUS_OPTIONS
   private status$ = new BehaviorSubject<UserStatusFilter>(this.allStatusFilter)
@@ -138,6 +168,13 @@ export class ManageUserComponent extends TranslationBaseComponent {
     this.search$.next(value)
   }
 
+  get userTypes() {
+    return this.userTypes$.value
+  }
+  set userTypes(value) {
+    this.userTypes$.next(value)
+  }
+
   get status() {
     return this.status$.value
   }
@@ -156,6 +193,21 @@ export class ManageUserComponent extends TranslationBaseComponent {
     this.roles = Array.isArray(value) ? value.map((item) => `${item}`) : []
   }
 
+  selectUserTypeQuickFilter(value: UserType | null) {
+    this.userTypes = value ? [value] : []
+  }
+
+  isUserTypeQuickFilterActive(value: UserType | null) {
+    return value ? this.userTypes.length === 1 && this.userTypes[0] === value : !this.userTypes.length
+  }
+
+  isDefaultUserTypeFilter() {
+    return (
+      this.userTypes.length === DEFAULT_USER_TYPES.length &&
+      DEFAULT_USER_TYPES.every((type, index) => this.userTypes[index] === type)
+    )
+  }
+
   onStatusSelectionChange(value: string | number | Array<string | number>) {
     this.status = this.normalizeStatusFilter(value)
   }
@@ -166,6 +218,7 @@ export class ManageUserComponent extends TranslationBaseComponent {
 
   clearFilters() {
     this.roles = []
+    this.userTypes = DEFAULT_USER_TYPES
     this.status = this.allStatusFilter
     this.organizationIds = []
   }
@@ -175,22 +228,26 @@ export class ManageUserComponent extends TranslationBaseComponent {
     this.refresh$,
     this.scopeLevel$,
     this.roles$,
+    this.userTypes$,
     this.search$,
     this.status$,
     this.organizationIds$
   ]).pipe(
-    switchMap(([, scopeLevel, roles, search, status, organizationIds]) =>
+    switchMap(([, scopeLevel, roles, userTypes, search, status, organizationIds]) =>
       scopeLevel === RequestScopeLevel.TENANT
         ? combineLatest([
-            this.userService.getAll(['role']),
+            this.userService.getAll(['role'], undefined, undefined, {
+              types: userTypes.length ? userTypes : MANAGED_USER_TYPES,
+              withDeleted: true
+            }),
             this.userOrganizationsService.getAll(['organization'])
           ]).pipe(
             map(([users, { items }]) => this.mapUsersWithMemberships(users, items)),
-            map((users) => this.filterUsers(users, search, roles, status, organizationIds, true))
+            map((users) => this.filterUsers(users, search, roles, userTypes, status, organizationIds, true))
           )
         : this.userOrganizationsService.getAllInOrg(['user', 'user.role', 'organization']).pipe(
             map(({ items }) => this.mapMembershipsToUsers(items)),
-            map((users) => this.filterUsers(users, search, roles, status, organizationIds, true))
+            map((users) => this.filterUsers(users, search, roles, userTypes, status, organizationIds, true))
           )
     )
   )
@@ -201,6 +258,16 @@ export class ManageUserComponent extends TranslationBaseComponent {
 
   openUser(user: IUser) {
     this.usersComponent.navUser(user)
+  }
+
+  userIdentityTitle(user: IUser) {
+    return userLabel(user)
+  }
+
+  userIdentitySubtitle(user: IUser) {
+    return [user.email, user.username && user.username !== userLabel(user) ? user.username : null]
+      .filter(Boolean)
+      .join(' / ')
   }
 
   /**
@@ -269,15 +336,19 @@ export class ManageUserComponent extends TranslationBaseComponent {
     users: UserTableRow[],
     search: string,
     roles: string[],
+    userTypes: UserType[],
     status: UserStatusFilter,
     organizationIds: string[],
     allowRoleFilter: boolean
   ) {
     const searchText = search?.toLowerCase().trim()
+    const filteredByType = userTypes?.length
+      ? users.filter((user) => includes(userTypes, this.normalizedUserType(user)))
+      : users
     const filteredByRole =
       allowRoleFilter && roles?.length
-        ? users.filter((user) => user.role?.name && includes(roles, user.role.name))
-        : users
+        ? filteredByType.filter((user) => user.role?.name && includes(roles, user.role.name))
+        : filteredByType
     const filteredByStatus =
       status === 'active'
         ? filteredByRole.filter((user) => !user.deletedAt)
@@ -304,7 +375,8 @@ export class ManageUserComponent extends TranslationBaseComponent {
         user.email?.toLowerCase().includes(searchText) ||
         user.username?.toLowerCase().includes(searchText) ||
         user.mobile?.toLowerCase().includes(searchText) ||
-        user.displayOrganizations.some((organization) => organization.name?.toLowerCase().includes(searchText))
+        user.displayOrganizations.some((organization) => organization.name?.toLowerCase().includes(searchText)) ||
+        this.userTypeDefaultLabel(user.type).toLowerCase().includes(searchText)
     )
   }
 
@@ -347,6 +419,35 @@ export class ManageUserComponent extends TranslationBaseComponent {
 
   private sortOrganizations(organizations: IOrganization[]) {
     return [...organizations].sort((left, right) => left.name.localeCompare(right.name))
+  }
+
+  isTechnicalUser(user: IUser) {
+    return user.type === UserType.COMMUNICATION
+  }
+
+  userTypeLabelKey(type?: UserType) {
+    return this.userTypeOption(type).labelKey
+  }
+
+  userTypeDefaultLabel(type?: UserType) {
+    return this.userTypeOption(type).defaultLabel
+  }
+
+  userTypeBadgeClass(type?: UserType) {
+    return this.normalizedUserType({ type } as IUser) === UserType.COMMUNICATION
+      ? 'text-text-accent'
+      : 'text-text-primary'
+  }
+
+  private userTypeOption(type?: UserType) {
+    return (
+      USER_TYPE_OPTIONS.find((option) => option.value === this.normalizedUserType({ type } as IUser)) ??
+      USER_TYPE_OPTIONS[0]
+    )
+  }
+
+  private normalizedUserType(user: Pick<IUser, 'type'>) {
+    return user.type ?? UserType.USER
   }
 
   private normalizeStatusFilter(value: string | number | Array<string | number>): UserStatusFilter {

--- a/apps/cloud/src/app/features/setting/users/user-basic/user-basic.component.html
+++ b/apps/cloud/src/app/features/setting/users/user-basic/user-basic.component.html
@@ -1,15 +1,22 @@
-<div class="w-full flex justify-center">
+<div class="w-full max-w-[700px]">
   <pac-user-basic-info-form
     #userBasicInfo
-    class="block max-w-[700px]"
+    class="block w-full"
     [isSuperAdmin]="true"
     [password]="false"
+    [readOnly]="readOnly()"
     [(ngModel)]="user"
   />
 </div>
 
-<div class="w-full flex justify-end p-2">
-  <button z-button zType="default" (click)="save()">
-    {{ 'PAC.ACTIONS.SAVE' | translate: { Default: 'Save' } }}
-  </button>
-</div>
+@if (readOnly()) {
+  <div class="w-full max-w-[700px] px-2 pt-2 text-sm text-text-tertiary">
+    {{ 'PAC.Users.TechnicalUserReadonlyHint' | translate: { Default: 'Basic account fields are read-only for technical users.' } }}
+  </div>
+} @else {
+  <div class="flex w-full max-w-[700px] justify-end p-2">
+    <button z-button zType="default" (click)="save()">
+      {{ 'PAC.ACTIONS.SAVE' | translate: { Default: 'Save' } }}
+    </button>
+  </div>
+}

--- a/apps/cloud/src/app/features/setting/users/user-basic/user-basic.component.ts
+++ b/apps/cloud/src/app/features/setting/users/user-basic/user-basic.component.ts
@@ -23,7 +23,7 @@ import { ZardButtonComponent } from '@xpert-ai/headless-ui'
         width: 100%;
         display: flex;
         flex-direction: column;
-        align-items: center;
+        align-items: stretch;
       }
     `
   ],
@@ -32,6 +32,7 @@ import { ZardButtonComponent } from '@xpert-ai/headless-ui'
 export class UserBasicComponent {
   // Inputs
   readonly allowRoleChange = input<boolean>()
+  readonly readOnly = input<boolean>(false)
 
   // Children
   readonly userBasicInfo = viewChild(BasicInfoFormComponent)
@@ -54,6 +55,10 @@ export class UserBasicComponent {
   // }
 
   async save() {
+    if (this.readOnly()) {
+      return
+    }
+
     const { email, username, firstName, lastName, tags, preferredLanguage, imageUrl, roleId, thirdPartyId, timeZone } =
       this.user
     let request: IUserUpdateInput = {

--- a/apps/cloud/src/app/features/setting/users/user-membership/user-membership.component.html
+++ b/apps/cloud/src/app/features/setting/users/user-membership/user-membership.component.html
@@ -1,35 +1,37 @@
 @if (canManage) {
-  <div class="flex flex-col gap-4">
+  <div class="flex max-w-6xl flex-col gap-6">
     @if (membership()) {
-      <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
-        <div>
-          <div class="text-sm text-text-tertiary">
-            {{ 'PAC.Membership.CurrentPlan' | translate: { Default: 'Current plan' } }}
+      <div class="flex flex-col gap-3">
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+          <div>
+            <div class="text-sm text-text-tertiary">
+              {{ 'PAC.Membership.CurrentPlan' | translate: { Default: 'Current plan' } }}
+            </div>
+            <div class="font-medium">{{ membership()?.plan?.name }}</div>
           </div>
-          <div class="font-medium">{{ membership()?.plan?.name }}</div>
+          <div>
+            <div class="text-sm text-text-tertiary">
+              {{ 'PAC.Membership.RemainingPoints' | translate: { Default: 'Remaining points' } }}
+            </div>
+            <div class="font-medium">{{ remainingPoints() | number }}</div>
+          </div>
+          <div>
+            <div class="text-sm text-text-tertiary">
+              {{ 'PAC.Membership.UsedPoints' | translate: { Default: 'Used points' } }}
+            </div>
+            <div class="font-medium">
+              {{ membership()?.pointsUsed | number }} / {{ membership()?.pointsGranted | number }}
+            </div>
+          </div>
+          <div>
+            <div class="text-sm text-text-tertiary">
+              {{ 'PAC.Membership.PeriodEnd' | translate: { Default: 'Period end' } }}
+            </div>
+            <div class="font-medium">{{ membership()?.currentPeriodEnd | date: 'mediumDate' }}</div>
+          </div>
         </div>
-        <div>
-          <div class="text-sm text-text-tertiary">
-            {{ 'PAC.Membership.RemainingPoints' | translate: { Default: 'Remaining points' } }}
-          </div>
-          <div class="font-medium">{{ remainingPoints() | number }}</div>
-        </div>
-        <div>
-          <div class="text-sm text-text-tertiary">
-            {{ 'PAC.Membership.UsedPoints' | translate: { Default: 'Used points' } }}
-          </div>
-          <div class="font-medium">
-            {{ membership()?.pointsUsed | number }} / {{ membership()?.pointsGranted | number }}
-          </div>
-        </div>
-        <div>
-          <div class="text-sm text-text-tertiary">
-            {{ 'PAC.Membership.PeriodEnd' | translate: { Default: 'Period end' } }}
-          </div>
-          <div class="font-medium">{{ membership()?.currentPeriodEnd | date: 'mediumDate' }}</div>
-        </div>
+        <z-progress-bar [progress]="usedPercent()" zShape="square" />
       </div>
-      <z-progress-bar [progress]="usedPercent()" zShape="square" />
     } @else {
       <div class="text-text-tertiary">
         {{
@@ -39,40 +41,42 @@
       </div>
     }
 
-    <div class="grid grid-cols-1 gap-3 md:grid-cols-[1fr_1fr_auto]">
-      <select class="h-10 rounded-md border border-divider-regular bg-transparent px-3" [(ngModel)]="selectedPlanId">
-        @for (plan of plans(); track plan.id) {
-          <option [value]="plan.id">{{ plan.name }}</option>
-        }
-      </select>
-      <input
-        z-input
-        [(ngModel)]="note"
-        [placeholder]="'PAC.Membership.AssignNote' | translate: { Default: 'Assignment note' }"
-      />
-      <button z-button zType="default" type="button" [disabled]="loading() || !selectedPlanId" (click)="assign()">
-        {{ 'PAC.Membership.AssignPlan' | translate: { Default: 'Assign plan' } }}
-      </button>
-    </div>
+    <div class="flex max-w-5xl flex-col gap-4">
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-[minmax(220px,320px)_minmax(240px,1fr)_auto]">
+        <select class="h-10 rounded-md border border-divider-regular bg-transparent px-3" [(ngModel)]="selectedPlanId">
+          @for (plan of plans(); track plan.id) {
+            <option [value]="plan.id">{{ plan.name }}</option>
+          }
+        </select>
+        <input
+          z-input
+          [(ngModel)]="note"
+          [placeholder]="'PAC.Membership.AssignNote' | translate: { Default: 'Assignment note' }"
+        />
+        <button z-button zType="default" type="button" [disabled]="loading() || !selectedPlanId" (click)="assign()">
+          {{ 'PAC.Membership.AssignPlan' | translate: { Default: 'Assign plan' } }}
+        </button>
+      </div>
 
-    <div class="grid grid-cols-1 gap-3 md:grid-cols-[160px_1fr_auto_auto]">
-      <input
-        z-input
-        type="number"
-        [(ngModel)]="pointDelta"
-        [placeholder]="'PAC.Membership.PointDelta' | translate: { Default: 'Point delta' }"
-      />
-      <input
-        z-input
-        [(ngModel)]="reason"
-        [placeholder]="'PAC.Membership.AdjustReason' | translate: { Default: 'Adjustment reason' }"
-      />
-      <button z-button zType="secondary" type="button" [disabled]="loading() || !pointDelta" (click)="adjust()">
-        {{ 'PAC.Membership.AdjustPoints' | translate: { Default: 'Adjust points' } }}
-      </button>
-      <button z-button zType="secondary" type="button" [disabled]="loading() || !membership()" (click)="renew()">
-        {{ 'PAC.Membership.Renew' | translate: { Default: 'Renew' } }}
-      </button>
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-[160px_minmax(240px,1fr)_auto_auto]">
+        <input
+          z-input
+          type="number"
+          [(ngModel)]="pointDelta"
+          [placeholder]="'PAC.Membership.PointDelta' | translate: { Default: 'Point delta' }"
+        />
+        <input
+          z-input
+          [(ngModel)]="reason"
+          [placeholder]="'PAC.Membership.AdjustReason' | translate: { Default: 'Adjustment reason' }"
+        />
+        <button z-button zType="secondary" type="button" [disabled]="loading() || !pointDelta" (click)="adjust()">
+          {{ 'PAC.Membership.AdjustPoints' | translate: { Default: 'Adjust points' } }}
+        </button>
+        <button z-button zType="secondary" type="button" [disabled]="loading() || !membership()" (click)="renew()">
+          {{ 'PAC.Membership.Renew' | translate: { Default: 'Renew' } }}
+        </button>
+      </div>
     </div>
   </div>
 }

--- a/apps/cloud/src/app/features/setting/users/users.component.html
+++ b/apps/cloud/src/app/features/setting/users/users.component.html
@@ -4,26 +4,28 @@
       <div class="pac-page-title">{{ 'PAC.MENU.MANAGE_USERS' | translate: { Default: 'Manage Users' } }}</div>
     </div>
 
-    <div class="flex flex-wrap items-center gap-2">
-      @if (canBatchImport()) {
-        <button type="button" z-button zType="secondary" (click)="batImport()">
-          <z-icon zType="upload"></z-icon>
-          {{ 'PAC.USERS_PAGE.BatchImport' | translate: { Default: 'Batch Import' } }}
-        </button>
-      }
-      @if (canInviteUsers()) {
-        <button type="button" z-button zType="secondary" (click)="invite()">
-          <z-icon zType="person_add"></z-icon>
-          {{ 'PAC.ACTIONS.INVITE' | translate: { Default: 'Invite' } }}
-        </button>
-      }
-      @if (canCreateUsers()) {
-        <button type="button" z-button zType="default" (click)="addUser()">
-          <z-icon zType="add"></z-icon>
-          {{ 'PAC.ACTIONS.NEW' | translate: { Default: 'New' } }}
-        </button>
-      }
-    </div>
+    @if (isListRoute()) {
+      <div class="flex flex-wrap items-center gap-2">
+        @if (canBatchImport()) {
+          <button type="button" z-button zType="secondary" (click)="batImport()">
+            <z-icon zType="upload"></z-icon>
+            {{ 'PAC.USERS_PAGE.BatchImport' | translate: { Default: 'Batch Import' } }}
+          </button>
+        }
+        @if (canInviteUsers()) {
+          <button type="button" z-button zType="secondary" (click)="invite()">
+            <z-icon zType="person_add"></z-icon>
+            {{ 'PAC.ACTIONS.INVITE' | translate: { Default: 'Invite' } }}
+          </button>
+        }
+        @if (canCreateUsers()) {
+          <button type="button" z-button zType="default" (click)="addUser()">
+            <z-icon zType="add"></z-icon>
+            {{ 'PAC.ACTIONS.NEW' | translate: { Default: 'New' } }}
+          </button>
+        }
+      </div>
+    }
   </div>
 
   <nav

--- a/apps/cloud/src/app/features/setting/users/users.component.ts
+++ b/apps/cloud/src/app/features/setting/users/users.component.ts
@@ -4,7 +4,7 @@ import { toSignal } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, Router } from '@angular/router'
 import { injectOrganization, Store } from '@xpert-ai/cloud/state'
 import { BehaviorSubject, Subject, firstValueFrom } from 'rxjs'
-import { distinctUntilChanged } from 'rxjs/operators'
+import { distinctUntilChanged, map, startWith } from 'rxjs/operators'
 import { NgxPermissionsService } from 'ngx-permissions'
 import {
   IUser,
@@ -49,6 +49,17 @@ export class PACUsersComponent extends TranslationBaseComponent {
     initialValue: this.permissionsService.getPermissions()
   })
   readonly isTenantScope = computed(() => this.activeScope().level === RequestScopeLevel.TENANT)
+  readonly childRoutePath = toSignal(
+    this.router.events.pipe(
+      startWith(null),
+      map(() => this._route.firstChild?.snapshot.routeConfig?.path ?? ''),
+      distinctUntilChanged()
+    ),
+    {
+      initialValue: this._route.firstChild?.snapshot.routeConfig?.path ?? ''
+    }
+  )
+  readonly isListRoute = computed(() => this.childRoutePath() === '')
   readonly canManageInvites = computed(() => {
     this.activeScope()
     this.permissions()

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -559,6 +559,21 @@
     "USERS_PAGE": {
       "ADD_USER": "Add User"
     },
+    "Users": {
+      "BackToList": "Back to users",
+      "UserType": "User type",
+      "UserTypes": {
+        "Regular": "Regular user",
+        "Technical": "Technical user"
+      },
+      "TechnicalUserReadonlyHint": "Basic account fields are read-only for technical users.",
+      "Tabs": {
+        "Basic": "Basic information",
+        "Membership": "Membership",
+        "Organizations": "Organizations",
+        "Security": "Security"
+      }
+    },
     "ACTIONS": {
       "NEW": "New",
       "CREATE": "Create",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -565,6 +565,18 @@
     },
     "Users": {
       "BackToList": "Back to users",
+      "UserType": "User type",
+      "UserTypes": {
+        "Regular": "Regular user",
+        "Technical": "Technical user"
+      },
+      "TechnicalUserReadonlyHint": "Basic account fields are read-only for technical users.",
+      "Tabs": {
+        "Basic": "Basic information",
+        "Membership": "Membership",
+        "Organizations": "Organizations",
+        "Security": "Security"
+      },
       "GroupsHint": "Manage which groups the user belongs to in each active organization.",
       "NoActiveOrganizations": "This user is not active in any organization.",
       "DefaultOrganizationUpdated": "Default organization updated",

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -2060,6 +2060,18 @@
     },
     "Users": {
       "BackToList": "返回用户列表",
+      "UserType": "用户类型",
+      "UserTypes": {
+        "Regular": "普通用户",
+        "Technical": "技术用户"
+      },
+      "TechnicalUserReadonlyHint": "技术用户的基础账号字段保持只读。",
+      "Tabs": {
+        "Basic": "基本信息",
+        "Membership": "会员",
+        "Organizations": "组织",
+        "Security": "安全"
+      },
       "NoMoreOrganizations": "没有更多的组织可添加",
       "GroupsHint": "查看用户在各个有效组织下所属的用户组。",
       "NoActiveOrganizations": "该用户当前不在任何有效组织中。",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -4055,6 +4055,18 @@
     },
     "Users": {
       "BackToList": "返回用户列表",
+      "UserType": "用户类型",
+      "UserTypes": {
+        "Regular": "普通用户",
+        "Technical": "技术用户"
+      },
+      "TechnicalUserReadonlyHint": "技术用户的基础账号字段保持只读。",
+      "Tabs": {
+        "Basic": "基本信息",
+        "Membership": "会员",
+        "Organizations": "组织",
+        "Security": "安全"
+      },
       "NoMoreOrganizations": "没有更多的组织可添加",
       "GroupsHint": "查看用户在各个有效组织下所属的用户组。",
       "NoActiveOrganizations": "该用户当前不在任何有效组织中。",

--- a/docker/handoff-routing.example.yaml
+++ b/docker/handoff-routing.example.yaml
@@ -68,7 +68,7 @@ typePolicies:
   agent.chat_dispatch.v1:
     queue: realtime
     lane: high
-    timeoutMs: 120000
+    idleTimeoutMs: 120000
     retry:
       maxAttempts: 2
       backoff: exponential

--- a/libs/apps/state/src/lib/users.service.ts
+++ b/libs/apps/state/src/lib/users.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http'
 import { Injectable } from '@angular/core'
-import { IUser, IUserFindInput, IUserPasswordInput, IUserUpdateInput } from '@xpert-ai/contracts'
+import { IUser, IUserFindInput, IUserPasswordInput, IUserUpdateInput, UserType } from '@xpert-ai/contracts'
 import { firstValueFrom, map } from 'rxjs'
 import { API_PREFIX } from './constants'
 
@@ -26,6 +26,11 @@ export type UserMeSelect = {
 export type UserMeOptions = {
   currentOrganizationId?: string | null
   limitOrganizations?: boolean
+}
+
+export type UserListOptions = {
+  types?: UserType[]
+  withDeleted?: boolean
 }
 
 export const CURRENT_USER_BOOTSTRAP_SELECT: UserMeSelect = {
@@ -145,8 +150,8 @@ export class UsersService {
     )
   }
 
-  getAll(relations?: string[], findInput?: IUserFindInput, search?: string) {
-    const data = JSON.stringify({ relations, findInput, search })
+  getAll(relations?: string[], findInput?: IUserFindInput, search?: string, options?: UserListOptions) {
+    const data = JSON.stringify({ relations, findInput, search, ...(options ?? {}) })
     return this.http
       .get<{ items: IUser[]; total: number }>(`${this.API_URL}`, {
         params: { data }

--- a/packages/contracts/src/ai/copilot-usage.model.ts
+++ b/packages/contracts/src/ai/copilot-usage.model.ts
@@ -39,6 +39,8 @@ export interface ICopilotUsageSummary extends IBasePerTenantAndOrganizationEntit
   priceTotalUsed: number
   priceGrandTotal: number
   userCount?: number
+  runtimeUserCount?: number
+  xpertCount?: number
   organizationCount?: number
   detailCount?: number
   updatedAt?: Date

--- a/packages/contracts/src/ai/membership.model.ts
+++ b/packages/contracts/src/ai/membership.model.ts
@@ -126,6 +126,9 @@ export interface IMembershipUsageGroupKey {
 
 export interface IMembershipUsageSummary extends IMembershipUsageGroupKey {
   groupKey: IMembershipUsageGroupKey
+  conversationTitle?: string | null
+  xpertTitle?: string | null
+  xpertName?: string | null
   callCount: number
   pointsDelta: number
   pointsUsed: number

--- a/packages/plugin-sdk/src/lib/agent/handoff/types.ts
+++ b/packages/plugin-sdk/src/lib/agent/handoff/types.ts
@@ -103,6 +103,8 @@ export interface HandoffMessageHeaders extends Record<string, string> {
 	source?: RunSource
 	requestedLane?: LaneName
 	integrationId?: string
+	policyTimeoutMs?: string
+	policyIdleTimeoutMs?: string
 }
 
 /**
@@ -111,12 +113,15 @@ export interface HandoffMessageHeaders extends Record<string, string> {
 export interface ProcessorPolicy {
 	lane: LaneName
 	timeoutMs?: number
+	idleTimeoutMs?: number
 }
 
 export interface ProcessContext {
 	runId: string
 	traceId: string
 	abortSignal: AbortSignal
+	heartbeat?: (reason?: string) => void
+	getAbortReason?: () => string | undefined
 	/**
 	 * Optional local-process event channel for queue waiters (e.g. SSE connection awaiting this message).
 	 * This is intentionally process-local and best-effort.

--- a/packages/server-ai/src/ai/conversation.controller.spec.ts
+++ b/packages/server-ai/src/ai/conversation.controller.spec.ts
@@ -1,0 +1,238 @@
+jest.mock('@xpert-ai/server-core', () => {
+    const { In } = jest.requireActual('typeorm')
+
+    return {
+        ApiKeyOrClientSecretAuthGuard: class {},
+        Public: () => () => undefined,
+        TransformInterceptor: class {},
+        UUIDValidationPipe: class {},
+        transformWhere: jest.fn((where: Record<string, unknown> = {}) => {
+            const result: Record<string, unknown> = {}
+            for (const [key, value] of Object.entries(where ?? {})) {
+                if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                    result[key] = value
+                    continue
+                }
+                if ('$eq' in value) {
+                    result[key] = (value as { $eq?: unknown }).$eq
+                } else if ('$in' in value) {
+                    result[key] = In((value as { $in?: unknown[] }).$in ?? [])
+                } else {
+                    result[key] = value
+                }
+            }
+            return result
+        })
+    }
+})
+
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+    RequestContext: {
+        currentUserId: jest.fn()
+    }
+}))
+
+jest.mock('../chat-conversation', () => ({
+    ChatConversationGoalService: class {},
+    ChatConversationService: class {}
+}))
+
+jest.mock('../chat-message/chat-message.service', () => ({
+    ChatMessageService: class {}
+}))
+
+jest.mock('../chat-message-feedback/feedback.service', () => ({
+    ChatMessageFeedbackService: class {}
+}))
+
+jest.mock('../chat-conversation/commands', () => ({
+    ChatConversationUpsertCommand: class {
+        constructor(public readonly input: unknown) {}
+    }
+}))
+
+jest.mock('../chat-message/commands', () => ({
+    ChatMessageUpsertCommand: class {
+        constructor(public readonly input: unknown) {}
+    }
+}))
+
+jest.mock('../core/entities/internal', () => ({
+    ChatConversation: class {},
+    ChatMessage: class {},
+    ChatMessageFeedback: class {}
+}))
+
+jest.mock('../xpert', () => ({
+    XpertService: class {}
+}))
+
+jest.mock('./commands', () => ({
+    ThreadDeleteCommand: class {
+        constructor(public readonly threadId: string) {}
+    }
+}))
+
+jest.mock('./dto', () => ({
+    ConversationDTO: class {
+        constructor(partial: unknown) {
+            Object.assign(this, partial)
+        }
+    },
+    ChatMessageDTO: class {
+        constructor(partial: unknown) {
+            Object.assign(this, partial)
+        }
+    },
+    ChatMessageFeedbackDTO: class {
+        constructor(partial: unknown) {
+            Object.assign(this, partial)
+        }
+    }
+}))
+
+jest.mock('./public-xpert-principal', () => ({
+    assertPublicXpertSessionConversationAccess: jest.fn(),
+    getPublicXpertSessionConversationScope: jest.fn()
+}))
+
+import { RequestContext } from '@xpert-ai/plugin-sdk'
+import { getPublicXpertSessionConversationScope } from './public-xpert-principal'
+import { ConversationsController } from './conversation.controller'
+
+describe('ConversationsController searchConversations', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(RequestContext.currentUserId as jest.Mock).mockReturnValue('user-1')
+        ;(getPublicXpertSessionConversationScope as jest.Mock).mockReturnValue(null)
+    })
+
+    it('includes the existing xpert technical account for an owned xpert', async () => {
+        const { controller, conversationService, xpertService } = createController()
+        xpertService.findOneInOrganizationOrTenant.mockResolvedValue({
+            id: 'xpert-1',
+            createdById: 'user-1',
+            userId: 'technical-user-1'
+        })
+
+        await controller.searchConversations({
+            where: {
+                xpertId: 'xpert-1',
+                createdById: 'client-supplied-user'
+            },
+            order: { updatedAt: 'DESC' },
+            limit: 50
+        } as any)
+
+        expect(xpertService.findOneInOrganizationOrTenant).toHaveBeenCalledWith('xpert-1', {
+            select: ['id', 'createdById', 'userId'],
+            where: { createdById: 'user-1' }
+        })
+
+        const options = conversationService.findAllInOrganizationOrTenant.mock.calls[0][0]
+        expect(options.order).toEqual({ updatedAt: 'DESC' })
+        expect(options.take).toBe(50)
+        expect(options.where.xpertId).toBe('xpert-1')
+        expect(Reflect.get(options.where.createdById, '_type')).toBe('in')
+        expect(Reflect.get(options.where.createdById, '_value')).toEqual(['user-1', 'technical-user-1'])
+    })
+
+    it.each([
+        ['lookup fails', new Error('not found')],
+        ['xpert is not owned by current user', { id: 'xpert-1', createdById: 'user-2', userId: 'technical-user-1' }],
+        ['xpert has no technical account', { id: 'xpert-1', createdById: 'user-1', userId: null }]
+    ])('keeps current-user filtering when %s', async (_name, xpertResult) => {
+        const { controller, conversationService, xpertService } = createController()
+        if (xpertResult instanceof Error) {
+            xpertService.findOneInOrganizationOrTenant.mockRejectedValue(xpertResult)
+        } else {
+            xpertService.findOneInOrganizationOrTenant.mockResolvedValue(xpertResult)
+        }
+
+        await controller.searchConversations({
+            where: {
+                xpertId: 'xpert-1'
+            }
+        } as any)
+
+        const options = conversationService.findAllInOrganizationOrTenant.mock.calls[0][0]
+        expect(options.where.createdById).toBe('user-1')
+    })
+
+    it('supports $eq xpertId filters for technical-account merging', async () => {
+        const { controller, conversationService, xpertService } = createController()
+        xpertService.findOneInOrganizationOrTenant.mockResolvedValue({
+            id: 'xpert-1',
+            createdById: 'user-1',
+            userId: 'technical-user-1'
+        })
+
+        await controller.searchConversations({
+            where: {
+                xpertId: { $eq: ' xpert-1 ' }
+            }
+        } as any)
+
+        expect(xpertService.findOneInOrganizationOrTenant).toHaveBeenCalledWith('xpert-1', expect.any(Object))
+        const options = conversationService.findAllInOrganizationOrTenant.mock.calls[0][0]
+        expect(options.where.xpertId).toBe(' xpert-1 ')
+        expect(Reflect.get(options.where.createdById, '_value')).toEqual(['user-1', 'technical-user-1'])
+    })
+
+    it('does not merge technical accounts for non-single xpertId filters', async () => {
+        const { controller, conversationService, xpertService } = createController()
+
+        await controller.searchConversations({
+            where: {
+                xpertId: { $in: ['xpert-1', 'xpert-2'] }
+            }
+        } as any)
+
+        expect(xpertService.findOneInOrganizationOrTenant).not.toHaveBeenCalled()
+        const options = conversationService.findAllInOrganizationOrTenant.mock.calls[0][0]
+        expect(options.where.createdById).toBe('user-1')
+    })
+
+    it('keeps public xpert session scope strict and skips xpert lookup', async () => {
+        const { controller, conversationService, xpertService } = createController()
+        ;(getPublicXpertSessionConversationScope as jest.Mock).mockReturnValue({
+            createdById: 'public-user-1',
+            xpertId: 'public-xpert-1'
+        })
+
+        await controller.searchConversations({
+            where: {
+                xpertId: 'requested-xpert-1'
+            }
+        } as any)
+
+        expect(xpertService.findOneInOrganizationOrTenant).not.toHaveBeenCalled()
+        const options = conversationService.findAllInOrganizationOrTenant.mock.calls[0][0]
+        expect(options.where.createdById).toBe('public-user-1')
+        expect(options.where.xpertId).toBe('public-xpert-1')
+    })
+})
+
+function createController() {
+    const conversationService = {
+        findAllInOrganizationOrTenant: jest.fn().mockResolvedValue({ items: [], total: 0 })
+    }
+    const xpertService = {
+        findOneInOrganizationOrTenant: jest.fn()
+    }
+
+    const controller = new ConversationsController(
+        conversationService as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        xpertService as any
+    )
+
+    return {
+        controller,
+        conversationService,
+        xpertService
+    }
+}

--- a/packages/server-ai/src/ai/conversation.controller.ts
+++ b/packages/server-ai/src/ai/conversation.controller.ts
@@ -23,7 +23,7 @@ import {
     UUIDValidationPipe
 } from '@xpert-ai/server-core'
 import { CommandBus } from '@nestjs/cqrs'
-import { FindOptionsOrder, Like } from 'typeorm'
+import { FindOptionsOrder, In, Like } from 'typeorm'
 import {
     IChatConversation,
     IChatMessage,
@@ -44,6 +44,7 @@ import {
     assertPublicXpertSessionConversationAccess,
     getPublicXpertSessionConversationScope
 } from './public-xpert-principal'
+import { XpertService } from '../xpert'
 
 type ConversationSearchRequest = {
     where?: Record<string, OperatorValue>
@@ -79,7 +80,8 @@ export class ConversationsController {
         private readonly goalService: ChatConversationGoalService,
         private readonly messageService: ChatMessageService,
         private readonly feedbackService: ChatMessageFeedbackService,
-        private readonly commandBus: CommandBus
+        private readonly commandBus: CommandBus,
+        private readonly xpertService: XpertService
     ) {}
 
     @Post()
@@ -103,13 +105,12 @@ export class ConversationsController {
             where['title'] = Like(`%${body.search}%`)
         }
         const currentUser = RequestContext.currentUserId()
-        if (currentUser) {
-            where['createdById'] = currentUser
-        }
         const publicScope = getPublicXpertSessionConversationScope()
         if (publicScope) {
             where['createdById'] = publicScope.createdById
             where['xpertId'] = publicScope.xpertId
+        } else if (currentUser) {
+            where['createdById'] = await this.resolveConversationCreatedByFilter(currentUser, body.where)
         }
         const result = await this.conversationService.findAllInOrganizationOrTenant({
             where,
@@ -121,6 +122,50 @@ export class ConversationsController {
             ...result,
             items: result.items.map((item) => new ConversationDTO(item))
         }
+    }
+
+    private async resolveConversationCreatedByFilter(
+        currentUser: string,
+        rawWhere?: ConversationSearchRequest['where']
+    ) {
+        const xpertId = this.extractSingleXpertId(rawWhere)
+        if (!xpertId) {
+            return currentUser
+        }
+
+        try {
+            // Conversation search is read-only: when a user filters one owned xpert, include conversations
+            // created by that xpert's existing technical account, but never create or initialize that account here.
+            const xpert = await this.xpertService.findOneInOrganizationOrTenant(xpertId, {
+                select: ['id', 'createdById', 'userId'],
+                where: { createdById: currentUser }
+            })
+            const xpertPrincipalUserId = this.normalizeString(xpert?.userId)
+            if (xpert?.createdById === currentUser && xpertPrincipalUserId) {
+                return In([currentUser, xpertPrincipalUserId])
+            }
+        } catch {
+            return currentUser
+        }
+
+        return currentUser
+    }
+
+    private extractSingleXpertId(where?: ConversationSearchRequest['where']) {
+        const value = where?.xpertId as unknown
+        if (typeof value === 'string') {
+            return this.normalizeString(value)
+        }
+
+        if (!value || typeof value !== 'object' || Array.isArray(value) || !('$eq' in value)) {
+            return null
+        }
+
+        return this.normalizeString((value as { $eq?: unknown }).$eq)
+    }
+
+    private normalizeString(value: unknown) {
+        return typeof value === 'string' ? value.trim() : ''
     }
 
     @Get(':conversation_id')

--- a/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.spec.ts
+++ b/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.spec.ts
@@ -1,0 +1,78 @@
+jest.mock('../../utils/context-size', () => ({
+    ensureCopilotModelContextSize: jest.fn()
+}))
+
+import { RequestContext } from '@xpert-ai/plugin-sdk'
+import { AIModelGetProviderQuery } from '../../../ai-model'
+import { GetCopilotProviderModelQuery } from '../../../copilot-provider'
+import { CopilotCheckLimitCommand } from '../../../copilot-user'
+import { CopilotModelGetChatModelQuery } from '../get-chat-model.query'
+import { CopilotModelGetChatModelHandler } from './get-chat-model.handler'
+
+describe('CopilotModelGetChatModelHandler', () => {
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it('includes xpertId when pre-checking copilot limits', async () => {
+        jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
+        jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('org-1')
+        jest.spyOn(RequestContext, 'currentUserId').mockReturnValue('assistant-tech-user')
+
+        const commandBus = {
+            execute: jest.fn().mockResolvedValue(undefined)
+        }
+        const getModelInstance = jest.fn().mockReturnValue({ invoke: jest.fn() })
+        const queryBus = {
+            execute: jest.fn(async (query) => {
+                if (query instanceof GetCopilotProviderModelQuery) {
+                    return []
+                }
+                if (query instanceof AIModelGetProviderQuery) {
+                    return {
+                        name: 'tongyi',
+                        getModelInstance
+                    }
+                }
+                throw new Error(`Unexpected query: ${query?.constructor?.name}`)
+            })
+        }
+        const handler = new CopilotModelGetChatModelHandler(
+            commandBus as never,
+            queryBus as never,
+            { t: jest.fn().mockReturnValue('not found') } as never
+        )
+
+        await handler.execute(
+            new CopilotModelGetChatModelQuery(
+                {
+                    id: 'copilot-1',
+                    modelProvider: {
+                        id: 'provider-1',
+                        providerName: 'tongyi'
+                    }
+                } as never,
+                {
+                    copilotId: 'copilot-1',
+                    model: 'qwen3.6-plus',
+                    modelType: 'llm'
+                } as never,
+                {
+                    usageCallback: jest.fn(),
+                    xpertId: 'xpert-1',
+                    threadId: 'thread-1'
+                }
+            )
+        )
+
+        expect(commandBus.execute).toHaveBeenCalledWith(expect.any(CopilotCheckLimitCommand))
+        const checkCommand = commandBus.execute.mock.calls[0][0] as CopilotCheckLimitCommand
+        expect(checkCommand.input).toMatchObject({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            userId: 'assistant-tech-user',
+            xpertId: 'xpert-1',
+            model: 'qwen3.6-plus'
+        })
+    })
+})

--- a/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.ts
+++ b/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.ts
@@ -4,7 +4,7 @@ import { Logger } from '@nestjs/common'
 import { CommandBus, IQueryHandler, QueryBus, QueryHandler } from '@nestjs/cqrs'
 import { AIModelProviderNotFoundException, RequestContext } from '@xpert-ai/plugin-sdk'
 import { I18nService } from 'nestjs-i18n'
-import { t } from 'i18next';
+import { t } from 'i18next'
 import { AIModelGetProviderQuery, ModelProvider } from '../../../ai-model'
 import { GetCopilotProviderModelQuery } from '../../../copilot-provider'
 import { CopilotCheckLimitCommand, CopilotTokenRecordCommand } from '../../../copilot-user'
@@ -13,118 +13,120 @@ import { CopilotModelGetChatModelQuery } from '../get-chat-model.query'
 import { CopilotGetOneQuery } from '../../../copilot/queries'
 import { ensureCopilotModelContextSize } from '../../utils/context-size'
 
-
 @QueryHandler(CopilotModelGetChatModelQuery)
 export class CopilotModelGetChatModelHandler implements IQueryHandler<CopilotModelGetChatModelQuery> {
-	readonly #logger = new Logger(CopilotModelGetChatModelHandler.name)
+    readonly #logger = new Logger(CopilotModelGetChatModelHandler.name)
 
-	constructor(
-		private readonly commandBus: CommandBus,
-		private readonly queryBus: QueryBus,
-		private readonly i18nService: I18nService
-	) {}
+    constructor(
+        private readonly commandBus: CommandBus,
+        private readonly queryBus: QueryBus,
+        private readonly i18nService: I18nService
+    ) {}
 
-	public async execute(command: CopilotModelGetChatModelQuery) {
-		const { abortController, usageCallback, xpertId, threadId } = command.options ?? {}
-		let copilot = command.copilot
-		const tenantId = RequestContext.currentTenantId()
-		const organizationId = RequestContext.getOrganizationId()
-		const userId = RequestContext.currentUserId()
+    public async execute(command: CopilotModelGetChatModelQuery) {
+        const { abortController, usageCallback, xpertId, threadId } = command.options ?? {}
+        let copilot = command.copilot
+        const tenantId = RequestContext.currentTenantId()
+        const organizationId = RequestContext.getOrganizationId()
+        const userId = RequestContext.currentUserId()
 
-		const copilotModel = command.copilotModel ?? copilot?.copilotModel
-		if (!copilotModel) {
-			throw new CopilotModelNotFoundException(
-				this.i18nService.t('copilot.Error.AIModelNotFound', {
-					lang: mapTranslationLanguage(RequestContext.getLanguageCode())
-				})
-			)
-		}
-		const modelName = copilotModel.model
+        const copilotModel = command.copilotModel ?? copilot?.copilotModel
+        if (!copilotModel) {
+            throw new CopilotModelNotFoundException(
+                this.i18nService.t('copilot.Error.AIModelNotFound', {
+                    lang: mapTranslationLanguage(RequestContext.getLanguageCode())
+                })
+            )
+        }
+        const modelName = copilotModel.model
 
-		if (!copilot) {
-			copilot = await this.queryBus.execute(new CopilotGetOneQuery(tenantId, copilotModel.copilotId, ['modelProvider']))
-		}
+        if (!copilot) {
+            copilot = await this.queryBus.execute(
+                new CopilotGetOneQuery(tenantId, copilotModel.copilotId, ['modelProvider'])
+            )
+        }
 
-		// Check token limit
-		await this.commandBus.execute(
-			new CopilotCheckLimitCommand({
-				tenantId,
-				organizationId,
-				userId,
-				copilot,
-				model: modelName
-			})
-		)
+        // Check token limit
+        await this.commandBus.execute(
+            new CopilotCheckLimitCommand({
+                tenantId,
+                organizationId,
+                userId,
+                xpertId,
+                copilot,
+                model: modelName
+            })
+        )
 
-		// Custom model
-		const customModels = await this.queryBus.execute(
-			new GetCopilotProviderModelQuery(copilot.modelProvider.id, {modelName})
-		)
+        // Custom model
+        const customModels = await this.queryBus.execute(
+            new GetCopilotProviderModelQuery(copilot.modelProvider.id, { modelName })
+        )
 
-		const modelProvider = await this.queryBus.execute<AIModelGetProviderQuery, ModelProvider>(
-			new AIModelGetProviderQuery(copilot.modelProvider.providerName)
-		)
+        const modelProvider = await this.queryBus.execute<AIModelGetProviderQuery, ModelProvider>(
+            new AIModelGetProviderQuery(copilot.modelProvider.providerName)
+        )
 
-		if (!modelProvider) {
-			throw new AIModelProviderNotFoundException(
-				t('server-ai:Error.AIModelProviderNotFound', {name: copilot.modelProvider.providerName})
-			)
-		}
+        if (!modelProvider) {
+            throw new AIModelProviderNotFoundException(
+                t('server-ai:Error.AIModelProviderNotFound', { name: copilot.modelProvider.providerName })
+            )
+        }
 
-		ensureCopilotModelContextSize(copilotModel, modelProvider, modelName, customModels)
+        ensureCopilotModelContextSize(copilotModel, modelProvider, modelName, customModels)
 
-		return modelProvider.getModelInstance(
-			copilotModel.modelType,
-			{
-				...copilotModel,
-				copilot
-			},
-			{
-				verbose: Logger.isLevelEnabled('verbose'),
-				modelProperties: customModels[0]?.modelProperties,
-				handleLLMTokens: async (input) => {
-					if (usageCallback && input.usage) {
-						usageCallback(input.usage)
-					}
+        return modelProvider.getModelInstance(
+            copilotModel.modelType,
+            {
+                ...copilotModel,
+                copilot
+            },
+            {
+                verbose: Logger.isLevelEnabled('verbose'),
+                modelProperties: customModels[0]?.modelProperties,
+                handleLLMTokens: async (input) => {
+                    if (usageCallback && input.usage) {
+                        usageCallback(input.usage)
+                    }
 
-					if (!input.model) {
-						const message = t('server-ai:Error.HandleLLMTokensNoModel', {provider: modelProvider.name})
-						this.#logger.error(message)
-						return
-					}
+                    if (!input.model) {
+                        const message = t('server-ai:Error.HandleLLMTokensNoModel', { provider: modelProvider.name })
+                        this.#logger.error(message)
+                        return
+                    }
 
-					// Record token usage and abort if error
-					try {
-						await this.commandBus.execute(
-							new CopilotTokenRecordCommand({
-								...omit(input, 'usage'),
-								tenantId,
-								organizationId,
-								userId,
-								xpertId,
-								threadId,
-								copilot,
-								model: input.model,
-								tokenUsed: input.usage?.totalTokens,
-								priceUsed: input.usage?.totalPrice,
-								currency: input.usage?.currency
-							})
-						)
-					} catch (err) {
-						if (err instanceof ExceedingLimitException) {
-							if (abortController && !abortController.signal.aborted) {
-								try {
-									abortController.abort(err.message)
-								} catch (err) {
-									//
-								}
-							}
-						} else {
-							this.#logger.error(err)
-						}
-					}
-				}
-			}
-		)
-	}
+                    // Record token usage and abort if error
+                    try {
+                        await this.commandBus.execute(
+                            new CopilotTokenRecordCommand({
+                                ...omit(input, 'usage'),
+                                tenantId,
+                                organizationId,
+                                userId,
+                                xpertId,
+                                threadId,
+                                copilot,
+                                model: input.model,
+                                tokenUsed: input.usage?.totalTokens,
+                                priceUsed: input.usage?.totalPrice,
+                                currency: input.usage?.currency
+                            })
+                        )
+                    } catch (err) {
+                        if (err instanceof ExceedingLimitException) {
+                            if (abortController && !abortController.signal.aborted) {
+                                try {
+                                    abortController.abort(err.message)
+                                } catch (err) {
+                                    //
+                                }
+                            }
+                        } else {
+                            this.#logger.error(err)
+                        }
+                    }
+                }
+            }
+        )
+    }
 }

--- a/packages/server-ai/src/copilot-usage/copilot-usage.service.spec.ts
+++ b/packages/server-ai/src/copilot-usage/copilot-usage.service.spec.ts
@@ -66,32 +66,33 @@ describe('CopilotUsageService', () => {
         mockRequestContext()
     })
 
-    it('summarizes user usage with current and grand totals', async () => {
+    it('summarizes user usage by xpert creator with current and grand totals', async () => {
+        const qb = createQueryBuilderMock<CopilotUser>([
+            {
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                orgId: 'provider-org-1',
+                userId: 'owner-user',
+                provider: 'openai',
+                model: 'gpt-4.1',
+                currency: 'USD',
+                tokenUsed: '40',
+                tokenTotalUsed: '60',
+                priceUsed: '0.4',
+                priceTotalUsed: '0.6',
+                tokenLimit: '1000',
+                runtimeUserCount: '2',
+                xpertCount: '3',
+                updatedAt: new Date('2026-06-01T00:00:00.000Z'),
+                userRelationId: 'owner-user',
+                userEmail: 'owner@example.com',
+                organizationRelationId: 'org-1',
+                organizationName: 'Org 1',
+                total: '1'
+            }
+        ])
         const userRepository: RepositoryMock = {
-            createQueryBuilder: jest.fn().mockReturnValue(
-                createQueryBuilderMock<CopilotUser>([
-                    {
-                        tenantId: 'tenant-1',
-                        organizationId: 'org-1',
-                        orgId: 'provider-org-1',
-                        userId: 'user-1',
-                        provider: 'openai',
-                        model: 'gpt-4.1',
-                        currency: 'USD',
-                        tokenUsed: '40',
-                        tokenTotalUsed: '60',
-                        priceUsed: '0.4',
-                        priceTotalUsed: '0.6',
-                        tokenLimit: '1000',
-                        updatedAt: new Date('2026-06-01T00:00:00.000Z'),
-                        userRelationId: 'user-1',
-                        userEmail: 'user@example.com',
-                        organizationRelationId: 'org-1',
-                        organizationName: 'Org 1',
-                        total: '1'
-                    }
-                ])
-            ),
+            createQueryBuilder: jest.fn().mockReturnValue(qb),
             find: jest.fn(),
             findOne: jest.fn(),
             create: jest.fn((input) => input),
@@ -111,11 +112,25 @@ describe('CopilotUsageService', () => {
             { order: { updatedAt: OrderTypeEnum.DESC }, take: 20, skip: 0 }
         )
 
+        expect((qb as any).leftJoin).toHaveBeenCalledWith(
+            'xpert',
+            'usage_xpert',
+            '"usage_xpert"."id"::text = "usage"."xpertId"'
+        )
+        expect((qb as any).addSelect).toHaveBeenCalledWith(
+            'COALESCE("usage_xpert"."createdById"::text, "usage"."userId")',
+            'userId'
+        )
+        expect((qb as any).addSelect).toHaveBeenCalledWith('COUNT(DISTINCT "usage"."userId")', 'runtimeUserCount')
+        expect((qb as any).addSelect).toHaveBeenCalledWith('COUNT(DISTINCT "usage"."xpertId")', 'xpertCount')
+        expect((qb as any).addGroupBy).toHaveBeenCalledWith(
+            'COALESCE("usage_xpert"."createdById"::text, "usage"."userId")'
+        )
         expect(result.total).toBe(1)
         expect(result.items[0]).toMatchObject({
             dimension: 'user',
             organizationId: 'org-1',
-            userId: 'user-1',
+            userId: 'owner-user',
             provider: 'openai',
             model: 'gpt-4.1',
             currency: 'USD',
@@ -125,7 +140,87 @@ describe('CopilotUsageService', () => {
             priceUsed: 0.4,
             priceTotalUsed: 0.6,
             priceGrandTotal: 1,
-            tokenLimit: 1000
+            tokenLimit: null,
+            priceLimit: null,
+            runtimeUserCount: 2,
+            xpertCount: 3
+        })
+    })
+
+    it('filters usage summaries and totals by xpert creator user id', async () => {
+        const summaryQb = createQueryBuilderMock<CopilotUser>([])
+        const totalsQb = createQueryBuilderMock<CopilotUser>([])
+        const userRepository: RepositoryMock = {
+            createQueryBuilder: jest.fn().mockReturnValueOnce(summaryQb).mockReturnValueOnce(totalsQb),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn((input) => input),
+            save: jest.fn()
+        }
+        const orgRepository: RepositoryMock = {
+            createQueryBuilder: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn((input) => input),
+            save: jest.fn()
+        }
+        const service = createService(userRepository, orgRepository)
+
+        await service.findSummaries({ dimension: 'user', userId: 'owner-user' })
+        await service.findTotals({ dimension: 'user', userId: 'owner-user' })
+
+        for (const qb of [summaryQb, totalsQb]) {
+            expect((qb as any).andWhere).toHaveBeenCalledWith(
+                'COALESCE("usage_xpert"."createdById"::text, "usage"."userId") = :filterUserId',
+                { filterUserId: 'owner-user' }
+            )
+        }
+    })
+
+    it('filters user details by creator but returns runtime user usage rows', async () => {
+        const detail = {
+            id: 'detail-1',
+            userId: 'assistant-tech-user',
+            xpertId: 'xpert-1',
+            provider: 'openai',
+            model: 'gpt-4.1',
+            currency: 'USD',
+            tokenUsed: 10
+        }
+        const qb = createQueryBuilderMock<CopilotUser>([detail])
+        const userRepository: RepositoryMock = {
+            createQueryBuilder: jest.fn().mockReturnValue(qb),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn((input) => input),
+            save: jest.fn()
+        }
+        const orgRepository: RepositoryMock = {
+            createQueryBuilder: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn((input) => input),
+            save: jest.fn()
+        }
+        const service = createService(userRepository, orgRepository)
+
+        const result = await service.findDetails({
+            dimension: 'user',
+            organizationId: 'org-1',
+            orgId: null,
+            userId: 'owner-user',
+            provider: 'openai',
+            model: 'gpt-4.1',
+            currency: 'USD'
+        })
+
+        expect((qb as any).andWhere).toHaveBeenCalledWith(
+            'COALESCE("usage_xpert"."createdById"::text, "usage"."userId") = :groupUserId',
+            { groupUserId: 'owner-user' }
+        )
+        expect(result[0]).toMatchObject({
+            userId: 'assistant-tech-user',
+            xpertId: 'xpert-1'
         })
     })
 
@@ -186,7 +281,7 @@ describe('CopilotUsageService', () => {
         })
     })
 
-    it('increases a user quota without resetting current usage', async () => {
+    it('rejects quota changes for creator-aggregated user usage', async () => {
         const quotaRow = {
             tenantId: 'tenant-1',
             organizationId: 'org-1',
@@ -215,27 +310,24 @@ describe('CopilotUsageService', () => {
         }
         const service = createService(userRepository, orgRepository)
 
-        await service.adjustQuota({
-            dimension: 'user',
-            mode: 'increase',
-            groupKey: {
+        await expect(
+            service.adjustQuota({
                 dimension: 'user',
-                organizationId: 'org-1',
-                userId: 'user-1',
-                provider: 'openai',
-                model: 'gpt-4.1',
-                currency: 'USD'
-            },
-            tokenLimit: 50
-        })
-
-        expect(userRepository.save).toHaveBeenCalledWith([
-            expect.objectContaining({
-                tokenUsed: 25,
-                tokenTotalUsed: 75,
-                tokenLimit: 150
+                mode: 'increase',
+                groupKey: {
+                    dimension: 'user',
+                    organizationId: 'org-1',
+                    userId: 'owner-user',
+                    provider: 'openai',
+                    model: 'gpt-4.1',
+                    currency: 'USD'
+                },
+                tokenLimit: 50
             })
-        ])
+        ).rejects.toThrow('Creator-aggregated user usage quota changes are not supported')
+
+        expect(userRepository.find).not.toHaveBeenCalled()
+        expect(userRepository.save).not.toHaveBeenCalled()
     })
 
     it('renews organization quota by rolling current usage into total usage', async () => {

--- a/packages/server-ai/src/copilot-usage/copilot-usage.service.ts
+++ b/packages/server-ai/src/copilot-usage/copilot-usage.service.ts
@@ -13,8 +13,8 @@ import {
 } from '@xpert-ai/contracts'
 import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { OrganizationPublicDTO, RequestContext, UserPublicDTO } from '@xpert-ai/server-core'
-import { FindOptionsWhere, IsNull, ObjectLiteral, Repository } from 'typeorm'
+import { OrganizationPublicDTO, RequestContext, User, UserPublicDTO } from '@xpert-ai/server-core'
+import { EntityTarget, FindOptionsWhere, IsNull, ObjectLiteral, Repository } from 'typeorm'
 import { CopilotOrganization } from '../copilot-organization/copilot-organization.entity'
 import { CopilotUser } from '../copilot-user/copilot-user.entity'
 import { formatInUTC0 } from '../shared/utils'
@@ -40,6 +40,8 @@ type UsageSummaryRaw = {
     priceLimit?: string | number | null
     priceTotalUsed?: string | number | null
     userCount?: string | number | null
+    runtimeUserCount?: string | number | null
+    xpertCount?: string | number | null
     organizationCount?: string | number | null
     detailCount?: string | number | null
     updatedAt?: Date | string | null
@@ -69,6 +71,10 @@ type QuotaRaw = {
 
 type WhereQueryBuilder = {
     andWhere(where: string, parameters?: ObjectLiteral): unknown
+}
+
+type UsageOwnerQueryBuilder = WhereQueryBuilder & {
+    leftJoin(table: EntityTarget<unknown>, alias: string, condition?: string): unknown
 }
 
 const GROUP_ID_SEPARATOR = '|'
@@ -112,6 +118,7 @@ export class CopilotUsageService {
             .where('usage.tenantId = :tenantId', { tenantId: scope.tenantId })
             .groupBy("COALESCE(usage.currency, '')")
 
+        this.leftJoinUsageXpert(qb, 'usage')
         this.applyScope(qb, 'usage', scope)
         this.applyUsageFilters(qb, 'usage', query)
 
@@ -146,6 +153,7 @@ export class CopilotUsageService {
             .orderBy('usage.updatedAt', OrderTypeEnum.DESC)
             .take(DETAIL_LIMIT)
 
+        this.leftJoinUsageXpert(qb, 'usage')
         this.applyScope(qb, 'usage', scope)
         this.applyGroupKeyFilters(qb, 'usage', { ...groupKey, dimension })
 
@@ -154,6 +162,7 @@ export class CopilotUsageService {
 
     async adjustQuota(input: TCopilotQuotaAdjustInput): Promise<ICopilotUsageSummary | null> {
         const dimension = this.normalizeQuotaDimension(input.dimension)
+        this.assertQuotaDimensionManageable(dimension)
         const records = await this.findQuotaRecords(dimension, input.groupKey, true)
         const tokenLimit = this.calculateAdjustedLimit(
             records.map((record) => record.tokenLimit),
@@ -181,6 +190,7 @@ export class CopilotUsageService {
 
     async renewQuota(input: TCopilotQuotaRenewInput): Promise<ICopilotUsageSummary | null> {
         const dimension = this.normalizeQuotaDimension(input.dimension)
+        this.assertQuotaDimensionManageable(dimension)
         const records = await this.findQuotaRecords(dimension, input.groupKey, true)
 
         for (const record of records) {
@@ -274,42 +284,41 @@ export class CopilotUsageService {
         options?: { take?: number; skip?: number; order?: { updatedAt?: unknown } }
     ): Promise<IPagination<ICopilotUsageSummary>> {
         const scope = this.resolveScope(query.organizationId)
+        const ownerUserIdSql = this.usageOwnerUserIdSql('usage')
         const qb = this.baseUsageSummaryQuery(scope, query, options)
-            .leftJoin('usage.user', 'usage_user')
+            .leftJoin(User, 'usage_user', `"usage_user"."id"::text = ${ownerUserIdSql}`)
             .leftJoin('usage.organization', 'usage_organization')
             .leftJoin('usage.org', 'usage_org')
-            .addSelect('usage.userId', 'userId')
+            .addSelect(ownerUserIdSql, 'userId')
             .addSelect('usage.orgId', 'orgId')
-            .addSelect('usage_user.id', 'userRelationId')
-            .addSelect('usage_user.firstName', 'userFirstName')
-            .addSelect('usage_user.lastName', 'userLastName')
-            .addSelect('usage_user.email', 'userEmail')
-            .addSelect('usage_user.username', 'userUsername')
-            .addSelect('usage_user.imageUrl', 'userImageUrl')
+            .addSelect('COUNT(DISTINCT "usage"."userId")', 'runtimeUserCount')
+            .addSelect('COUNT(DISTINCT "usage"."xpertId")', 'xpertCount')
+            .addSelect('"usage_user"."id"', 'userRelationId')
+            .addSelect('"usage_user"."firstName"', 'userFirstName')
+            .addSelect('"usage_user"."lastName"', 'userLastName')
+            .addSelect('"usage_user"."email"', 'userEmail')
+            .addSelect('"usage_user"."username"', 'userUsername')
+            .addSelect('"usage_user"."imageUrl"', 'userImageUrl')
             .addSelect('usage_organization.id', 'organizationRelationId')
             .addSelect('usage_organization.name', 'organizationName')
             .addSelect('usage_organization.imageUrl', 'organizationImageUrl')
             .addSelect('usage_org.id', 'orgRelationId')
             .addSelect('usage_org.name', 'orgName')
             .addSelect('usage_org.imageUrl', 'orgImageUrl')
-            .addGroupBy('usage.userId')
+            .addGroupBy(ownerUserIdSql)
             .addGroupBy('usage.orgId')
-            .addGroupBy('usage_user.id')
-            .addGroupBy('usage_user.firstName')
-            .addGroupBy('usage_user.lastName')
-            .addGroupBy('usage_user.email')
-            .addGroupBy('usage_user.username')
-            .addGroupBy('usage_user.imageUrl')
+            .addGroupBy('"usage_user"."id"')
+            .addGroupBy('"usage_user"."firstName"')
+            .addGroupBy('"usage_user"."lastName"')
+            .addGroupBy('"usage_user"."email"')
+            .addGroupBy('"usage_user"."username"')
+            .addGroupBy('"usage_user"."imageUrl"')
             .addGroupBy('usage_organization.id')
             .addGroupBy('usage_organization.name')
             .addGroupBy('usage_organization.imageUrl')
             .addGroupBy('usage_org.id')
             .addGroupBy('usage_org.name')
             .addGroupBy('usage_org.imageUrl')
-
-        if (query.userId) {
-            qb.andWhere('usage.userId = :userId', { userId: query.userId })
-        }
 
         const rows = await qb.getRawMany<UsageSummaryRaw>()
         return this.toPagination(rows, 'user')
@@ -385,6 +394,7 @@ export class CopilotUsageService {
             .take(take)
             .skip(skip)
 
+        this.leftJoinUsageXpert(qb, 'usage')
         this.applyScope(qb, 'usage', scope)
         this.applyUsageFilters(qb, 'usage', query)
 
@@ -436,6 +446,7 @@ export class CopilotUsageService {
             .take(take)
             .skip(skip)
 
+        this.leftJoinUsageXpert(qb, 'usage')
         this.applyScope(qb, 'usage', scope)
         this.applyUsageFilters(qb, 'usage', query)
 
@@ -628,7 +639,7 @@ export class CopilotUsageService {
             qb.andWhere(`${alias}.currency = :currency`, { currency: query.currency })
         }
         if (!options?.skipUser && query.userId) {
-            qb.andWhere(`${alias}.userId = :filterUserId`, { filterUserId: query.userId })
+            qb.andWhere(`${this.usageOwnerUserIdSql(alias)} = :filterUserId`, { filterUserId: query.userId })
         }
         if (!options?.skipTime) {
             const start = this.toUsageHour(query.start)
@@ -647,7 +658,7 @@ export class CopilotUsageService {
             if (!groupKey.userId) {
                 throw new BadRequestException('Missing required user usage group fields.')
             }
-            qb.andWhere(`${alias}.userId = :groupUserId`, { groupUserId: groupKey.userId })
+            qb.andWhere(`${this.usageOwnerUserIdSql(alias)} = :groupUserId`, { groupUserId: groupKey.userId })
             if (groupKey.orgId) {
                 qb.andWhere(`${alias}.orgId = :groupOrgId`, { groupOrgId: groupKey.orgId })
             } else {
@@ -715,6 +726,28 @@ export class CopilotUsageService {
         throw new BadRequestException('Quota changes are only supported for user or organization dimensions.')
     }
 
+    private assertQuotaDimensionManageable(dimension: 'user' | 'organization') {
+        if (dimension === 'user') {
+            throw new BadRequestException(
+                'Creator-aggregated user usage quota changes are not supported. Use copilot user usage endpoints for runtime-user quota management.'
+            )
+        }
+    }
+
+    private leftJoinUsageXpert(qb: UsageOwnerQueryBuilder, alias: string) {
+        const xpertAlias = this.usageXpertAlias(alias)
+        qb.leftJoin('xpert', xpertAlias, `"${xpertAlias}"."id"::text = "${alias}"."xpertId"`)
+    }
+
+    private usageOwnerUserIdSql(alias: string) {
+        const xpertAlias = this.usageXpertAlias(alias)
+        return `COALESCE("${xpertAlias}"."createdById"::text, "${alias}"."userId")`
+    }
+
+    private usageXpertAlias(alias: string) {
+        return `${alias}_xpert`
+    }
+
     private calculateAdjustedLimit(
         currentValues: Array<string | number | null | undefined>,
         inputValue: number | null | undefined,
@@ -773,14 +806,16 @@ export class CopilotUsageService {
             model: groupKey.model,
             currency: groupKey.currency,
             tokenUsed,
-            tokenLimit: toOptionalNumber(row.tokenLimit) ?? null,
+            tokenLimit: dimension === 'user' ? null : (toOptionalNumber(row.tokenLimit) ?? null),
             tokenTotalUsed,
             tokenGrandTotal: tokenUsed + tokenTotalUsed,
             priceUsed,
-            priceLimit: toOptionalNumber(row.priceLimit) ?? null,
+            priceLimit: dimension === 'user' ? null : (toOptionalNumber(row.priceLimit) ?? null),
             priceTotalUsed,
             priceGrandTotal: priceUsed + priceTotalUsed,
             userCount: toOptionalNumber(row.userCount),
+            runtimeUserCount: toOptionalNumber(row.runtimeUserCount),
+            xpertCount: toOptionalNumber(row.xpertCount),
             organizationCount: toOptionalNumber(row.organizationCount),
             detailCount: toOptionalNumber(row.detailCount),
             updatedAt: row.updatedAt ? new Date(row.updatedAt) : undefined

--- a/packages/server-ai/src/copilot-user/commands/check-limit.command.ts
+++ b/packages/server-ai/src/copilot-user/commands/check-limit.command.ts
@@ -2,15 +2,16 @@ import { ICopilot } from '@xpert-ai/contracts'
 import { ICommand } from '@nestjs/cqrs'
 
 export class CopilotCheckLimitCommand implements ICommand {
-	static readonly type = '[Copilot] Check limit'
+    static readonly type = '[Copilot] Check limit'
 
-	constructor(
-		public readonly input: {
-			tenantId: string;
-			organizationId?: string;
-			userId: string;
-			copilot?: ICopilot;
-			model: string
-		}
-	) {}
+    constructor(
+        public readonly input: {
+            tenantId: string
+            organizationId?: string
+            userId: string
+            xpertId?: string
+            copilot?: ICopilot
+            model: string
+        }
+    ) {}
 }

--- a/packages/server-ai/src/copilot-user/commands/handlers/check-limit.handler.spec.ts
+++ b/packages/server-ai/src/copilot-user/commands/handlers/check-limit.handler.spec.ts
@@ -1,0 +1,62 @@
+import { CopilotCheckLimitCommand } from '../check-limit.command'
+import { CopilotCheckLimitHandler } from './check-limit.handler'
+
+describe('CopilotCheckLimitHandler', () => {
+    it('passes xpertId to membership checks while keeping runtime user quota checks', async () => {
+        const copilotUserService = {
+            getUsageSummary: jest.fn().mockResolvedValue({
+                tokenUsed: 0,
+                tokenLimit: null
+            })
+        }
+        const copilotOrganizationService = {
+            getUsageSummary: jest.fn().mockResolvedValue({
+                tokenUsed: 0,
+                tokenLimit: null
+            })
+        }
+        const membershipService = {
+            assertCanUse: jest.fn().mockResolvedValue(undefined)
+        }
+        const handler = new CopilotCheckLimitHandler(
+            copilotUserService as never,
+            copilotOrganizationService as never,
+            membershipService as never,
+            { t: jest.fn().mockResolvedValue('limit exceeded') } as never
+        )
+
+        await handler.execute(
+            new CopilotCheckLimitCommand({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                userId: 'assistant-tech-user',
+                xpertId: 'xpert-1',
+                copilot: {
+                    organizationId: 'copilot-org-1',
+                    modelProvider: {
+                        providerName: 'tongyi'
+                    }
+                } as never,
+                model: 'qwen3.6-plus'
+            })
+        )
+
+        expect(membershipService.assertCanUse).toHaveBeenCalledWith({
+            tenantId: 'tenant-1',
+            userId: 'assistant-tech-user',
+            xpertId: 'xpert-1',
+            provider: 'tongyi',
+            model: 'qwen3.6-plus'
+        })
+        expect(copilotUserService.getUsageSummary).toHaveBeenCalledWith(
+            expect.objectContaining({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                orgId: 'copilot-org-1',
+                userId: 'assistant-tech-user',
+                provider: 'tongyi',
+                model: 'qwen3.6-plus'
+            })
+        )
+    })
+})

--- a/packages/server-ai/src/copilot-user/commands/handlers/check-limit.handler.ts
+++ b/packages/server-ai/src/copilot-user/commands/handlers/check-limit.handler.ts
@@ -19,11 +19,12 @@ export class CopilotCheckLimitHandler implements ICommandHandler<CopilotCheckLim
 
     public async execute(command: CopilotCheckLimitCommand): Promise<void> {
         const { input } = command
-        const { copilot, tenantId, organizationId, userId } = input
+        const { copilot, tenantId, organizationId, userId, xpertId } = input
 
         await this.membershipService.assertCanUse({
             tenantId,
             userId,
+            xpertId,
             provider: copilot.modelProvider.providerName,
             model: input.model
         })

--- a/packages/server-ai/src/handoff/dispatcher/handoff-route-resolver.service.ts
+++ b/packages/server-ai/src/handoff/dispatcher/handoff-route-resolver.service.ts
@@ -32,13 +32,14 @@ export class HandoffRouteResolver {
 			config.defaultQueue
 		const lane = this.resolveLane(message, typePolicy, matchedRoute, config.defaultLane)
 		const timeoutMs = this.resolveTimeoutMs(message, typePolicy, matchedRoute)
-		const policy: ProcessorPolicy =
-			timeoutMs === undefined
-				? { lane }
-				: {
-						lane,
-						timeoutMs
-				  }
+		const idleTimeoutMs = this.resolveIdleTimeoutMs(message, typePolicy, matchedRoute)
+		const policy: ProcessorPolicy = { lane }
+		if (timeoutMs !== undefined) {
+			policy.timeoutMs = timeoutMs
+		}
+		if (idleTimeoutMs !== undefined) {
+			policy.idleTimeoutMs = idleTimeoutMs
+		}
 
 		return {
 			queue,
@@ -85,6 +86,21 @@ export class HandoffRouteResolver {
 			}
 		}
 		return typePolicy?.timeoutMs ?? route?.target.timeoutMs
+	}
+
+	private resolveIdleTimeoutMs(
+		message: HandoffMessage,
+		typePolicy: HandoffTypePolicy | undefined,
+		route: HandoffRouteRule | undefined
+	): number | undefined {
+		const idleTimeoutHeader = message.headers?.policyIdleTimeoutMs
+		if (idleTimeoutHeader) {
+			const idleTimeoutMs = parseInt(idleTimeoutHeader, 10)
+			if (Number.isFinite(idleTimeoutMs) && idleTimeoutMs > 0) {
+				return idleTimeoutMs
+			}
+		}
+		return typePolicy?.idleTimeoutMs ?? route?.target.idleTimeoutMs
 	}
 
 	private matches(message: HandoffMessage, route: HandoffRouteRule): boolean {

--- a/packages/server-ai/src/handoff/dispatcher/handoff-routing-config.service.spec.ts
+++ b/packages/server-ai/src/handoff/dispatcher/handoff-routing-config.service.spec.ts
@@ -1,0 +1,140 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { HandoffMessage } from '@xpert-ai/plugin-sdk'
+import { HandoffRouteResolver } from './handoff-route-resolver.service'
+import { HandoffRoutingConfigService } from './handoff-routing-config.service'
+
+describe('HandoffRoutingConfigService idle timeout policy', () => {
+	const previousConfigPath = process.env.HANDOFF_ROUTING_CONFIG_PATH
+	let tempRoot: string | undefined
+
+	afterEach(() => {
+		if (previousConfigPath === undefined) {
+			delete process.env.HANDOFF_ROUTING_CONFIG_PATH
+		} else {
+			process.env.HANDOFF_ROUTING_CONFIG_PATH = previousConfigPath
+		}
+		if (tempRoot) {
+			fs.rmSync(tempRoot, { recursive: true, force: true })
+			tempRoot = undefined
+		}
+	})
+
+	const createService = () => {
+		tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'handoff-routing-'))
+		fs.writeFileSync(
+			path.join(tempRoot, 'routing.yaml'),
+			[
+				'version: 1',
+				'defaultQueue: handoff',
+				'defaultLane: main',
+				'typePolicies:',
+				'  agent.chat_dispatch.v1:',
+				'    queue: realtime',
+				'    lane: high',
+				'    idleTimeoutMs: 120000',
+				'    timeoutMs: 600000',
+				'routes:',
+				'  - match:',
+				'      typePrefix: agent.',
+				'    target:',
+				'      queue: batch',
+				'      lane: normal',
+				'      idleTimeoutMs: 45000',
+				'      timeoutMs: 90000',
+				'  - match:',
+				'      typePrefix: channel.wechat.',
+				'    target:',
+				'      queue: integration',
+				'      lane: normal',
+				'      idleTimeoutMs: 30000',
+				''
+			].join('\n')
+		)
+		process.env.HANDOFF_ROUTING_CONFIG_PATH = 'routing.yaml'
+		const service = new HandoffRoutingConfigService({
+			assetOptions: { serverRoot: tempRoot }
+		} as any)
+		service.onModuleInit()
+		return service
+	}
+
+	const createMessage = (overrides?: Partial<HandoffMessage>): HandoffMessage => ({
+		id: 'message-id',
+		type: 'agent.chat_dispatch.v1',
+		version: 1,
+		tenantId: 'tenant-id',
+		sessionKey: 'session-id',
+		businessKey: 'business-id',
+		attempt: 1,
+		maxAttempts: 1,
+		enqueuedAt: Date.now(),
+		traceId: 'trace-id',
+		payload: {},
+		...overrides
+	})
+
+	it('parses idle timeout from type policies and route targets', () => {
+		const service = createService()
+		const snapshot = service.getSnapshot()
+
+		expect(snapshot.typePolicies['agent.chat_dispatch.v1']).toMatchObject({
+			timeoutMs: 600000,
+			idleTimeoutMs: 120000
+		})
+		expect(snapshot.routes[0].target).toMatchObject({
+			timeoutMs: 90000,
+			idleTimeoutMs: 45000
+		})
+		expect(snapshot.routes[1].target).toMatchObject({
+			idleTimeoutMs: 30000
+		})
+	})
+
+	it('resolves header timeout policy ahead of type policy', () => {
+		const resolver = new HandoffRouteResolver(createService())
+
+		const resolution = resolver.resolve(
+			createMessage({
+				headers: {
+					policyTimeoutMs: '1000',
+					policyIdleTimeoutMs: '2000'
+				}
+			})
+		)
+
+		expect(resolution.policy).toEqual({
+			lane: 'main',
+			timeoutMs: 1000,
+			idleTimeoutMs: 2000
+		})
+	})
+
+	it('resolves type policy ahead of matching route target', () => {
+		const resolver = new HandoffRouteResolver(createService())
+
+		const resolution = resolver.resolve(createMessage())
+
+		expect(resolution.policy).toEqual({
+			lane: 'main',
+			timeoutMs: 600000,
+			idleTimeoutMs: 120000
+		})
+	})
+
+	it('resolves route target idle timeout when type policy is absent', () => {
+		const resolver = new HandoffRouteResolver(createService())
+
+		const resolution = resolver.resolve(
+			createMessage({
+				type: 'channel.wechat.chat_callback.v1'
+			})
+		)
+
+		expect(resolution.policy).toEqual({
+			lane: 'main',
+			idleTimeoutMs: 30000
+		})
+	})
+})

--- a/packages/server-ai/src/handoff/dispatcher/handoff-routing-config.service.ts
+++ b/packages/server-ai/src/handoff/dispatcher/handoff-routing-config.service.ts
@@ -73,6 +73,7 @@ const HandoffTypePolicySchema = z.object({
 	queue: z.string().min(1).optional(),
 	lane: z.string().min(1).optional(),
 	timeoutMs: z.number().int().positive().optional(),
+	idleTimeoutMs: z.number().int().positive().optional(),
 	retry: HandoffTypeRetryPolicySchema.optional(),
 	idempotency: HandoffTypeIdempotencyPolicySchema.optional()
 })
@@ -80,7 +81,8 @@ const HandoffTypePolicySchema = z.object({
 const HandoffRouteTargetSchema = z.object({
 	queue: z.string().min(1),
 	lane: z.string().min(1).optional(),
-	timeoutMs: z.number().int().positive().optional()
+	timeoutMs: z.number().int().positive().optional(),
+	idleTimeoutMs: z.number().int().positive().optional()
 })
 
 const HandoffRoutingFileSchema = z.object({
@@ -114,6 +116,7 @@ export interface HandoffRouteRule {
 		queue: HandoffQueueName
 		lane?: LaneName
 		timeoutMs?: number
+		idleTimeoutMs?: number
 	}
 }
 
@@ -148,6 +151,7 @@ export interface HandoffTypePolicy {
 	queue?: HandoffQueueName
 	lane?: LaneName
 	timeoutMs?: number
+	idleTimeoutMs?: number
 	retry?: HandoffTypeRetryPolicy
 	idempotency?: HandoffTypeIdempotencyPolicy
 }
@@ -265,7 +269,8 @@ export class HandoffRoutingConfigService implements OnModuleInit {
 								defaultLane
 						  )
 						: undefined,
-					timeoutMs: route.target.timeoutMs
+					timeoutMs: route.target.timeoutMs,
+					idleTimeoutMs: route.target.idleTimeoutMs
 				}
 			})),
 			queueAliases
@@ -349,9 +354,10 @@ export class HandoffRoutingConfigService implements OnModuleInit {
 							`typePolicies.${messageType}.lane`,
 							lanePolicy,
 							defaultLane
-					  )
+						  )
 					: undefined,
 				timeoutMs: typePolicy.timeoutMs,
+				idleTimeoutMs: typePolicy.idleTimeoutMs,
 				retry: typePolicy.retry,
 				idempotency: typePolicy.idempotency
 			}

--- a/packages/server-ai/src/handoff/message-dispatcher.service.spec.ts
+++ b/packages/server-ai/src/handoff/message-dispatcher.service.spec.ts
@@ -3,7 +3,11 @@ import { buildCanceledReason } from './cancel-reason'
 import { MessageDispatcherService } from './message-dispatcher.service'
 
 describe('MessageDispatcherService', () => {
-	const createMessage = (): HandoffMessage => ({
+	afterEach(() => {
+		jest.useRealTimers()
+	})
+
+	const createMessage = (overrides?: Partial<HandoffMessage>): HandoffMessage => ({
 		id: 'message-id',
 		type: 'agent.chat.v1',
 		version: 1,
@@ -14,7 +18,8 @@ describe('MessageDispatcherService', () => {
 		maxAttempts: 1,
 		enqueuedAt: Date.now(),
 		traceId: 'trace-id',
-		payload: {}
+		payload: {},
+		...overrides
 	})
 
 	it('dispatches message and forwards local events', async () => {
@@ -122,6 +127,190 @@ describe('MessageDispatcherService', () => {
 		)
 
 		const result = await service.dispatch(createMessage())
+
+		expect(result).toEqual({
+			status: 'dead',
+			reason: cancelReason
+		})
+		expect(handoffCancelService.unregister).toHaveBeenCalledWith('message-id')
+	})
+
+	it('aborts processing when policyTimeoutMs is exceeded', async () => {
+		jest.useFakeTimers()
+		const pendingResults = { publish: jest.fn() }
+		const process = jest.fn().mockImplementation(
+			(_message, ctx) =>
+				new Promise((resolve) => {
+					ctx.abortSignal.addEventListener(
+						'abort',
+						() => {
+							resolve({ status: 'ok' })
+						},
+						{ once: true }
+					)
+				})
+		)
+		const processorRegistry = {
+			get: jest.fn().mockReturnValue({ process })
+		}
+		const handoffCancelService = {
+			register: jest.fn(),
+			unregister: jest.fn(),
+			getCancelReason: jest.fn()
+		}
+		const service = new MessageDispatcherService(
+			processorRegistry as any,
+			pendingResults as any,
+			handoffCancelService as any
+		)
+
+		const resultPromise = service.dispatch(
+			createMessage({
+				headers: {
+					policyTimeoutMs: '25'
+				}
+			})
+		)
+		await jest.advanceTimersByTimeAsync(25)
+
+		await expect(resultPromise).resolves.toEqual({
+			status: 'dead',
+			reason: buildCanceledReason('Handoff total timeout after 25ms')
+		})
+		expect(handoffCancelService.unregister).toHaveBeenCalledWith('message-id')
+	})
+
+	it('aborts processing when policyIdleTimeoutMs is exceeded without heartbeat', async () => {
+		jest.useFakeTimers()
+		const pendingResults = { publish: jest.fn() }
+		const process = jest.fn().mockImplementation(
+			(_message, ctx) =>
+				new Promise((resolve) => {
+					ctx.abortSignal.addEventListener(
+						'abort',
+						() => {
+							resolve({ status: 'ok' })
+						},
+						{ once: true }
+					)
+				})
+		)
+		const processorRegistry = {
+			get: jest.fn().mockReturnValue({ process })
+		}
+		const handoffCancelService = {
+			register: jest.fn(),
+			unregister: jest.fn(),
+			getCancelReason: jest.fn()
+		}
+		const service = new MessageDispatcherService(
+			processorRegistry as any,
+			pendingResults as any,
+			handoffCancelService as any
+		)
+
+		const resultPromise = service.dispatch(
+			createMessage({
+				headers: {
+					policyIdleTimeoutMs: '25'
+				}
+			})
+		)
+		await jest.advanceTimersByTimeAsync(25)
+
+		await expect(resultPromise).resolves.toEqual({
+			status: 'dead',
+			reason: buildCanceledReason('Handoff idle timeout after 25ms')
+		})
+		expect(handoffCancelService.unregister).toHaveBeenCalledWith('message-id')
+	})
+
+	it('resets idle timeout when processors send heartbeat', async () => {
+		jest.useFakeTimers()
+		const pendingResults = { publish: jest.fn() }
+		const process = jest.fn().mockImplementation(
+			(_message, ctx) =>
+				new Promise((resolve) => {
+					setTimeout(() => {
+						ctx.heartbeat?.('progress')
+					}, 20)
+					setTimeout(() => {
+						resolve({ status: 'ok' })
+					}, 40)
+					ctx.abortSignal.addEventListener(
+						'abort',
+						() => {
+							resolve({ status: 'dead', reason: 'aborted' })
+						},
+						{ once: true }
+					)
+				})
+		)
+		const processorRegistry = {
+			get: jest.fn().mockReturnValue({ process })
+		}
+		const handoffCancelService = {
+			register: jest.fn(),
+			unregister: jest.fn(),
+			getCancelReason: jest.fn()
+		}
+		const service = new MessageDispatcherService(
+			processorRegistry as any,
+			pendingResults as any,
+			handoffCancelService as any
+		)
+
+		const resultPromise = service.dispatch(
+			createMessage({
+				headers: {
+					policyIdleTimeoutMs: '30'
+				}
+			})
+		)
+		await jest.advanceTimersByTimeAsync(40)
+
+		await expect(resultPromise).resolves.toEqual({ status: 'ok' })
+		expect(handoffCancelService.unregister).toHaveBeenCalledWith('message-id')
+	})
+
+	it('keeps manual cancel reason ahead of timeout reason', async () => {
+		jest.useFakeTimers()
+		const cancelReason = buildCanceledReason('Canceled by user')
+		const reasonByMessageId = new Map<string, string>()
+		const pendingResults = { publish: jest.fn() }
+		const process = jest.fn().mockImplementation(async (_message, ctx) => {
+			if (ctx.abortSignal.aborted) {
+				throw new Error('This operation was aborted')
+			}
+			return { status: 'ok' }
+		})
+		const processorRegistry = {
+			get: jest.fn().mockReturnValue({ process })
+		}
+		const handoffCancelService = {
+			register: jest.fn((messageId: string, controller: AbortController) => {
+				reasonByMessageId.set(messageId, cancelReason)
+				controller.abort()
+			}),
+			unregister: jest.fn((messageId: string) => {
+				reasonByMessageId.delete(messageId)
+			}),
+			getCancelReason: jest.fn((messageId: string) => reasonByMessageId.get(messageId))
+		}
+		const service = new MessageDispatcherService(
+			processorRegistry as any,
+			pendingResults as any,
+			handoffCancelService as any
+		)
+
+		const result = await service.dispatch(
+			createMessage({
+				headers: {
+					policyTimeoutMs: '25',
+					policyIdleTimeoutMs: '25'
+				}
+			})
+		)
 
 		expect(result).toEqual({
 			status: 'dead',

--- a/packages/server-ai/src/handoff/message-dispatcher.service.ts
+++ b/packages/server-ai/src/handoff/message-dispatcher.service.ts
@@ -31,6 +31,16 @@ export class MessageDispatcherService {
 		const resolved = this.processorRegistry.get(message.type, organizationId)
 		const runId = message.id
 		const abortController = new AbortController()
+		const timeoutPolicy = this.resolveTimeoutPolicy(message)
+		let localAbortReason: string | undefined
+		const abortWithReason = (reason: string) => {
+			if (abortController.signal.aborted) {
+				return
+			}
+			localAbortReason = reason
+			abortController.abort()
+		}
+		const timeoutTimers = this.startTimeoutTimers(timeoutPolicy, abortWithReason)
 		this.handoffCancelService.register(runId, abortController)
 
 		try {
@@ -38,6 +48,10 @@ export class MessageDispatcherService {
 				runId,
 				traceId: message.traceId,
 				abortSignal: abortController.signal,
+				heartbeat: () => {
+					timeoutTimers.heartbeat()
+				},
+				getAbortReason: () => this.resolveVisibleAbortReason(runId, localAbortReason),
 				emit: (event) => {
 					this.pendingResults.publish(message.id, event)
 				}
@@ -45,7 +59,7 @@ export class MessageDispatcherService {
 			if (abortController.signal.aborted) {
 				return {
 					status: 'dead',
-					reason: this.resolveCanceledReason(runId)
+					reason: this.resolveCanceledReason(runId, localAbortReason)
 				}
 			}
 			return result
@@ -53,21 +67,103 @@ export class MessageDispatcherService {
 			if (abortController.signal.aborted || isAbortLikeError(error)) {
 				return {
 					status: 'dead',
-					reason: this.resolveCanceledReason(runId, error)
+					reason: this.resolveCanceledReason(runId, localAbortReason, error)
 				}
 			}
 			throw error
 		} finally {
+			timeoutTimers.clear()
 			this.handoffCancelService.unregister(runId)
 		}
 	}
 
-	private resolveCanceledReason(messageId: string, error?: unknown): string {
+	private resolveCanceledReason(messageId: string, localAbortReason?: string, error?: unknown): string {
 		const reason = this.handoffCancelService.getCancelReason(messageId)
 		if (reason) {
 			return reason
 		}
+		if (localAbortReason) {
+			return buildCanceledReason(localAbortReason)
+		}
 		return buildCanceledReason(getErrorMessage(error))
+	}
+
+	private resolveVisibleAbortReason(messageId: string, localAbortReason?: string): string | undefined {
+		const reason = this.handoffCancelService.getCancelReason(messageId)
+		return this.stripCanceledReason(reason) ?? localAbortReason
+	}
+
+	private stripCanceledReason(reason?: string): string | undefined {
+		const prefix = 'canceled:'
+		if (!reason) {
+			return undefined
+		}
+		return reason.startsWith(prefix) ? reason.slice(prefix.length) : reason
+	}
+
+	private resolveTimeoutPolicy(message: HandoffMessage): {
+		timeoutMs?: number
+		idleTimeoutMs?: number
+	} {
+		return {
+			timeoutMs: this.parsePositiveIntegerHeader(message.headers?.policyTimeoutMs),
+			idleTimeoutMs: this.parsePositiveIntegerHeader(message.headers?.policyIdleTimeoutMs)
+		}
+	}
+
+	private parsePositiveIntegerHeader(value?: string): number | undefined {
+		if (!value) {
+			return undefined
+		}
+		const parsed = parseInt(value, 10)
+		return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+	}
+
+	private startTimeoutTimers(
+		policy: { timeoutMs?: number; idleTimeoutMs?: number },
+		abortWithReason: (reason: string) => void
+	): {
+		heartbeat: () => void
+		clear: () => void
+	} {
+		let totalTimer: ReturnType<typeof setTimeout> | undefined
+		let idleTimer: ReturnType<typeof setTimeout> | undefined
+
+		const clearIdleTimer = () => {
+			if (idleTimer) {
+				clearTimeout(idleTimer)
+				idleTimer = undefined
+			}
+		}
+		const scheduleIdleTimer = () => {
+			clearIdleTimer()
+			if (!policy.idleTimeoutMs) {
+				return
+			}
+			idleTimer = setTimeout(() => {
+				abortWithReason(`Handoff idle timeout after ${policy.idleTimeoutMs}ms`)
+			}, policy.idleTimeoutMs)
+		}
+
+		if (policy.timeoutMs) {
+			totalTimer = setTimeout(() => {
+				abortWithReason(`Handoff total timeout after ${policy.timeoutMs}ms`)
+			}, policy.timeoutMs)
+		}
+		scheduleIdleTimer()
+
+		return {
+			heartbeat: () => {
+				scheduleIdleTimer()
+			},
+			clear: () => {
+				if (totalTimer) {
+					clearTimeout(totalTimer)
+					totalTimer = undefined
+				}
+				clearIdleTimer()
+			}
+		}
 	}
 
 	private assertMessage(message: HandoffMessage) {

--- a/packages/server-ai/src/handoff/message-queue.service.spec.ts
+++ b/packages/server-ai/src/handoff/message-queue.service.spec.ts
@@ -1,0 +1,93 @@
+import { HandoffMessage } from '@xpert-ai/plugin-sdk'
+import { XPERT_HANDOFF_QUEUE_REALTIME } from './constants'
+import { HandoffQueueService } from './message-queue.service'
+
+describe('HandoffQueueService route policy headers', () => {
+	const createMessage = (overrides?: Partial<HandoffMessage>): HandoffMessage => ({
+		id: 'message-id',
+		type: 'agent.chat_dispatch.v1',
+		version: 1,
+		tenantId: 'tenant-id',
+		sessionKey: 'session-id',
+		businessKey: 'business-id',
+		attempt: 1,
+		maxAttempts: 1,
+		enqueuedAt: Date.now(),
+		traceId: 'trace-id',
+		payload: {},
+		...overrides
+	})
+
+	it('writes total and idle timeout policy headers when absent', async () => {
+		const queueGateway = {
+			enqueue: jest.fn().mockResolvedValue(undefined)
+		}
+		const routeResolver = {
+			resolve: jest.fn().mockReturnValue({
+				queue: XPERT_HANDOFF_QUEUE_REALTIME,
+				lane: 'main',
+				policy: {
+					lane: 'main',
+					timeoutMs: 600000,
+					idleTimeoutMs: 120000
+				}
+			})
+		}
+		const pendingResults = {}
+		const service = new HandoffQueueService(queueGateway as any, routeResolver as any, pendingResults as any)
+
+		await service.enqueue(createMessage())
+
+		expect(queueGateway.enqueue).toHaveBeenCalledWith(
+			XPERT_HANDOFF_QUEUE_REALTIME,
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					requestedLane: 'main',
+					handoffQueue: XPERT_HANDOFF_QUEUE_REALTIME,
+					policyTimeoutMs: '600000',
+					policyIdleTimeoutMs: '120000'
+				})
+			}),
+			undefined
+		)
+	})
+
+	it('keeps explicit timeout policy headers from the message', async () => {
+		const queueGateway = {
+			enqueue: jest.fn().mockResolvedValue(undefined)
+		}
+		const routeResolver = {
+			resolve: jest.fn().mockReturnValue({
+				queue: XPERT_HANDOFF_QUEUE_REALTIME,
+				lane: 'main',
+				policy: {
+					lane: 'main',
+					timeoutMs: 600000,
+					idleTimeoutMs: 120000
+				}
+			})
+		}
+		const pendingResults = {}
+		const service = new HandoffQueueService(queueGateway as any, routeResolver as any, pendingResults as any)
+
+		await service.enqueue(
+			createMessage({
+				headers: {
+					policyTimeoutMs: '1000',
+					policyIdleTimeoutMs: '2000'
+				}
+			})
+		)
+
+		expect(queueGateway.enqueue).toHaveBeenCalledWith(
+			XPERT_HANDOFF_QUEUE_REALTIME,
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					policyTimeoutMs: '1000',
+					policyIdleTimeoutMs: '2000'
+				})
+			}),
+			undefined
+		)
+	})
+})

--- a/packages/server-ai/src/handoff/message-queue.service.ts
+++ b/packages/server-ai/src/handoff/message-queue.service.ts
@@ -114,6 +114,9 @@ export class HandoffQueueService implements HandoffPermissionService {
 		if (route.policy.timeoutMs && !headers['policyTimeoutMs']) {
 			headers['policyTimeoutMs'] = String(route.policy.timeoutMs)
 		}
+		if (route.policy.idleTimeoutMs && !headers['policyIdleTimeoutMs']) {
+			headers['policyIdleTimeoutMs'] = String(route.policy.idleTimeoutMs)
+		}
 
 		return {
 			...message,

--- a/packages/server-ai/src/handoff/plugins/agent-chat/agent-chat-dispatch.processor.spec.ts
+++ b/packages/server-ai/src/handoff/plugins/agent-chat/agent-chat-dispatch.processor.spec.ts
@@ -312,6 +312,47 @@ describe('AgentChatDispatchHandoffProcessor', () => {
         expect(callbackPayloads.map((payload) => payload.kind)).toEqual(['stream', 'stream', 'complete'])
     })
 
+    it('heartbeats for handoff callback stream events', async () => {
+        const commandBus = { execute: jest.fn() }
+        const handoffQueueService = { enqueue: jest.fn().mockResolvedValue({ id: 'callback-job-id' }) }
+        const agentChatRealtime = { publish: jest.fn() }
+        const processor = new AgentChatDispatchHandoffProcessor(
+            commandBus as any,
+            handoffQueueService as any,
+            agentChatRealtime as any
+        )
+        const heartbeat = jest.fn()
+
+        commandBus.execute.mockResolvedValue(
+            of(
+                { data: { type: 'message', data: 'hello' } } as MessageEvent,
+                { data: { type: 'message', data: 'world' } } as MessageEvent
+            )
+        )
+
+        const result = await processor.process(
+            createMessage({
+                request: { input: { input: 'hello world' } },
+                options: { xpertId: 'xpert-id' },
+                callback: {
+                    messageType: 'channel.lark.chat_stream_event.v1'
+                }
+            }) as any,
+            {
+                ...createContext(),
+                heartbeat
+            } as any
+        )
+
+        expect(result).toEqual({ status: 'ok' })
+        expect(heartbeat.mock.calls.map(([reason]) => reason)).toEqual([
+            'agent_chat_dispatch_stream_start',
+            'agent_chat_dispatch_stream_event',
+            'agent_chat_dispatch_stream_event',
+            'agent_chat_dispatch_stream_complete'
+        ])
+    })
+
     it('emits error callback message when source observable fails', async () => {
         const commandBus = { execute: jest.fn() }
         const handoffQueueService = { enqueue: jest.fn().mockResolvedValue({ id: 'callback-job-id' }) }
@@ -388,6 +429,99 @@ describe('AgentChatDispatchHandoffProcessor', () => {
             'complete'
         ])
         expect(agentChatRealtime.publish.mock.calls.map(([, payload]) => payload.sequence)).toEqual([1, 2, 3])
+    })
+
+    it('heartbeats for redis pubsub stream events', async () => {
+        const commandBus = { execute: jest.fn() }
+        const handoffQueueService = { enqueue: jest.fn() }
+        const agentChatRealtime = { publish: jest.fn().mockResolvedValue(undefined) }
+        const processor = new AgentChatDispatchHandoffProcessor(
+            commandBus as any,
+            handoffQueueService as any,
+            agentChatRealtime as any
+        )
+        const heartbeat = jest.fn()
+
+        commandBus.execute.mockResolvedValue(
+            of(
+                { data: { type: 'message', data: 'hello' } } as MessageEvent,
+                { data: { type: 'message', data: 'world' } } as MessageEvent
+            )
+        )
+
+        const result = await processor.process(
+            createMessage({
+                request: { input: { input: 'hello world' } },
+                options: { xpertId: 'xpert-id' },
+                callback: {
+                    transport: 'redis-pubsub',
+                    context: { requestId: 'request-id' }
+                }
+            }) as any,
+            {
+                ...createContext(),
+                heartbeat
+            } as any
+        )
+
+        expect(result).toEqual({ status: 'ok' })
+        expect(heartbeat.mock.calls.map(([reason]) => reason)).toEqual([
+            'agent_chat_dispatch_stream_start',
+            'agent_chat_dispatch_stream_event',
+            'agent_chat_dispatch_stream_event',
+            'agent_chat_dispatch_stream_complete'
+        ])
+    })
+
+    it('enqueues abort callback with the dispatcher abort reason', async () => {
+        const commandBus = { execute: jest.fn() }
+        const handoffQueueService = { enqueue: jest.fn().mockResolvedValue({ id: 'callback-job-id' }) }
+        const agentChatRealtime = { publish: jest.fn() }
+        const processor = new AgentChatDispatchHandoffProcessor(
+            commandBus as any,
+            handoffQueueService as any,
+            agentChatRealtime as any
+        )
+        const abortController = new AbortController()
+        let markSubscribed!: () => void
+        const subscribed = new Promise<void>((resolve) => {
+            markSubscribed = resolve
+        })
+
+        commandBus.execute.mockResolvedValue(
+            new Observable<MessageEvent>(() => {
+                markSubscribed()
+            })
+        )
+
+        const resultPromise = processor.process(
+            createMessage({
+                request: { input: { input: 'hello world' } },
+                options: { xpertId: 'xpert-id' },
+                callback: {
+                    messageType: 'channel.wechat.chat_final_event.v1',
+                    context: { integrationId: 'integration-id' }
+                }
+            }) as any,
+            {
+                runId: 'run-id',
+                traceId: 'trace-id',
+                abortSignal: abortController.signal,
+                getAbortReason: () => 'Handoff idle timeout after 120000ms'
+            } as any
+        )
+
+        await subscribed
+        abortController.abort()
+
+        await expect(resultPromise).resolves.toEqual({ status: 'ok' })
+        expect(handoffQueueService.enqueue).toHaveBeenCalledTimes(1)
+        expect(handoffQueueService.enqueue.mock.calls[0][0].payload).toEqual(
+            expect.objectContaining({
+                kind: 'error',
+                error: 'Agent chat dispatch aborted: Handoff idle timeout after 120000ms'
+            })
+        )
     })
 
     it('publishes redis pubsub error when command dispatch fails before stream starts', async () => {

--- a/packages/server-ai/src/handoff/plugins/agent-chat/agent-chat-dispatch.processor.ts
+++ b/packages/server-ai/src/handoff/plugins/agent-chat/agent-chat-dispatch.processor.ts
@@ -197,7 +197,7 @@ export class AgentChatDispatchHandoffProcessor implements IHandoffProcessor<Agen
                 enqueueCallback({
                     kind: 'error',
                     sourceMessageId: sourceMessage.id,
-                    error: 'Agent chat dispatch aborted',
+                    error: this.getAbortError(ctx),
                     context: callback.context
                 }).finally(() => {
                     finish(() => resolve())
@@ -205,9 +205,11 @@ export class AgentChatDispatchHandoffProcessor implements IHandoffProcessor<Agen
             }
 
             ctx.abortSignal.addEventListener('abort', onAbort, { once: true })
+            ctx.heartbeat?.('agent_chat_dispatch_stream_start')
 
             subscription = observable.subscribe({
                 next: (event) => {
+                    ctx.heartbeat?.('agent_chat_dispatch_stream_event')
                     // this.logger.debug(`Received stream event for source message "${sourceMessage.id}"`, event)
                     enqueueCallback({
                         kind: 'stream',
@@ -223,6 +225,7 @@ export class AgentChatDispatchHandoffProcessor implements IHandoffProcessor<Agen
                         `Stream error for source message "${sourceMessage.id}": ${this.getErrorMessage(error)}`,
                         error instanceof Error ? error.stack : undefined
                     )
+                    ctx.heartbeat?.('agent_chat_dispatch_stream_error')
                     enqueueCallback({
                         kind: 'error',
                         sourceMessageId: sourceMessage.id,
@@ -238,6 +241,7 @@ export class AgentChatDispatchHandoffProcessor implements IHandoffProcessor<Agen
                 },
                 complete: () => {
                     this.logger.debug(`Stream completed for source message "${sourceMessage.id}"`)
+                    ctx.heartbeat?.('agent_chat_dispatch_stream_complete')
                     enqueueCallback({
                         kind: 'complete',
                         sourceMessageId: sourceMessage.id,
@@ -292,7 +296,7 @@ export class AgentChatDispatchHandoffProcessor implements IHandoffProcessor<Agen
                 publish({
                     kind: 'error',
                     sourceMessageId: sourceMessage.id,
-                    error: 'Agent chat dispatch aborted',
+                    error: this.getAbortError(ctx),
                     context: callback.context
                 }).finally(() => {
                     finish(() => resolve())
@@ -300,9 +304,11 @@ export class AgentChatDispatchHandoffProcessor implements IHandoffProcessor<Agen
             }
 
             ctx.abortSignal.addEventListener('abort', onAbort, { once: true })
+            ctx.heartbeat?.('agent_chat_dispatch_stream_start')
 
             subscription = observable.subscribe({
                 next: (event) => {
+                    ctx.heartbeat?.('agent_chat_dispatch_stream_event')
                     publish({
                         kind: 'stream',
                         sourceMessageId: sourceMessage.id,
@@ -317,6 +323,7 @@ export class AgentChatDispatchHandoffProcessor implements IHandoffProcessor<Agen
                         `Realtime stream error for source message "${sourceMessage.id}": ${this.getErrorMessage(error)}`,
                         error instanceof Error ? error.stack : undefined
                     )
+                    ctx.heartbeat?.('agent_chat_dispatch_stream_error')
                     publish({
                         kind: 'error',
                         sourceMessageId: sourceMessage.id,
@@ -332,6 +339,7 @@ export class AgentChatDispatchHandoffProcessor implements IHandoffProcessor<Agen
                 },
                 complete: () => {
                     this.logger.debug(`Realtime stream completed for source message "${sourceMessage.id}"`)
+                    ctx.heartbeat?.('agent_chat_dispatch_stream_complete')
                     publish({
                         kind: 'complete',
                         sourceMessageId: sourceMessage.id,
@@ -557,6 +565,11 @@ export class AgentChatDispatchHandoffProcessor implements IHandoffProcessor<Agen
         return (
             !!callback && callback.transport !== 'redis-pubsub' && 'messageType' in callback && !!callback.messageType
         )
+    }
+
+    private getAbortError(ctx: ProcessContext): string {
+        const reason = ctx.getAbortReason?.()
+        return reason ? `Agent chat dispatch aborted: ${reason}` : 'Agent chat dispatch aborted'
     }
 
     private getErrorMessage(error: unknown): string {

--- a/packages/server-ai/src/membership/membership.module.ts
+++ b/packages/server-ai/src/membership/membership.module.ts
@@ -8,11 +8,12 @@ import { MembershipPlan } from './membership-plan.entity'
 import { MembershipPointLedger } from './membership-point-ledger.entity'
 import { MembershipService } from './membership.service'
 import { UserMembership } from './user-membership.entity'
+import { Xpert } from '../xpert/xpert.entity'
 
 @Module({
     imports: [
         RouterModule.register([{ path: '/membership', module: MembershipModule }]),
-        TypeOrmModule.forFeature([MembershipPlan, UserMembership, MembershipPointLedger]),
+        TypeOrmModule.forFeature([MembershipPlan, UserMembership, MembershipPointLedger, Xpert]),
         TenantModule,
         CqrsModule
     ],

--- a/packages/server-ai/src/membership/membership.service.spec.ts
+++ b/packages/server-ai/src/membership/membership.service.spec.ts
@@ -1,10 +1,22 @@
+jest.mock('../xpert/xpert.entity', () => ({
+    Xpert: class Xpert {}
+}))
+
 import { MembershipService } from './membership.service'
+import { MembershipPointLedger } from './membership-point-ledger.entity'
+import { UserMembership } from './user-membership.entity'
+import { Xpert } from '../xpert/xpert.entity'
 
 describe('MembershipService', () => {
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
     function createQueryBuilder(rawRows: Array<Record<string, unknown>>) {
         return {
             select: jest.fn().mockReturnThis(),
             addSelect: jest.fn().mockReturnThis(),
+            leftJoin: jest.fn().mockReturnThis(),
             where: jest.fn().mockReturnThis(),
             andWhere: jest.fn().mockReturnThis(),
             groupBy: jest.fn().mockReturnThis(),
@@ -13,6 +25,34 @@ describe('MembershipService', () => {
             take: jest.fn().mockReturnThis(),
             skip: jest.fn().mockReturnThis(),
             getRawMany: jest.fn().mockResolvedValue(rawRows)
+        }
+    }
+
+    function createMembership(overrides: Partial<UserMembership> = {}) {
+        return {
+            id: 'membership-owner',
+            tenantId: 'tenant-1',
+            userId: 'owner-user',
+            planId: 'plan-1',
+            status: 'active',
+            currentPeriodStart: new Date('2026-07-01T00:00:00.000Z'),
+            currentPeriodEnd: new Date('2026-08-01T00:00:00.000Z'),
+            pointsGranted: 100,
+            pointsUsed: 2,
+            pointsTotalUsed: 0,
+            plan: {
+                id: 'plan-1',
+                tenantId: 'tenant-1',
+                code: 'default',
+                name: 'Default',
+                status: 'active',
+                period: 'monthly',
+                includedPoints: 100,
+                tokensPerPoint: 1000,
+                modelMultipliers: [],
+                rateLimits: []
+            },
+            ...overrides
         }
     }
 
@@ -30,7 +70,7 @@ describe('MembershipService', () => {
         const manager = {
             getRepository: jest.fn().mockReturnValue(repository)
         }
-        const service = new MembershipService({} as never, {} as never, {} as never, {} as never)
+        const service = new MembershipService({} as never, {} as never, {} as never, {} as never, {} as never)
 
         await (
             service as unknown as { findActiveMembershipForUpdate: (...args: unknown[]) => Promise<unknown> }
@@ -56,6 +96,9 @@ describe('MembershipService', () => {
                 xpertId: 'xpert-1',
                 threadId: 'thread-1',
                 copilotId: 'copilot-1',
+                conversationTitle: 'Quarterly Planning',
+                xpertTitle: 'Research Assistant',
+                xpertName: 'research-assistant',
                 callCount: '9',
                 pointsDelta: '-14',
                 pointsUsed: '14',
@@ -68,7 +111,13 @@ describe('MembershipService', () => {
         const ledgerRepository = {
             createQueryBuilder: jest.fn().mockReturnValue(queryBuilder)
         }
-        const service = new MembershipService({} as never, {} as never, {} as never, ledgerRepository as never)
+        const service = new MembershipService(
+            {} as never,
+            {} as never,
+            {} as never,
+            ledgerRepository as never,
+            {} as never
+        )
 
         const result = await service.findUserUsageSummaries('tenant-1', 'user-1', undefined, { take: 20, skip: 0 })
 
@@ -81,6 +130,9 @@ describe('MembershipService', () => {
             xpertId: 'xpert-1',
             threadId: 'thread-1',
             copilotId: 'copilot-1',
+            conversationTitle: 'Quarterly Planning',
+            xpertTitle: 'Research Assistant',
+            xpertName: 'research-assistant',
             callCount: 9,
             pointsDelta: -14,
             pointsUsed: 14,
@@ -96,10 +148,208 @@ describe('MembershipService', () => {
             }
         })
         expect(queryBuilder.andWhere).toHaveBeenCalledWith('ledger.source = :source', { source: 'usage' })
+        expect(queryBuilder.leftJoin).toHaveBeenCalledWith(
+            'chat_conversation',
+            'conversation',
+            '"conversation"."tenantId" = ledger."tenantId" AND "conversation"."threadId" = ledger."threadId"'
+        )
+        expect(queryBuilder.leftJoin).toHaveBeenCalledWith(
+            'xpert',
+            'usage_xpert',
+            '"usage_xpert"."tenantId" = ledger."tenantId" AND "usage_xpert"."id"::text = ledger."xpertId"'
+        )
         expect(queryBuilder.groupBy).toHaveBeenCalledWith('ledger.usageHour')
         expect(queryBuilder.addGroupBy).toHaveBeenCalledWith('ledger.provider')
         expect(queryBuilder.addGroupBy).toHaveBeenCalledWith('ledger.model')
         expect(queryBuilder.addGroupBy).toHaveBeenCalledWith('ledger.threadId')
         expect(queryBuilder.orderBy).toHaveBeenCalledWith('MAX(ledger.createdAt)', 'DESC')
+    })
+
+    it('records xpert usage against the xpert creator membership', async () => {
+        const xpertRepository = {
+            findOne: jest.fn().mockResolvedValue({
+                id: 'xpert-1',
+                createdById: 'owner-user'
+            })
+        }
+        const membershipRepository = {
+            save: jest.fn().mockImplementation(async (membership) => membership)
+        }
+        const manager = {
+            getRepository: jest.fn((entity) => {
+                if (entity === Xpert) {
+                    return xpertRepository
+                }
+                if (entity === UserMembership) {
+                    return membershipRepository
+                }
+                return {}
+            })
+        }
+        const dataSource = {
+            transaction: jest.fn((callback) => callback(manager))
+        }
+        const service = new MembershipService(dataSource as never, {} as never, {} as never, {} as never, {} as never)
+        const membership = createMembership()
+        jest.spyOn(service as any, 'ensureActiveMembership').mockResolvedValue(membership)
+        const createLedger = jest
+            .spyOn(service as any, 'createLedger')
+            .mockImplementation(async (_manager, input) => input as MembershipPointLedger)
+
+        const ledger = await service.recordUsage({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            userId: 'assistant-tech-user',
+            xpertId: 'xpert-1',
+            threadId: 'thread-1',
+            copilotId: 'copilot-1',
+            provider: 'tongyi',
+            model: 'qwen3.6-plus',
+            tokenUsed: 2500
+        })
+
+        expect(xpertRepository.findOne).toHaveBeenCalledWith({
+            where: {
+                tenantId: 'tenant-1',
+                id: 'xpert-1'
+            },
+            select: {
+                id: true,
+                createdById: true
+            }
+        })
+        expect((service as any).ensureActiveMembership).toHaveBeenCalledWith('tenant-1', 'owner-user', manager, true)
+        expect(membershipRepository.save).toHaveBeenCalledWith(expect.objectContaining({ pointsUsed: 5 }))
+        expect(createLedger).toHaveBeenCalledWith(
+            manager,
+            expect.objectContaining({
+                tenantId: 'tenant-1',
+                userId: 'owner-user',
+                membershipId: 'membership-owner',
+                planId: 'plan-1',
+                source: 'usage',
+                pointsDelta: -3,
+                tokenUsed: 2500,
+                xpertId: 'xpert-1',
+                threadId: 'thread-1',
+                copilotId: 'copilot-1'
+            })
+        )
+        expect(ledger).toMatchObject({
+            userId: 'owner-user',
+            xpertId: 'xpert-1',
+            threadId: 'thread-1',
+            copilotId: 'copilot-1',
+            tokenUsed: 2500
+        })
+    })
+
+    it('uses the xpert creator when checking membership limits', async () => {
+        const xpertRepository = {
+            findOne: jest.fn().mockResolvedValue({
+                id: 'xpert-1',
+                createdById: 'owner-user'
+            })
+        }
+        const service = new MembershipService(
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            xpertRepository as never
+        )
+        const membership = createMembership({ pointsUsed: 0 })
+        jest.spyOn(service as any, 'ensureActiveMembership').mockResolvedValue(membership)
+
+        await service.assertCanUse({
+            tenantId: 'tenant-1',
+            userId: 'assistant-tech-user',
+            xpertId: 'xpert-1',
+            provider: 'tongyi',
+            model: 'qwen3.6-plus'
+        })
+
+        expect((service as any).ensureActiveMembership).toHaveBeenCalledWith('tenant-1', 'owner-user')
+    })
+
+    it('falls back to the runtime user when xpert has no creator', async () => {
+        const xpertRepository = {
+            findOne: jest.fn().mockResolvedValue({
+                id: 'xpert-1',
+                createdById: null
+            })
+        }
+        const service = new MembershipService(
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            xpertRepository as never
+        )
+        const membership = createMembership({ userId: 'assistant-tech-user', pointsUsed: 0 })
+        jest.spyOn(service as any, 'ensureActiveMembership').mockResolvedValue(membership)
+
+        await service.assertCanUse({
+            tenantId: 'tenant-1',
+            userId: 'assistant-tech-user',
+            xpertId: 'xpert-1'
+        })
+
+        expect((service as any).ensureActiveMembership).toHaveBeenCalledWith('tenant-1', 'assistant-tech-user')
+    })
+
+    it('keeps non-xpert usage on the runtime user', async () => {
+        const xpertRepository = {
+            findOne: jest.fn()
+        }
+        const membershipRepository = {
+            save: jest.fn().mockImplementation(async (membership) => membership)
+        }
+        const manager = {
+            getRepository: jest.fn((entity) => {
+                if (entity === UserMembership) {
+                    return membershipRepository
+                }
+                return {}
+            })
+        }
+        const dataSource = {
+            transaction: jest.fn((callback) => callback(manager))
+        }
+        const service = new MembershipService(
+            dataSource as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            xpertRepository as never
+        )
+        const membership = createMembership({ userId: 'assistant-tech-user' })
+        jest.spyOn(service as any, 'ensureActiveMembership').mockResolvedValue(membership)
+        const createLedger = jest
+            .spyOn(service as any, 'createLedger')
+            .mockImplementation(async (_manager, input) => input as MembershipPointLedger)
+
+        await service.recordUsage({
+            tenantId: 'tenant-1',
+            userId: 'assistant-tech-user',
+            provider: 'tongyi',
+            model: 'qwen3.6-plus',
+            tokenUsed: 1000
+        })
+
+        expect(xpertRepository.findOne).not.toHaveBeenCalled()
+        expect((service as any).ensureActiveMembership).toHaveBeenCalledWith(
+            'tenant-1',
+            'assistant-tech-user',
+            manager,
+            true
+        )
+        expect(createLedger).toHaveBeenCalledWith(
+            manager,
+            expect.objectContaining({
+                userId: 'assistant-tech-user',
+                tokenUsed: 1000
+            })
+        )
     })
 })

--- a/packages/server-ai/src/membership/membership.service.ts
+++ b/packages/server-ai/src/membership/membership.service.ts
@@ -20,6 +20,7 @@ import { formatInUTC0 } from '../shared/utils'
 import { MembershipPlan } from './membership-plan.entity'
 import { MembershipPointLedger } from './membership-point-ledger.entity'
 import { UserMembership } from './user-membership.entity'
+import { Xpert } from '../xpert/xpert.entity'
 
 const DEFAULT_PLAN_CODE = 'default'
 const DEFAULT_PLAN_NAME = 'Default'
@@ -39,6 +40,8 @@ type RecordUsageInput = {
     copilotId?: string
 }
 
+type BillableUserInput = Pick<RecordUsageInput, 'tenantId' | 'userId' | 'xpertId'>
+
 type MembershipWithPlan = UserMembership & { plan: MembershipPlan }
 
 type NumericRaw = Record<string, string | number | null | undefined>
@@ -51,6 +54,9 @@ type MembershipUsageSummaryRaw = NumericRaw & {
     xpertId?: string | null
     threadId?: string | null
     copilotId?: string | null
+    conversationTitle?: string | null
+    xpertTitle?: string | null
+    xpertName?: string | null
     firstUsedAt?: Date | string | null
     lastUsedAt?: Date | string | null
 }
@@ -93,7 +99,9 @@ export class MembershipService {
         @InjectRepository(UserMembership)
         private readonly membershipRepository: Repository<UserMembership>,
         @InjectRepository(MembershipPointLedger)
-        private readonly ledgerRepository: Repository<MembershipPointLedger>
+        private readonly ledgerRepository: Repository<MembershipPointLedger>,
+        @InjectRepository(Xpert)
+        private readonly xpertRepository: Repository<Xpert>
     ) {}
 
     async findPlans(): Promise<MembershipPlan[]> {
@@ -402,6 +410,9 @@ export class MembershipService {
                 .addSelect('ledger.xpertId', 'xpertId')
                 .addSelect('ledger.threadId', 'threadId')
                 .addSelect('ledger.copilotId', 'copilotId')
+                .addSelect('MAX(conversation.title)', 'conversationTitle')
+                .addSelect('MAX(usage_xpert.title)', 'xpertTitle')
+                .addSelect('MAX(usage_xpert.name)', 'xpertName')
                 .addSelect('COUNT(ledger.id)', 'callCount')
                 .addSelect('COALESCE(SUM(ledger.pointsDelta), 0)', 'pointsDelta')
                 .addSelect('COALESCE(SUM(ABS(ledger.pointsDelta)), 0)', 'pointsUsed')
@@ -409,6 +420,16 @@ export class MembershipService {
                 .addSelect('MIN(ledger.createdAt)', 'firstUsedAt')
                 .addSelect('MAX(ledger.createdAt)', 'lastUsedAt')
                 .addSelect('COUNT(*) OVER()', 'total')
+                .leftJoin(
+                    'chat_conversation',
+                    'conversation',
+                    `"conversation"."tenantId" = ledger."tenantId" AND "conversation"."threadId" = ledger."threadId"`
+                )
+                .leftJoin(
+                    'xpert',
+                    'usage_xpert',
+                    `"usage_xpert"."tenantId" = ledger."tenantId" AND "usage_xpert"."id"::text = ledger."xpertId"`
+                )
                 .where('ledger.tenantId = :tenantId', { tenantId })
                 .andWhere('ledger.userId = :userId', { userId })
                 .andWhere('ledger.source = :source', { source: MembershipLedgerSourceEnum.Usage })
@@ -459,8 +480,11 @@ export class MembershipService {
         return { items, total }
     }
 
-    async assertCanUse(input: Pick<RecordUsageInput, 'tenantId' | 'userId' | 'provider' | 'model'>): Promise<void> {
-        const membership = await this.ensureActiveMembership(input.tenantId, input.userId)
+    async assertCanUse(
+        input: Pick<RecordUsageInput, 'tenantId' | 'userId' | 'xpertId' | 'provider' | 'model'>
+    ): Promise<void> {
+        const billableUserId = await this.resolveBillableUserId(input)
+        const membership = await this.ensureActiveMembership(input.tenantId, billableUserId)
         if (this.pointsRemaining(membership) <= 0) {
             throw new ExceedingLimitException('Membership points limit exceeded.')
         }
@@ -475,13 +499,14 @@ export class MembershipService {
 
         let exceeded = false
         const ledger = await this.dataSource.transaction(async (manager) => {
-            const membership = await this.ensureActiveMembership(input.tenantId, input.userId, manager, true)
+            const billableUserId = await this.resolveBillableUserId(input, manager)
+            const membership = await this.ensureActiveMembership(input.tenantId, billableUserId, manager, true)
             const pointsUsed = this.calculatePoints(tokenUsed, membership.plan, input.provider, input.model)
             membership.pointsUsed = (membership.pointsUsed ?? 0) + pointsUsed
             const saved = await manager.getRepository(UserMembership).save(membership)
             const ledger = await this.createLedger(manager, {
                 tenantId: input.tenantId,
-                userId: input.userId,
+                userId: billableUserId,
                 membershipId: saved.id,
                 planId: saved.planId,
                 source: MembershipLedgerSourceEnum.Usage,
@@ -508,6 +533,27 @@ export class MembershipService {
         }
 
         return ledger
+    }
+
+    private async resolveBillableUserId(input: BillableUserInput, manager?: EntityManager): Promise<string> {
+        const xpertId = input.xpertId?.trim()
+        if (!xpertId) {
+            return input.userId
+        }
+
+        const repository = manager?.getRepository(Xpert) ?? this.xpertRepository
+        const xpert = await repository.findOne({
+            where: {
+                tenantId: input.tenantId,
+                id: xpertId
+            },
+            select: {
+                id: true,
+                createdById: true
+            }
+        })
+
+        return xpert?.createdById ?? input.userId
     }
 
     calculatePoints(tokenUsed: number, plan: MembershipPlan, provider?: string, model?: string): number {
@@ -830,6 +876,9 @@ export class MembershipService {
         return {
             ...groupKey,
             groupKey,
+            conversationTitle: row.conversationTitle,
+            xpertTitle: row.xpertTitle,
+            xpertName: row.xpertName,
             callCount: toNumber(row.callCount),
             pointsDelta: toNumber(row.pointsDelta),
             pointsUsed: toNumber(row.pointsUsed),

--- a/packages/server-ai/src/xpert-workspace/workspace-base.service.spec.ts
+++ b/packages/server-ai/src/xpert-workspace/workspace-base.service.spec.ts
@@ -1,9 +1,14 @@
 import { FindManyOptions, FindOptionsWhere, In, IsNull, Repository } from 'typeorm'
+import { RequestContext } from '@xpert-ai/server-core'
 import { WorkspaceBaseEntity } from '../core/entities/base.entity'
 import { XpertWorkspaceAccessService } from './workspace-access.service'
 import { XpertWorkspaceBaseService } from './workspace-base.service'
 
 describe('XpertWorkspaceBaseService', () => {
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
     it('queries tenant-level records from the requested tenant workspace in organization scope', async () => {
         const findAndCount = jest.fn().mockResolvedValue([[], 0])
         const repository = {
@@ -44,5 +49,45 @@ describe('XpertWorkspaceBaseService', () => {
         expect(scopedWhere.workspaceId).toBe('workspace-1')
         expect(scopedWhere.tenantId).toBe('tenant-1')
         expect(scopedWhere.organizationId).toEqual(IsNull())
+    })
+
+    it('keeps findOne readable when select omits scope fields', async () => {
+        jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
+        jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('org-1')
+
+        const findOne = jest.fn().mockResolvedValue({
+            id: 'xpert-1',
+            createdById: 'user-1',
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            workspaceId: null
+        })
+        const repository = {
+            findOne
+        } as Pick<Repository<WorkspaceBaseEntity>, 'findOne'>
+        const assertCan = jest.fn()
+        const workspaceAccessService = {
+            assertCan
+        } as Pick<XpertWorkspaceAccessService, 'assertCan'>
+        const service = new XpertWorkspaceBaseService(
+            repository as Repository<WorkspaceBaseEntity>,
+            workspaceAccessService as XpertWorkspaceAccessService
+        )
+
+        const result = await service.findOne('xpert-1', {
+            select: ['id', 'createdById'] as never
+        })
+
+        const options = findOne.mock.calls[0][0]
+        expect(options.select).toEqual(['id', 'createdById', 'tenantId', 'organizationId', 'workspaceId'])
+        expect(options.where).toEqual({
+            id: 'xpert-1',
+            tenantId: 'tenant-1'
+        })
+        expect(assertCan).not.toHaveBeenCalled()
+        expect(result).toEqual({
+            id: 'xpert-1',
+            createdById: 'user-1'
+        })
     })
 })

--- a/packages/server-ai/src/xpert-workspace/workspace-base.service.ts
+++ b/packages/server-ai/src/xpert-workspace/workspace-base.service.ts
@@ -1,368 +1,430 @@
 import { IPagination, IUser } from '@xpert-ai/contracts'
-import { PaginationParams, RequestContext, TenantOrganizationAwareCrudService, transformWhere } from '@xpert-ai/server-core'
+import {
+    PaginationParams,
+    RequestContext,
+    TenantOrganizationAwareCrudService,
+    transformWhere
+} from '@xpert-ai/server-core'
 import { BadRequestException, ForbiddenException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import {
-	DeepPartial,
-	DeleteResult,
-	FindManyOptions,
-	FindOneOptions,
-	FindOptionsWhere,
-	IsNull,
-	Not,
-	Repository,
-	UpdateResult
+    DeepPartial,
+    DeleteResult,
+    FindManyOptions,
+    FindOneOptions,
+    FindOptionsWhere,
+    IsNull,
+    Not,
+    Repository,
+    UpdateResult
 } from 'typeorm'
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity'
 import { WorkspaceBaseEntity } from '../core/entities/base.entity'
-import { XpertWorkspaceAccessAction, XpertWorkspaceAccessResult, XpertWorkspaceAccessService } from './workspace-access.service'
+import {
+    XpertWorkspaceAccessAction,
+    XpertWorkspaceAccessResult,
+    XpertWorkspaceAccessService
+} from './workspace-access.service'
 import { XpertWorkspace } from './workspace.entity'
 
+const READABLE_SCOPE_SELECT_FIELDS = ['tenantId', 'organizationId', 'workspaceId'] as const
+
 type WorkspaceScopedPartial<T extends WorkspaceBaseEntity> = DeepPartial<T> & {
-	id?: string | number
-	workspaceId?: string | null
-	tenantId?: string | null
-	organizationId?: string | null
-	createdById?: string | null
-	updatedById?: string | null
+    id?: string | number
+    workspaceId?: string | null
+    tenantId?: string | null
+    organizationId?: string | null
+    createdById?: string | null
+    updatedById?: string | null
 }
 
 @Injectable()
 export class XpertWorkspaceBaseService<T extends WorkspaceBaseEntity> extends TenantOrganizationAwareCrudService<T> {
-	readonly #logger = new Logger(XpertWorkspaceBaseService.name)
+    readonly #logger = new Logger(XpertWorkspaceBaseService.name)
 
-	@Inject(CommandBus)
-	protected readonly commandBus: CommandBus
-	@Inject(QueryBus)
-	protected readonly queryBus: QueryBus
+    @Inject(CommandBus)
+    protected readonly commandBus: CommandBus
+    @Inject(QueryBus)
+    protected readonly queryBus: QueryBus
 
-	constructor(
-		repository: Repository<T>,
-		protected readonly workspaceAccessService: XpertWorkspaceAccessService
-	) {
-		super(repository)
-	}
+    constructor(
+        repository: Repository<T>,
+        protected readonly workspaceAccessService: XpertWorkspaceAccessService
+    ) {
+        super(repository)
+    }
 
-	async getAllByWorkspace(workspaceId: string, data: PaginationParams<T>, published: boolean, user: IUser) {
-		const { select, relations, order, take } = data ?? {}
-		let { where } = data ?? {}
-		where = transformWhere(where ?? {})
+    async getAllByWorkspace(workspaceId: string, data: PaginationParams<T>, published: boolean, user: IUser) {
+        const { select, relations, order, take } = data ?? {}
+        let { where } = data ?? {}
+        where = transformWhere(where ?? {})
 
-		if (this.isEmptyWorkspaceId(workspaceId)) {
-			where = {
-				...(where as FindOptionsWhere<T>),
-				workspaceId: IsNull(),
-				createdById: user.id
-			}
-		} else {
-			await this.assertWorkspaceReadAccess(workspaceId)
-			where = {
-				...(where as FindOptionsWhere<T>),
-				workspaceId
-			}
-		}
+        if (this.isEmptyWorkspaceId(workspaceId)) {
+            where = {
+                ...(where as FindOptionsWhere<T>),
+                workspaceId: IsNull(),
+                createdById: user.id
+            }
+        } else {
+            await this.assertWorkspaceReadAccess(workspaceId)
+            where = {
+                ...(where as FindOptionsWhere<T>),
+                workspaceId
+            }
+        }
 
-		if (published) {
-			where.publishAt = Not(IsNull())
-		}
+        if (published) {
+            where.publishAt = Not(IsNull())
+        }
 
-		return this.findAll({
-			select,
-			where,
-			relations,
-			order,
-			take
-		})
-	}
+        return this.findAll({
+            select,
+            where,
+            relations,
+            order,
+            take
+        })
+    }
 
-	public async findAll(filter?: FindManyOptions<T>): Promise<IPagination<T>> {
-		const scopedFilter = await this.resolveWorkspaceScopedFindManyOptions(filter)
-		if (!scopedFilter) {
-			return super.findAll(filter)
-		}
+    public async findAll(filter?: FindManyOptions<T>): Promise<IPagination<T>> {
+        const scopedFilter = await this.resolveWorkspaceScopedFindManyOptions(filter)
+        if (!scopedFilter) {
+            return super.findAll(filter)
+        }
 
-		const [items, total] = await this.repository.findAndCount(scopedFilter)
-		return { items, total }
-	}
+        const [items, total] = await this.repository.findAndCount(scopedFilter)
+        return { items, total }
+    }
 
-	public async findOne(id: string | number | FindOneOptions<T>, options?: FindOneOptions<T>): Promise<T> {
-		if (typeof id === 'string' || typeof id === 'number') {
-			const record = await this.repository.findOne({
-				...(options ?? {}),
-				where: this.mergeFindOneWhereWithTenant(id, options?.where)
-			})
-			return this.assertRecordReadable(record)
-		}
+    public async findOne(id: string | number | FindOneOptions<T>, options?: FindOneOptions<T>): Promise<T> {
+        if (typeof id === 'string' || typeof id === 'number') {
+            const scopedSelect = this.withReadableScopeSelect(options)
+            const record = await this.repository.findOne({
+                ...(scopedSelect.options ?? {}),
+                where: this.mergeFindOneWhereWithTenant(id, options?.where)
+            })
+            return this.stripReadableScopeSelectFields(
+                await this.assertRecordReadable(record),
+                scopedSelect.addedFields
+            )
+        }
 
-		const record = await this.repository.findOne(id)
-		return this.assertRecordReadable(record)
-	}
+        const scopedSelect = this.withReadableScopeSelect(id)
+        const record = await this.repository.findOne(scopedSelect.options)
+        return this.stripReadableScopeSelectFields(await this.assertRecordReadable(record), scopedSelect.addedFields)
+    }
 
-	public async findOneByIdString(id: string, options?: FindOneOptions<T>): Promise<T> {
-		return this.findOne(id, options)
-	}
+    public async findOneByIdString(id: string, options?: FindOneOptions<T>): Promise<T> {
+        return this.findOne(id, options)
+    }
 
-	public async create(entity: DeepPartial<T>, ...options: unknown[]): Promise<T> {
-		const workspaceId = this.getEntityWorkspaceId(entity)
-		if (!workspaceId) {
-			return super.create(entity, ...options)
-		}
+    public async create(entity: DeepPartial<T>, ...options: unknown[]): Promise<T> {
+        const workspaceId = this.getEntityWorkspaceId(entity)
+        if (!workspaceId) {
+            return super.create(entity, ...options)
+        }
 
-		const { workspace } = await this.assertWorkspaceWriteAccess(workspaceId)
-		return this.createInWorkspaceScope(this.applyWorkspaceScope(entity, workspace))
-	}
+        const { workspace } = await this.assertWorkspaceWriteAccess(workspaceId)
+        return this.createInWorkspaceScope(this.applyWorkspaceScope(entity, workspace))
+    }
 
-	public async save(entity: DeepPartial<T>): Promise<T> {
-		const workspaceId = this.getEntityWorkspaceId(entity)
-		if (!workspaceId) {
-			return super.save(entity)
-		}
+    public async save(entity: DeepPartial<T>): Promise<T> {
+        const workspaceId = this.getEntityWorkspaceId(entity)
+        if (!workspaceId) {
+            return super.save(entity)
+        }
 
-		const { workspace } = await this.assertWorkspaceWriteAccess(workspaceId)
-		return this.repository.save(this.applyWorkspaceScope(entity, workspace))
-	}
+        const { workspace } = await this.assertWorkspaceWriteAccess(workspaceId)
+        return this.repository.save(this.applyWorkspaceScope(entity, workspace))
+    }
 
-	public async update(
-		id: string | number | FindOptionsWhere<T>,
-		partialEntity: QueryDeepPartialEntity<T>,
-		...options: unknown[]
-	): Promise<UpdateResult | T> {
-		if (typeof id !== 'string') {
-			return super.update(id, partialEntity, ...options)
-		}
+    public async update(
+        id: string | number | FindOptionsWhere<T>,
+        partialEntity: QueryDeepPartialEntity<T>,
+        ...options: unknown[]
+    ): Promise<UpdateResult | T> {
+        if (typeof id !== 'string') {
+            return super.update(id, partialEntity, ...options)
+        }
 
-		const current = await this.findOneByIdString(id)
-		const mutationWorkspaceId = this.getMutationWorkspaceId(partialEntity)
-		const targetWorkspaceId = mutationWorkspaceId === undefined ? current.workspaceId : mutationWorkspaceId
+        const current = await this.findOneByIdString(id)
+        const mutationWorkspaceId = this.getMutationWorkspaceId(partialEntity)
+        const targetWorkspaceId = mutationWorkspaceId === undefined ? current.workspaceId : mutationWorkspaceId
 
-		if (!targetWorkspaceId) {
-			if (current.workspaceId) {
-				await this.assertWorkspaceWriteAccess(current.workspaceId)
-			}
-			return super.update(id, partialEntity, ...options)
-		}
+        if (!targetWorkspaceId) {
+            if (current.workspaceId) {
+                await this.assertWorkspaceWriteAccess(current.workspaceId)
+            }
+            return super.update(id, partialEntity, ...options)
+        }
 
-		const { workspace } = await this.assertWorkspaceWriteAccess(targetWorkspaceId)
-		const scopedEntity = this.applyWorkspaceScope(partialEntity as WorkspaceScopedPartial<T>, workspace)
-		Object.assign(current, scopedEntity, {
-			updatedById: RequestContext.currentUserId() ?? current.updatedById
-		})
+        const { workspace } = await this.assertWorkspaceWriteAccess(targetWorkspaceId)
+        const scopedEntity = this.applyWorkspaceScope(partialEntity as WorkspaceScopedPartial<T>, workspace)
+        Object.assign(current, scopedEntity, {
+            updatedById: RequestContext.currentUserId() ?? current.updatedById
+        })
 
-		return this.repository.save(current)
-	}
+        return this.repository.save(current)
+    }
 
-	public async delete(criteria: string | FindOptionsWhere<T>): Promise<DeleteResult> {
-		if (typeof criteria === 'string') {
-			const record = await this.findOneByIdString(criteria)
-			if (record.workspaceId) {
-				await this.assertWorkspaceWriteAccess(record.workspaceId)
-			}
-		}
+    public async delete(criteria: string | FindOptionsWhere<T>): Promise<DeleteResult> {
+        if (typeof criteria === 'string') {
+            const record = await this.findOneByIdString(criteria)
+            if (record.workspaceId) {
+                await this.assertWorkspaceWriteAccess(record.workspaceId)
+            }
+        }
 
-		return super.delete(criteria)
-	}
+        return super.delete(criteria)
+    }
 
-	public async softDelete(criteria: string | number | FindOptionsWhere<T>): Promise<UpdateResult | T> {
-		if (typeof criteria === 'string') {
-			const record = await this.findOneByIdString(criteria)
-			if (record.workspaceId) {
-				await this.assertWorkspaceWriteAccess(record.workspaceId)
-			}
-		}
+    public async softDelete(criteria: string | number | FindOptionsWhere<T>): Promise<UpdateResult | T> {
+        if (typeof criteria === 'string') {
+            const record = await this.findOneByIdString(criteria)
+            if (record.workspaceId) {
+                await this.assertWorkspaceWriteAccess(record.workspaceId)
+            }
+        }
 
-		return super.softDelete(criteria)
-	}
+        return super.softDelete(criteria)
+    }
 
-	protected async assertWorkspaceReadAccess(workspaceId: string): Promise<XpertWorkspaceAccessResult> {
-		return this.assertWorkspaceAccess(workspaceId, 'read')
-	}
+    protected async assertWorkspaceReadAccess(workspaceId: string): Promise<XpertWorkspaceAccessResult> {
+        return this.assertWorkspaceAccess(workspaceId, 'read')
+    }
 
-	protected async assertWorkspaceRunAccess(workspaceId: string): Promise<XpertWorkspaceAccessResult> {
-		return this.assertWorkspaceAccess(workspaceId, 'run')
-	}
+    protected async assertWorkspaceRunAccess(workspaceId: string): Promise<XpertWorkspaceAccessResult> {
+        return this.assertWorkspaceAccess(workspaceId, 'run')
+    }
 
-	protected async assertWorkspaceWriteAccess(workspaceId: string): Promise<XpertWorkspaceAccessResult> {
-		return this.assertWorkspaceAccess(workspaceId, 'write')
-	}
+    protected async assertWorkspaceWriteAccess(workspaceId: string): Promise<XpertWorkspaceAccessResult> {
+        return this.assertWorkspaceAccess(workspaceId, 'write')
+    }
 
-	protected async assertWorkspaceAccess(
-		workspaceId: string,
-		action: XpertWorkspaceAccessAction
-	): Promise<XpertWorkspaceAccessResult> {
-		if (this.isEmptyWorkspaceId(workspaceId)) {
-			throw new BadRequestException('Workspace id is required.')
-		}
+    protected async assertWorkspaceAccess(
+        workspaceId: string,
+        action: XpertWorkspaceAccessAction
+    ): Promise<XpertWorkspaceAccessResult> {
+        if (this.isEmptyWorkspaceId(workspaceId)) {
+            throw new BadRequestException('Workspace id is required.')
+        }
 
-		return this.workspaceAccessService.assertCan(workspaceId, action)
-	}
+        return this.workspaceAccessService.assertCan(workspaceId, action)
+    }
 
-	protected applyWorkspaceScope<E extends WorkspaceScopedPartial<T>>(entity: E, workspace: XpertWorkspace): E {
-		return {
-			...entity,
-			workspaceId: workspace.id,
-			tenantId: workspace.tenantId,
-			organizationId: workspace.organizationId ?? null
-		}
-	}
+    protected applyWorkspaceScope<E extends WorkspaceScopedPartial<T>>(entity: E, workspace: XpertWorkspace): E {
+        return {
+            ...entity,
+            workspaceId: workspace.id,
+            tenantId: workspace.tenantId,
+            organizationId: workspace.organizationId ?? null
+        }
+    }
 
-	private async createInWorkspaceScope(entity: DeepPartial<T>): Promise<T> {
-		const userId = RequestContext.currentUserId()
-		const scopedEntity: WorkspaceScopedPartial<T> = {
-			...(entity as WorkspaceScopedPartial<T>),
-			...(userId && !this.getCreatedById(entity) ? { createdById: userId } : {}),
-			...(userId ? { updatedById: userId } : {})
-		}
-		const obj = this.repository.create(scopedEntity)
+    private async createInWorkspaceScope(entity: DeepPartial<T>): Promise<T> {
+        const userId = RequestContext.currentUserId()
+        const scopedEntity: WorkspaceScopedPartial<T> = {
+            ...(entity as WorkspaceScopedPartial<T>),
+            ...(userId && !this.getCreatedById(entity) ? { createdById: userId } : {}),
+            ...(userId ? { updatedById: userId } : {})
+        }
+        const obj = this.repository.create(scopedEntity)
 
-		try {
-			return await this.repository.save(obj)
-		} catch (error) {
-			throw new BadRequestException(error)
-		}
-	}
+        try {
+            return await this.repository.save(obj)
+        } catch (error) {
+            throw new BadRequestException(error)
+        }
+    }
 
-	private async resolveWorkspaceScopedFindManyOptions(filter?: FindManyOptions<T>): Promise<FindManyOptions<T> | null> {
-		if (!filter?.where) {
-			return null
-		}
+    private async resolveWorkspaceScopedFindManyOptions(
+        filter?: FindManyOptions<T>
+    ): Promise<FindManyOptions<T> | null> {
+        if (!filter?.where) {
+            return null
+        }
 
-		const whereItems = this.asWorkspaceWhereArray(filter.where)
-		if (!whereItems.some((where) => !!this.getWhereWorkspaceId(where))) {
-			return null
-		}
+        const whereItems = this.asWorkspaceWhereArray(filter.where)
+        if (!whereItems.some((where) => !!this.getWhereWorkspaceId(where))) {
+            return null
+        }
 
-		const resolvedWhere: FindOptionsWhere<T>[] = []
-		for (const where of whereItems) {
-			const workspaceId = this.getWhereWorkspaceId(where)
-			const normalizedWhere = transformWhere(where) as FindOptionsWhere<T>
-			if (!workspaceId) {
-				resolvedWhere.push(this.mergeCurrentScopeWhere(normalizedWhere))
-				continue
-			}
+        const resolvedWhere: FindOptionsWhere<T>[] = []
+        for (const where of whereItems) {
+            const workspaceId = this.getWhereWorkspaceId(where)
+            const normalizedWhere = transformWhere(where) as FindOptionsWhere<T>
+            if (!workspaceId) {
+                resolvedWhere.push(this.mergeCurrentScopeWhere(normalizedWhere))
+                continue
+            }
 
-			const { workspace } = await this.assertWorkspaceReadAccess(workspaceId)
-			resolvedWhere.push(this.mergeWorkspaceScopeWhere(normalizedWhere, workspace))
-		}
+            const { workspace } = await this.assertWorkspaceReadAccess(workspaceId)
+            resolvedWhere.push(this.mergeWorkspaceScopeWhere(normalizedWhere, workspace))
+        }
 
-		return {
-			...filter,
-			where: Array.isArray(filter.where) ? resolvedWhere : resolvedWhere[0]
-		}
-	}
+        return {
+            ...filter,
+            where: Array.isArray(filter.where) ? resolvedWhere : resolvedWhere[0]
+        }
+    }
 
-	private mergeFindOneWhereWithTenant(
-		id: string | number,
-		where?: FindOneOptions<T>['where']
-	): FindOneOptions<T>['where'] {
-		const tenantId = this.requireTenantId()
-		const idWhere = {
-			id,
-			tenantId
-		} as FindOptionsWhere<T>
+    private mergeFindOneWhereWithTenant(
+        id: string | number,
+        where?: FindOneOptions<T>['where']
+    ): FindOneOptions<T>['where'] {
+        const tenantId = this.requireTenantId()
+        const idWhere = {
+            id,
+            tenantId
+        } as FindOptionsWhere<T>
 
-		if (Array.isArray(where)) {
-			return where.map((item) => ({
-				...item,
-				...idWhere
-			}))
-		}
+        if (Array.isArray(where)) {
+            return where.map((item) => ({
+                ...item,
+                ...idWhere
+            }))
+        }
 
-		return {
-			...(where ?? {}),
-			...idWhere
-		} as FindOptionsWhere<T>
-	}
+        return {
+            ...(where ?? {}),
+            ...idWhere
+        } as FindOptionsWhere<T>
+    }
 
-	private async assertRecordReadable(record: T | null): Promise<T> {
-		if (!record) {
-			throw new NotFoundException(`The requested record was not found`)
-		}
+    private withReadableScopeSelect(options?: FindOneOptions<T>): {
+        options?: FindOneOptions<T>
+        addedFields: string[]
+    } {
+        if (!options?.select) {
+            return { options, addedFields: [] }
+        }
 
-		if (record.workspaceId) {
-			await this.assertWorkspaceReadAccess(record.workspaceId)
-			return record
-		}
+        if (Array.isArray(options.select)) {
+            const selectedFields = options.select as string[]
+            const addedFields = READABLE_SCOPE_SELECT_FIELDS.filter((field) => !selectedFields.includes(field))
 
-		const tenantId = RequestContext.currentTenantId()
-		if (tenantId && record.tenantId !== tenantId) {
-			throw new NotFoundException(`The requested record was not found`)
-		}
+            return {
+                options: {
+                    ...options,
+                    select: [...selectedFields, ...addedFields] as FindOneOptions<T>['select']
+                },
+                addedFields
+            }
+        }
 
-		const organizationId = RequestContext.getOrganizationId()
-		if ((record.organizationId ?? null) !== (organizationId ?? null)) {
-			throw new NotFoundException(`The requested record was not found`)
-		}
+        const selectedFields = options.select as Record<string, unknown>
+        const addedFields = READABLE_SCOPE_SELECT_FIELDS.filter((field) => selectedFields[field] !== true)
 
-		return record
-	}
+        return {
+            options: {
+                ...options,
+                select: {
+                    ...selectedFields,
+                    ...Object.fromEntries(addedFields.map((field) => [field, true]))
+                } as FindOneOptions<T>['select']
+            },
+            addedFields
+        }
+    }
 
-	private mergeWorkspaceScopeWhere(where: FindOptionsWhere<T>, workspace: XpertWorkspace): FindOptionsWhere<T> {
-		return {
-			...where,
-			workspaceId: workspace.id,
-			tenantId: workspace.tenantId,
-			organizationId: workspace.organizationId ?? IsNull()
-		} as FindOptionsWhere<T>
-	}
+    private stripReadableScopeSelectFields(record: T, addedFields: string[]) {
+        for (const field of addedFields) {
+            delete (record as Record<string, unknown>)[field]
+        }
 
-	private mergeCurrentScopeWhere(where: FindOptionsWhere<T>): FindOptionsWhere<T> {
-		return {
-			...where,
-			tenantId: this.requireTenantId(),
-			organizationId: RequestContext.getOrganizationId() ?? IsNull()
-		} as FindOptionsWhere<T>
-	}
+        return record
+    }
 
-	private asWorkspaceWhereArray(where: FindManyOptions<T>['where']): FindOptionsWhere<T>[] {
-		if (Array.isArray(where)) {
-			return where
-		}
+    private async assertRecordReadable(record: T | null): Promise<T> {
+        if (!record) {
+            throw new NotFoundException(`The requested record was not found`)
+        }
 
-		return [where as FindOptionsWhere<T>]
-	}
+        if (record.workspaceId) {
+            await this.assertWorkspaceReadAccess(record.workspaceId)
+            return record
+        }
 
-	private getWhereWorkspaceId(where: FindOptionsWhere<T>): string | null {
-		return this.normalizeWorkspaceId(where.workspaceId)
-	}
+        const tenantId = RequestContext.currentTenantId()
+        if (tenantId && record.tenantId !== tenantId) {
+            throw new NotFoundException(`The requested record was not found`)
+        }
 
-	private getEntityWorkspaceId(entity: DeepPartial<T>): string | null {
-		return this.normalizeWorkspaceId((entity as WorkspaceScopedPartial<T>).workspaceId)
-	}
+        const organizationId = RequestContext.getOrganizationId()
+        if ((record.organizationId ?? null) !== (organizationId ?? null)) {
+            throw new NotFoundException(`The requested record was not found`)
+        }
 
-	private getMutationWorkspaceId(entity: QueryDeepPartialEntity<T>): string | null | undefined {
-		if (!('workspaceId' in entity)) {
-			return undefined
-		}
+        return record
+    }
 
-		return this.normalizeWorkspaceId((entity as WorkspaceScopedPartial<T>).workspaceId)
-	}
+    private mergeWorkspaceScopeWhere(where: FindOptionsWhere<T>, workspace: XpertWorkspace): FindOptionsWhere<T> {
+        return {
+            ...where,
+            workspaceId: workspace.id,
+            tenantId: workspace.tenantId,
+            organizationId: workspace.organizationId ?? IsNull()
+        } as FindOptionsWhere<T>
+    }
 
-	private getCreatedById(entity: DeepPartial<T>): string | number | null | undefined {
-		return (entity as WorkspaceScopedPartial<T>).createdById
-	}
+    private mergeCurrentScopeWhere(where: FindOptionsWhere<T>): FindOptionsWhere<T> {
+        return {
+            ...where,
+            tenantId: this.requireTenantId(),
+            organizationId: RequestContext.getOrganizationId() ?? IsNull()
+        } as FindOptionsWhere<T>
+    }
 
-	private normalizeWorkspaceId(value: unknown): string | null {
-		if (typeof value !== 'string') {
-			return null
-		}
+    private asWorkspaceWhereArray(where: FindManyOptions<T>['where']): FindOptionsWhere<T>[] {
+        if (Array.isArray(where)) {
+            return where
+        }
 
-		const workspaceId = value.trim()
-		if (!workspaceId || workspaceId === 'null' || workspaceId === 'undefined') {
-			return null
-		}
+        return [where as FindOptionsWhere<T>]
+    }
 
-		return workspaceId
-	}
+    private getWhereWorkspaceId(where: FindOptionsWhere<T>): string | null {
+        return this.normalizeWorkspaceId(where.workspaceId)
+    }
 
-	private isEmptyWorkspaceId(workspaceId: string | null | undefined) {
-		return !this.normalizeWorkspaceId(workspaceId)
-	}
+    private getEntityWorkspaceId(entity: DeepPartial<T>): string | null {
+        return this.normalizeWorkspaceId((entity as WorkspaceScopedPartial<T>).workspaceId)
+    }
 
-	private requireTenantId() {
-		const tenantId = RequestContext.currentTenantId()
-		if (!tenantId) {
-			throw new ForbiddenException('Tenant context is required.')
-		}
-		return tenantId
-	}
+    private getMutationWorkspaceId(entity: QueryDeepPartialEntity<T>): string | null | undefined {
+        if (!('workspaceId' in entity)) {
+            return undefined
+        }
+
+        return this.normalizeWorkspaceId((entity as WorkspaceScopedPartial<T>).workspaceId)
+    }
+
+    private getCreatedById(entity: DeepPartial<T>): string | number | null | undefined {
+        return (entity as WorkspaceScopedPartial<T>).createdById
+    }
+
+    private normalizeWorkspaceId(value: unknown): string | null {
+        if (typeof value !== 'string') {
+            return null
+        }
+
+        const workspaceId = value.trim()
+        if (!workspaceId || workspaceId === 'null' || workspaceId === 'undefined') {
+            return null
+        }
+
+        return workspaceId
+    }
+
+    private isEmptyWorkspaceId(workspaceId: string | null | undefined) {
+        return !this.normalizeWorkspaceId(workspaceId)
+    }
+
+    private requireTenantId() {
+        const tenantId = RequestContext.currentTenantId()
+        if (!tenantId) {
+            throw new ForbiddenException('Tenant context is required.')
+        }
+        return tenantId
+    }
 }

--- a/packages/server/src/core/seeds/seed-data.service.ts
+++ b/packages/server/src/core/seeds/seed-data.service.ts
@@ -1,110 +1,68 @@
-import { rimraf } from 'rimraf';
-import path from 'path';
-import { Injectable } from '@nestjs/common';
+import { rimraf } from 'rimraf'
+import path from 'path'
+import { Injectable } from '@nestjs/common'
+import { Connection, createConnection, ConnectionOptions, getConnection, getManager } from 'typeorm'
+import chalk from 'chalk'
+import moment from 'moment'
+import { IPluginConfig, SEEDER_DB_CONNECTION } from '@xpert-ai/server-common'
+import { environment as env, getConfig, ConfigService } from '@xpert-ai/server-config'
+import { IEmployee, IOrganization, IRole, ITenant, IUser, DEFAULT_TENANT } from '@xpert-ai/contracts'
+import { createRoles } from '../../role/role.seed'
 import {
-	Connection,
-	createConnection,
-	ConnectionOptions,
-	getConnection,
-	getManager
-} from 'typeorm';
-import chalk from 'chalk';
-import moment from 'moment';
-import { IPluginConfig, SEEDER_DB_CONNECTION } from '@xpert-ai/server-common';
-import { environment as env, getConfig, ConfigService } from '@xpert-ai/server-config';
-import {
-	IEmployee,
-	IOrganization,
-	IRole,
-	ITenant,
-	IUser,
-	DEFAULT_TENANT
-} from '@xpert-ai/contracts';
-import { createRoles } from '../../role/role.seed';
-import {	
 	createDefaultAdminUsers,
 	createDefaultEmployeesUsers,
 	createDefaultUsers,
 	createRandomSuperAdminUsers,
 	createRandomUsers
-} from '../../user/user.seed';
-import {
-	createDefaultEmployees,
-	createRandomEmployees
-} from '../../employee/employee.seed';
-import {
-	createDefaultOrganizations,
-	DEFAULT_ORGANIZATIONS,
-	getTenantDefaultOrganization,
-} from '../../organization';
+} from '../../user/user.seed'
+import { createDefaultEmployees, createRandomEmployees } from '../../employee/employee.seed'
+import { createDefaultOrganizations, DEFAULT_ORGANIZATIONS, getTenantDefaultOrganization } from '../../organization'
 import {
 	createDefaultUsersOrganizations,
 	createRandomUsersOrganizations
-} from '../../user-organization/user-organization.seed';
-import { createCountries } from '../../country/country.seed';
-import { cleanUpRolePermissions, createRolePermissions } from '../../role-permission/';
-import {
-	createDefaultTenant,
-	createRandomTenants,
-	TenantService
-} from '../../tenant';
-import {
-	createDefaultTenantSetting
-} from './../../tenant/tenant-setting/tenant-setting.seed';
-import { createDefaultEmailTemplates } from '../../email-template/email-template.seed';
-import {
-	createDefaultTags,
-	createRandomOrganizationTags,
-	createTags
-} from '../../tags/tag.seed';
-import { createCurrencies } from '../../currency/currency.seed';
-import {
-	createDefaultFeatureToggle,
-	createFeatures,
-} from '../../feature/feature.seed';
-import { DEFAULT_EMPLOYEES, DEFAULT_PEANUT_EMPLOYEES } from './../../employee';
-import { createLanguages } from '../../language/language.seed';
-import { Role, Tenant } from '../entities/internal';
-
+} from '../../user-organization/user-organization.seed'
+import { createCountries } from '../../country/country.seed'
+import { cleanUpRolePermissions, createRolePermissions } from '../../role-permission/'
+import { createDefaultTenant, createRandomTenants, TenantService } from '../../tenant'
+import { createDefaultTenantSetting } from './../../tenant/tenant-setting/tenant-setting.seed'
+import { createDefaultEmailTemplates } from '../../email-template/email-template.seed'
+import { createDefaultTags, createRandomOrganizationTags, createTags } from '../../tags/tag.seed'
+import { createCurrencies } from '../../currency/currency.seed'
+import { createDefaultFeatureToggle, createFeatures } from '../../feature/feature.seed'
+import { DEFAULT_EMPLOYEES, DEFAULT_PEANUT_EMPLOYEES } from './../../employee'
+import { createLanguages } from '../../language/language.seed'
+import { Role, Tenant } from '../entities/internal'
 
 export enum SeederTypeEnum {
 	ALL = 'all',
 	DEFAULT = 'default',
-	TENANT = 'tenant',
+	TENANT = 'tenant'
 }
 
 @Injectable()
 export class SeedDataService {
-	connection: Connection;
-	log = console.log;
+	connection: Connection
+	log = console.log
 
-	organizations: IOrganization[] = [];
-	defaultOrganization: IOrganization;
-	tenant: ITenant;
-	roles: IRole[] = [];
-	superAdminUsers: IUser[] = [];
-	defaultUsers: IUser[] = [];
-	defaultCandidateUsers: IUser[] = [];
-	defaultEmployees: IEmployee[] = [];
-	adminUser: IUser;
+	organizations: IOrganization[] = []
+	defaultOrganization: IOrganization
+	tenant: ITenant
+	roles: IRole[] = []
+	superAdminUsers: IUser[] = []
+	defaultUsers: IUser[] = []
+	defaultCandidateUsers: IUser[] = []
+	defaultEmployees: IEmployee[] = []
+	adminUser: IUser
 
-	config: IPluginConfig = getConfig();
-	seedType: SeederTypeEnum;
+	config: IPluginConfig = getConfig()
+	seedType: SeederTypeEnum
 
 	constructor(
 		// private readonly moduleRef: ModuleRef,
-		protected readonly configService: ConfigService,
+		protected readonly configService: ConfigService
 	) {
-		this.log(
-			chalk.blueBright(
-				`📧 Environments ${JSON.stringify(this.configService.environment)}`
-			)
-		);
-		this.log(
-			chalk.blueBright(
-				`📧 Configs ${JSON.stringify(this.configService.config)}`
-			)
-		);
+		this.log(chalk.blueBright(`📧 Environments ${JSON.stringify(this.configService.environment)}`))
+		this.log(chalk.blueBright(`📧 Configs ${JSON.stringify(this.configService.config)}`))
 	}
 
 	/**
@@ -115,243 +73,194 @@ export class SeedDataService {
 		logging: true,
 		logger: 'file' //Removes console logging, instead logs all queries in a file ormlogs.log
 		// dropSchema: !env.production //Drops the schema each time connection is being established in development mode.
-	};
+	}
 
 	/**
-	* Seed All Data
-	*/
+	 * Seed All Data
+	 */
 	public async runAllSeed() {
 		try {
-			this.seedType = SeederTypeEnum.ALL;
+			this.seedType = SeederTypeEnum.ALL
 
-			await this.cleanUpPreviousRuns();
+			await this.cleanUpPreviousRuns()
 
 			// Connect to database
-			await this.createConnection();
+			await this.createConnection()
 
 			// Reset database to start with new, fresh data
-			await this.resetDatabase();
+			await this.resetDatabase()
 
 			// Seed basic default data for default tenant
-			await this.seedBasicDefaultData();
+			await this.seedBasicDefaultData()
 
 			// Seed data with mock / fake data for default tenant
-			await this.seedDefaultData();
+			await this.seedDefaultData()
 
 			// Disconnect to database
-			await this.closeConnection();
+			await this.closeConnection()
 
-			console.log('Database All Seed Completed');
+			console.log('Database All Seed Completed')
 		} catch (error) {
-			this.handleError(error);
+			this.handleError(error)
 		}
 	}
 
 	/**
-	* Seed Default Data
-	*/
+	 * Seed Default Data
+	 */
 	public async runDefaultSeed(fromAPI: boolean) {
 		try {
 			if (this.configService.get('demo') === true && fromAPI === true) {
-				this.seedType = SeederTypeEnum.ALL;
+				this.seedType = SeederTypeEnum.ALL
 			} else {
-				this.seedType = SeederTypeEnum.DEFAULT;
+				this.seedType = SeederTypeEnum.DEFAULT
 			}
 
-			await this.cleanUpPreviousRuns();
+			await this.cleanUpPreviousRuns()
 
 			// Connect to database
-			await this.createConnection();
+			await this.createConnection()
 
 			// Reset database to start with new, fresh data
-			await this.resetDatabase();
+			await this.resetDatabase()
 
 			// Seed basic default data for default tenant
-			await this.seedBasicDefaultData();
+			await this.seedBasicDefaultData()
 
 			// Disconnect to database
-			await this.closeConnection();
+			await this.closeConnection()
 
-			console.log('Database Default Seed Completed');
+			console.log('Database Default Seed Completed')
 		} catch (error) {
-			this.handleError(error);
+			this.handleError(error)
 		}
 	}
 
 	/**
-	* Seed Tenant Data
-	*/
+	 * Seed Tenant Data
+	 */
 	public async runTenantSeed(name: string) {
 		try {
-			this.seedType = SeederTypeEnum.TENANT;
-			
-			await this.cleanUpPreviousRuns();
+			this.seedType = SeederTypeEnum.TENANT
+
+			await this.cleanUpPreviousRuns()
 
 			// Connect to database
-			await this.createConnection();
+			await this.createConnection()
 
 			// Seed basic default data for default tenant
-			await this.seedTenantDefaultData(name || DEFAULT_TENANT);
+			await this.seedTenantDefaultData(name || DEFAULT_TENANT)
 
 			// Disconnect to database
-			await this.closeConnection();
+			await this.closeConnection()
 
-			console.log(`Database for Tenant '${name}' Seed Completed`);
+			console.log(`Database for Tenant '${name}' Seed Completed`)
 		} catch (error) {
-			this.handleError(error);
+			this.handleError(error)
 		}
 	}
 
 	public async runTenantEmailTSeed(name: string) {
 		name = name || DEFAULT_TENANT
 		try {
-			this.seedType = SeederTypeEnum.TENANT;
-			
-			await this.cleanUpPreviousRuns();
+			this.seedType = SeederTypeEnum.TENANT
+
+			await this.cleanUpPreviousRuns()
 
 			// Connect to database
-			await this.createConnection();
+			await this.createConnection()
 
 			// Find tenant or default tenant
-			this.tenant = await (await this.connection.getRepository(Tenant)).findOne({where: {name}})
+			this.tenant = await (await this.connection.getRepository(Tenant)).findOne({ where: { name } })
 
 			// Seed email templates
-			await this.tryExecute(
-				'Default Email Templates',
-				createDefaultEmailTemplates(this.connection, this.tenant)
-			);
+			await this.tryExecute('Default Email Templates', createDefaultEmailTemplates(this.connection, this.tenant))
 
 			// Disconnect to database
-			await this.closeConnection();
+			await this.closeConnection()
 
-			console.log(`Email Templates for Tenant '${name}' Seed Completed`);
+			console.log(`Email Templates for Tenant '${name}' Seed Completed`)
 		} catch (error) {
-			this.handleError(error);
+			this.handleError(error)
 		}
 	}
 
 	/**
-	* Seed Default & Random Data
-	*/
+	 * Seed Default & Random Data
+	 */
 	public async excuteDemoSeed() {
 		try {
-			console.log('Database Demo Seed Started');
+			console.log('Database Demo Seed Started')
 
 			// Connect to database
-			await this.createConnection();
+			await this.createConnection()
 
 			// Seed default data
-			await this.seedDefaultData();
+			await this.seedDefaultData()
 
 			// Disconnect to database
-			await this.closeConnection();
+			await this.closeConnection()
 
-			console.log('Database Demo Seed Completed');
+			console.log('Database Demo Seed Completed')
 		} catch (error) {
-			this.handleError(error);
+			this.handleError(error)
 		}
 	}
 
 	/**
-	* Populate Database with Basic Default Data
-	*/
+	 * Populate Database with Basic Default Data
+	 */
 	private async seedBasicDefaultData() {
-		this.log(
-			chalk.magenta(
-				`🌱 SEEDING BASIC ${env.production ? 'PRODUCTION' : ''
-				} DATABASE...`
-			)
-		);
+		this.log(chalk.magenta(`🌱 SEEDING BASIC ${env.production ? 'PRODUCTION' : ''} DATABASE...`))
 
 		// Seed data which only needs connection
-		await this.tryExecute(
-			'Countries',
-			createCountries(this.connection)
-		);
+		await this.tryExecute('Countries', createCountries(this.connection))
 
-		await this.tryExecute(
-			'Currencies',
-			createCurrencies(this.connection)
-		);
+		await this.tryExecute('Currencies', createCurrencies(this.connection))
 
-		await this.tryExecute(
-			'Languages', 
-			createLanguages(this.connection)
-		);
+		await this.tryExecute('Languages', createLanguages(this.connection))
 
-		await this.tryExecute(
-			'Features', 
-			createFeatures(this.connection)
-		);
+		await this.tryExecute('Features', createFeatures(this.connection))
 
 		// default and internal tenant
 		await this.seedTenantDefaultData(DEFAULT_TENANT)
-		
-		this.log(
-			chalk.magenta(
-				`✅ SEEDED BASIC ${env.production ? 'PRODUCTION' : ''} DATABASE`
-			)
-		);
+
+		this.log(chalk.magenta(`✅ SEEDED BASIC ${env.production ? 'PRODUCTION' : ''} DATABASE`))
 	}
 
 	/**
 	 * Populate default data for default tenant
 	 */
 	private async seedDefaultData() {
-		this.log(
-			chalk.magenta(
-				`🌱 SEEDING DEFAULT ${env.production ? 'PRODUCTION' : ''
-				} DATABASE...`
-			)
-		);
+		this.log(chalk.magenta(`🌱 SEEDING DEFAULT ${env.production ? 'PRODUCTION' : ''} DATABASE...`))
 
-		await this.tryExecute(
-			'Default Tags',
-			createDefaultTags(
-				this.connection, 
-				this.tenant, 
-				this.organizations
-			)
-		);
+		await this.tryExecute('Default Tags', createDefaultTags(this.connection, this.tenant, this.organizations))
 
-		const {
-			defaultEmployeeUsers 
-		} = await createDefaultEmployeesUsers(
-			this.connection, 
-			this.tenant
-		);
+		const { defaultEmployeeUsers } = await createDefaultEmployeesUsers(this.connection, this.tenant)
 
 		if (this.seedType !== SeederTypeEnum.DEFAULT) {
-			const { 
-				defaultPeanutEmployeeUsers,
-				defaultCandidateUsers 
-			} = await createDefaultUsers(
-				this.connection, 
+			const { defaultPeanutEmployeeUsers, defaultCandidateUsers } = await createDefaultUsers(
+				this.connection,
 				this.tenant
-			);
-			this.defaultCandidateUsers.push(...defaultCandidateUsers);
-			defaultEmployeeUsers.push(...defaultPeanutEmployeeUsers);
+			)
+			this.defaultCandidateUsers.push(...defaultCandidateUsers)
+			defaultEmployeeUsers.push(...defaultPeanutEmployeeUsers)
 		}
 
 		await this.tryExecute(
 			'Users',
-			createDefaultUsersOrganizations(
-				this.connection,
-				this.tenant,
-				this.organizations,
-				defaultEmployeeUsers
-			)
-		);
+			createDefaultUsersOrganizations(this.connection, this.tenant, this.organizations, defaultEmployeeUsers)
+		)
 
-		const allDefaultEmployees = DEFAULT_EMPLOYEES.concat(DEFAULT_PEANUT_EMPLOYEES);
+		const allDefaultEmployees = DEFAULT_EMPLOYEES.concat(DEFAULT_PEANUT_EMPLOYEES)
 		//User level data that needs connection, tenant, organization, role, users
 		this.defaultEmployees = await createDefaultEmployees(
-			this.connection, 
+			this.connection,
 			this.tenant,
 			this.defaultOrganization,
 			defaultEmployeeUsers,
 			allDefaultEmployees
-		);
+		)
 
 		// // run all plugins default seed method
 		// await this.bootstrapPluginSeedMethods(
@@ -365,103 +274,59 @@ export class SeedDataService {
 		// 	}
 		// );
 
-		this.log(
-			chalk.magenta(
-				`✅ SEEDED DEFAULT ${env.production ? 'PRODUCTION' : ''} DATABASE`
-			)
-		);
+		this.log(chalk.magenta(`✅ SEEDED DEFAULT ${env.production ? 'PRODUCTION' : ''} DATABASE`))
 	}
 
 	/**
 	 * Create a new Tenant and initialize the corresponding default data
-	 * 
-	 * @param tenantName 
+	 *
+	 * @param tenantName
 	 */
 	public async seedTenantDefaultData(tenantName: string) {
+		this.tenant = (await this.tryExecute('Tenant', createDefaultTenant(this.connection, tenantName))) as ITenant
 
-		this.tenant = await this.tryExecute(
-			'Tenant',
-			createDefaultTenant(
-				this.connection,
-				tenantName
-			) 
-		) as ITenant;
+		this.roles = await createRoles(this.connection, [this.tenant])
 
-		this.roles = await createRoles(
-			this.connection, 
-			[this.tenant]
-		);
+		await createDefaultTenantSetting(this.connection, [this.tenant])
 
-		await createDefaultTenantSetting(
-			this.connection, 
-			[this.tenant]
-		);
-
-		const isDemo = this.configService.get('demo') as boolean;
-		await createRolePermissions(
-			this.connection, 
-			this.roles,
-			[this.tenant],
-			isDemo
-		);
+		const isDemo = this.configService.get('demo') as boolean
+		await createRolePermissions(this.connection, this.roles, [this.tenant], isDemo)
 
 		// Tenant level inserts which only need connection, tenant, roles
 		const organizations = [...DEFAULT_ORGANIZATIONS]
 		if (this.seedType !== SeederTypeEnum.DEFAULT) {
 			organizations.push(getTenantDefaultOrganization(this.tenant.name))
 		}
-		this.organizations = await this.tryExecute(
+		this.organizations = (await this.tryExecute(
 			'Organizations',
-			createDefaultOrganizations(
-				this.connection,
-				this.tenant,
-				organizations
-			)
-		) as IOrganization[];
+			createDefaultOrganizations(this.connection, this.tenant, organizations)
+		)) as IOrganization[]
 
 		//default organization set as main orgnaization
-		this.defaultOrganization = this.organizations.find(
-			(organization: IOrganization) => organization.isDefault
-		);
+		this.defaultOrganization = this.organizations.find((organization: IOrganization) => organization.isDefault)
 
 		await this.tryExecute(
 			'Default Feature Toggle',
-			createDefaultFeatureToggle(
-				this.connection,
-				this.config,
-				this.tenant
-			)
-		);
+			createDefaultFeatureToggle(this.connection, this.config, this.tenant)
+		)
 
-		await this.tryExecute(
-			'Default Email Templates',
-			createDefaultEmailTemplates(this.connection, this.tenant)
-		);
+		await this.tryExecute('Default Email Templates', createDefaultEmailTemplates(this.connection, this.tenant))
 
-		const {
-			defaultSuperAdminUsers,
-			defaultAdminUsers
-		} = await createDefaultAdminUsers(
-			this.connection, 
+		const { defaultSuperAdminUsers, defaultAdminUsers } = await createDefaultAdminUsers(
+			this.connection,
 			this.tenant
-		);
-		this.superAdminUsers.push(...defaultSuperAdminUsers as IUser[]);
+		)
+		this.superAdminUsers.push(...(defaultSuperAdminUsers as IUser[]))
 		this.adminUser = defaultAdminUsers[0]
 
-		const defaultUsers = [ 
-			...this.superAdminUsers,
-			...defaultAdminUsers,
+		const defaultUsers = [
+			...defaultAdminUsers
 			// ...defaultEmployeeUsers
-		];
+		]
 		await this.tryExecute(
 			'Users',
-			createDefaultUsersOrganizations(
-				this.connection,
-				this.tenant,
-				this.organizations,
-				defaultUsers
-			)
-		);
+			createDefaultUsersOrganizations(this.connection, this.tenant, this.organizations, defaultUsers)
+		)
 
 		// run all plugins random seed method
 		// await this.bootstrapPluginSeedMethods(
@@ -473,50 +338,40 @@ export class SeedDataService {
 		// 	}
 		// );
 
-		await this.seedTenantMoreDefault(
-			this.connection, 
-			this.tenant
-		)
+		await this.seedTenantMoreDefault(this.connection, this.tenant)
 
 		// Trigger create demo command for the default organization; After all default data is seeded
 		if (isDemo) {
 			await this.tryExecute(
 				'Demos',
-				this.seedOrganizationDemo(
-					this.connection,
-					this.tenant,
-					this.defaultOrganization
-				)
-			);
+				this.seedOrganizationDemo(this.connection, this.tenant, this.defaultOrganization)
+			)
 		}
 
-		this.log(
-			chalk.magenta(
-				`✅ SEEDED TENANT '${tenantName}' ${env.production ? 'PRODUCTION' : ''} DATABASE`
-			)
-		);
-		
+		this.log(chalk.magenta(`✅ SEEDED TENANT '${tenantName}' ${env.production ? 'PRODUCTION' : ''} DATABASE`))
 	}
 
 	public async runRolePermissionsSeed(tenantName: string) {
 		try {
-			await this.cleanUpPreviousRuns();
+			await this.cleanUpPreviousRuns()
 
 			// Connect to database
-			await this.createConnection();
+			await this.createConnection()
 
 			// Find tenant or default tenant
-			this.tenant = await (await this.connection.getRepository(Tenant)).findOne({where: {name: tenantName} })
+			this.tenant = await (await this.connection.getRepository(Tenant)).findOne({ where: { name: tenantName } })
 
 			// Find all roles in tenant
-			this.roles = await (await this.connection.getRepository(Role)).find({
+			this.roles = await (
+				await this.connection.getRepository(Role)
+			).find({
 				relations: ['tenant'],
 				where: {
 					tenantId: this.tenant.id
 				}
 			})
 
-			const isDemo = this.configService.get('demo') as boolean;
+			const isDemo = this.configService.get('demo') as boolean
 			// Clean role permissions
 			await this.tryExecute(
 				'Clean Role Permissions',
@@ -525,20 +380,15 @@ export class SeedDataService {
 			// Seed role permissions
 			await this.tryExecute(
 				'Role Permissions',
-				createRolePermissions(
-					this.connection, 
-					this.roles,
-					[this.tenant],
-					isDemo
-				)
+				createRolePermissions(this.connection, this.roles, [this.tenant], isDemo)
 			)
 
 			// Disconnect to database
-			await this.closeConnection();
+			await this.closeConnection()
 
-			console.log('Database Default Seed Completed');
+			console.log('Database Default Seed Completed')
 		} catch (error) {
-			this.handleError(error);
+			this.handleError(error)
 		}
 	}
 
@@ -572,62 +422,60 @@ export class SeedDataService {
 	// }
 
 	/**
-	* Cleans all the previous generate screenshots, reports etc
-	*/
+	 * Cleans all the previous generate screenshots, reports etc
+	 */
 	protected async cleanUpPreviousRuns() {
-		this.log(chalk.green(`CLEANING UP FROM PREVIOUS RUNS...`));
+		this.log(chalk.green(`CLEANING UP FROM PREVIOUS RUNS...`))
 
 		await new Promise((resolve) => {
-			const assetOptions = this.config.assetOptions;
-			const dir = path.join(assetOptions.assetPublicPath, 'screenshots');
+			const assetOptions = this.config.assetOptions
+			const dir = path.join(assetOptions.assetPublicPath, 'screenshots')
 
 			// delete old generated screenshots
 			rimraf(`${dir}/!(rimraf|.gitkeep)`).then(() => {
-				this.log(chalk.green(`✅ CLEANED UP`));
-				resolve(true);
+				this.log(chalk.green(`✅ CLEANED UP`))
+				resolve(true)
 			})
-		});
+		})
 	}
 
 	/**
-	* Create connection from database
-	*/
+	 * Create connection from database
+	 */
 	protected async createConnection() {
 		try {
-			this.connection = getConnection(SEEDER_DB_CONNECTION);
+			this.connection = getConnection(SEEDER_DB_CONNECTION)
 		} catch (error) {
-			this.log(
-				'NOTE: DATABASE CONNECTION DOES NOT EXIST YET. NEW ONE WILL BE CREATED!'
-			);
+			this.log('NOTE: DATABASE CONNECTION DOES NOT EXIST YET. NEW ONE WILL BE CREATED!')
 		}
-		const { dbConnectionOptions } = this.config;
+		const { dbConnectionOptions } = this.config
 		if (!this.connection || !this.connection.isConnected) {
 			try {
-				this.log(chalk.green(`CONNECTING TO DATABASE...`));
-				this.connection = await createConnection({ 
-					name: SEEDER_DB_CONNECTION, 
-					...dbConnectionOptions, 
-					...this.overrideDbConfig 
-				} as ConnectionOptions);
-				this.log(chalk.green(`✅ CONNECTED TO DATABASE!`));
+				this.log(chalk.green(`CONNECTING TO DATABASE...`))
+				this.connection = await createConnection({
+					name: SEEDER_DB_CONNECTION,
+					...dbConnectionOptions,
+					...this.overrideDbConfig
+				} as ConnectionOptions)
+				this.log(chalk.green(`✅ CONNECTED TO DATABASE!`))
 			} catch (error) {
-				this.handleError(error, 'Unable to connect to database');
+				this.handleError(error, 'Unable to connect to database')
 			}
 		}
 	}
 
 	/**
-	* Close connection from database
-	*/
+	 * Close connection from database
+	 */
 	protected async closeConnection() {
 		try {
-			this.connection = getConnection(SEEDER_DB_CONNECTION);
+			this.connection = getConnection(SEEDER_DB_CONNECTION)
 			if (this.connection && this.connection.isConnected) {
-				await this.connection.close();
-				this.log(chalk.green(`✅ DISCONNECTED TO DATABASE!`));
+				await this.connection.close()
+				this.log(chalk.green(`✅ DISCONNECTED TO DATABASE!`))
 			}
 		} catch (error) {
-			this.log('NOTE: DATABASE CONNECTION DOES NOT EXIST YET. CANT CLOSE CONNECTION!');
+			this.log('NOTE: DATABASE CONNECTION DOES NOT EXIST YET. CANT CLOSE CONNECTION!')
 		}
 	}
 
@@ -635,39 +483,32 @@ export class SeedDataService {
 	 * Use this wrapper function for all seed functions which are not essential.
 	 * Essentials seeds are ONLY those which are required to start the UI/login
 	 */
-	public tryExecute<T>(
-		name: string,
-		p: Promise<T>
-	): Promise<T> | Promise<void> {
-		this.log(chalk.green(`${moment().format('DD.MM.YYYY HH:mm:ss')} SEEDING ${name}`));
+	public tryExecute<T>(name: string, p: Promise<T>): Promise<T> | Promise<void> {
+		this.log(chalk.green(`${moment().format('DD.MM.YYYY HH:mm:ss')} SEEDING ${name}`))
 
 		return (p as any).then(
 			(x: T) => x,
 			(error: Error) => {
-				this.log(
-					chalk.bgRed(
-						`🛑 ERROR: ${error ? error.message : 'unknown'}`
-					)
-				);
+				this.log(chalk.bgRed(`🛑 ERROR: ${error ? error.message : 'unknown'}`))
 			}
-		);
+		)
 	}
 
 	/**
 	 * Retrieve entities metadata
 	 */
 	private async getEntities() {
-		const entities = [];
+		const entities = []
 		try {
 			this.connection.entityMetadatas.forEach((entity) =>
 				entities.push({
 					name: entity.name,
 					tableName: entity.tableName
 				})
-			);
-			return entities;
+			)
+			return entities
 		} catch (error) {
-			this.handleError(error, 'Unable to retrieve database metadata');
+			this.handleError(error, 'Unable to retrieve database metadata')
 		}
 	}
 
@@ -677,30 +518,24 @@ export class SeedDataService {
 	 */
 	private async cleanAll(entities: Array<any>) {
 		try {
-			const manager = getManager(SEEDER_DB_CONNECTION);
-			const database = this.config.dbConnectionOptions;
+			const manager = getManager(SEEDER_DB_CONNECTION)
+			const database = this.config.dbConnectionOptions
 
 			switch (database.type) {
 				case 'postgres': {
-					const tables = entities.map(
-						(entity) => '"' + entity.tableName + '"'
-					);
-					const truncateSql = `TRUNCATE TABLE ${tables.join(
-						','
-					)} RESTART IDENTITY CASCADE;`;
-					await manager.query(truncateSql);
-					break;
+					const tables = entities.map((entity) => '"' + entity.tableName + '"')
+					const truncateSql = `TRUNCATE TABLE ${tables.join(',')} RESTART IDENTITY CASCADE;`
+					await manager.query(truncateSql)
+					break
 				}
 				default:
-					await manager.query(`PRAGMA foreign_keys = OFF;`);
+					await manager.query(`PRAGMA foreign_keys = OFF;`)
 					for (const entity of entities) {
-						await manager.query(
-							`DELETE FROM "${entity.tableName}";`
-						);
+						await manager.query(`DELETE FROM "${entity.tableName}";`)
 					}
 			}
 		} catch (error) {
-			this.handleError(error, 'Unable to clean database');
+			this.handleError(error, 'Unable to clean database')
 		}
 	}
 
@@ -708,22 +543,17 @@ export class SeedDataService {
 	 * Reset the database, truncate all tables (remove all data)
 	 */
 	private async resetDatabase() {
-		this.log(chalk.green(`RESETTING DATABASE`));
+		this.log(chalk.green(`RESETTING DATABASE`))
 
-		const entities = await this.getEntities();
-		await this.cleanAll(entities);
+		const entities = await this.getEntities()
+		await this.cleanAll(entities)
 
-		this.log(chalk.green(`✅ RESET DATABASE SUCCESSFUL`));
+		this.log(chalk.green(`✅ RESET DATABASE SUCCESSFUL`))
 	}
 
 	private handleError(error: Error, message?: string): void {
-		this.log(
-			chalk.bgRed(
-				`🛑 ERROR: ${message ? message + '-> ' : ''} ${error ? error.message : ''
-				}`
-			)
-		);
-		throw error;
+		this.log(chalk.bgRed(`🛑 ERROR: ${message ? message + '-> ' : ''} ${error ? error.message : ''}`))
+		throw error
 	}
 
 	// private async bootstrapPluginSeedMethods(

--- a/packages/server/src/organization/commands/handlers/organization.create.handler.spec.ts
+++ b/packages/server/src/organization/commands/handlers/organization.create.handler.spec.ts
@@ -1,0 +1,71 @@
+jest.mock('../../../core/context/request-context', () => ({
+	RequestContext: {
+		currentUserId: jest.fn()
+	}
+}))
+
+import type { EventEmitter2 } from '@nestjs/event-emitter'
+import type { CommandBus } from '@nestjs/cqrs'
+import type { IOrganization, IOrganizationCreateInput } from '@xpert-ai/contracts'
+import { RequestContext } from '../../../core/context/request-context'
+import { EVENT_ORGANIZATION_CREATED } from '../../events'
+import { OrganizationService } from '../../organization.service'
+import { OrganizationCreateCommand } from '../organization.create.command'
+import { OrganizationCreateHandler } from './organization.create.handler'
+
+describe('OrganizationCreateHandler', () => {
+	function createHandler() {
+		const commandBus = {
+			execute: jest.fn()
+		}
+		const organizationService = {
+			create: jest.fn(),
+			findOne: jest.fn()
+		}
+		const eventEmitter = {
+			emit: jest.fn()
+		}
+		const handler = new OrganizationCreateHandler(
+			commandBus as unknown as CommandBus,
+			organizationService as unknown as OrganizationService,
+			eventEmitter as unknown as EventEmitter2
+		)
+
+		return {
+			eventEmitter,
+			handler,
+			organizationService
+		}
+	}
+
+	it('creates organizations without adding tenant super admins as members', async () => {
+		const { eventEmitter, handler, organizationService } = createHandler()
+		const createdOrganization = {
+			id: 'org-1',
+			tenantId: 'tenant-1',
+			name: 'Organization 1'
+		} as IOrganization
+		jest.mocked(RequestContext.currentUserId).mockReturnValue(null)
+		organizationService.create.mockResolvedValue(createdOrganization)
+		organizationService.findOne.mockResolvedValue(createdOrganization)
+
+		const result = await handler.execute(
+			new OrganizationCreateCommand({
+				name: 'Organization 1',
+				tenantId: 'tenant-1'
+			} as unknown as IOrganizationCreateInput)
+		)
+
+		expect(result).toBe(createdOrganization)
+		expect(organizationService.create).toHaveBeenCalledTimes(2)
+		expect(organizationService.findOne).toHaveBeenCalledWith('org-1')
+		expect(eventEmitter.emit).toHaveBeenCalledWith(
+			EVENT_ORGANIZATION_CREATED,
+			expect.objectContaining({
+				tenantId: 'tenant-1',
+				organizationId: 'org-1',
+				ownerUserId: null
+			})
+		)
+	})
+})

--- a/packages/server/src/organization/commands/handlers/organization.create.handler.ts
+++ b/packages/server/src/organization/commands/handlers/organization.create.handler.ts
@@ -1,55 +1,25 @@
-import { IOrganization, RolesEnum } from '@xpert-ai/contracts';
-import { EventEmitter2 } from '@nestjs/event-emitter';
-import { CommandBus, CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { getManager } from 'typeorm';
-import { RequestContext } from '../../../core/context/request-context';
-import { RoleService } from '../../../role/role.service';
-import { UserService } from '../../../user/user.service';
-import { UserOrganizationService } from '../../../user-organization/user-organization.services';
-import { EVENT_ORGANIZATION_CREATED, OrganizationCreatedEvent } from '../../events';
-import { OrganizationService } from '../../organization.service';
-import { OrganizationCreateCommand } from '../organization.create.command';
-import { Organization, UserOrganization } from './../../../core/entities/internal';
-import { ImportRecordUpdateOrCreateCommand } from './../../../export-import/import-record/commands/import-record-update-or-create.command';
-
+import { IOrganization } from '@xpert-ai/contracts'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { CommandBus, CommandHandler, ICommandHandler } from '@nestjs/cqrs'
+import { getManager } from 'typeorm'
+import { RequestContext } from '../../../core/context/request-context'
+import { EVENT_ORGANIZATION_CREATED, OrganizationCreatedEvent } from '../../events'
+import { OrganizationService } from '../../organization.service'
+import { OrganizationCreateCommand } from '../organization.create.command'
+import { Organization } from './../../../core/entities/internal'
+import { ImportRecordUpdateOrCreateCommand } from './../../../export-import/import-record/commands/import-record-update-or-create.command'
 
 @CommandHandler(OrganizationCreateCommand)
-export class OrganizationCreateHandler
-	implements ICommandHandler<OrganizationCreateCommand> {
+export class OrganizationCreateHandler implements ICommandHandler<OrganizationCreateCommand> {
 	constructor(
 		private readonly commandBus: CommandBus,
 		private readonly organizationService: OrganizationService,
-		private readonly userOrganizationService: UserOrganizationService,
-		private readonly userService: UserService,
-		private readonly roleService: RoleService,
 		private readonly eventEmitter: EventEmitter2
 	) {}
 
-	public async execute(
-		command: OrganizationCreateCommand
-	): Promise<IOrganization> {
-		const { input } = command;
-		const { isImporting = false, sourceId = null, userOrganizationSourceId = null, tenantId = null } = input;
-
-		//1. Get roleId for Super Admin user of the Tenant
-		const { id: roleId } = await this.roleService.findOneByOptions({
-			where: {
-				name: RolesEnum.SUPER_ADMIN,
-				tenantId
-			}
-		});
-
-		// 2. Get all Super Admin Users of the Tenant
-		// have to get user from context, as user service is not tenant-aware
-		// const user = RequestContext.currentUser();
-
-		const { items: superAdminUsers } = await this.userService.findAll({
-			relations: ['role'],
-			where: {
-				tenant: { id: tenantId },
-				role: { id: roleId }
-			}
-		});
+	public async execute(command: OrganizationCreateCommand): Promise<IOrganization> {
+		const { input } = command
+		const { isImporting = false, sourceId = null, tenantId = null } = input
 
 		// let { contact = {} } = input;
 		// delete input['contact'];
@@ -65,35 +35,12 @@ export class OrganizationCreateHandler
 			show_minimum_project_size: input.show_minimum_project_size || true,
 			show_clients_count: input.show_clients_count || true,
 			show_clients: input.show_clients || true,
-			show_employees_count: input.show_employees_count || true,
+			show_employees_count: input.show_employees_count || true
 			// brandColor: faker.internet.color()
-		});
-
-		// 4. Take each super admin user and add him/her to created organization
-		try {
-			for await (const superAdmin of superAdminUsers) {
-				const userOrganization = await this.userOrganizationService.ensureMembership({
-					organizationId: createdOrganization.id,
-					tenantId,
-					userId: superAdmin.id
-				});
-				if (isImporting && userOrganizationSourceId) {
-					await this.commandBus.execute(
-						new ImportRecordUpdateOrCreateCommand({
-							entityType: getManager().getRepository(UserOrganization).metadata.tableName,
-							sourceId: userOrganizationSourceId,
-							destinationId: userOrganization.id,
-							tenantId
-						})
-					);
-				}
-			}
-		} catch (e) {
-			console.log('caught', e)
-		}
+		})
 
 		//5. Create contact details of created organization
-		const { id } = createdOrganization;
+		const { id } = createdOrganization
 		// contact = Object.assign({}, contact, {
 		// 	organizationId: id,
 		// 	tenantId
@@ -102,18 +49,17 @@ export class OrganizationCreateHandler
 		const organization = await this.organizationService.create({
 			// contact,
 			...createdOrganization
-		});
+		})
 
 		// //6. Create Enabled/Disabled reports for relative organization.
 		// await this.commandBus.execute(
 		// 	new ReportOrganizationCreateCommand(organization)
 		// );
 
-
 		//7. Create Import Records while migrating for relative organization.
 		if (isImporting && sourceId) {
-			const { sourceId } = input;
-			const entityType = getManager().getRepository(Organization).metadata.tableName;
+			const { sourceId } = input
+			const entityType = getManager().getRepository(Organization).metadata.tableName
 			await this.commandBus.execute(
 				new ImportRecordUpdateOrCreateCommand({
 					entityType,
@@ -121,18 +67,14 @@ export class OrganizationCreateHandler
 					destinationId: organization.id,
 					tenantId
 				})
-			);
+			)
 		}
 
 		this.eventEmitter.emit(
 			EVENT_ORGANIZATION_CREATED,
-			new OrganizationCreatedEvent(
-				organization.tenantId,
-				organization.id,
-				RequestContext.currentUserId() ?? superAdminUsers[0]?.id ?? null
-			)
-		);
+			new OrganizationCreatedEvent(organization.tenantId, organization.id, RequestContext.currentUserId() ?? null)
+		)
 
-		return await this.organizationService.findOne(id);
+		return await this.organizationService.findOne(id)
 	}
 }

--- a/packages/server/src/user-organization/user-organization.controller.spec.ts
+++ b/packages/server/src/user-organization/user-organization.controller.spec.ts
@@ -1,10 +1,27 @@
 import { BadRequestException } from '@nestjs/common'
+import { LanguagesEnum } from '@xpert-ai/contracts'
+
+jest.mock('@xpert-ai/contracts', () => {
+	const actual = jest.requireActual('@xpert-ai/contracts')
+
+	return {
+		...actual,
+		isUserOrganizationEntryGuideKey: (value: string) => value === 'clawxpert'
+	}
+})
 
 jest.mock('./../core/crud', () => ({
 	CrudController: class CrudController {
 		constructor(_crudService: unknown) {}
 
 		findById = jest.fn()
+	}
+}))
+
+jest.mock('../core/context', () => ({
+	RequestContext: {
+		hasAnyPermission: jest.fn(),
+		requireOrganizationScope: jest.fn()
 	}
 }))
 
@@ -40,6 +57,7 @@ jest.mock('./../core/interceptors', () => ({
 	TransformInterceptor: class TransformInterceptor {}
 }))
 
+import { RequestContext } from '../core/context'
 import { UserOrganizationController } from './user-organization.controller'
 
 describe('UserOrganizationController', () => {
@@ -59,17 +77,24 @@ describe('UserOrganizationController', () => {
 		}
 
 		const controller = new UserOrganizationController(
-			userOrganizationService as any,
-			commandBus as any,
-			userService as any
+			userOrganizationService as unknown as ConstructorParameters<typeof UserOrganizationController>[0],
+			commandBus as unknown as ConstructorParameters<typeof UserOrganizationController>[1],
+			userService as unknown as ConstructorParameters<typeof UserOrganizationController>[2]
 		)
 
 		return {
+			commandBus,
 			controller,
 			userOrganizationService,
 			userService
 		}
 	}
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+		jest.mocked(RequestContext.hasAnyPermission).mockReturnValue(true)
+		jest.mocked(RequestContext.requireOrganizationScope).mockReturnValue('org-1')
+	})
 
 	it('marks the current user entry guide through the current membership', async () => {
 		const { controller, userOrganizationService } = createController()
@@ -145,6 +170,96 @@ describe('UserOrganizationController', () => {
 		})
 	})
 
+	it('rejects direct super admin membership creation when the service skips it', async () => {
+		const { controller, userOrganizationService, userService } = createController()
+		userService.findOne.mockResolvedValue({
+			id: 'super-admin-1',
+			tenantId: 'tenant-1',
+			role: {
+				name: 'SUPER_ADMIN'
+			}
+		})
+		userOrganizationService.addUserToOrganization.mockResolvedValue([])
+
+		await expect(
+			controller.create({
+				userId: 'super-admin-1',
+				organizationId: 'org-1'
+			})
+		).rejects.toThrow('Super admin users are not organization members.')
+
+		expect(userOrganizationService.update).not.toHaveBeenCalled()
+	})
+
+	it('filters super admin users out of membership list responses', async () => {
+		const { controller, userOrganizationService } = createController()
+		userOrganizationService.findAll.mockResolvedValue({
+			items: [],
+			total: 0
+		})
+
+		const result = await controller.findAll({
+			relations: ['user', 'user.role'],
+			findInput: {
+				organizationId: 'org-1'
+			}
+		})
+
+		expect(result).toEqual({
+			items: [],
+			total: 0
+		})
+		expect(userOrganizationService.findAll).toHaveBeenCalledWith({
+			where: expect.objectContaining({
+				organizationId: 'org-1',
+				user: {
+					role: {
+						name: expect.any(Object)
+					}
+				}
+			}),
+			relations: ['user', 'user.role']
+		})
+	})
+
+	it('rejects direct updates to historical super admin memberships', async () => {
+		const { controller, userOrganizationService } = createController()
+		userOrganizationService.findOne.mockResolvedValue({
+			id: 'membership-1',
+			organizationId: 'org-1',
+			user: {
+				role: {
+					name: 'SUPER_ADMIN'
+				}
+			}
+		})
+
+		await expect(controller.update('membership-1', { isActive: false })).rejects.toThrow(
+			'Super admin users are not organization members.'
+		)
+
+		expect(userOrganizationService.update).not.toHaveBeenCalled()
+	})
+
+	it('rejects direct deletes of historical super admin memberships', async () => {
+		const { commandBus, controller, userOrganizationService } = createController()
+		userOrganizationService.findOne.mockResolvedValue({
+			id: 'membership-1',
+			organizationId: 'org-1',
+			user: {
+				role: {
+					name: 'SUPER_ADMIN'
+				}
+			}
+		})
+
+		await expect(
+			controller.delete('membership-1', { user: { id: 'actor-1' } }, LanguagesEnum.English)
+		).rejects.toThrow('Super admin users are not organization members.')
+
+		expect(commandBus.execute).not.toHaveBeenCalled()
+	})
+
 	it('persists explicit membership flags after resolving the requested membership', async () => {
 		const { controller, userOrganizationService, userService } = createController()
 		userService.findOne.mockResolvedValue({
@@ -202,7 +317,7 @@ describe('UserOrganizationController', () => {
 		await expect(
 			controller.create({
 				userId: 'user-1'
-			} as any)
+			} as Parameters<UserOrganizationController['create']>[0])
 		).rejects.toBeInstanceOf(BadRequestException)
 	})
 })

--- a/packages/server/src/user-organization/user-organization.controller.ts
+++ b/packages/server/src/user-organization/user-organization.controller.ts
@@ -20,11 +20,14 @@ import { CrudController } from './../core/crud'
 import {
 	IUserOrganization,
 	IUserOrganizationCreateInput,
+	IUserOrganizationFindInput,
 	LanguagesEnum,
 	IPagination,
 	PermissionsEnum,
+	RolesEnum,
 	isUserOrganizationEntryGuideKey
 } from '@xpert-ai/contracts'
+import { Not } from 'typeorm'
 import { UserOrganizationService } from './user-organization.services'
 import { UserOrganization } from './user-organization.entity'
 import { CommandBus } from '@nestjs/cqrs'
@@ -69,7 +72,7 @@ export class UserOrganizationController extends CrudController<UserOrganization>
 			: created
 
 		if (!membership) {
-			throw new BadRequestException(`Unable to resolve membership for organization '${entity.organizationId}'`)
+			throw new BadRequestException('Super admin users are not organization members.')
 		}
 
 		const patch: Partial<IUserOrganization> = {}
@@ -110,12 +113,12 @@ export class UserOrganizationController extends CrudController<UserOrganization>
 		const { relations, findInput } = data
 		this.ensureAccessibleOrganization(findInput?.organizationId)
 		return this.userOrganizationService.findAll({
-			where: {
+			where: this.buildVisibleMembershipWhere({
 				...(findInput ?? {}),
 				...(!this.canViewAllOrganizations()
 					? { organizationId: this.requireAccessibleOrganizationId(findInput?.organizationId) }
 					: {})
-			},
+			}),
 			relations
 		})
 	}
@@ -217,10 +220,24 @@ export class UserOrganizationController extends CrudController<UserOrganization>
 		this.requireAccessibleOrganizationId(organizationId)
 	}
 
+	private buildVisibleMembershipWhere(findInput?: IUserOrganizationFindInput | null) {
+		return {
+			...(findInput ?? {}),
+			user: {
+				role: {
+					name: Not(RolesEnum.SUPER_ADMIN)
+				}
+			}
+		}
+	}
+
 	private async ensureMembershipAccess(id: string) {
 		const membership = await this.userOrganizationService.findOne(id, {
-			relations: ['organization']
+			relations: ['organization', 'user', 'user.role']
 		})
+		if (membership.user?.role?.name === RolesEnum.SUPER_ADMIN) {
+			throw new BadRequestException('Super admin users are not organization members.')
+		}
 		this.ensureAccessibleOrganization(membership.organizationId)
 		return membership
 	}

--- a/packages/server/src/user-organization/user-organization.seed.spec.ts
+++ b/packages/server/src/user-organization/user-organization.seed.spec.ts
@@ -1,0 +1,85 @@
+import type { Connection } from 'typeorm'
+import {
+	RolesEnum,
+	type IOrganization,
+	type ISeedUsers,
+	type ITenant,
+	type IUser,
+	type IUserOrganization
+} from '@xpert-ai/contracts'
+import { createDefaultUsersOrganizations, createRandomUsersOrganizations } from './user-organization.seed'
+
+describe('user organization seed helpers', () => {
+	function createConnection() {
+		const save = jest.fn(async (userOrganizations: IUserOrganization[]) => userOrganizations)
+		const connection = {
+			manager: {
+				save
+			}
+		} as unknown as Connection
+
+		return { connection, save }
+	}
+
+	it('excludes super admins from default organization memberships', async () => {
+		const { connection, save } = createConnection()
+		const tenant = { id: 'tenant-1' } as ITenant
+		const organization = { id: 'org-1' } as IOrganization
+		const adminUser = {
+			id: 'admin-1',
+			role: {
+				name: RolesEnum.ADMIN
+			}
+		} as IUser
+		const superAdminUser = {
+			id: 'super-admin-1',
+			role: {
+				name: RolesEnum.SUPER_ADMIN
+			}
+		} as IUser
+
+		const result = await createDefaultUsersOrganizations(
+			connection,
+			tenant,
+			[organization],
+			[superAdminUser, adminUser]
+		)
+
+		expect(result).toHaveLength(1)
+		expect(save).toHaveBeenCalledWith([
+			expect.objectContaining({
+				organization,
+				tenantId: 'tenant-1',
+				user: adminUser
+			})
+		])
+	})
+
+	it('excludes tenant super admins from random organization memberships', async () => {
+		const { connection } = createConnection()
+		const tenant = { id: 'tenant-1' } as ITenant
+		const organization = {
+			id: 'org-1',
+			tenant
+		} as IOrganization
+		const employeeUser = { id: 'employee-1' } as IUser
+		const adminUser = { id: 'admin-1' } as IUser
+		const superAdminUser = { id: 'super-admin-1' } as IUser
+		const seedUsers = {
+			adminUsers: [adminUser],
+			employeeUsers: [employeeUser],
+			candidateUsers: []
+		} as ISeedUsers
+
+		const result = await createRandomUsersOrganizations(
+			connection,
+			[tenant],
+			new Map([[tenant, [organization]]]),
+			new Map([[tenant, [superAdminUser]]]),
+			new Map([[tenant, seedUsers]]),
+			1
+		)
+
+		expect(result.map((membership) => membership.userId)).toEqual(['employee-1', 'admin-1'])
+	})
+})

--- a/packages/server/src/user-organization/user-organization.seed.ts
+++ b/packages/server/src/user-organization/user-organization.seed.ts
@@ -1,12 +1,8 @@
-import { Connection } from 'typeorm';
-import {
-	IOrganization,
-	IUser,
-	IUserOrganization,
-	ISeedUsers,
-	ITenant
-} from '@xpert-ai/contracts';
-import { UserOrganization } from './user-organization.entity';
+import { Connection } from 'typeorm'
+import { IOrganization, IUser, IUserOrganization, ISeedUsers, ITenant, RolesEnum } from '@xpert-ai/contracts'
+import { UserOrganization } from './user-organization.entity'
+
+const isSuperAdminUser = (user: IUser) => user.role?.name === RolesEnum.SUPER_ADMIN
 
 export const createDefaultUsersOrganizations = async (
 	connection: Connection,
@@ -14,68 +10,64 @@ export const createDefaultUsersOrganizations = async (
 	organizations: IOrganization[],
 	users: IUser[]
 ): Promise<IUserOrganization[]> => {
-	let userOrganization: IUserOrganization;
-	const usersOrganizations: IUserOrganization[] = [];
+	let userOrganization: IUserOrganization
+	const usersOrganizations: IUserOrganization[] = []
+	const organizationUsers = users.filter((user) => !isSuperAdminUser(user))
 	for (const organization of organizations) {
-		for (const user of users) {
-			userOrganization = new UserOrganization();
-			userOrganization.organization = organization;
-			userOrganization.tenantId = tenant.id;
-			userOrganization.user = user;
-			usersOrganizations.push(userOrganization);
+		for (const user of organizationUsers) {
+			userOrganization = new UserOrganization()
+			userOrganization.organization = organization
+			userOrganization.tenantId = tenant.id
+			userOrganization.user = user
+			usersOrganizations.push(userOrganization)
 		}
 	}
-	return await insertUserOrganization(connection, usersOrganizations);
-};
+	return await insertUserOrganization(connection, usersOrganizations)
+}
 
 export const createRandomUsersOrganizations = async (
 	connection: Connection,
 	tenants: ITenant[],
 	tenantOrganizationsMap: Map<ITenant, IOrganization[]>,
-	tenantSuperAdminsMap: Map<ITenant, IUser[]>,
+	_tenantSuperAdminsMap: Map<ITenant, IUser[]>,
 	tenantUsersMap: Map<ITenant, ISeedUsers>,
 	employeesPerOrganization: number
 ): Promise<IUserOrganization[]> => {
-	const usersOrganizations: IUserOrganization[] = [];
+	const usersOrganizations: IUserOrganization[] = []
 
 	for (const tenant of tenants) {
-		const orgs = tenantOrganizationsMap.get(tenant);
-		const superAdmins = tenantSuperAdminsMap.get(tenant);
-		const { adminUsers, employeeUsers } = tenantUsersMap.get(tenant);
+		const orgs = tenantOrganizationsMap.get(tenant)
+		const { adminUsers, employeeUsers } = tenantUsersMap.get(tenant)
 
-		let start = 0;
-		let end: number = employeesPerOrganization;
+		let start = 0
+		let end: number = employeesPerOrganization
 
-		let count = 0;
+		let count = 0
 
 		orgs.forEach((org) => {
-			const userList = [
-				...employeeUsers.slice(start, end),
-				adminUsers[count % adminUsers.length],
-				...superAdmins
-			];
-			start = end;
-			end = end + employeesPerOrganization;
-			count++;
+			const userList = [...employeeUsers.slice(start, end), adminUsers[count % adminUsers.length]]
+			start = end
+			end = end + employeesPerOrganization
+			count++
 
 			userList.forEach(async (user) => {
 				if (user.id) {
-					const userOrganization = new UserOrganization();
-					userOrganization.organizationId = org.id;
-					userOrganization.userId = user.id;
-					userOrganization.tenant = org.tenant;
-					usersOrganizations.push(userOrganization);
+					const userOrganization = new UserOrganization()
+					userOrganization.organizationId = org.id
+					userOrganization.userId = user.id
+					userOrganization.tenant = org.tenant
+					usersOrganizations.push(userOrganization)
 				}
-			});
-		});
+			})
+		})
 	}
 
-	return await insertUserOrganization(connection, usersOrganizations);
-};
+	return await insertUserOrganization(connection, usersOrganizations)
+}
 
 const insertUserOrganization = async (
 	connection: Connection,
 	userOrganizations: IUserOrganization[]
 ): Promise<IUserOrganization[]> => {
-	return await connection.manager.save(userOrganizations);
-};
+	return await connection.manager.save(userOrganizations)
+}

--- a/packages/server/src/user-organization/user-organization.services.spec.ts
+++ b/packages/server/src/user-organization/user-organization.services.spec.ts
@@ -10,8 +10,8 @@ jest.mock('../core/context', () => ({
 import type { Cache } from 'cache-manager'
 import type { EventEmitter2 } from '@nestjs/event-emitter'
 import type { Repository } from 'typeorm'
+import { RolesEnum, type IUser, type IUserOrganization } from '@xpert-ai/contracts'
 import { RequestContext } from '../core/context'
-import { Organization } from '../organization/organization.entity'
 import { EVENT_USER_ORGANIZATION_DELETED } from '../user/events'
 import { UserOrganization } from './user-organization.entity'
 import { UserOrganizationService } from './user-organization.services'
@@ -22,9 +22,6 @@ describe('UserOrganizationService', () => {
 		findOne: jest.fn(),
 		delete: jest.fn(),
 		update: jest.fn()
-	}
-	const organizationRepository = {
-		find: jest.fn()
 	}
 	const eventEmitter = {
 		emit: jest.fn()
@@ -46,10 +43,58 @@ describe('UserOrganizationService', () => {
 
 		service = new UserOrganizationService(
 			userOrganizationRepository as unknown as Repository<UserOrganization>,
-			organizationRepository as unknown as Repository<Organization>,
 			eventEmitter as unknown as EventEmitter2,
 			cacheManager as unknown as Cache
 		)
+	})
+
+	it('skips super admin users instead of creating organization memberships', async () => {
+		const ensureMembership = jest.spyOn(service, 'ensureMembership')
+
+		const result = await service.addUserToOrganization(
+			{
+				id: 'super-admin-1',
+				tenantId: 'tenant-1',
+				role: {
+					name: RolesEnum.SUPER_ADMIN
+				}
+			} as IUser,
+			'org-1'
+		)
+
+		expect(result).toEqual([])
+		expect(ensureMembership).not.toHaveBeenCalled()
+		expect(userOrganizationRepository.findOne).not.toHaveBeenCalled()
+	})
+
+	it('creates requested memberships for non-super-admin users', async () => {
+		const membership = {
+			id: 'membership-1',
+			tenantId: 'tenant-1',
+			organizationId: 'org-1',
+			userId: 'admin-1',
+			isDefault: true,
+			isActive: true
+		} as IUserOrganization
+		const ensureMembership = jest.spyOn(service, 'ensureMembership').mockResolvedValue(membership)
+
+		const result = await service.addUserToOrganization(
+			{
+				id: 'admin-1',
+				tenantId: 'tenant-1',
+				role: {
+					name: RolesEnum.ADMIN
+				}
+			} as IUser,
+			'org-1'
+		)
+
+		expect(result).toBe(membership)
+		expect(ensureMembership).toHaveBeenCalledWith({
+			organizationId: 'org-1',
+			tenantId: 'tenant-1',
+			userId: 'admin-1'
+		})
 	})
 
 	it('bulk removes organization memberships and preserves per-user side effects', async () => {

--- a/packages/server/src/user-organization/user-organization.services.ts
+++ b/packages/server/src/user-organization/user-organization.services.ts
@@ -18,7 +18,7 @@ import {
 	UserOrganizationCreatedEvent,
 	UserOrganizationDeletedEvent
 } from '../user/events'
-import { Organization, UserOrganization } from './../core/entities/internal'
+import { UserOrganization } from './../core/entities/internal'
 import { RequestContext } from '../core/context'
 import { touchCurrentUserFeatureUserCacheVersion } from '../user/current-user-feature-cache'
 
@@ -37,8 +37,6 @@ export class UserOrganizationService extends TenantAwareCrudService<UserOrganiza
 		@InjectRepository(UserOrganization)
 		private readonly userOrganizationRepository: Repository<UserOrganization>,
 
-		@InjectRepository(Organization)
-		private readonly organizationRepository: Repository<Organization>,
 		private readonly eventEmitter: EventEmitter2,
 		@Optional()
 		@Inject(CACHE_MANAGER)
@@ -289,14 +287,8 @@ export class UserOrganizationService extends TenantAwareCrudService<UserOrganiza
 	}
 
 	async addUserToOrganization(user: IUser, organizationId: string): Promise<IUserOrganization | IUserOrganization[]> {
-		const roleName: string = user.role?.name
-		const tenantId = user.tenant?.id ?? user.tenantId
-
-		if (roleName === RolesEnum.SUPER_ADMIN) {
-			if (!tenantId) {
-				throw new Error('User tenant is required for SUPER_ADMIN role')
-			}
-			return this._addUserToAllOrganizations(user.id, tenantId)
+		if (user.role?.name === RolesEnum.SUPER_ADMIN) {
+			return []
 		}
 
 		return await this.ensureMembership({
@@ -468,27 +460,6 @@ export class UserOrganizationService extends TenantAwareCrudService<UserOrganiza
 		}
 
 		return result
-	}
-
-	private async _addUserToAllOrganizations(userId: string, tenantId: string): Promise<IUserOrganization[]> {
-		const organizations = await this.organizationRepository.find({
-			select: ['id'],
-			where: { tenant: { id: tenantId } },
-			relations: ['tenant']
-		})
-		const memberships: IUserOrganization[] = []
-
-		for await (const organization of organizations) {
-			memberships.push(
-				await this.ensureMembership({
-					organizationId: organization.id,
-					tenantId,
-					userId
-				})
-			)
-		}
-
-		return memberships
 	}
 }
 

--- a/packages/server/src/user/user.controller.spec.ts
+++ b/packages/server/src/user/user.controller.spec.ts
@@ -1,0 +1,54 @@
+import { UserType } from '@xpert-ai/contracts'
+import { In, Not } from 'typeorm'
+import { UserController } from './user.controller'
+
+describe('UserController', () => {
+	function createController() {
+		const userService = {
+			findAll: jest.fn().mockResolvedValue({ items: [], total: 0 })
+		}
+		const factoryResetService = {}
+		const commandBus = {}
+
+		const controller = new UserController(userService as any, factoryResetService as any, commandBus as any)
+
+		return {
+			controller,
+			userService
+		}
+	}
+
+	it('excludes technical users by default for the user list', async () => {
+		const { controller, userService } = createController()
+
+		await controller.findAll({
+			relations: ['role']
+		})
+
+		expect(userService.findAll).toHaveBeenCalledWith({
+			where: {
+				type: Not(UserType.COMMUNICATION)
+			},
+			relations: ['role'],
+			withDeleted: false
+		})
+	})
+
+	it('includes explicitly requested user types in the user list', async () => {
+		const { controller, userService } = createController()
+
+		await controller.findAll({
+			relations: ['role'],
+			types: [UserType.USER, UserType.COMMUNICATION, 'unknown'],
+			withDeleted: true
+		})
+
+		expect(userService.findAll).toHaveBeenCalledWith({
+			where: {
+				type: In([UserType.USER, UserType.COMMUNICATION])
+			},
+			relations: ['role'],
+			withDeleted: true
+		})
+	})
+})

--- a/packages/server/src/user/user.controller.ts
+++ b/packages/server/src/user/user.controller.ts
@@ -38,7 +38,7 @@ import { CurrentUserFindOptions, UserService } from './user.service'
 import { UserBulkCreateCommand, UserCreateCommand } from './commands'
 import { FactoryResetService } from './factory-reset/factory-reset.service'
 import { UserDeleteCommand } from './commands/user.delete.command'
-import { Like, Not } from 'typeorm'
+import { In, Like, Not } from 'typeorm'
 import { UserPasswordDTO } from './dto'
 
 @ApiTags('User')
@@ -181,19 +181,26 @@ export class UserController extends CrudController<User> {
 	@Permissions(PermissionsEnum.ALL_ORG_VIEW, PermissionsEnum.ALL_ORG_EDIT)
 	@Get()
 	async findAll(@Query('data', ParseJsonPipe) data: any): Promise<IPagination<User>> {
-		const { relations, search } = data
-		let { findInput } = data
+		const { relations, search, types, withDeleted } = data ?? {}
+		let { findInput } = data ?? {}
 		if (search) {
 			findInput = findInput ?? {}
 			findInput.email = Like(`%${search.split('%').join('')}%`)
 		}
+		const requestedTypes = Array.isArray(types)
+			? types.filter((type): type is UserType => Object.values(UserType).includes(type))
+			: []
+		const typeFilter = requestedTypes.length
+			? { type: In(requestedTypes) }
+			: { type: Not(UserType.COMMUNICATION) }
 
 		return this.userService.findAll({
 			where: {
 				...(findInput ?? {}),
-				type: Not(UserType.COMMUNICATION)
+				...typeFilter
 			},
-			relations
+			relations,
+			withDeleted: !!withDeleted
 		})
 	}
 

--- a/packages/server/src/user/user.service.spec.ts
+++ b/packages/server/src/user/user.service.spec.ts
@@ -2,7 +2,9 @@ jest.mock('../core/context', () => ({
 	RequestContext: {
 		currentUserId: jest.fn(),
 		currentTenantId: jest.fn(),
-		hasPermission: jest.fn()
+		currentRoleId: jest.fn(),
+		hasPermission: jest.fn(),
+		hasAnyPermission: jest.fn()
 	}
 }))
 
@@ -60,7 +62,8 @@ jest.mock('./events', () => ({
 }))
 
 const { RequestContext } = require('../core/context')
-const { RolesEnum } = require('@xpert-ai/contracts')
+const { BadRequestException } = require('@nestjs/common')
+const { RolesEnum, UserType } = require('@xpert-ai/contracts')
 const { UserService } = require('./user.service')
 
 describe('UserService', () => {
@@ -98,7 +101,9 @@ describe('UserService', () => {
 		jest.clearAllMocks()
 		RequestContext.currentUserId.mockReturnValue('requester-1')
 		RequestContext.currentTenantId.mockReturnValue('tenant-1')
+		RequestContext.currentRoleId.mockReturnValue('role-1')
 		RequestContext.hasPermission.mockReturnValue(true)
+		RequestContext.hasAnyPermission.mockReturnValue(true)
 
 		service = new UserService(
 			userRepository as any,
@@ -540,6 +545,52 @@ describe('UserService', () => {
 			})
 		)
 		expect(userRepository.softDelete).toHaveBeenCalledWith('user-1')
+	})
+
+	it('rejects profile updates for technical users', async () => {
+		service.findOneByIdString = jest.fn().mockResolvedValue({
+			id: 'technical-user-1',
+			type: UserType.COMMUNICATION,
+			role: {
+				name: RolesEnum.ADMIN
+			}
+		})
+
+		await expect(
+			service.updateProfile('technical-user-1', {
+				id: 'technical-user-1',
+				username: 'updated-technical-user'
+			} as any)
+		).rejects.toBeInstanceOf(BadRequestException)
+	})
+
+	it('rejects password resets for technical users', async () => {
+		service.findOne = jest.fn().mockResolvedValue({
+			id: 'technical-user-1',
+			type: UserType.COMMUNICATION,
+			role: {
+				name: RolesEnum.ADMIN
+			}
+		})
+
+		await expect(service.resetPassword('technical-user-1', undefined, 'new-password')).rejects.toBeInstanceOf(
+			BadRequestException
+		)
+	})
+
+	it('rejects user deletion for technical users', async () => {
+		service.findOneByIdWithinTenant = jest.fn().mockResolvedValue({
+			id: 'technical-user-1',
+			tenantId: 'tenant-1',
+			type: UserType.COMMUNICATION,
+			role: {
+				name: RolesEnum.ADMIN
+			}
+		})
+
+		await expect(service.deleteWithGuards('technical-user-1')).rejects.toBeInstanceOf(BadRequestException)
+		expect(userOrganizationService.findAll).not.toHaveBeenCalled()
+		expect(userRepository.softDelete).not.toHaveBeenCalled()
 	})
 
 })

--- a/packages/server/src/user/user.service.spec.ts
+++ b/packages/server/src/user/user.service.spec.ts
@@ -2,7 +2,8 @@ jest.mock('../core/context', () => ({
 	RequestContext: {
 		currentUserId: jest.fn(),
 		currentTenantId: jest.fn(),
-		hasPermission: jest.fn()
+		hasPermission: jest.fn(),
+		hasRole: jest.fn()
 	}
 }))
 
@@ -99,6 +100,7 @@ describe('UserService', () => {
 		RequestContext.currentUserId.mockReturnValue('requester-1')
 		RequestContext.currentTenantId.mockReturnValue('tenant-1')
 		RequestContext.hasPermission.mockReturnValue(true)
+		RequestContext.hasRole.mockReturnValue(false)
 
 		service = new UserService(
 			userRepository as any,
@@ -131,7 +133,14 @@ describe('UserService', () => {
 		const result = await service.findCurrentUser('user-1', ['organizations', 'organizations.organization'])
 
 		expect(service.findOne).toHaveBeenCalledWith('user-1', {
-			relations: ['employee', 'role', 'role.rolePermissions', 'tenant', 'organizations', 'organizations.organization']
+			relations: [
+				'employee',
+				'role',
+				'role.rolePermissions',
+				'tenant',
+				'organizations',
+				'organizations.organization'
+			]
 		})
 		expect(result).toBe(user)
 	})
@@ -470,6 +479,34 @@ describe('UserService', () => {
 		expect(cacheManager.set.mock.calls[0][0]).toContain(':tenant-version-2.user-version-7')
 	})
 
+	it('treats super admins as having tenant-wide organization access without requiring membership', async () => {
+		const queryBuilder = {
+			leftJoin: jest.fn().mockReturnThis(),
+			where: jest.fn().mockReturnThis(),
+			andWhere: jest.fn().mockReturnThis(),
+			getCount: jest.fn().mockResolvedValue(1)
+		}
+		userRepository.createQueryBuilder.mockReturnValue(queryBuilder)
+
+		const result = await service.isActiveMemberOfOrganization('super-admin-1', 'org-1')
+
+		expect(result).toBe(true)
+		expect(queryBuilder.leftJoin).toHaveBeenNthCalledWith(1, 'user.role', 'role')
+		expect(queryBuilder.leftJoin).toHaveBeenNthCalledWith(
+			2,
+			'user.organizations',
+			'userOrganization',
+			'userOrganization.organizationId = :organizationId AND userOrganization.isActive = :isActive',
+			{
+				organizationId: 'org-1',
+				isActive: true
+			}
+		)
+		expect(queryBuilder.andWhere).toHaveBeenCalledWith(expect.anything(), {
+			superAdminRole: RolesEnum.SUPER_ADMIN
+		})
+	})
+
 	it('removes user organizations through the service and emits deletion events before soft deleting the user', async () => {
 		userRepository.findOne.mockResolvedValue({
 			id: 'user-1',
@@ -542,4 +579,22 @@ describe('UserService', () => {
 		expect(userRepository.softDelete).toHaveBeenCalledWith('user-1')
 	})
 
+	it('excludes super admins from organization non-member search results', async () => {
+		const queryBuilder = {
+			leftJoin: jest.fn().mockReturnThis(),
+			where: jest.fn().mockReturnThis(),
+			andWhere: jest.fn().mockReturnThis(),
+			take: jest.fn().mockReturnThis(),
+			getManyAndCount: jest.fn().mockResolvedValue([[], 0])
+		}
+		userRepository.createQueryBuilder.mockReturnValue(queryBuilder)
+
+		const result = await service.search('ada', 'org-1', 'non-members')
+
+		expect(result).toEqual({ items: [], total: 0 })
+		expect(queryBuilder.leftJoin).toHaveBeenCalledWith('user.role', 'role')
+		expect(queryBuilder.andWhere).toHaveBeenCalledWith('(role.name IS NULL OR role.name != :superAdminRole)', {
+			superAdminRole: RolesEnum.SUPER_ADMIN
+		})
+	})
 })

--- a/packages/server/src/user/user.service.ts
+++ b/packages/server/src/user/user.service.ts
@@ -504,6 +504,10 @@ export class UserService extends TenantAwareCrudService<User> {
 			throw new NotFoundException(`The user was not found`)
 		}
 
+		if (user.type === UserType.COMMUNICATION) {
+			throw new BadRequestException('Technical users cannot be updated through user profile management.')
+		}
+
 		const isSelf = RequestContext.currentUserId() === id
 		const canManageUsers = RequestContext.hasAnyPermission([
 			PermissionsEnum.ALL_ORG_EDIT,
@@ -578,6 +582,10 @@ export class UserService extends TenantAwareCrudService<User> {
 			throw new NotFoundException(`The user '${id}' was not found`)
 		}
 
+		if (user.type === UserType.COMMUNICATION) {
+			throw new BadRequestException('Technical users cannot be updated through user profile management.')
+		}
+
 		if (user.role?.name === RolesEnum.SUPER_ADMIN) {
 			if (!RequestContext.hasPermission(PermissionsEnum.SUPER_ADMIN_EDIT)) {
 				throw new ForbiddenException()
@@ -610,6 +618,10 @@ export class UserService extends TenantAwareCrudService<User> {
 		const user = await this.findOneByIdWithinTenant(id, tenantId, {
 			relations: ['role']
 		})
+
+		if (user.type === UserType.COMMUNICATION) {
+			throw new BadRequestException('Technical users cannot be deleted through user management.')
+		}
 
 		if (!user.role?.name) {
 			throw new BadRequestException('The user role is required before deleting the user.')

--- a/packages/server/src/user/user.service.ts
+++ b/packages/server/src/user/user.service.ts
@@ -1,15 +1,45 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
-import { BadRequestException, ForbiddenException, Injectable, Logger, NotFoundException, Inject, forwardRef, Optional } from '@nestjs/common'
+import {
+	BadRequestException,
+	ForbiddenException,
+	Injectable,
+	Logger,
+	NotFoundException,
+	Inject,
+	forwardRef,
+	Optional
+} from '@nestjs/common'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { InjectRepository } from '@nestjs/typeorm'
 import type { Cache } from 'cache-manager'
-import { Repository, InsertResult, Like, Brackets, WhereExpressionBuilder, In, FindOneOptions, DeleteResult, IsNull, FindManyOptions, FindOptionsSelect, FindOptionsWhere } from 'typeorm'
+import {
+	Repository,
+	InsertResult,
+	Like,
+	Brackets,
+	WhereExpressionBuilder,
+	In,
+	FindOneOptions,
+	DeleteResult,
+	IsNull,
+	FindManyOptions,
+	FindOptionsSelect,
+	FindOptionsWhere
+} from 'typeorm'
 import bcrypt from 'bcryptjs'
 import { environment as env } from '@xpert-ai/server-config'
 import { nanoid } from 'nanoid'
 import { User } from './user.entity'
 import { TenantAwareCrudService } from './../core/crud'
-import { ID, IFeatureOrganization, IUser, LanguagesEnum, PermissionsEnum, RolesEnum, UserType } from '@xpert-ai/contracts'
+import {
+	ID,
+	IFeatureOrganization,
+	IUser,
+	LanguagesEnum,
+	PermissionsEnum,
+	RolesEnum,
+	UserType
+} from '@xpert-ai/contracts'
 import { RequestContext } from '../core/context'
 import { EmailVerification } from './email-verification/email-verification.entity'
 import { UserPublicDTO } from './dto'
@@ -206,7 +236,7 @@ export class UserService extends TenantAwareCrudService<User> {
 			? await organizationQuery({
 					...baseWhere,
 					organizationId: currentOrganizationId
-			  })
+				})
 			: null
 
 		const membership =
@@ -287,7 +317,7 @@ export class UserService extends TenantAwareCrudService<User> {
 						organizationId: In(organizationIds)
 					},
 					relations: ['feature']
-			  })
+				})
 			: []
 
 		this.attachFeatureOrganizationsToCurrentUser(user, tenantFeatureOrganizations, organizationFeatureOrganizations)
@@ -530,7 +560,8 @@ export class UserService extends TenantAwareCrudService<User> {
 
 		const total = await this.repository
 			.createQueryBuilder('user')
-			.innerJoin(
+			.leftJoin('user.role', 'role')
+			.leftJoin(
 				'user.organizations',
 				'userOrganization',
 				'userOrganization.organizationId = :organizationId AND userOrganization.isActive = :isActive',
@@ -541,6 +572,13 @@ export class UserService extends TenantAwareCrudService<User> {
 			)
 			.where('user.id = :userId', { userId })
 			.andWhere('user.tenantId = :tenantId', { tenantId })
+			.andWhere(
+				new Brackets((qb: WhereExpressionBuilder) => {
+					qb.where('role.name = :superAdminRole')
+					qb.orWhere('userOrganization.id IS NOT NULL')
+				}),
+				{ superAdminRole: RolesEnum.SUPER_ADMIN }
+			)
 			.getCount()
 
 		return total > 0
@@ -747,6 +785,7 @@ export class UserService extends TenantAwareCrudService<User> {
 						organizationId
 					}
 				)
+				.leftJoin('user.role', 'role')
 				.where(
 					new Brackets((qb: WhereExpressionBuilder) => {
 						qb.orWhere('user.email LIKE :searchText')
@@ -758,6 +797,9 @@ export class UserService extends TenantAwareCrudService<User> {
 				)
 				.andWhere('user.tenantId = :tenantId', { tenantId })
 				.andWhere('organizationMembership.id IS NULL')
+				.andWhere('(role.name IS NULL OR role.name != :superAdminRole)', {
+					superAdminRole: RolesEnum.SUPER_ADMIN
+				})
 				.take(20)
 
 			return query.getManyAndCount().then(([items, total]) => ({


### PR DESCRIPTION
## Summary

This PR brings the current `develop` branch into `main`.

It includes updates for:

- tenant user type management and user membership administration in the cloud UI and server APIs
- user conversation visibility and conversation search behavior for owned xperts
- handoff idle-timeout heartbeat handling and routing configuration coverage
- copilot token usage tracking, limits, and billing/usage center display updates
- super admin access cleanup so it is no longer coupled to organization membership records
- release notes for handoff message updates

## Notes

`develop` and `main` have diverged: the compare currently reports `develop` ahead by 7 commits and behind `main` by 7 commits.

## Validation

- Passed: `git diff --check origin/main...origin/develop`
- Failed: `./node_modules/.bin/nx affected -t test --base=origin/main --head=origin/develop --parallel=3`
  - Failing affected projects: `copilot`, `contracts`, `story-angular`, `adapter`, `server`, `analytics`, `cloud`, and `server-ai`.
  - The failures include existing-looking legacy/spec configuration issues, Jest transform/setup issues, and several assertion/type errors that should be reviewed before marking the PR ready.