### PR TITLE
fix: validate recursive agent subgraph builds

### DIFF
--- a/packages/server-ai/src/xpert-agent/graph-validator.spec.ts
+++ b/packages/server-ai/src/xpert-agent/graph-validator.spec.ts
@@ -1,0 +1,235 @@
+import {
+    IXpertAgent,
+    TXpertTeamConnection,
+    TXpertTeamDraft,
+    TXpertTeamNode,
+    WorkflowNodeTypeEnum
+} from '@xpert-ai/contracts'
+import { AGENT_SUBGRAPH_BUILD_CYCLE, XpertAgentGraphValidator } from './graph-validator'
+
+describe('XpertAgentGraphValidator', () => {
+    const validator = new XpertAgentGraphValidator()
+
+    it('reports a cycle when a parent and child agent share an entry workflow branch', () => {
+        const draft = createDraft(
+            ['main', 'child'],
+            [
+                createEdge('shared/output', 'main'),
+                createEdge('shared/output', 'child'),
+                createAgentConnection('main', 'child')
+            ],
+            [createWorkflowNode('shared')]
+        )
+
+        expect(validator.handle({ draft })).toEqual([
+            expect.objectContaining({
+                ruleCode: AGENT_SUBGRAPH_BUILD_CYCLE,
+                level: 'error',
+                field: 'connections',
+                value: 'Child → Main → Child'
+            })
+        ])
+    })
+
+    it('allows a shared workflow fan-out when there is no recursive agent dependency', () => {
+        const draft = createDraft(
+            ['main', 'child'],
+            [createEdge('shared/output', 'main'), createEdge('shared/output', 'child')],
+            [createWorkflowNode('shared')]
+        )
+
+        expect(validator.handle({ draft })).toEqual([])
+    })
+
+    it('allows a one-way sub-agent connection without a shared entry path', () => {
+        const draft = createDraft(['main', 'child'], [createAgentConnection('main', 'child')])
+
+        expect(validator.handle({ draft })).toEqual([])
+    })
+
+    it('reports a multi-level mixed build cycle', () => {
+        const draft = createDraft(
+            ['main', 'reviewer', 'runner'],
+            [
+                createAgentConnection('main', 'reviewer'),
+                createAgentConnection('reviewer', 'runner'),
+                createEdge('shared', 'main'),
+                createEdge('shared', 'runner')
+            ],
+            [createWorkflowNode('shared')]
+        )
+
+        const results = validator.handle({ draft })
+
+        expect(results).toHaveLength(1)
+        expect(results[0]).toEqual(
+            expect.objectContaining({
+                ruleCode: AGENT_SUBGRAPH_BUILD_CYCLE,
+                value: 'Reviewer → Runner → Main → Reviewer'
+            })
+        )
+    })
+
+    it('allows the primary agent swarm handled by the dedicated swarm compiler', () => {
+        const draft = createDraft(
+            ['main', 'partner'],
+            [createAgentConnection('main', 'partner'), createAgentConnection('partner', 'main')]
+        )
+
+        expect(validator.handle({ draft })).toEqual([])
+    })
+
+    it('reports a nested agent cycle that is not the primary swarm', () => {
+        const draft = createDraft(
+            ['main', 'agent-a', 'agent-b'],
+            [
+                createAgentConnection('main', 'agent-a'),
+                createAgentConnection('agent-a', 'agent-b'),
+                createAgentConnection('agent-b', 'agent-a')
+            ]
+        )
+
+        const results = validator.handle({ draft })
+
+        expect(results).toHaveLength(1)
+        expect(results[0].ruleCode).toBe(AGENT_SUBGRAPH_BUILD_CYCLE)
+    })
+
+    it('reports a cycle that re-enters an agent through an iterator child graph', () => {
+        const draft = createDraft(
+            ['main', 'inner', 'child'],
+            [
+                createAgentConnection('main', 'child'),
+                createAgentConnection('inner', 'child'),
+                createEdge('iterator/start', 'inner'),
+                createEdge('iterator', 'child')
+            ],
+            [createWorkflowNode('iterator', WorkflowNodeTypeEnum.ITERATOR)],
+            { inner: 'iterator' }
+        )
+
+        expect(validator.handle({ draft })).toEqual([
+            expect.objectContaining({
+                ruleCode: AGENT_SUBGRAPH_BUILD_CYCLE,
+                value: 'Child → Inner → Child'
+            })
+        ])
+    })
+
+    it('allows an iterator child graph when its internal agent does not reconnect to the entry agent', () => {
+        const draft = createDraft(
+            ['main', 'inner', 'child'],
+            [
+                createAgentConnection('main', 'child'),
+                createEdge('iterator/start', 'inner'),
+                createEdge('iterator', 'child')
+            ],
+            [createWorkflowNode('iterator', WorkflowNodeTypeEnum.ITERATOR)],
+            { inner: 'iterator' }
+        )
+
+        expect(validator.handle({ draft })).toEqual([])
+    })
+
+    it('reports a cycle that re-enters an agent through a subflow target', () => {
+        const draft = createDraft(
+            ['main', 'child'],
+            [
+                createAgentConnection('main', 'child'),
+                createAgentConnection('subflow', 'main'),
+                createEdge('subflow', 'child')
+            ],
+            [createWorkflowNode('subflow', WorkflowNodeTypeEnum.SUBFLOW)]
+        )
+
+        expect(validator.handle({ draft })).toEqual([
+            expect.objectContaining({
+                ruleCode: AGENT_SUBGRAPH_BUILD_CYCLE,
+                value: 'Main → Child → Main'
+            })
+        ])
+    })
+
+    it('allows a subflow target that does not reconnect to the entry agent', () => {
+        const draft = createDraft(
+            ['main', 'helper', 'child'],
+            [
+                createAgentConnection('main', 'child'),
+                createAgentConnection('subflow', 'helper'),
+                createEdge('subflow', 'child')
+            ],
+            [createWorkflowNode('subflow', WorkflowNodeTypeEnum.SUBFLOW)]
+        )
+
+        expect(validator.handle({ draft })).toEqual([])
+    })
+
+    function createDraft(
+        agentKeys: string[],
+        connections: TXpertTeamConnection[],
+        workflowNodes: TXpertTeamNode<'workflow'>[] = [],
+        agentParentIds: Record<string, string> = {}
+    ): TXpertTeamDraft {
+        const agents = agentKeys.map((key) => createAgentNode(key, agentParentIds[key]))
+        return {
+            team: {
+                agent: agents[0].entity
+            },
+            nodes: [...agents, ...workflowNodes],
+            connections
+        }
+    }
+
+    function createAgentNode(key: string, parentId?: string): TXpertTeamNode<'agent'> {
+        const title = key
+            .split('-')
+            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+            .join(' ')
+        const entity: IXpertAgent = {
+            key,
+            name: title,
+            title
+        }
+        return {
+            type: 'agent',
+            key,
+            parentId,
+            position: { x: 0, y: 0 },
+            entity
+        }
+    }
+
+    function createWorkflowNode(
+        key: string,
+        type: WorkflowNodeTypeEnum = WorkflowNodeTypeEnum.TEMPLATE
+    ): TXpertTeamNode<'workflow'> {
+        return {
+            type: 'workflow',
+            key,
+            position: { x: 0, y: 0 },
+            entity: {
+                id: key,
+                key,
+                type
+            }
+        }
+    }
+
+    function createEdge(from: string, to: string): TXpertTeamConnection {
+        return {
+            type: 'edge',
+            key: `${from}/${to}`,
+            from,
+            to
+        }
+    }
+
+    function createAgentConnection(from: string, to: string): TXpertTeamConnection {
+        return {
+            type: 'agent',
+            key: `${from}/${to}`,
+            from,
+            to
+        }
+    }
+})

