### PR TITLE
[codex] feat: initialize template prompt workflows

### DIFF
--- a/.changeset/template-prompt-workflows.md
+++ b/.changeset/template-prompt-workflows.md
@@ -1,0 +1,8 @@
+---
+'@xpert-ai/contracts': patch
+'@xpert-ai/plugin-sdk': patch
+'@xpert-ai/server-ai': patch
+'@xpert-ai/xpert-ui': patch
+---
+
+Initialize assistant template prompt workflows as reusable workspace commands.

--- a/apps/cloud/src/app/@core/services/xpert.service.ts
+++ b/apps/cloud/src/app/@core/services/xpert.service.ts
@@ -256,8 +256,13 @@ export class XpertAPIService extends XpertWorkspaceBaseCrudService<IXpert> {
     return this.httpClient.delete<void>(this.apiBaseUrl + `/${id}/export/template`).pipe(tap(() => this.refresh()))
   }
 
-  importDSL(dslObject: Record<string, any>) {
-    return this.httpClient.post<IXpert>(this.apiBaseUrl + `/import`, dslObject)
+  importDSL(dslObject: Record<string, any>, options?: { templateId?: string }) {
+    const templateId = options?.templateId?.trim()
+    return this.httpClient.post<IXpert>(
+      this.apiBaseUrl + `/import`,
+      dslObject,
+      templateId ? { params: { templateId } } : undefined
+    )
   }
 
   duplicate(id: string, options: { basic: Partial<IXpert>; isDraft: boolean }) {

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.spec.ts
@@ -1121,7 +1121,8 @@ describe('XpertNewBlankComponent', () => {
           title: 'Template Agent',
           workspaceId: 'workspace-1'
         })
-      })
+      }),
+      { templateId: '@xpert-ai/plugin-salesclaw:salesclaw-business-assistant' }
     )
   })
 
@@ -2334,7 +2335,8 @@ describe('XpertNewBlankComponent', () => {
             })
           })
         ])
-      })
+      }),
+      { templateId: 'template-agent' }
     )
 
     expect(dialogRef.close).toHaveBeenCalledWith({
@@ -2543,7 +2545,8 @@ describe('XpertNewBlankComponent', () => {
           title: 'Template Agent',
           workspaceId: undefined
         })
-      })
+      }),
+      { templateId: 'template-agent' }
     )
     expect(xpertService.saveDraft).not.toHaveBeenCalled()
     expect(environmentService.getDefaultByWorkspace).toHaveBeenCalledWith('workspace-1')
@@ -2613,7 +2616,8 @@ describe('XpertNewBlankComponent', () => {
             }
           }
         })
-      })
+      }),
+      { templateId: 'template-agent' }
     )
   })
 

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.ts
@@ -1187,7 +1187,11 @@ export class XpertNewBlankComponent {
       this.buildTemplateImportDraftWithTemplateToolsets(draft, defaultSandboxProvider),
       primaryAgentPrompt
     )
-    const xpert = await firstValueFrom(this.xpertService.importDSL(nextDraft))
+    const xpert = await firstValueFrom(
+      this.xpertService.importDSL(nextDraft, {
+        templateId: this.selectedTemplate()?.id ?? this.selectedTemplateId() ?? undefined
+      })
+    )
     const hydratedXpert = this.withInitialPrimaryAgentPrompt(xpert, primaryAgentPrompt)
     const preparedXpert = await this.provisionKnowledgebaseIfNeeded(hydratedXpert)
     return this.completeImportedCreation(preparedXpert)

--- a/packages/contracts/src/ai/xpert-template.model.ts
+++ b/packages/contracts/src/ai/xpert-template.model.ts
@@ -3,6 +3,7 @@ import { IconDefinition, TAvatar } from '../types'
 import { TCopilotModel } from './copilot-model.model'
 import { MCPServerType, TMCPServer } from './xpert-tool-mcp.model'
 import { XpertTypeEnum } from './xpert.model'
