### PR TITLE
[codex] Hide file memory selector output

### DIFF
--- a/packages/server-ai/src/file-memory/file-memory.middleware.spec.ts
+++ b/packages/server-ai/src/file-memory/file-memory.middleware.spec.ts
@@ -179,7 +179,11 @@ describe('XpertFileMemoryMiddleware', () => {
         const results = await middleware.tools?.[0].invoke({ query: 'history' }, toolConfig())
 
         expect((context.runtime as any).createModelClient).toHaveBeenCalled()
-        expect(selectorInvoke).toHaveBeenCalled()
+        expect(selectorInvoke).toHaveBeenCalledWith(expect.any(Array), {
+            metadata: {
+                internal: true
+            }
+        })
         expect(fileMemoryService.recordRecallHits).toHaveBeenCalledWith(
             { tenantId: 'tenant-1', id: 'xpert-1' },
             expect.objectContaining({

--- a/packages/server-ai/src/file-memory/recall-planner.ts
+++ b/packages/server-ai/src/file-memory/recall-planner.ts
@@ -91,10 +91,17 @@ export class FileMemoryRecallPlanner {
         const humanInput = `Query: ${query}\n\nAvailable memories:\n${manifest}\n\nRespond with JSON only.`
         const selector = Promise.resolve()
             .then(() =>
-                chatModel.withStructuredOutput(schema).invoke([
-                    { role: 'system', content: prompt },
-                    { role: 'human', content: humanInput }
-                ])
+                chatModel.withStructuredOutput(schema).invoke(
+                    [
+                        { role: 'system', content: prompt },
+                        { role: 'human', content: humanInput }
+                    ],
+                    {
+                        metadata: {
+                            internal: true
+                        }
+                    }
+                )
             )
             .then((value) => ({ status: 'fulfilled' as const, value }))
             .catch((error) => ({ status: 'rejected' as const, error }))


### PR DESCRIPTION
## Issue

The Xpert file-memory recall selector returns an internal structured payload such as `{"selectedIds":["mem_..."]}`. Because the selector run was not marked as internal, LangGraph stream events exposed that JSON and the selector model's reasoning chunks in the user-facing conversation.

## Root cause

The recall planner invoked the structured selector model without `metadata.internal`. The agent stream mapper already suppresses events carrying that metadata, but the selector events did not meet the filter condition.

## Fix

- Mark the file-memory selector model invocation with `metadata.internal: true`.
- Add a focused regression assertion that the selector receives the internal run metadata.

Memory ranking, selected IDs, recall injection, and the public `memory_search` result contract remain unchanged.

## Validation

- `corepack pnpm nx test server-ai --testFile=packages/server-ai/src/file-memory/file-memory.middleware.spec.ts --runInBand`
- `corepack pnpm nx test server-ai --testFile=packages/server-ai/src/xpert-agent/agent.spec.ts --runInBand`
- `git diff --check origin/develop...HEAD`
- `git merge-tree --write-tree origin/develop HEAD`

Both focused test suites passed with 6 tests each. Browser validation was not run.
