### PR TITLE
fix: limit agent entry graph to upstream paths

### DIFF
--- a/packages/contracts/src/agent/utils.spec.ts
+++ b/packages/contracts/src/agent/utils.spec.ts
@@ -1,6 +1,6 @@
 import { TXpertGraph } from '../ai/xpert.model'
 import { DeepPartial } from '../types'
-import { allChannels, findStartNodes, getCurrentGraph } from './utils'
+import { allChannels, findStartNodes, getCurrentGraph, getUpstreamGraph } from './utils'
 
 describe('findStartNodes', () => {
   it('should return the correct start nodes for a given key', () => {
@@ -169,6 +169,24 @@ describe('findStartNodes', () => {
         to: 'Http_T9uLo1NJUV'
       }
     ])
+  })
+})
+
+describe('getUpstreamGraph', () => {
+  it('removes sibling and downstream edge branches while preserving non-edge connections', () => {
+    const upstream = { key: 'upstream/shared', type: 'edge' as const, from: 'upstream', to: 'shared' }
+    const target = { key: 'shared/agent-a', type: 'edge' as const, from: 'shared', to: 'agent-a' }
+    const sibling = { key: 'shared/agent-b', type: 'edge' as const, from: 'shared', to: 'agent-b' }
+    const downstream = { key: 'agent-a/after-a', type: 'edge' as const, from: 'agent-a', to: 'after-a' }
+    const toolset = { key: 'agent-a/tool-a', type: 'toolset' as const, from: 'agent-a', to: 'tool-a' }
+    const graph: TXpertGraph = {
+      nodes: [],
+      connections: [upstream, target, sibling, downstream, toolset]
+    }
+
+    const result = getUpstreamGraph(graph, 'agent-a')
+
+    expect(result.connections).toEqual([upstream, target, toolset])
   })
 })
 

