### PR TITLE
[codex] simplify billing usage details

### DIFF
--- a/apps/cloud/src/app/features/setting/account/billing.component.html
+++ b/apps/cloud/src/app/features/setting/account/billing.component.html
@@ -30,7 +30,7 @@
       </z-card-header>
 
       <z-card-content class="p-5">
-        <div class="grid gap-3 md:grid-cols-3">
+        <div class="grid gap-3 md:grid-cols-2">
           <div class="rounded-lg bg-components-panel-bg p-4">
             <div class="text-xs font-medium text-text-tertiary">
               {{ 'PAC.Membership.PointBalance' | translate: { Default: 'Point balance' } }}
@@ -59,20 +59,6 @@
             <div class="mt-2 text-2xl font-semibold text-text-primary">{{ me()?.pointsUsed | number: '1.0-10' }}</div>
             <div class="mt-1 text-xs text-text-tertiary">
               {{ usedPercent() | number }}% {{ 'PAC.Membership.PointUsage' | translate: { Default: 'Point usage' } }}
-            </div>
-          </div>
-
-          <div class="rounded-lg bg-components-panel-bg p-4">
-            <div class="text-xs font-medium text-text-tertiary">
-              {{ 'PAC.Membership.Ratio' | translate: { Default: 'Ratio' } }}
-            </div>
-            <div class="mt-2 text-2xl font-semibold text-text-primary">
-              1 : {{ me()?.plan?.tokensPerPoint | number }}
-            </div>
-            <div class="mt-1 text-xs text-text-tertiary">
-              {{ 'PAC.Membership.OnePointEquals' | translate: { Default: '1 point =' } }}
-              {{ me()?.plan?.tokensPerPoint | number }}
-              {{ 'PAC.Membership.Tokens' | translate: { Default: 'tokens' } }}
             </div>
           </div>
         </div>
@@ -124,64 +110,12 @@
             }
           </span>
         </div>
-        <div class="flex items-center justify-between rounded-lg bg-components-panel-bg px-3 py-2">
-          <span class="text-sm text-text-tertiary">{{
-            'PAC.Membership.ModelMultipliers' | translate: { Default: 'Model multipliers' }
-          }}</span>
-          <span class="font-semibold text-text-primary">{{ me()?.plan?.modelMultipliers?.length ?? 0 }}</span>
-        </div>
-        <div class="flex items-center justify-between rounded-lg bg-components-panel-bg px-3 py-2">
-          <span class="text-sm text-text-tertiary">{{
-            'PAC.Membership.RateLimits' | translate: { Default: 'Rate limits' }
-          }}</span>
-          <span class="font-semibold text-text-primary">{{ me()?.plan?.rateLimits?.length ?? 0 }}</span>
-        </div>
       </z-card-content>
     </z-card>
   </div>
 
   <div class="grid gap-4 xl:grid-cols-12">
-    <z-card class="overflow-hidden border border-divider-regular bg-components-card-bg shadow-none xl:col-span-5">
-      <z-card-header class="border-b border-divider-regular py-4">
-        <div class="flex items-center gap-2">
-          <z-icon zType="sparkles" class="text-text-tertiary"></z-icon>
-          <z-card-title>{{
-            'PAC.Membership.ModelMultipliers' | translate: { Default: 'Model multipliers' }
-          }}</z-card-title>
-        </div>
-      </z-card-header>
-
-      <z-card-content class="p-3">
-        @for (item of me()?.plan?.modelMultipliers ?? []; track item.provider + item.model) {
-          <div class="flex items-center justify-between gap-3 rounded-lg px-3 py-2 hover:bg-hover-bg">
-            <div class="min-w-0">
-              <div class="truncate text-sm font-medium text-text-primary">
-                {{ item.provider || '*' }} / {{ item.model || '*' }}
-              </div>
-              <div class="text-xs text-text-tertiary">
-                {{ 'PAC.Copilot.Model' | translate: { Default: 'Model' } }}
-              </div>
-            </div>
-            <z-badge zType="outline" zShape="pill">x{{ item.multiplier }}</z-badge>
-          </div>
-        } @empty {
-          <div
-            class="flex min-h-40 flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-divider-regular bg-components-panel-bg p-6 text-center"
-          >
-            <span class="flex size-11 items-center justify-center rounded-xl bg-components-card-bg text-text-tertiary">
-              <z-icon zType="sparkles"></z-icon>
-            </span>
-            <div class="text-sm text-text-tertiary">
-              {{
-                'PAC.Membership.NoModelMultipliers' | translate: { Default: 'No model-specific multiplier configured.' }
-              }}
-            </div>
-          </div>
-        }
-      </z-card-content>
-    </z-card>
-
-    <z-card class="overflow-hidden border border-divider-regular bg-components-card-bg shadow-none xl:col-span-7">
+    <z-card class="overflow-hidden border border-divider-regular bg-components-card-bg shadow-none xl:col-span-12">
       <z-card-header class="border-b border-divider-regular py-4">
         <div class="flex w-full flex-col gap-2 md:flex-row md:items-center md:justify-between">
           <div>
