### PR TITLE
[codex] Handle unavailable file memory writeback model

### DIFF
--- a/packages/server-ai/src/file-memory/file-memory.writeback-runner.spec.ts
+++ b/packages/server-ai/src/file-memory/file-memory.writeback-runner.spec.ts
@@ -1,0 +1,25 @@
+import { HumanMessage } from '@langchain/core/messages'
+import { FileMemoryWritebackRunner } from './file-memory.writeback-runner'
+
+describe('FileMemoryWritebackRunner', () => {
+    it('skips a background writeback when its configured model is unavailable', async () => {
+        const fileMemoryService = {
+            recordWritebackCandidate: jest.fn().mockResolvedValue(undefined)
+        }
+        const runner = new FileMemoryWritebackRunner(fileMemoryService as never)
+        const getModel = jest.fn().mockRejectedValue(new Error('No AI model provided'))
+
+        const key = runner.enqueue({
+            xpert: {
+                tenantId: 'tenant-1',
+                id: 'xpert-1'
+            },
+            messages: [new HumanMessage('Remember this preference.')],
+            getModel
+        })
+
+        await expect(runner.softDrain(key, 1000)).resolves.toBe(true)
+        expect(fileMemoryService.recordWritebackCandidate).toHaveBeenCalled()
+        expect(getModel).toHaveBeenCalled()
+    })
+})

--- a/packages/server-ai/src/file-memory/file-memory.writeback-runner.ts
+++ b/packages/server-ai/src/file-memory/file-memory.writeback-runner.ts
@@ -94,13 +94,15 @@ export class FileMemoryWritebackRunner {
             }
         }, snapshot.runtime)
 
-        const model = await snapshot.getModel?.()
-        if (!model) {
-            this.logger.warn(`[XpertFileMemory] writeback model is not configured; candidate recorded only xpert=${snapshot.xpert.id}`)
-            return
-        }
-
         try {
+            const model = await snapshot.getModel?.()
+            if (!model) {
+                this.logger.warn(
+                    `[XpertFileMemory] writeback model is not configured; candidate recorded only xpert=${snapshot.xpert.id}`
+                )
+                return
+            }
+
             const searchStartedAt = Date.now()
             const candidates = await this.fileMemoryService.searchMemory(snapshot.xpert, {
                 query: conversationText,


### PR DESCRIPTION
## Summary

Make FileMemory automatic writeback degrade safely when its configured model can no longer be resolved.

## Problem

The writeback runner records a candidate and then resolves the configured writeback model. Model resolution happened outside the runner's existing error boundary, so an unavailable or deleted model caused the background slot promise to reject with errors such as `No AI model provided`.

This could leave an otherwise non-blocking after-agent writeback reported as a failed background task even though the candidate had already been recorded.

## Fix

Move writeback model resolution inside the existing `try/catch`. The runner now keeps the recorded candidate, logs the failure, and skips only the model-driven search and writeback decision for that snapshot.

Add a focused regression test that verifies a rejected model resolver is handled and `softDrain()` completes successfully.

## Validation

- `corepack pnpm exec nx test server-ai --testFile=packages/server-ai/src/file-memory/file-memory.writeback-runner.spec.ts --runInBand --skipNxCache --outputStyle=static`
- `git diff --check origin/develop...HEAD`