--- a/packages/contracts/src/agent/utils.ts
+++ b/packages/contracts/src/agent/utils.ts
@@ -55,6 +55,44 @@ export function findStartNodes(graph: DeepPartial<TXpertGraph>, key: string): st
 }
 
 /**
+ * Keep only edge connections that can reach the target node.
+ * Non-edge connections are preserved because workflow nodes may depend on attached resources.
+ */
+export function getUpstreamGraph(graph: TXpertGraph, key: string): TXpertGraph {
+  const normalize = (value: string) => value.split('/')[0]
+  const edgeConnections = graph.connections.filter((connection) => connection.type === 'edge')
+  const upstreamConnections = new Set<TXpertGraph['connections'][number]>()
+  const visited = new Set<string>()
+  const pending = [normalize(key)]
+
+  while (pending.length) {
+    const current = pending.pop()
+    if (!current || visited.has(current)) {
+      continue
+    }
+    visited.add(current)
+
+    for (const connection of edgeConnections) {
+      if (normalize(connection.to) !== current) {
+        continue
+      }
+      upstreamConnections.add(connection)
+      const parent = normalize(connection.from)
+      if (!visited.has(parent)) {
+        pending.push(parent)
+      }
+    }
+  }
+
+  return {
+    nodes: graph.nodes,
+    connections: graph.connections.filter(
+      (connection) => connection.type !== 'edge' || upstreamConnections.has(connection)
+    )
+  }
+}
+
+/**
  * Keep the content in the same graph as the key node (including the node, its connected nodes, and the 'edge' type connections between them)
  * 
  * @param graph 

--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts
@@ -28,6 +28,7 @@ import { STATE_VARIABLE_PENDING_FOLLOW_UPS } from '../../../shared/agent/state'
 import { CreateNodeConsumePendingSteerFollowUpsCommand } from '../create-node-consume-pending-steer-follow-ups.command'
 import { CreateNodeStagePendingSteerFollowUpsCommand } from '../create-node-stage-pending-steer-follow-ups.command'
 import { XpertAgentSubgraphCommand } from '../subgraph.command'
+import { CreateWorkflowNodeCommand } from '../../workflow/create-workflow.command'
 import { CreateNodeConsumePendingSteerFollowUpsHandler } from './create-node-consume-pending-steer-follow-ups.handler'
 import { CreateNodeStagePendingSteerFollowUpsHandler } from './create-node-stage-pending-steer-follow-ups.handler'
 import { XpertAgentSubgraphHandler } from './subgraph.handler'
@@ -524,6 +525,185 @@ describe('XpertAgentSubgraphHandler hidden agent graph', () => {
             .filter((command) => command.constructor.name === 'CreateWorkflowNodeCommand')
         expect(workflowCommands).toHaveLength(1)
         expect(workflowCommands[0].node.key).toBe('trigger-1')
+    })
+})
+
+describe('XpertAgentSubgraphHandler shared upstream branches', () => {
+    it('does not compile sibling agents when preparing the target agent entry path', async () => {
+        const model = RunnableLambda.from(async () => new AIMessage(''))
+        const targetAgent = {
+            key: 'agent-target',
+            name: 'Target Agent',
+            title: 'Target Agent',
+            prompt: 'Handle the request.',
+            toolsetIds: [],
+            knowledgebaseIds: [],
+            options: {
+                fileUnderstanding: {
+                    enabled: false
+                }
+            },
+            team: {
+                id: 'xpert-1',
+                workspaceId: 'workspace-1',
+                agentConfig: {},
+                copilotModel: {
+                    model: 'fake-model',
+                    copilot: {
+                        modelProvider: {
+                            providerName: 'fake-provider'
+                        },
+                        copilotModel: {
+                            model: 'provider-model'
+                        }
+                    }
+                }
+            }
+        }
+        const targetEdge = {
+            key: 'shared/agent-target',
+            type: 'edge' as const,
+            from: 'shared',
+            to: 'agent-target'
+        }
+        const siblingEdge = {
+            key: 'shared/agent-sibling',
+            type: 'edge' as const,
+            from: 'shared',
+            to: 'agent-sibling'
+        }
+        const graph = {
+            nodes: [
+                {
+                    type: 'agent' as const,
+                    key: 'agent-target',
+                    entity: targetAgent
+                },
+                {
+                    type: 'workflow' as const,
+                    key: 'shared',
+                    entity: {
+                        key: 'shared',
+                        type: WorkflowNodeTypeEnum.TEMPLATE
+                    }
+                },
+                {
+                    type: 'agent' as const,
+                    key: 'agent-sibling',
+                    entity: {
+                        ...targetAgent,
+                        key: 'agent-sibling',
+                        name: 'Sibling Agent',
+                        title: 'Sibling Agent'
+                    }
+                }
+            ],
+            connections: [targetEdge, siblingEdge]
+        }
+        const workflowGraphs: Array<CreateWorkflowNodeCommand['graph']> = []
+        const commandBus = {
+            execute: jest.fn(async (command: unknown) => {
+                if (command instanceof CreateWorkflowNodeCommand) {
+                    workflowGraphs.push(command.graph)
+                    return {
+                        workflowNode: {
+                            graph: RunnableLambda.from(() => ({})),
+                            ends: []
+                        },
+                        nextNodes: command.graph.connections
+                            .filter((connection) => connection.type === 'edge' && connection.from === command.node.key)
+                            .map((connection) => command.graph.nodes.find((node) => node.key === connection.to))
+                            .filter((node) => !!node)
+                    }
+                }
+
+                const commandName = command && typeof command === 'object' ? command.constructor.name : ''
+                switch (commandName) {
+                    case 'ToolsetGetToolsCommand':
+                        return []
+                    case 'CreateNodeStagePendingSteerFollowUpsCommand':
+                        return RunnableLambda.from(() => ({
+                            [STATE_VARIABLE_PENDING_FOLLOW_UPS]: []
+                        }))
+                    case 'CreateNodeConsumePendingSteerFollowUpsCommand':
+                        return RunnableLambda.from(() => ({}))
+                    default:
+                        throw new Error(`Unexpected command: ${commandName}`)
+                }
+            })
+        }
+        const queryBus = {
+            execute: jest.fn(async (query: unknown) => {
+                const queryName = query && typeof query === 'object' ? query.constructor.name : ''
+                switch (queryName) {
+                    case 'GetXpertWorkflowQuery':
+                        return {
+                            agent: targetAgent,
+                            graph,
+                            next: [],
+                            fail: []
+                        }
+                    case 'GetXpertChatModelQuery':
+                        return model
+                    default:
+                        throw new Error(`Unexpected query: ${queryName}`)
+                }
+            })
+        }
+        const handler = new XpertAgentSubgraphHandler(
+            null,
+            commandBus as unknown as CommandBus,
+            queryBus as unknown as QueryBus,
+            null,
+            null,
+            {
+                api: {},
+                createScopedApi: jest.fn().mockReturnValue({})
+            } as unknown as AgentMiddlewareRuntimeService
+        )
+        Object.defineProperty(handler, 'agentMiddlewareRegistry', {
+            value: {
+                get: jest.fn()
+            }
+        })
+
+        await handler.execute(
+            new XpertAgentSubgraphCommand(
+                'agent-target',
+                {
+                    id: 'xpert-1',
+                    workspaceId: 'workspace-1'
+                },
+                {
+                    isStart: true,
+                    isDraft: true,
+                    mute: [],
+                    store: null,
+                    subscriber: null,
+                    execution: {
+                        id: 'execution-1'
+                    } as IXpertAgentExecution,
+                    rootController: new AbortController(),
+                    signal: new AbortController().signal,
+                    channel: channelName('agent-target'),
+                    thread_id: 'thread-1',
+                    disableCheckpointer: true,
+                    environment: {
+                        variables: []
+                    } as IEnvironment,
+                    partners: []
+                }
+            )
+        )
+
+        expect(workflowGraphs).toHaveLength(1)
+        expect(workflowGraphs[0].connections.filter((connection) => connection.type === 'edge')).toEqual([targetEdge])
+        expect(
+            commandBus.execute.mock.calls.some(
+                ([command]) =>
+                    command && typeof command === 'object' && command.constructor.name === 'XpertAgentSubgraphCommand'
+            )
+        ).toBe(false)
     })
 })
 

--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
@@ -32,7 +32,7 @@ import {
     ChatMessageEventTypeEnum,
     figureOutXpert,
     findStartNodes,
-    getCurrentGraph,
+    getUpstreamGraph,
     getWorkflowTriggers,
     GRAPH_NODE_SUMMARIZE_CONVERSATION,
     isAgentKey,
@@ -536,7 +536,12 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
          * @param parentKey The pre-node of this node
          * @param finalReturn The end node if this node is the end of the workflow
          */