@@ -222,9 +156,6 @@
                 </th>
                 <th class="whitespace-nowrap px-4 py-3 text-right font-medium">
                   {{ 'PAC.Membership.Points' | translate: { Default: 'Points' } }}
-                </th>
-                <th class="whitespace-nowrap px-4 py-3 text-right font-medium">
-                  {{ 'PAC.Membership.Tokens' | translate: { Default: 'Tokens' } }}
                 </th>
               </tr>
             </thead>
@@ -286,13 +217,10 @@
                   >
                     {{ summary.pointsDelta > 0 ? '+' : '' }}{{ summary.pointsDelta | number: '1.0-10' }}
                   </td>
-                  <td class="whitespace-nowrap px-4 py-3 text-right text-text-secondary">
-                    {{ summary.tokenUsed | number }}
-                  </td>
                 </tr>
                 @if (isExpanded(summary)) {
                   <tr class="border-b border-divider-subtle bg-components-panel-bg">
-                    <td colspan="6" class="px-4 py-3">
+                    <td colspan="5" class="px-4 py-3">
                       <div class="rounded-lg border border-divider-subtle bg-components-card-bg">
                         <div class="flex items-center justify-between border-b border-divider-subtle px-4 py-3">
                           <div class="text-sm font-medium text-text-primary">
@@ -317,9 +245,6 @@
                               <th class="px-4 py-2 text-right font-medium">
                                 {{ 'PAC.Membership.Points' | translate: { Default: 'Points' } }}
                               </th>
-                              <th class="px-4 py-2 text-right font-medium">
-                                {{ 'PAC.Membership.Tokens' | translate: { Default: 'Tokens' } }}
-                              </th>
                             </tr>
                           </thead>
                           <tbody>
@@ -342,13 +267,10 @@
                                 >
                                   {{ ledger.pointsDelta > 0 ? '+' : '' }}{{ ledger.pointsDelta | number: '1.0-10' }}
                                 </td>
-                                <td class="whitespace-nowrap px-4 py-2 text-right text-text-secondary">
-                                  {{ ledger.tokenUsed | number }}
-                                </td>
                               </tr>
                             } @empty {
                               <tr>
-                                <td colspan="4" class="px-4 py-6 text-center text-text-tertiary">
+                                <td colspan="3" class="px-4 py-6 text-center text-text-tertiary">
                                   {{
                                     isSummaryDetailsLoading(summary)
                                       ? ('PAC.KEY_WORDS.Loading' | translate: { Default: 'Loading...' })
@@ -365,7 +287,7 @@
                 }
               } @empty {
                 <tr>
-                  <td colspan="6" class="px-4 py-12">
+                  <td colspan="5" class="px-4 py-12">
                     <div
                       class="flex min-h-32 flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-divider-regular bg-components-panel-bg p-6 text-center"
                     >


### PR DESCRIPTION
## Problem

The billing page exposed token conversion ratios, model multiplier configuration, rate-limit counts, and raw token usage alongside the point ledger. These implementation details made the account view harder to understand and could conflict with point-based billing as the user-facing accounting model.

## Root cause

The billing template rendered both the point-based account summary and lower-level token/model configuration details in the same view.

## Changes

- Remove the token-to-point ratio card.
- Remove model multiplier and rate-limit summary details.
- Remove the model multiplier card.
- Remove raw token columns from usage summaries and ledger details.
- Expand the remaining usage-history card to the full available width.

The backend billing calculations, point deductions, usage records, and API contracts are unchanged.

## Validation

- Commit hook formatted the Angular template successfully.
- Hardcoded color usage check passed.
- TypeORM column type check passed for the staged scope.
- `git diff --check origin/develop...HEAD` passed.
- No browser validation was run, per repository guidance.
