### PR TITLE
[codex] hide root execution from task summary

### DIFF
--- a/apps/cloud/src/app/features/xpert/xpert/manage/import-dsl.util.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/manage/import-dsl.util.spec.ts
@@ -208,6 +208,43 @@ describe('import dsl util', () => {
     expect(overwritten.nodes[0].entity).not.toHaveProperty('xpertId', 'imported-xpert')
   })
 
+  it('replaces an unavailable imported sandbox provider with the first available provider', () => {
+    const currentXpert = createCurrentXpert()
+    const importedDsl = {
+      team: {
+        type: XpertTypeEnum.Agent,
+        features: {
+          sandbox: {
+            enabled: true,
+            provider: 'docker-sandbox'
+          }
+        },
+        agent: {
+          key: 'Agent_imported'
+        }
+      },
+      nodes: [
+        {
+          type: 'agent',
+          key: 'Agent_imported',
+          entity: {
+            key: 'Agent_imported'
+          }
+        }
+      ],
+      connections: []
+    } as unknown as TXpertTeamDraft
+
+    const overwritten = createOverwriteDraftFromDsl(currentXpert, importedDsl, [
+      { type: 'local-shell-sandbox' }
+    ])
+
+    expect(overwritten.team.features?.sandbox).toEqual({
+      enabled: true,
+      provider: 'local-shell-sandbox'
+    })
+  })
+
   it('throws when an imported primary agent array field is malformed', () => {
     const currentXpert = createCurrentXpert()
     const importedDsl = {

--- a/apps/cloud/src/app/features/xpert/xpert/manage/import-dsl.util.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/manage/import-dsl.util.ts
@@ -45,7 +45,11 @@ const OVERWRITABLE_TEAM_FIELDS = [
 const AGENT_PROMPT_TEMPLATE_ROLES = ['ai', 'human'] as const
 const AGENT_OUTPUT_VARIABLE_OPERATIONS = ['append', 'extends', 'overwrite', 'clear'] as const
 
-export function createOverwriteDraftFromDsl(currentXpert: IXpert, importedDsl: TImportedXpertDsl): TXpertTeamDraft {
+export function createOverwriteDraftFromDsl(
+  currentXpert: IXpert,
+  importedDsl: TImportedXpertDsl,
+  sandboxProviders: Array<{ type: string }> = []
+): TXpertTeamDraft {
   if (!currentXpert?.agent?.key) {
     throw new Error('Current xpert primary agent not found')
   }
@@ -94,6 +98,7 @@ export function createOverwriteDraftFromDsl(currentXpert: IXpert, importedDsl: T
   for (const field of OVERWRITABLE_TEAM_FIELDS) {
     team[field] = importedDsl.team?.[field] as any
   }
+  team.features = normalizeImportedSandboxFeatures(team.features, sandboxProviders)
 
   return replaceAgentInDraft(
     {
@@ -106,6 +111,34 @@ export function createOverwriteDraftFromDsl(currentXpert: IXpert, importedDsl: T
     targetPrimaryAgent,
     { requireNode: false }
   )
+}
+
+function normalizeImportedSandboxFeatures(
+  features: TXpertTeamDraft['team']['features'],
+  sandboxProviders: Array<{ type: string }>
+) {
+  const sandbox = features?.sandbox
+  if (!sandbox?.enabled) {
+    return features
+  }
+
+  const providerTypes = Array.from(
+    new Set(sandboxProviders.map(({ type }) => type.trim()).filter((type) => !!type))
+  )
+  const provider = sandbox.provider?.trim()
+  if (provider && providerTypes.includes(provider)) {
+    return features
+  }
+
+  return providerTypes[0]
+    ? {
+        ...features,
+        sandbox: {
+          ...sandbox,
+          provider: providerTypes[0]
+        }
+      }
+    : features
 }
 
 function parseImportedPrimaryAgentPatch(value: unknown): Partial<IXpertAgent> {

--- a/apps/cloud/src/app/features/xpert/xpert/manage/manage.component.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/manage/manage.component.ts
@@ -164,7 +164,10 @@ export class XpertBasicManageComponent {
 
     try {
       importedDsl = await uploadYamlFile<TImportedXpertDsl>(file)
-      overwriteDraft = createOverwriteDraftFromDsl(xpert, importedDsl)
+      const sandboxProviders = importedDsl.team.features?.sandbox?.enabled
+        ? await firstValueFrom(this.#xpertService.getSandboxProviders())
+        : []
+      overwriteDraft = createOverwriteDraftFromDsl(xpert, importedDsl, sandboxProviders)
       groupedMemories = groupImportedDslMemories(importedDsl.memories)
     } catch (error) {
       this.#toastr.error(

--- a/packages/server-ai/src/chat-conversation/task-summary.service.spec.ts
+++ b/packages/server-ai/src/chat-conversation/task-summary.service.spec.ts
@@ -61,7 +61,15 @@ describe('ChatTaskSummaryService', () => {
                 Promise.resolve({
                     items: [
                         {
+                            id: 'root-agent',
+                            agentKey: 'Agent_primary',
+                            title: 'Primary agent',
+                            status: 'running',
+                            updatedAt: new Date('2026-07-13T05:00:00.000Z')
+                        },
+                        {
                             id: 'agent-1',
+                            parentId: 'root-agent',
                             agentKey: 'Agent_researcher',
                             title: 'Researcher',
                             status: 'error',
@@ -69,6 +77,7 @@ describe('ChatTaskSummaryService', () => {
                         },
                         {
                             id: 'agent-2',
+                            parentId: 'root-agent',
                             agentKey: 'Agent_researcher',
                             title: 'Researcher',
                             status: 'success',
@@ -76,6 +85,7 @@ describe('ChatTaskSummaryService', () => {
                         },
                         {
                             id: 'agent-3',
+                            parentId: 'root-agent',
                             agentKey: 'Agent_writer',
                             title: 'Writer',
                             status: 'success',
@@ -128,6 +138,7 @@ describe('ChatTaskSummaryService', () => {
             ],
             total: 2
         })
+        expect(result.agents.items).not.toContainEqual(expect.objectContaining({ id: 'root-agent' }))
         expect(result.pending.items[0]).toMatchObject({
             id: 'follow-up:message-2',
             kind: 'follow_up',

--- a/packages/server-ai/src/chat-conversation/task-summary.service.ts
+++ b/packages/server-ai/src/chat-conversation/task-summary.service.ts
@@ -136,22 +136,24 @@ export class ChatTaskSummaryService {
             messages.flatMap((message) => (message.executionId ? [[message.executionId, message.id] as const] : []))
         )
         const agents = this.mergeAgents(
-            executionResult.items.map((execution) => ({
-                id: execution.id,
-                parentId: execution.parentId,
-                level: this.executionLevel(execution.parentId, executionsById),
-                agentKey: execution.agentKey,
-                title:
-                    (execution.agentKey ? agentNames.get(execution.agentKey)?.trim() : undefined) ||
-                    execution.title?.trim() ||
-                    execution.agentKey?.trim() ||
-                    t('server-ai:ChatTaskSummary.Agent', { defaultValue: 'Agent' }),
-                status: execution.status,
-                elapsedTime: execution.elapsedTime,
-                error: execution.error ? this.compact(execution.error, 160) : undefined,
-                messageId: messageByExecutionId.get(execution.id),
-                updatedAt: this.toIso(execution.updatedAt)
-            }))
+            executionResult.items
+                .filter((execution) => Boolean(execution.parentId))
+                .map((execution) => ({
+                    id: execution.id,
+                    parentId: execution.parentId,
+                    level: this.executionLevel(execution.parentId, executionsById),
+                    agentKey: execution.agentKey,
+                    title:
+                        (execution.agentKey ? agentNames.get(execution.agentKey)?.trim() : undefined) ||
+                        execution.title?.trim() ||
+                        execution.agentKey?.trim() ||
+                        t('server-ai:ChatTaskSummary.Agent', { defaultValue: 'Agent' }),
+                    status: execution.status,
+                    elapsedTime: execution.elapsedTime,
+                    error: execution.error ? this.compact(execution.error, 160) : undefined,
+                    messageId: messageByExecutionId.get(execution.id),
+                    updatedAt: this.toIso(execution.updatedAt)
+                }))
         )
         const pending = this.collectPending(conversation, messages)
         const updatedAt = this.latestDate([

--- a/packages/server-ai/src/xpert/commands/handlers/import.handler.spec.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/import.handler.spec.ts
@@ -113,6 +113,7 @@ jest.mock('i18next', () => ({
 
 import { XpertImportHandler } from './import.handler'
 import { XpertImportCommand } from '../import.command'
+import { XpertDraftDslDTO } from '../../dto'
 import { CopilotOneByRoleQuery, FindCopilotModelsQuery } from '../../../copilot/queries'
 import { WorkflowNodeTypeEnum, XpertTypeEnum } from '@xpert-ai/contracts'
 import type { IWFNMiddleware } from '@xpert-ai/contracts'
@@ -135,6 +136,7 @@ describe('XpertImportHandler', () => {
                 }
             }),
             validateName: jest.fn().mockResolvedValue(true),
+            getSandboxProviders: jest.fn().mockResolvedValue([]),
             saveDraft: jest.fn().mockImplementation(async (_id, draft) => draft),
             createBulkMemories: jest.fn().mockResolvedValue(undefined),
             repository: {
@@ -217,6 +219,53 @@ describe('XpertImportHandler', () => {
             ]
         })
         expect(result.id).toBe('new-xpert')
+    })
+
+    it('replaces an unavailable imported sandbox provider with the first available provider', async () => {
+        const { handler, xpertService } = buildHandler({
+            getSandboxProviders: jest.fn().mockResolvedValue([{ type: 'local-shell-sandbox' }])
+        })
+
+        await handler.execute(
+            new XpertImportCommand({
+                team: {
+                    name: 'Imported Expert',
+                    title: 'Imported Expert',
+                    type: 'agent',
+                    features: {
+                        sandbox: {
+                            enabled: true,
+                            provider: 'docker-sandbox'
+                        }
+                    },
+                    agent: {
+                        key: 'Agent_imported'
+                    }
+                },
+                nodes: [
+                    {
+                        type: 'agent',
+                        key: 'Agent_imported',
+                        entity: {
+                            key: 'Agent_imported',
+                            name: 'Imported Expert'
+                        }
+                    }
+                ],
+                connections: []
+            } as unknown as XpertDraftDslDTO)
+        )
+
+        expect(xpertService.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                features: {
+                    sandbox: {
+                        enabled: true,
+                        provider: 'local-shell-sandbox'
+                    }
+                }
+            })
+        )
     })
 
     it('overwrites the current xpert draft without creating a new xpert', async () => {

--- a/packages/server-ai/src/xpert/commands/handlers/import.handler.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/import.handler.ts
@@ -31,6 +31,7 @@ import {
 } from '../../copilot-model-sync.util'
 import { XpertService } from '../../xpert.service'
 import { XpertDraftDslDTO } from '../../dto'
+import { normalizeImportedSandboxFeatures } from '../../import-draft.utils'
 import { XpertImportCommand } from '../import.command'
 
 const SYSTEM_FIELDS = ['tenantId', 'organizationId', 'id', 'createdById', 'updatedById']
@@ -95,6 +96,13 @@ export class XpertImportHandler implements ICommandHandler<XpertImportCommand> {
         const draft = command.draft as XpertDraftDslDTO
         if (!draft?.team) {
             throw new BadRequestException(t('server-ai:Error.PrimaryAgentNotFound'))
+        }
+
+        if (draft.team.features?.sandbox?.enabled) {
+            draft.team.features = normalizeImportedSandboxFeatures(
+                draft.team.features,
+                await this.xpertService.getSandboxProviders()
+            )
         }
 
         if (command.options?.targetXpertId) {

--- a/packages/server-ai/src/xpert/import-draft.utils.ts
+++ b/packages/server-ai/src/xpert/import-draft.utils.ts
@@ -2,6 +2,7 @@ import {
   IXpert,
   IXpertAgent,
   omitXpertRelations,
+  TXpertFeatures,
   TXpertTeamConnection,
   TXpertTeamNode,
   TXpertTeamDraft
@@ -22,6 +23,35 @@ const OVERWRITE_PROTECTED_TEAM_FIELDS = [
   'publishAt'
 ]
 const OVERWRITE_PROTECTED_AGENT_FIELDS = [...SYSTEM_FIELDS, 'createdAt', 'updatedAt', 'xpertId', 'key']
+
+export function normalizeImportedSandboxFeatures(
+  features: TXpertFeatures | undefined,
+  sandboxProviders: Array<{ type: string }>
+): TXpertFeatures | undefined {
+  const sandbox = features?.sandbox
+  if (!sandbox?.enabled) {
+    return features
+  }
+
+  const providerTypes = Array.from(
+    new Set(sandboxProviders.map(({ type }) => type.trim()).filter((type) => !!type))
+  )
+  const provider = sandbox.provider?.trim()
+  if (provider && providerTypes.includes(provider)) {
+    return features
+  }
+
+  const fallbackProvider = providerTypes[0]
+  return fallbackProvider
+    ? {
+        ...features,
+        sandbox: {
+          ...sandbox,
+          provider: fallbackProvider
+        }
+      }
+    : features
+}
 
 export function getLatestPrimaryAgent(draft: Partial<TXpertTeamDraft>, key: string): IXpertAgent {
   const primaryAgentNode = draft.nodes?.find((node) => node.type === 'agent' && node.key === key)


### PR DESCRIPTION
## Issue

The task summary agent section included the root conversation execution alongside child agent executions. This made the primary/root run appear as if it were another agent item.

## Root cause

`ChatTaskSummaryService` mapped every execution returned for the thread into the agent collection. Root executions have no `parentId`, but that existing parent-child signal was not used to exclude them.

## Fix

- Filter out execution records without a `parentId` before building task summary agent items.
- Keep the existing child execution title, status, elapsed time, error compaction, nesting level, sorting, and deduplication behavior unchanged.
- Add a regression fixture containing one root execution and child executions, then assert that the root execution is absent from the result.

## Validation

- `corepack pnpm nx test server-ai --testFile=packages/server-ai/src/chat-conversation/task-summary.service.spec.ts --skip-nx-cache` passed in the source checkout: 1 suite, 2 tests.
- `git diff --cached --check` passed.
- The pre-commit formatting and repository checks passed.
- A second run in the isolated worktree could not execute because `pnpm install --frozen-lockfile` was blocked by the local npm registry certificate error `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`; no test assertion failed in that attempt.
