### PR TITLE
[codex] Fix user save ID handling

### DIFF
--- a/apps/cloud/src/app/features/setting/users/user-basic/user-basic.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/users/user-basic/user-basic.component.spec.ts
@@ -54,4 +54,64 @@ describe('UserBasicComponent', () => {
     expect(xpertService.getByPrincipalUser).toHaveBeenCalledWith('user-1')
     expect(fixture.componentInstance.linkedXpert()).toMatchObject({ id: 'xpert-1' })
   }))
+
+  it('uses the latest loaded user id when the editable form model loses its id', async () => {
+    const firstUserId = '123e4567-e89b-42d3-a456-426614174000'
+    const latestUserId = '223e4567-e89b-42d3-a456-426614174000'
+    const userId$ = new BehaviorSubject(firstUserId)
+    const currentUser = signal({
+      id: firstUserId,
+      email: 'first@example.com',
+      username: 'first@example.com'
+    })
+    const update = jest.fn().mockRejectedValue(new Error('stop after update request'))
+    const danger = jest.fn()
+
+    TestBed.configureTestingModule({
+      imports: [UserBasicComponent],
+      providers: [
+        {
+          provide: PACEditUserComponent,
+          useValue: {
+            userId$,
+            user: currentUser
+          }
+        },
+        { provide: UsersService, useValue: { update } },
+        { provide: XpertAPIService, useValue: { getByPrincipalUser: jest.fn() } },
+        { provide: ToastrService, useValue: { danger } }
+      ]
+    }).overrideComponent(UserBasicComponent, {
+      set: {
+        imports: [],
+        template: ''
+      }
+    })
+
+    const fixture = TestBed.createComponent(UserBasicComponent)
+    fixture.detectChanges()
+
+    userId$.next(latestUserId)
+    currentUser.set({
+      id: latestUserId,
+      email: 'latest@example.com',
+      username: 'latest@example.com'
+    })
+    fixture.detectChanges()
+
+    const editableUser = { ...fixture.componentInstance.user }
+    Reflect.deleteProperty(editableUser, 'id')
+    Reflect.set(fixture.componentInstance, 'user', editableUser)
+
+    await fixture.componentInstance.save()
+
+    expect(update).toHaveBeenCalledWith(
+      latestUserId,
+      expect.objectContaining({
+        email: 'latest@example.com',
+        username: 'latest@example.com'
+      })
+    )
+    expect(danger).toHaveBeenCalled()
+  })
 })

--- a/apps/cloud/src/app/features/setting/users/user-basic/user-basic.component.ts
+++ b/apps/cloud/src/app/features/setting/users/user-basic/user-basic.component.ts
@@ -58,10 +58,15 @@ export class UserBasicComponent {
   )
 
   user: User
+  private loadedUserId: string
 
   constructor() {
     effect(() => {
-      this.user = this.userComponent.user() as User
+      const user = this.userComponent.user()
+      if (user) {
+        this.user = user as User
+        this.loadedUserId = user.id
+      }
     })
   }
 
@@ -99,7 +104,7 @@ export class UserBasicComponent {
     }
 
     try {
-      await this.userService.update(this.user.id, request)
+      await this.userService.update(this.loadedUserId, request)
       this.toastrService.success(`PAC.NOTES.USERS.USER_UPDATED`, { name: new CreatedByPipe().transform(this.user) })
       this.userBasicInfo().form.markAsPristine()
     } catch (error) {


### PR DESCRIPTION
## Summary

- preserve the loaded user ID separately from the editable form model
- use that stable ID for the user update request
- add a regression test covering both form-model ID loss and switching to a newly loaded user

## Problem

The user basic-information form is two-way bound to the component's `user` value. When the form emits an editable model without the entity ID, the save handler previously built a request such as `PUT /user/undefined`. The server rejected that path before the update logic with `Validation failed (uuid is expected)`.

## Root cause

The persisted entity identity was coupled to a mutable form model. The editable fields and the request target have different lifecycles and should not share the same source of truth.

## Fix

The component now records the ID whenever the parent user detail finishes loading and uses that ID for save requests. Form changes can replace the editable model without removing the request identity. When navigation loads another user in the reused component, both the displayed model and recorded ID update together.

## Validation

- `jest --config apps/cloud/jest.config.ts --runInBand --runTestsByPath apps/cloud/src/app/features/setting/users/user-basic/user-basic.component.spec.ts`
- focused ESLint for the component and spec
- `git diff --check origin/develop...HEAD`

Browser validation was not run.