-        const createSubgraph = async (node: TXpertTeamNode, parentKey?: string, finalReturn?: string) => {
+        const createSubgraph = async (
+            node: TXpertTeamNode,
+            parentKey?: string,
+            finalReturn?: string,
+            traversalGraph: TXpertGraph = graph
+        ) => {
             if (node?.type === 'agent') {
                 if (agentKeys.has(node.key)) {
                     return
@@ -576,7 +581,7 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
                 // The failure process of non-starting agents is created here
                 if (failNode) {
                     ends.push(failNode.key)
-                    await createSubgraph(failNode, null, finalReturn)
+                    await createSubgraph(failNode, null, finalReturn, traversalGraph)
                 }
                 nodes[node.key] = {
                     graph: stateGraph,
@@ -602,7 +607,7 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
                         edges[node.key] = _nextNodes[0].key
                     }
                     for await (const nextNode of _nextNodes) {
-                        await createSubgraph(nextNode, node.key, finalReturn)
+                        await createSubgraph(nextNode, node.key, finalReturn, traversalGraph)
                     }
                 } else if (finalReturn) {
                     if (failNode) {
@@ -629,7 +634,7 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
                 }
                 const { workflowNode, navigator, nextNodes, channel, tool, caller, toolset, variables } =
                     await this.commandBus.execute<CreateWorkflowNodeCommand, TWorkflowGraphNode>(
-                        new CreateWorkflowNodeCommand(xpert.id, graph, node, parentKey, {
+                        new CreateWorkflowNodeCommand(xpert.id, traversalGraph, node, parentKey, {
                             mute: options.mute,
                             store: options.store,
                             isDraft: options.isDraft,
@@ -683,7 +688,7 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
                 }
 
                 for await (const nNode of nextNodes ?? []) {
-                    await createSubgraph(nNode, null, finalReturn)
+                    await createSubgraph(nNode, null, finalReturn, traversalGraph)
                 }
 
                 if (!nextNodes.length) {
@@ -726,9 +731,16 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
                     ? runtimeTriggerNodes
                     : getWorkflowTriggers(graph, 'chat').map((n) => n.key)
             } else {
-                startNodes = findStartNodes(getCurrentGraph(graph, agent.key), agent.key).filter((_) => _ !== agent.key)
+                const upstreamGraph = getUpstreamGraph(graph, agent.key)
+                startNodes = findStartNodes(upstreamGraph, agent.key).filter((_) => _ !== agent.key)
+                if (startNodes.length) {
+                    for await (const key of startNodes) {
+                        const node = graph.nodes.find((_) => _.key === key)
+                        await createSubgraph(node, null, undefined, upstreamGraph)
+                    }
+                }
             }
-            if (startNodes.length) {
+            if (hiddenAgent && startNodes.length) {
                 for await (const key of startNodes) {
                     const node = graph.nodes.find((_) => _.key === key)
                     await createSubgraph(node, null)


### PR DESCRIPTION
## What changed

- add an upstream-only graph projection for targeted agent entry
- preserve non-edge resource connections while removing sibling and downstream edge branches
- build workflow nodes with the projected graph so sibling agents are not compiled
- add contract and handler regression coverage

## Why

When multiple agents share an upstream workflow node, entering one target agent could compile sibling branches from the full graph. The target entry path should contain only edges that can reach that agent.

## Checks

- `corepack pnpm@10.24.0 nx test contracts --runInBand --testPathPatterns='agent/utils.spec.ts'`
- `corepack pnpm@10.24.0 nx test server-ai --runInBand --testPathPatterns='xpert-agent/commands/handlers/subgraph.handler.spec.ts' --testNamePattern='does not compile sibling agents when preparing the target agent entry path'`

The complete `subgraph.handler.spec.ts` currently includes unrelated existing failures from outdated `AgentMiddlewareRuntimeService` mocks; the new regression test passes in isolation.