### PR TITLE
[codex] display OIDC login errors

### DIFF
--- a/libs/apps/auth/src/lib/login/login.component.spec.ts
+++ b/libs/apps/auth/src/lib/login/login.component.spec.ts
@@ -117,6 +117,14 @@ describe('UserLoginComponent', () => {
     expect(component.errors).toEqual(['Feishu OAuth failed: User denied access.'])
   })
 
+  it('shows the tenant error returned from an OIDC interaction', async () => {
+    const { component } = await createFixture({
+      error: 'invalid_tenant'
+    })
+
+    expect(component.errors).toEqual(['The requested tenant is not available.'])
+  })
+
   it('falls back to a generic provider message when only the SSO error code is present', async () => {
     const { component, queryParamMap$, fixture } = await createFixture(
       {},

--- a/libs/apps/auth/src/lib/login/login.component.ts
+++ b/libs/apps/auth/src/lib/login/login.component.ts
@@ -75,6 +75,11 @@ export class UserLoginComponent implements OnDestroy {
   /**
    * Signals
    */
+  readonly #oidcErrorMap: Record<string, string> = {
+    invalid_credentials: 'Login/Email combination is not correct, please try again.',
+    invalid_tenant: 'The requested tenant is not available.',
+    interaction_expired: 'Session expired, please try again.'
+  }
   readonly ssoProviders = toSignal(
     this.#http.get<SSOProviderDiscoveryResponse>('/api/auth/sso/providers').pipe(
       map((result) => result.providers ?? []),
@@ -214,6 +219,11 @@ export class UserLoginComponent implements OnDestroy {
   }
 
   private resolveSsoErrors(params: ParamMap): string[] {
+    const oidcError = params.get('error')?.trim()
+    if (oidcError) {
+      return [this.#oidcErrorMap[oidcError] ?? oidcError]
+    }
+
     const ssoMessage = params.get('ssoMessage')?.trim()
     if (ssoMessage) {
       return [ssoMessage]


### PR DESCRIPTION
## Problem

The shared login component in xpert-develop ignores the error query parameter returned by an OIDC interaction. Pro had to carry a local error mapping, so tenant lookup failures could otherwise surface as a raw error code and the shared file would continue to diverge.

## Fix

- map the existing OIDC login errors, including invalid_tenant, to user-facing messages
- resolve the OIDC error through the existing reactive query-parameter path
- add a focused regression test for the invalid tenant response

Existing password login and SSO callback handling are unchanged when no OIDC error parameter is present.

## Validation

- git diff --check passed
- focused Jest was attempted; the existing apps-auth Jest/TypeScript configuration cannot resolve Angular 21 package exports with moduleResolution=node
- focused ESLint was attempted; it reports pre-existing standalone and constructor-injection violations in login.component.ts, with no finding on the added lines