### PR TITLE
feat: configure template market recommendations

### DIFF
--- a/packages/server-ai/src/xpert-template/templates-market.yaml
+++ b/packages/server-ai/src/xpert-template/templates-market.yaml
@@ -1,0 +1,5 @@
+recommendedApps:
+    - id: '@xpert-ai/plugin-sites:sites-builder-assistant'
+    - id: '@xpert-ai/plugin-docx-editor:docx-editor-assistant'
+    - id: xpert--client-browser-automation-tools
+    - id: '@xpert-ai/plugin-presentation-studio:presentation-studio-assistant'

--- a/packages/server-ai/src/xpert-template/xpert-template.service.spec.ts
+++ b/packages/server-ai/src/xpert-template/xpert-template.service.spec.ts
@@ -481,7 +481,51 @@ describe('XpertTemplateService', () => {
         expect(catalog.details).not.toHaveProperty(exportedTemplate.id)
     })
 
-    it('merges plugin xpert templates into the template catalog with namespaced ids', async () => {
+    it('returns every configured recommendation in configuration order without a fixed limit', async () => {
+        const workspaceRoot = createTempDir()
+        const dataRoot = createTempDir()
+        const externalRoot = join(dataRoot, 'external-templates')
+        const configuredIds = Array.from({ length: 7 }, (_, index) => `template-${7 - index}`)
+        seedBuiltinTemplates(workspaceRoot, {
+            templatesJson: {
+                templates: {
+                    'en-US': {
+                        categories: ['Built-in'],
+                        recommendedApps: Array.from({ length: 7 }, (_, index) => ({
+                            id: `template-${index + 1}`,
+                            name: `Template ${index + 1}`,
+                            category: 'Built-in'
+                        }))
+                    }
+                },
+                details: {}
+            },
+            templatesMarketYaml: ['recommendedApps:', ...configuredIds.map((id) => `  - id: ${id}`)].join('\n')
+        })
+        mkdirSync(externalRoot, { recursive: true })
+        writeJson(join(externalRoot, 'templates.json'), {
+            templates: {
+                'en-US': {
+                    categories: ['External'],
+                    recommendedApps: [{ id: 'template-1', name: 'External Template 1', category: 'External' }]
+                }
+            },
+            details: {}
+        })
+        const { service } = createService({
+            serverRoot: workspaceRoot,
+            dataPath: join(dataRoot, 'fallback-data'),
+            env: {
+                XPERT_TEMPLATE_DIR: externalRoot
+            }
+        })
+
+        const catalog = await service.getAll(LanguagesEnum.English)
+
+        expect(catalog.recommendedApps.map((template) => template.id)).toEqual(configuredIds)
+    })
+
+    it('resolves configured plugin templates with namespaced ids and skips unavailable refs', async () => {
         const workspaceRoot = createTempDir()
         const dataRoot = createTempDir()
         seedBuiltinTemplates(workspaceRoot, {
@@ -493,7 +537,12 @@ describe('XpertTemplateService', () => {
                     }
                 },
                 details: {}
-            }
+            },
+            templatesMarketYaml: [
+                'recommendedApps:',
+                '  - id: "@xpert-ai/plugin-demo:business"',
+                '  - id: "@xpert-ai/plugin-missing:assistant"'
+            ].join('\n')
         })
         const { service } = createService({
             serverRoot: workspaceRoot,
@@ -1350,6 +1399,7 @@ describe('XpertTemplateService', () => {
             mcpTemplatesJson?: Record<string, unknown>
             knowledgePipelinesJson?: Record<string, unknown>
             skillsMarketYaml?: string
+            templatesMarketYaml?: string
             skillRepositoriesYaml?: string
             workspaceDefaultsYaml?: string
             templateYaml?: string
@@ -1408,6 +1458,11 @@ describe('XpertTemplateService', () => {
                     '      label: Trending',
                     '      options: []'
                 ].join('\n'),
+            'utf8'
+        )
+        writeFileSync(
+            join(builtinRoot, 'templates-market.yaml'),
+            overrides.templatesMarketYaml ?? ['recommendedApps:', '  - id: template-1'].join('\n'),
             'utf8'
         )
         writeFileSync(

--- a/packages/server-ai/src/xpert-template/xpert-template.service.ts
+++ b/packages/server-ai/src/xpert-template/xpert-template.service.ts
@@ -53,6 +53,7 @@ const templateFiles = [
     'skill-repositories.yaml',
     'workspace-defaults.yaml'
 ] as const
+const builtinTemplateFiles = [...templateFiles, 'templates-market.yaml'] as const
 
 type TXpertTemplateDescriptor = {
     id: string
@@ -87,6 +88,14 @@ type TXpertTemplateGroup = {
 type TXpertTemplatesCatalog = {
     templates: Record<string, TXpertTemplateGroup>
     details: Record<string, TXpertTemplateDescriptor>
+}
+
+type TTemplateMarketRef = {
+    id: string
+}
+
+type TTemplateMarketConfig = {
+    recommendedApps: TTemplateMarketRef[]
 }
 
 type TLocalizedTemplates<T> = Record<string, { categories?: string[]; templates: T[] }>
@@ -249,6 +258,9 @@ const isWorkspaceDefaultSkillRef = (value: unknown): value is TWorkspaceDefaultS
     typeof Reflect.get(value, 'repositoryName') === 'string' &&
     typeof Reflect.get(value, 'skillId') === 'string'
 
+const isTemplateMarketRef = (value: unknown): value is TTemplateMarketRef =>
+    isObjectValue(value) && typeof Reflect.get(value, 'id') === 'string'
+
 const isOptionalRepositoryPayload = (value: unknown): value is ISkillRepository['options'] | null | undefined =>
     typeof value === 'undefined' || value === null || isObjectValue(value)
 
@@ -343,26 +355,46 @@ export class XpertTemplateService extends TenantAwareCrudService<XpertTemplate> 
     }
 
     async getAll(language: LanguagesEnum, query?: TXpertTemplateQuery) {
-        const templatesData = await this.readTemplatesFile()
+        const [templatesData, builtinTemplatesData, marketConfig, pluginTemplates] = await Promise.all([
+            this.readTemplatesFile(),
+            this.readBuiltinTemplatesFile(),
+            this.readTemplatesMarketConfig(),
+            this.getPluginTemplates(query)
+        ])
         const group = templatesData.templates[language]?.recommendedApps?.length
             ? templatesData.templates[language]
             : templatesData.templates[fallbackLanguage]
-        const pluginTemplates = await this.getPluginTemplates(query)
-        const recommendedApps = [...(group?.recommendedApps ?? []), ...pluginTemplates]
-            .filter((template) => this.matchesTemplateQuery(template, query))
-            .sort(
-                (left, right) =>
-                    this.getTemplateOrder(left) - this.getTemplateOrder(right) || left.id.localeCompare(right.id)
-            )
+        const recommendedApps = this.resolveRecommendedTemplates(
+            marketConfig.recommendedApps,
+            templatesData,
+            builtinTemplatesData,
+            pluginTemplates,
+            language,
+            query
+        )
 
         return {
             ...(group ?? { categories: [], recommendedApps: [] }),
             categories: this.mergeTemplateCategories(
                 group?.categories,
-                pluginTemplates.map((template) => template.category)
+                recommendedApps.map((template) => template.category)
             ),
             recommendedApps
         }
+    }
+
+    async readTemplatesMarketConfig(): Promise<TTemplateMarketConfig> {
+        let config = await this.cacheManager.get<TTemplateMarketConfig>('xpert:templates-market')
+        if (config) {
+            return config
+        }
+
+        const filePath = path.join(this.getBuiltinTemplateRoot(), 'templates-market.yaml')
+        const raw = await this.readYamlFromFile(filePath, 'templates market config')
+        config = this.normalizeTemplatesMarketConfig(raw)
+        await this.cacheManager.set('xpert:templates-market', config, 10 * 1000)
+
+        return config
     }
 
     async getTemplateDetail(id: string, language: LanguagesEnum, query?: TXpertTemplateQuery) {
@@ -389,10 +421,18 @@ export class XpertTemplateService extends TenantAwareCrudService<XpertTemplate> 
         id: string,
         language: LanguagesEnum
     ): Promise<TXpertTemplateDescriptor | null> {
+        const templatesData = await this.readBuiltinTemplatesFile()
+        if (!templatesData) {
+            return null
+        }
+
+        return templatesData.details[id] ?? this.findTemplateDescriptorById(templatesData, id, language)
+    }
+
+    private async readBuiltinTemplatesFile(): Promise<TXpertTemplatesCatalog | null> {
         try {
             const templatesFilePath = path.join(this.getBuiltinTemplateRoot(), 'templates.json')
-            const templatesData = await this.readJsonFromFile<TXpertTemplatesCatalog>(templatesFilePath)
-            return templatesData.details[id] ?? this.findTemplateDescriptorById(templatesData, id, language)
+            return await this.readJsonFromFile<TXpertTemplatesCatalog>(templatesFilePath)
         } catch {
             return null
         }
@@ -785,6 +825,10 @@ export class XpertTemplateService extends TenantAwareCrudService<XpertTemplate> 
         query?: TXpertTemplateQuery
     ): Promise<TXpertTemplateDescriptor | null> {
         const templates = await this.getPluginTemplates(query)
+        return this.findPluginTemplateById(templates, id)
+    }
+
+    private findPluginTemplateById(templates: TXpertTemplateDescriptor[], id: string) {
         const normalizedId = this.normalizePluginTemplateId(id)
         return (
             templates.find(
@@ -795,6 +839,32 @@ export class XpertTemplateService extends TenantAwareCrudService<XpertTemplate> 
                     this.normalizePluginTemplateId(template.key) === normalizedId
             ) ?? null
         )
+    }
+
+    private resolveRecommendedTemplates(
+        refs: TTemplateMarketRef[],
+        templatesData: TXpertTemplatesCatalog,
+        builtinTemplatesData: TXpertTemplatesCatalog | null,
+        pluginTemplates: TXpertTemplateDescriptor[],
+        language: LanguagesEnum,
+        query?: TXpertTemplateQuery
+    ) {
+        const recommendedApps: TXpertTemplateDescriptor[] = []
+
+        for (const ref of refs) {
+            const externalTemplate = this.findTemplateDescriptorById(templatesData, ref.id, language)
+            const builtinTemplate = builtinTemplatesData
+                ? this.findTemplateDescriptorById(builtinTemplatesData, ref.id, language)
+                : null
+            const template =
+                this.findPluginTemplateById(pluginTemplates, ref.id) ??
+                this.mergeTemplateDescriptorDependencies(externalTemplate, builtinTemplate)
+            if (template && this.matchesTemplateQuery(template, query)) {
+                recommendedApps.push(template)
+            }
+        }
+
+        return recommendedApps
     }
 
     private getEffectivePluginRecords() {
@@ -914,12 +984,6 @@ export class XpertTemplateService extends TenantAwareCrudService<XpertTemplate> 
         }
 
         return true
-    }
-
-    private getTemplateOrder(template: TXpertTemplateDescriptor) {
-        return typeof template.order === 'number' && Number.isFinite(template.order)
-            ? template.order
-            : Number.MAX_SAFE_INTEGER
     }
 
     private mergeTemplateCategories(categories: string[] = [], extraCategories: Array<string | undefined>) {
@@ -1175,7 +1239,7 @@ export class XpertTemplateService extends TenantAwareCrudService<XpertTemplate> 
     }
 
     private async assertBuiltinTemplateLayout(builtinRoot: string, externalRoot: string) {
-        for (const fileName of templateFiles) {
+        for (const fileName of builtinTemplateFiles) {
             await this.assertPathAvailable(
                 path.join(builtinRoot, fileName),
                 'file',
@@ -1330,6 +1394,24 @@ export class XpertTemplateService extends TenantAwareCrudService<XpertTemplate> 
                 featured: [],
                 filters: DEFAULT_SKILL_MARKET_FILTERS
             }
+        }
+    }
+
+    private normalizeTemplatesMarketConfig(value: unknown): TTemplateMarketConfig {
+        if (!isObjectValue(value)) {
+            return { recommendedApps: [] }
+        }
+
+        const recommendedApps = Reflect.get(value, 'recommendedApps')
+        if (!Array.isArray(recommendedApps)) {
+            return { recommendedApps: [] }
+        }
+
+        return {
+            recommendedApps: recommendedApps
+                .filter(isTemplateMarketRef)
+                .map((item) => ({ id: item.id.trim() }))
+                .filter((item) => !!item.id)
         }
     }
 


### PR DESCRIPTION
## What changed

- Add a built-in `templates-market.yaml` recommendation list.
- Resolve recommended templates in configuration order.
- Support built-in, external, and namespaced plugin templates.
- Skip unavailable references and remove the fixed recommendation limit.

## Why

Template recommendations were previously derived by merging and sorting entries from multiple catalogs, which made the visible recommendations and their order implicit. A release-owned built-in list makes both the recommendation set and display order explicit.

## Checks

- `corepack pnpm@10.24.0 nx test server-ai --runInBand --testPathPatterns='xpert-template/xpert-template.service.spec.ts'` (25 tests passed)