--- a/packages/server-ai/src/xpert-agent/graph-validator.ts
+++ b/packages/server-ai/src/xpert-agent/graph-validator.ts
@@ -1,0 +1,307 @@
+import {
+    ChecklistItem,
+    findStartNodes,
+    getCurrentGraph,
+    getSwarmPartners,
+    TXpertGraph,
+    TXpertTeamDraft,
+    TXpertTeamNode
+} from '@xpert-ai/contracts'
+import { Injectable } from '@nestjs/common'
+import { OnEvent } from '@nestjs/event-emitter'
+import { EventNameXpertValidate, XpertDraftValidateEvent } from '../xpert/types'
+
+export const AGENT_SUBGRAPH_BUILD_CYCLE = 'AGENT_SUBGRAPH_BUILD_CYCLE'
+
+type TAgentNode = TXpertTeamNode<'agent'>
+type TBuildMode = 'start' | 'normal'
+
+@Injectable()
+export class XpertAgentGraphValidator {
+    @OnEvent(EventNameXpertValidate)
+    handle(event: XpertDraftValidateEvent) {
+        return validateAgentSubgraphBuildCycles(event.draft)
+    }
+}
+
+export function validateAgentSubgraphBuildCycles(draft: TXpertTeamDraft): ChecklistItem[] {
+    const agentNodes = draft.nodes.filter((node): node is TAgentNode => node.type === 'agent')
+    if (!agentNodes.length) {
+        return []
+    }
+
+    const agentNodeMap = new Map(agentNodes.map((node) => [node.key, node]))
+    const runtimeNodeMap = new Map(
+        draft.nodes
+            .filter(
+                (node): node is TXpertTeamNode<'agent' | 'workflow'> =>
+                    node.type === 'agent' || node.type === 'workflow'
+            )
+            .map((node) => [node.key, node])
+    )
+    const runtimeOutgoing = buildRuntimeOutgoing(draft, runtimeNodeMap)
+    const followerTargets = buildFollowerTargets(draft, agentNodeMap)
+    const workflowStartTargets = buildWorkflowStartTargets(draft, runtimeNodeMap, agentNodeMap)
+    const agentsWithWorkflowInput = new Set(
+        draft.connections
+            .filter((connection) => connection.type === 'edge' && agentNodeMap.has(connection.to))
+            .map((connection) => connection.to)
+    )
+    const primaryAgentKey = draft.team.agent?.key
+    const swarmAgentKeys = getPrimarySwarmAgentKeys(draft, primaryAgentKey, agentNodeMap)
+    const dependencies = new Map<string, Set<string>>()
+    const getDependencies = (state: string) => {
+        const cached = dependencies.get(state)
+        if (cached) {
+            return cached
+        }
+
+        const nextStates = getOrCreateSet(dependencies, state)
+        const agentKey = agentKeyFromState(state)
+        for (const followerKey of followerTargets.get(agentKey) ?? []) {
+            if (!swarmAgentKeys.has(followerKey)) {
+                nextStates.add(buildState('start', followerKey))
+            }
+        }
+
+        if (buildModeFromState(state) === 'start' && agentsWithWorkflowInput.has(agentKey)) {
+            for (const entryState of collectEntryBuildStates(
+                draft,
+                agentKey,
+                runtimeNodeMap,
+                runtimeOutgoing,
+                workflowStartTargets
+            )) {
+                nextStates.add(entryState)
+            }
+        }
+
+        return nextStates
+    }
+
+    const startStates = getValidationStartStates(primaryAgentKey, swarmAgentKeys, agentNodeMap)
+    const cycles = findReachableCycles(getDependencies, startStates)
+
+    return cycles.map((cycle) => {
+        const agentKeys = cycle.map(agentKeyFromState)
+        const labels = agentKeys.map((key) => agentNodeLabel(agentNodeMap.get(key), key))
+        const path = labels.join(' → ')
+
+        return {
+            node: agentKeys[0],
+            ruleCode: AGENT_SUBGRAPH_BUILD_CYCLE,
+            field: 'connections',
+            value: path,
+            message: {
+                en_US: `Agent configuration creates a recursive subgraph build path: ${path}. Remove a sub-agent connection or separate the shared workflow entry path.`,
+                zh_Hans: `智能体配置形成递归子图构建路径：${path}。请移除重复的子智能体连接，或拆分共享的工作流入口路径。`
+            },
+            level: 'error'
+        }
+    })
+}
+
+function buildRuntimeOutgoing(graph: TXpertGraph, nodeMap: Map<string, TXpertTeamNode<'agent' | 'workflow'>>) {
+    const outgoing = new Map<string, Set<string>>()
+
+    for (const connection of graph.connections) {
+        if (connection.type !== 'edge') {
+            continue
+        }
+
+        const sourceKey = normalizeNodeKey(connection.from)
+        const sourceNode = nodeMap.get(sourceKey)
+        const targetNode = nodeMap.get(connection.to)
+        if (!sourceNode || !targetNode) {
+            continue
+        }
+
+        // Container-owned child edges still build their child nodes, even though they are not outer workflow successors.
+        if (sourceNode.type === 'agent' && connection.from !== sourceKey && connection.from !== `${sourceKey}/fail`) {
+            continue
+        }
+
+        getOrCreateSet(outgoing, sourceKey).add(targetNode.key)
+    }
+
+    return outgoing
+}
+
+function buildFollowerTargets(graph: TXpertGraph, agentNodeMap: Map<string, TAgentNode>) {
+    const followers = new Map<string, Set<string>>()
+
+    for (const connection of graph.connections) {
+        if (connection.type === 'agent' && agentNodeMap.has(connection.from) && agentNodeMap.has(connection.to)) {
+            getOrCreateSet(followers, connection.from).add(connection.to)
+        }
+    }
+
+    return followers
+}
+
+function buildWorkflowStartTargets(
+    graph: TXpertGraph,
+    nodeMap: Map<string, TXpertTeamNode<'agent' | 'workflow'>>,
+    agentNodeMap: Map<string, TAgentNode>
+) {
+    const targets = new Map<string, Set<string>>()
+
+    for (const connection of graph.connections) {
+        if (connection.type !== 'agent' || !agentNodeMap.has(connection.to)) {
+            continue
+        }
+
+        const sourceKey = normalizeNodeKey(connection.from)
+        if (nodeMap.get(sourceKey)?.type === 'workflow') {
+            getOrCreateSet(targets, sourceKey).add(connection.to)
+        }
+    }
+
+    return targets
+}
+
+function collectEntryBuildStates(
+    graph: TXpertGraph,
+    targetAgentKey: string,
+    nodeMap: Map<string, TXpertTeamNode<'agent' | 'workflow'>>,
+    runtimeOutgoing: Map<string, Set<string>>,
+    workflowStartTargets: Map<string, Set<string>>
+) {
+    const currentGraph = getCurrentGraph(graph, targetAgentKey)
+    const startNodes = findStartNodes(currentGraph, targetAgentKey).filter((key) => key !== targetAgentKey)
+    const entryStates = new Set<string>()
+    const visited = new Set<string>()
+    const pending = [...startNodes]
+
+    while (pending.length) {
+        const current = pending.pop()
+        if (!current || current === targetAgentKey || visited.has(current)) {
+            continue
+        }
+        visited.add(current)
+
+        const node = nodeMap.get(current)
+        if (!node) {
+            continue
+        }
+        if (node.type === 'agent') {
+            entryStates.add(buildState('normal', node.key))
+        } else {
+            for (const startTarget of workflowStartTargets.get(node.key) ?? []) {
+                entryStates.add(buildState('start', startTarget))
+            }
+        }
+
+        for (const next of runtimeOutgoing.get(current) ?? []) {
+            if (!visited.has(next)) {
+                pending.push(next)
+            }
+        }
+    }
+
+    return entryStates
+}
+
+function getPrimarySwarmAgentKeys(
+    graph: TXpertGraph,
+    primaryAgentKey: string | undefined,
+    agentNodeMap: Map<string, TAgentNode>
+) {
+    if (!primaryAgentKey || !agentNodeMap.has(primaryAgentKey)) {
+        return new Set<string>()
+    }
+
+    const partners: string[] = []
+    getSwarmPartners(graph, primaryAgentKey, partners)
+    if (partners.length <= 1) {
+        return new Set<string>()
+    }
+
+    return new Set(partners.filter((key) => agentNodeMap.has(key)))
+}
+
+function getValidationStartStates(
+    primaryAgentKey: string | undefined,
+    swarmAgentKeys: Set<string>,
+    agentNodeMap: Map<string, TAgentNode>
+) {
+    if (swarmAgentKeys.size) {
+        return Array.from(swarmAgentKeys, (key) => buildState('start', key))
+    }
+    if (primaryAgentKey && agentNodeMap.has(primaryAgentKey)) {
+        return [buildState('start', primaryAgentKey)]
+    }
+    return Array.from(agentNodeMap.keys(), (key) => buildState('start', key))
+}
+
+function findReachableCycles(getDependencies: (state: string) => Set<string>, startStates: string[]) {
+    const visited = new Set<string>()
+    const activeIndexes = new Map<string, number>()
+    const stack: string[] = []
+    const cycles = new Map<string, string[]>()
+
+    const visit = (state: string) => {
+        if (visited.has(state)) {
+            return
+        }
+        visited.add(state)
+        activeIndexes.set(state, stack.length)
+        stack.push(state)
+
+        for (const next of getDependencies(state)) {
+            const activeIndex = activeIndexes.get(next)
+            if (activeIndex !== undefined) {
+                const cycle = [...stack.slice(activeIndex), next]
+                cycles.set(normalizeCycle(cycle), cycle)
+            } else {
+                visit(next)
+            }
+        }
+
+        stack.pop()
+        activeIndexes.delete(state)
+    }
+
+    startStates.forEach(visit)
+    return Array.from(cycles.values())
+}
+
+function normalizeCycle(cycle: string[]) {
+    const states = cycle.slice(0, -1)
+    if (!states.length) {
+        return ''
+    }
+
+    const rotations = states.map((_, index) => [...states.slice(index), ...states.slice(0, index)])
+    const normalized = rotations.map((rotation) => rotation.join('>')).sort()[0]
+    return normalized
+}
+
+function buildState(mode: TBuildMode, agentKey: string) {
+    return `${mode}:${agentKey}`
+}
+
+function agentKeyFromState(state: string) {
+    return state.slice(state.indexOf(':') + 1)
+}
+
+function buildModeFromState(state: string): TBuildMode {
+    return state.startsWith('start:') ? 'start' : 'normal'
+}
+
+function normalizeNodeKey(key: string) {
+    return key.split('/')[0]
+}
+
+function agentNodeLabel(node: TAgentNode | undefined, fallback: string) {
+    return node?.entity.title?.trim() || node?.entity.name?.trim() || fallback
+}
+
+function getOrCreateSet(map: Map<string, Set<string>>, key: string) {
+    let values = map.get(key)
+    if (!values) {
+        values = new Set<string>()
+        map.set(key, values)
+    }
+    return values
+}