+import type { TPromptWorkflow } from './prompt-workflow.model'
 import { PluginTargetApp, PluginTargetAppMeta, XpertTemplatePluginDependencies } from '../plugin'
 
 export interface IXpertTemplate extends IBasePerTenantEntityModel {
@@ -102,6 +103,7 @@ export type TTemplate = {
   order?: number
   default?: boolean
   startPrompts?: string[]
+  promptWorkflows?: TPromptWorkflow[]
   releaseNotes?: string
   xpertName?: string
   dependencies?: XpertTemplatePluginDependencies

--- a/packages/plugin-sdk/src/lib/types.ts
+++ b/packages/plugin-sdk/src/lib/types.ts
@@ -5,6 +5,7 @@ import {
   PluginTargetApp,
   PluginTargetAppMeta,
   TAvatar,
+  type TPromptWorkflow,
   XpertTemplatePluginDependencies,
   XpertTypeEnum
 } from '@xpert-ai/contracts'
@@ -120,6 +121,7 @@ export interface XpertTemplateContribution {
   order?: number
   default?: boolean
   startPrompts?: string[]
+  promptWorkflows?: TPromptWorkflow[]
   releaseNotes?: string
   xpertName?: string
   dependencies?: XpertTemplatePluginDependencies

--- a/packages/server-ai/src/plugin-resource/commands/install-template.handler.spec.ts
+++ b/packages/server-ai/src/plugin-resource/commands/install-template.handler.spec.ts
@@ -24,6 +24,10 @@ jest.mock('../../xpert-template/xpert-template.service', () => ({
     XpertTemplateService: class XpertTemplateService {}
 }))
 
+jest.mock('../../xpert/template-workspace-initializer.service', () => ({
+    XpertTemplateWorkspaceInitializer: class XpertTemplateWorkspaceInitializer {}
+}))
+
 jest.mock('../../xpert-toolset/xpert-toolset.entity', () => ({
     XpertToolset: class XpertToolset {}
 }))
@@ -38,6 +42,7 @@ jest.mock('../plugin-resource-installer.service', () => ({
 
 import { AiModelTypeEnum, LanguagesEnum, XpertToolsetCategoryEnum } from '@xpert-ai/contracts'
 import { XpertImportCommand } from '../../xpert/commands/import.command'
+import { XpertTemplateWorkspaceInitializer } from '../../xpert/template-workspace-initializer.service'
 import { PluginTemplateInstallCommand } from './install-template.command'
 import { PluginTemplateInstallHandler } from './install-template.handler'
 
@@ -92,6 +97,26 @@ connections:
 `
 
 describe('PluginTemplateInstallHandler', () => {
+    it('initializes template prompt workflows after plugin dependencies are installed', async () => {
+        const { handler, templateWorkspaceInitializer } = createHandler({
+            templateDsl: createSandboxTemplateDsl()
+        })
+
+        await handler.execute(
+            new PluginTemplateInstallCommand(
+                '@xpert-ai/plugin-presentation-studio:presentation-studio-assistant',
+                'workspace-1',
+                LanguagesEnum.English
+            )
+        )
+
+        expect(templateWorkspaceInitializer.initializeByTemplateId).toHaveBeenCalledWith(
+            '@xpert-ai/plugin-presentation-studio:presentation-studio-assistant',
+            'workspace-1',
+            LanguagesEnum.English
+        )
+    })
+
     it('attaches template builtin toolset dependencies to the imported xpert draft', async () => {
         const { handler, xpertService, toolsetRepo } = createHandler({
             toolsets: [createSeedreamToolset()]
@@ -378,6 +403,13 @@ function createHandler(options?: {
     const commandBus = {
         execute: jest.fn((_command: unknown) => Promise.resolve(importedXpert))
     }
+    const templateWorkspaceInitializer = {
+        initializeByTemplateId: jest.fn(async () => ({
+            status: 'initialized',
+            created: [],
+            skipped: []
+        }))
+    }
     const xpertService = {
         getSandboxProviders: jest.fn(() =>
             Promise.resolve(options?.sandboxProviders ?? [{ type: 'local-shell-sandbox' }])
@@ -393,6 +425,7 @@ function createHandler(options?: {
         installer as any,
         workspaceAccess as any,
         templateService as any,
+        templateWorkspaceInitializer as unknown as XpertTemplateWorkspaceInitializer,
         commandBus as any,
         xpertService as any,
         toolsetRepo as any
@@ -403,6 +436,7 @@ function createHandler(options?: {
         installer,
         workspaceAccess,
         templateService,
+        templateWorkspaceInitializer,
         commandBus,
         xpertService,
         toolsetRepo

--- a/packages/server-ai/src/plugin-resource/commands/install-template.handler.ts
+++ b/packages/server-ai/src/plugin-resource/commands/install-template.handler.ts
@@ -22,6 +22,7 @@ import { Repository } from 'typeorm'
 import { XpertImportCommand } from '../../xpert/commands/import.command'
 import { XpertDraftDslDTO } from '../../xpert/dto'
 import { XpertService } from '../../xpert/xpert.service'
+import { XpertTemplateWorkspaceInitializer } from '../../xpert/template-workspace-initializer.service'
 import { XpertTemplateService } from '../../xpert-template/xpert-template.service'
 import { XpertToolset } from '../../xpert-toolset/xpert-toolset.entity'
 import { XpertWorkspaceAccessService } from '../../xpert-workspace'
@@ -47,6 +48,7 @@ export class PluginTemplateInstallHandler implements ICommandHandler<PluginTempl
         private readonly installer: PluginResourceInstallerService,
         private readonly workspaceAccess: XpertWorkspaceAccessService,
         private readonly xpertTemplateService: XpertTemplateService,
+        private readonly templateWorkspaceInitializer: XpertTemplateWorkspaceInitializer,
         private readonly commandBus: CommandBus,
         private readonly xpertService: XpertService,
         @InjectRepository(XpertToolset)
@@ -76,6 +78,11 @@ export class PluginTemplateInstallHandler implements ICommandHandler<PluginTempl
             if (toolsets.length) {
                 await this.attachTemplateToolsetsToXpert(xpert.id, toolsets)
             }
+            await this.templateWorkspaceInitializer.initializeByTemplateId(
+                command.templateId,
+                xpert.workspaceId ?? command.workspaceId,
+                command.language
+            )
             return {
                 ...result,
                 xpert

--- a/packages/server-ai/src/prompt-workflow/prompt-workflow.service.spec.ts
+++ b/packages/server-ai/src/prompt-workflow/prompt-workflow.service.spec.ts
@@ -32,6 +32,11 @@ jest.mock('../xpert-workspace', () => ({
         }
     }
 }))
+jest.mock('@xpert-ai/server-core', () => ({
+    RequestContext: {
+        currentUserId: jest.fn()
+    }
+}))
 jest.mock('../xpert/xpert.entity', () => ({
     Xpert: class {}
 }))
@@ -40,8 +45,17 @@ jest.mock('./prompt-workflow.entity', () => ({
 }))
 
 import { PromptWorkflowService } from './prompt-workflow.service'
+import { RequestContext } from '@xpert-ai/server-core'
+import { Repository } from 'typeorm'
+import { XpertWorkspaceAccessService } from '../xpert-workspace'
+import { Xpert } from '../xpert/xpert.entity'
+import { PromptWorkflow } from './prompt-workflow.entity'
 
 describe('PromptWorkflowService', () => {
+    beforeEach(() => {
+        jest.mocked(RequestContext.currentUserId).mockReturnValue('user-1')
+    })
+
     it('returns all active workspace prompt workflows when no command profile is configured', async () => {
         const repository = {
             find: jest.fn(async () => [
@@ -224,5 +238,174 @@ describe('PromptWorkflowService', () => {
                 archivedAt: expect.any(Date)
             })
         )
+    })
+
+    it('creates missing template defaults and preserves active or archived names', async () => {
+        const existing = [
+            { name: 'presentation-refine', template: 'User refine command', archivedAt: null },
+            {
+                name: 'presentation-export',
+                template: 'Archived user export command',
+                archivedAt: new Date('2026-07-01T00:00:00.000Z')
+            }
+        ]
+        const transactionRepository = {
+            find: jest.fn(async () => existing),
+            create: jest.fn((entity) => entity),
+            save: jest.fn(async (entities) =>
+                entities.map((entity, index) => ({ id: `workflow-${index + 1}`, ...entity }))
+            )
+        }
+        const manager = {
+            getRepository: jest.fn(() => transactionRepository)
+        }
+        const repository = {
+            manager: {
+                transaction: jest.fn((run: (value: typeof manager) => Promise<unknown>) => run(manager))
+            }
+        }
+        const service = new PromptWorkflowService(
+            repository as unknown as Repository<PromptWorkflow>,
+            Object.create(XpertWorkspaceAccessService.prototype) as XpertWorkspaceAccessService,
+            Object.create(Repository.prototype) as Repository<Xpert>
+        )
+
+        const result = await service.initializeDefaultsInWorkspace('workspace-1', [
+            { name: 'presentation-create', template: 'Create {{args}}.', visibility: 'team' },
+            { name: 'presentation-refine', template: 'Refine {{args}}.', visibility: 'team' },
+            { name: 'presentation-export', template: 'Export {{args}}.', visibility: 'team' },
+            { name: 'presentation-share', template: 'Share {{args}}.', visibility: 'team' }
+        ])
+
+        expect(result.created.map(({ name }) => name)).toEqual(['presentation-create', 'presentation-share'])
+        expect(result.skipped).toEqual(['presentation-refine', 'presentation-export'])
+        expect(transactionRepository.save).toHaveBeenCalledTimes(1)
+        expect(transactionRepository.save).toHaveBeenCalledWith([
+            expect.objectContaining({
+                name: 'presentation-create',
+                workspaceId: 'workspace-1',
+                createdById: 'user-1',
+                updatedById: 'user-1'
+            }),
+            expect.objectContaining({
+                name: 'presentation-share',
+                workspaceId: 'workspace-1',
+                createdById: 'user-1',
+                updatedById: 'user-1'
+            })
+        ])
+        expect(existing).toEqual([
+            { name: 'presentation-refine', template: 'User refine command', archivedAt: null },
+            {
+                name: 'presentation-export',
+                template: 'Archived user export command',
+                archivedAt: new Date('2026-07-01T00:00:00.000Z')
+            }
+        ])
+    })
+
+    it('creates template defaults once and skips every name on repeated initialization', async () => {
+        const stored: Array<{ id: string; name: string; template: string }> = []
+        const transactionRepository = {
+            find: jest.fn(async () => stored),
+            create: jest.fn((entity) => entity),
+            save: jest.fn(async (entities: Array<{ name: string; template: string }>) => {
+                const created = entities.map((entity, index) => ({
+                    id: `workflow-${stored.length + index + 1}`,
+                    ...entity
+                }))
+                stored.push(...created)
+                return created
+            })
+        }
+        const manager = {
+            getRepository: jest.fn(() => transactionRepository)
+        }
+        const repository = {
+            manager: {
+                transaction: jest.fn((run: (value: typeof manager) => Promise<unknown>) => run(manager))
+            }
+        }
+        const service = new PromptWorkflowService(
+            repository as unknown as Repository<PromptWorkflow>,
+            Object.create(XpertWorkspaceAccessService.prototype) as XpertWorkspaceAccessService,
+            Object.create(Repository.prototype) as Repository<Xpert>
+        )
+        const inputs = [
+            { name: 'presentation-create', template: 'Create {{args}}.', visibility: 'team' as const },
+            { name: 'presentation-refine', template: 'Refine {{args}}.', visibility: 'team' as const },
+            { name: 'presentation-export', template: 'Export {{args}}.', visibility: 'team' as const },
+            { name: 'presentation-share', template: 'Share {{args}}.', visibility: 'team' as const }
+        ]
+
+        const first = await service.initializeDefaultsInWorkspace('workspace-1', inputs)
+        const repeated = await service.initializeDefaultsInWorkspace('workspace-1', inputs)
+
+        expect(first.created.map(({ name }) => name)).toEqual(inputs.map(({ name }) => name))
+        expect(first.skipped).toEqual([])
+        expect(repeated).toEqual({
+            created: [],
+            skipped: inputs.map(({ name }) => name)
+        })
+        expect(transactionRepository.save).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps the template batch atomic when persistence fails', async () => {
+        const persisted = [{ id: 'existing', name: 'existing', template: 'Existing command' }]
+        const transactionRepository = {
+            find: jest.fn(async () => []),
+            create: jest.fn((entity) => entity),
+            save: jest.fn(async (entities: Array<{ name: string; template: string }>) => {
+                persisted.push({ id: 'partial', ...entities[0] })
+                throw new Error('batch write failed')
+            })
+        }
+        const manager = {
+            getRepository: jest.fn(() => transactionRepository)
+        }
+        const repository = {
+            manager: {
+                transaction: jest.fn(async (run: (value: typeof manager) => Promise<unknown>) => {
+                    const snapshot = [...persisted]
+                    try {
+                        return await run(manager)
+                    } catch (error) {
+                        persisted.splice(0, persisted.length, ...snapshot)
+                        throw error
+                    }
+                })
+            }
+        }
+        const service = new PromptWorkflowService(
+            repository as unknown as Repository<PromptWorkflow>,
+            Object.create(XpertWorkspaceAccessService.prototype) as XpertWorkspaceAccessService,
+            Object.create(Repository.prototype) as Repository<Xpert>
+        )
+
+        await expect(
+            service.initializeDefaultsInWorkspace('workspace-1', [
+                { name: 'presentation-create', template: 'Create {{args}}.' },
+                { name: 'presentation-export', template: 'Export {{args}}.' }
+            ])
+        ).rejects.toThrow('batch write failed')
+        expect(persisted).toEqual([{ id: 'existing', name: 'existing', template: 'Existing command' }])
+    })
+
+    it('validates the complete template batch before starting a transaction', async () => {
+        const transaction = jest.fn()
+        const repository = { manager: { transaction } }
+        const service = new PromptWorkflowService(
+            repository as unknown as Repository<PromptWorkflow>,
+            Object.create(XpertWorkspaceAccessService.prototype) as XpertWorkspaceAccessService,
+            Object.create(Repository.prototype) as Repository<Xpert>
+        )
+
+        await expect(
+            service.initializeDefaultsInWorkspace('workspace-1', [
+                { name: 'presentation-create', template: 'Create {{args}}.' },
+                { name: 'presentation-export', template: ' ' }
+            ])
+        ).rejects.toThrow('Prompt workflow template is required')
+        expect(transaction).not.toHaveBeenCalled()
     })
 })

--- a/packages/server-ai/src/prompt-workflow/prompt-workflow.service.ts
+++ b/packages/server-ai/src/prompt-workflow/prompt-workflow.service.ts
@@ -10,7 +10,8 @@ import {
 } from '@xpert-ai/contracts'
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { FindOptionsWhere, IsNull, Repository } from 'typeorm'
+import { RequestContext } from '@xpert-ai/server-core'
+import { FindOptionsWhere, In, IsNull, Repository } from 'typeorm'
 import { XpertWorkspaceAccessService, XpertWorkspaceBaseService } from '../xpert-workspace'
 import { Xpert } from '../xpert/xpert.entity'
 import { PromptWorkflow } from './prompt-workflow.entity'
@@ -43,6 +44,11 @@ export type PromptWorkflowKeyMutationResult = {
 	workflow: PromptWorkflow
 }
 
+export type PromptWorkflowDefaultsInitializationResult = {
+	created: PromptWorkflow[]
+	skipped: string[]
+}
+
 @Injectable()
 export class PromptWorkflowService extends XpertWorkspaceBaseService<PromptWorkflow> {
 	constructor(
@@ -60,6 +66,50 @@ export class PromptWorkflowService extends XpertWorkspaceBaseService<PromptWorkf
 		return this.create({
 			...workflow,
 			workspaceId
+		})
+	}
+
+	async initializeDefaultsInWorkspace(
+		workspaceId: string,
+		inputs: TPromptWorkflow[]
+	): Promise<PromptWorkflowDefaultsInitializationResult> {
+		if (!inputs.length) {
+			return { created: [], skipped: [] }
+		}
+
+		const { workspace } = await this.assertWorkspaceWriteAccess(workspaceId)
+		const workflows = inputs.map((input) => this.normalizePromptWorkflowInput(input))
+		const names = workflows.map(({ name }) => name)
+		if (new Set(names).size !== names.length) {
+			throw new BadRequestException('Template prompt workflow names must be unique')
+		}
+		const userId = RequestContext.currentUserId()
+
+		return this.repository.manager.transaction(async (manager) => {
+			const repository = manager.getRepository(PromptWorkflow)
+			const existing = await repository.find({
+				where: {
+					workspaceId: workspace.id,
+					name: In(names)
+				} as FindOptionsWhere<PromptWorkflow>
+			})
+			const existingNames = new Set(existing.map(({ name }) => name))
+			const missing = workflows.filter(({ name }) => !existingNames.has(name))
+			const entities = missing.map((workflow) =>
+				repository.create({
+					...workflow,
+					workspaceId: workspace.id,
+					tenantId: workspace.tenantId,
+					organizationId: workspace.organizationId ?? null,
+					...(userId ? { createdById: userId, updatedById: userId } : {})
+				})
+			)
+			const created = entities.length ? await repository.save(entities) : []
+
+			return {
+				created,
+				skipped: names.filter((name) => existingNames.has(name))
+			}
 		})
 	}
 

--- a/packages/server-ai/src/xpert-template/xpert-template.service.spec.ts
+++ b/packages/server-ai/src/xpert-template/xpert-template.service.spec.ts
@@ -579,6 +579,13 @@ describe('XpertTemplateService', () => {
                                 category: 'Plugin',
                                 type: XpertTypeEnum.Agent,
                                 dslContent: 'team:\n  name: Plugin Business\n',
+                                promptWorkflows: [
+                                    {
+                                        name: 'presentation-create',
+                                        template: 'Create a presentation from {{args}}.',
+                                        visibility: 'team'
+                                    }
+                                ],
                                 order: 1
                             }
                         ]
@@ -609,7 +616,14 @@ describe('XpertTemplateService', () => {
             type: XpertTypeEnum.Agent,
             source: 'plugin',
             pluginDisplayName: 'Demo Plugin',
-            export_data: 'team:\n  name: Plugin Business'
+            export_data: 'team:\n  name: Plugin Business',
+            promptWorkflows: [
+                {
+                    name: 'presentation-create',
+                    template: 'Create a presentation from {{args}}.',
+                    visibility: 'team'
+                }
+            ]
         })
         expect(legacyVersionedDetail.id).toBe('@xpert-ai/plugin-demo:business')
     })

--- a/packages/server-ai/src/xpert-template/xpert-template.service.ts
+++ b/packages/server-ai/src/xpert-template/xpert-template.service.ts
@@ -13,6 +13,7 @@ import {
     WORKSPACE_PUBLIC_SKILL_SOURCE_PROVIDER,
     TAvatar,
     TKnowledgePipelineTemplate,
+    type TPromptWorkflow,
     TXpertExportedTemplate,
     TXpertTemplate,
     XpertTemplatePluginDependencies,
@@ -77,6 +78,7 @@ type TXpertTemplateDescriptor = {
     order?: number
     default?: boolean
     startPrompts?: string[]
+    promptWorkflows?: TPromptWorkflow[]
     releaseNotes?: string
     xpertName?: string
     dependencies?: XpertTemplatePluginDependencies

--- a/packages/server-ai/src/xpert/template-workspace-initializer.service.spec.ts
+++ b/packages/server-ai/src/xpert/template-workspace-initializer.service.spec.ts
@@ -1,0 +1,75 @@
+import { LanguagesEnum } from '@xpert-ai/contracts'
+import { Logger } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { PromptWorkflowService } from '../prompt-workflow/prompt-workflow.service'
+import { XpertTemplateService } from '../xpert-template/xpert-template.service'
+import { XpertTemplateWorkspaceInitializer } from './template-workspace-initializer.service'
+
+describe('XpertTemplateWorkspaceInitializer', () => {
+    const templateId = '@xpert-ai/plugin-presentation-studio:presentation-studio-assistant'
+    const workspaceId = 'workspace-1'
+    const promptWorkflows = [
+        {
+            name: 'presentation-create',
+            template: 'Create a presentation from {{args}}.',
+            visibility: 'team' as const
+        }
+    ]
+
+    it('initializes prompt workflows resolved from the server-side template', async () => {
+        const xpertTemplateService = {
+            getTemplateDetail: jest.fn(async () => ({ id: templateId, promptWorkflows }))
+        }
+        const promptWorkflowService = {
+            initializeDefaultsInWorkspace: jest.fn(async () => ({
+                created: [{ name: 'presentation-create' }],
+                skipped: ['presentation-share']
+            }))
+        }
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                XpertTemplateWorkspaceInitializer,
+                { provide: XpertTemplateService, useValue: xpertTemplateService },
+                { provide: PromptWorkflowService, useValue: promptWorkflowService }
+            ]
+        }).compile()
+        const service = moduleRef.get(XpertTemplateWorkspaceInitializer)
+
+        await expect(service.initializeByTemplateId(templateId, workspaceId, LanguagesEnum.English)).resolves.toEqual({
+            status: 'initialized',
+            created: ['presentation-create'],
+            skipped: ['presentation-share']
+        })
+        expect(xpertTemplateService.getTemplateDetail).toHaveBeenCalledWith(templateId, LanguagesEnum.English)
+        expect(promptWorkflowService.initializeDefaultsInWorkspace).toHaveBeenCalledWith(workspaceId, promptWorkflows)
+    })
+
+    it('logs and ignores prompt workflow initialization failures', async () => {
+        const warning = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined)
+        const xpertTemplateService = {
+            getTemplateDetail: jest.fn(async () => ({ id: templateId, promptWorkflows }))
+        }
+        const promptWorkflowService = {
+            initializeDefaultsInWorkspace: jest.fn(async () => {
+                throw new Error('database unavailable')
+            })
+        }
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                XpertTemplateWorkspaceInitializer,
+                { provide: XpertTemplateService, useValue: xpertTemplateService },
+                { provide: PromptWorkflowService, useValue: promptWorkflowService }
+            ]
+        }).compile()
+        const service = moduleRef.get(XpertTemplateWorkspaceInitializer)
+
+        await expect(service.initializeByTemplateId(templateId, workspaceId, LanguagesEnum.English)).resolves.toEqual({
+            status: 'failed',
+            created: [],
+            skipped: []
+        })
+        expect(warning).toHaveBeenCalledWith(expect.stringContaining(templateId))
+        expect(warning).toHaveBeenCalledWith(expect.stringContaining(workspaceId))
+        expect(warning).toHaveBeenCalledWith(expect.stringContaining('database unavailable'))
+    })
+})

--- a/packages/server-ai/src/xpert/template-workspace-initializer.service.ts
+++ b/packages/server-ai/src/xpert/template-workspace-initializer.service.ts
@@ -1,0 +1,55 @@
+import { LanguagesEnum } from '@xpert-ai/contracts'
+import { getErrorMessage } from '@xpert-ai/server-common'
+import { Injectable, Logger } from '@nestjs/common'
+import { PromptWorkflowService } from '../prompt-workflow/prompt-workflow.service'
+import { XpertTemplateService } from '../xpert-template/xpert-template.service'
+
+export type TemplateWorkspaceInitializationResult =
+    | {
+          status: 'initialized'
+          created: string[]
+          skipped: string[]
+      }
+    | {
+          status: 'failed'
+          created: []
+          skipped: []
+      }
+
+@Injectable()
+export class XpertTemplateWorkspaceInitializer {
+    readonly #logger = new Logger(XpertTemplateWorkspaceInitializer.name)
+
+    constructor(
+        private readonly xpertTemplateService: XpertTemplateService,
+        private readonly promptWorkflowService: PromptWorkflowService
+    ) {}
+
+    async initializeByTemplateId(
+        templateId: string,
+        workspaceId: string,
+        language: LanguagesEnum
+    ): Promise<TemplateWorkspaceInitializationResult> {
+        try {
+            const template = await this.xpertTemplateService.getTemplateDetail(templateId, language)
+            const result = await this.promptWorkflowService.initializeDefaultsInWorkspace(
+                workspaceId,
+                template.promptWorkflows ?? []
+            )
+            return {
+                status: 'initialized',
+                created: result.created.map(({ name }) => name),
+                skipped: result.skipped
+            }
+        } catch (error) {
+            this.#logger.warn(
+                `Failed to initialize prompt workflows for template '${templateId}' in workspace '${workspaceId}': ${getErrorMessage(error)}`
+            )
+            return {
+                status: 'failed',
+                created: [],
+                skipped: []
+            }
+        }
+    }
+}

--- a/packages/server-ai/src/xpert/xpert.controller.spec.ts
+++ b/packages/server-ai/src/xpert/xpert.controller.spec.ts
@@ -16,6 +16,8 @@ import { XpertController } from './xpert.controller'
 import type { XpertFrequentQuestionsService } from './xpert-frequent-questions.service'
 import type { XpertPrincipalService } from './xpert-principal.service'
 import type { XpertService } from './xpert.service'
+import type { XpertTemplateWorkspaceInitializer } from './template-workspace-initializer.service'
+import type { XpertDraftDslDTO } from './dto'
 
 jest.mock('@xpert-ai/server-core', () => ({
     CrudController: class {
@@ -80,6 +82,10 @@ jest.mock('./xpert-frequent-questions.service', () => ({
 
 jest.mock('./xpert-principal.service', () => ({
     XpertPrincipalService: class {}
+}))
+
+jest.mock('./template-workspace-initializer.service', () => ({
+    XpertTemplateWorkspaceInitializer: class {}
 }))
 
 jest.mock('../copilot-store/copilot-store.service', () => ({
@@ -178,6 +184,9 @@ describe('XpertController', () => {
     let xpertPrincipalService: {
         ensurePrincipalUser: jest.Mock
     }
+    let templateWorkspaceInitializer: {
+        initializeByTemplateId: jest.Mock
+    }
     let commandBus: {
         execute: jest.Mock
     }
@@ -211,6 +220,13 @@ describe('XpertController', () => {
         xpertPrincipalService = {
             ensurePrincipalUser: jest.fn()
         }
+        templateWorkspaceInitializer = {
+            initializeByTemplateId: jest.fn(async () => ({
+                status: 'initialized',
+                created: [],
+                skipped: []
+            }))
+        }
         commandBus = {
             execute: jest.fn()
         }
@@ -232,6 +248,7 @@ describe('XpertController', () => {
             agentChatRealtime as unknown as AgentChatRealtimeService,
             xpertPrincipalService as unknown as XpertPrincipalService,
             {} as unknown as XpertFrequentQuestionsService,
+            templateWorkspaceInitializer as unknown as XpertTemplateWorkspaceInitializer,
             commandBus as unknown as CommandBus,
             queryBus as unknown as QueryBus
         )
@@ -248,6 +265,44 @@ describe('XpertController', () => {
 
     afterEach(() => {
         jest.clearAllMocks()
+    })
+
+    it('initializes workspace prompt workflows after importing a trusted template', async () => {
+        const xpert = {
+            id: 'xpert-1',
+            workspaceId: 'workspace-1'
+        }
+        commandBus.execute.mockResolvedValue(xpert)
+
+        await expect(
+            controller.importDSL(
+                { team: { name: 'presentation-assistant' } } as XpertDraftDslDTO,
+                '  @xpert-ai/plugin-presentation-studio:presentation-studio-assistant  ',
+                LanguagesEnum.English
+            )
+        ).resolves.toEqual(xpert)
+        expect(templateWorkspaceInitializer.initializeByTemplateId).toHaveBeenCalledWith(
+            '@xpert-ai/plugin-presentation-studio:presentation-studio-assistant',
+            'workspace-1',
+            LanguagesEnum.English
+        )
+    })
+
+    it('keeps plain DSL imports unchanged when no template id is provided', async () => {
+        const xpert = {
+            id: 'xpert-1',
+            workspaceId: 'workspace-1'
+        }
+        commandBus.execute.mockResolvedValue(xpert)
+
+        await expect(
+            controller.importDSL(
+                { team: { name: 'plain-assistant' } } as XpertDraftDslDTO,
+                undefined,
+                LanguagesEnum.English
+            )
+        ).resolves.toEqual(xpert)
+        expect(templateWorkspaceInitializer.initializeByTemplateId).not.toHaveBeenCalled()
     })
 
     it('initializes the xpert principal user when enabling Chat API', async () => {

--- a/packages/server-ai/src/xpert/xpert.controller.ts
+++ b/packages/server-ai/src/xpert/xpert.controller.ts
@@ -4,6 +4,7 @@ import {
     IIntegration,
     IXpert,
     LanguagesEnum,
+    LanguagesMap,
     LongTermMemoryTypeEnum,
     TChatApi,
     TChatApp,
@@ -130,6 +131,7 @@ import { RUNTIME_CAPABILITY_XPERT_RELATIONS, RuntimeCapabilitiesService } from '
 import { XpertFrequentQuestionsService } from './xpert-frequent-questions.service'
 import { XpertPrincipalService } from './xpert-principal.service'
 import { parseXpertPublishMarketplaceInput } from './marketplace-profile.parser'
+import { XpertTemplateWorkspaceInitializer } from './template-workspace-initializer.service'
 
 @ApiTags('Xpert')
 @ApiBearerAuth()
@@ -150,6 +152,7 @@ export class XpertController extends CrudController<Xpert> {
         private readonly agentChatRealtime: AgentChatRealtimeService,
         private readonly xpertPrincipalService: XpertPrincipalService,
         private readonly frequentQuestionsService: XpertFrequentQuestionsService,
+        private readonly templateWorkspaceInitializer: XpertTemplateWorkspaceInitializer,
         private readonly commandBus: CommandBus,
         private readonly queryBus: QueryBus
     ) {
@@ -206,9 +209,22 @@ export class XpertController extends CrudController<Xpert> {
 
     @UseValidationPipe({ transform: true })
     @Post('import')
-    async importDSL(@Body() dsl: XpertDraftDslDTO) {
+    async importDSL(
+        @Body() dsl: XpertDraftDslDTO,
+        @Query('templateId') templateId?: string,
+        @I18nLang() language: LanguagesEnum = LanguagesEnum.English
+    ) {
         try {
-            return await this.commandBus.execute(new XpertImportCommand(dsl))
+            const xpert = await this.commandBus.execute<XpertImportCommand, IXpert>(new XpertImportCommand(dsl))
+            const normalizedTemplateId = typeof templateId === 'string' ? templateId.trim() : ''
+            if (normalizedTemplateId && xpert.workspaceId) {
+                await this.templateWorkspaceInitializer.initializeByTemplateId(
+                    normalizedTemplateId,
+                    xpert.workspaceId,
+                    LanguagesMap[language] ?? language
+                )
+            }
+            return xpert
         } catch (error) {
             throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR)
         }

--- a/packages/server-ai/src/xpert/xpert.module.ts
+++ b/packages/server-ai/src/xpert/xpert.module.ts
@@ -39,6 +39,7 @@ import { XpertFrequentQuestionCache } from './xpert-frequent-question-cache.enti
 import { XpertFrequentQuestionsService } from './xpert-frequent-questions.service'
 import { XpertPrincipalService } from './xpert-principal.service'
 import { ScheduleTriggerStrategies } from './plugins'
+import { XpertTemplateWorkspaceInitializer } from './template-workspace-initializer.service'
 
 @Module({
     imports: [
@@ -81,10 +82,11 @@ import { ScheduleTriggerStrategies } from './plugins'
         RuntimeCommandService,
         RuntimeCapabilitiesService,
         XpertFrequentQuestionsService,
+        XpertTemplateWorkspaceInitializer,
         ...ScheduleTriggerStrategies,
         ...CommandHandlers,
         ...QueryHandlers
     ],
-    exports: [XpertService, XpertPrincipalService, PublishedXpertAccessService]
+    exports: [XpertService, XpertPrincipalService, PublishedXpertAccessService, XpertTemplateWorkspaceInitializer]
 })
 export class XpertModule {}


### PR DESCRIPTION
## Summary

Assistant templates can now declare reusable prompt workflows that are initialized into the target workspace when the assistant is created.

## Problem

Template authors could provide start prompts, but they could not provision reusable workspace slash commands. Users therefore had to create common commands manually after initializing an assistant.

## Root cause

The template contract and plugin SDK did not expose prompt workflow definitions, and the two template installation paths did not have a host-owned persistence step for workspace commands.

## Changes

- Add the optional `promptWorkflows` field to template contracts and the plugin SDK.
- Pass a trusted template ID from the template wizard without accepting command definitions from the client.
- Resolve prompt workflows from the server-loaded template and initialize missing workspace commands in one transaction.
- Preserve active and archived same-name commands and make repeated initialization idempotent.
- Initialize commands from both DSL template import and plugin template installation.
- Log initialization failures without rolling back assistant creation.
- Add patch changesets for the affected host packages.

## Validation

- Server AI focused Jest: 5 suites, 53 tests passed.
- Cloud Blank Wizard Jest: 1 suite, 44 tests passed.
- Re-run after commit cleanup: 2 server suites, 16 tests passed.
- `git diff --check` passed.

No browser validation was run; manual workspace verification remains intentional.