--- a/packages/server-ai/src/xpert-agent/xpert-agent.module.ts
+++ b/packages/server-ai/src/xpert-agent/xpert-agent.module.ts
@@ -15,6 +15,7 @@ import { XpertModule } from '../xpert/xpert.module'
 import { CommandHandlers } from './commands/handlers'
 import { QueryHandlers } from './queries/handlers'
 import { XpertAgentNodeValidator } from './agent-validator'
+import { XpertAgentGraphValidator } from './graph-validator'
 import { XpertTitleMiddlewareService } from './title/xpert-title.middleware'
 import { Validators } from './workflow'
 import { WorkflowCommandHandlers } from './workflow/handlers'
@@ -54,6 +55,7 @@ import { PromptWorkflowModule } from '../prompt-workflow'
         AgentMiddlewareRegistry,
         ConnectorMiddleware,
         XpertAgentNodeValidator,
+        XpertAgentGraphValidator,
         ...CommandHandlers,
         ...WorkflowCommandHandlers,
         ...QueryHandlers,


### PR DESCRIPTION
## Problem

Agent subgraph construction can recurse when an agent start graph reaches another agent that eventually rebuilds an agent already on the active construction path. Each recursive build can initialize the same MCP toolsets again, flooding the chat event stream with repeated MCP-ready messages.

## Root cause

The existing draft validation checked node-level configuration but did not model runtime agent-build dependencies. Cycles could therefore pass validation, including paths through shared workflow entry branches, Iterator-owned child graphs, and Subflow agent targets.

## Fix

- register an agent graph validator in `XpertAgentModule`
- model start-agent and normal-agent build dependencies without changing runtime subgraph behavior
- detect active-stack cycles and report `AGENT_SUBGRAPH_BUILD_CYCLE` as a validation error
- cover direct, multi-level, nested, Iterator, and Subflow cycles while preserving legal one-way and fan-out graphs

## Validation

- `corepack pnpm exec jest --config packages/server-ai/jest.config.ts --runInBand packages/server-ai/src/xpert-agent/graph-validator.spec.ts` (10/10 passed)
- `corepack pnpm exec tsc -p packages/server-ai/tsconfig.lib.json --noEmit`
- `corepack pnpm exec eslint packages/server-ai/src/xpert-agent/graph-validator.ts packages/server-ai/src/xpert-agent/graph-validator.spec.ts`
- `git diff --check`

This PR contains only the agent graph cycle validation change; the unfinished Marketplace work remains outside this branch.