### PR TITLE
[codex] Bind threads to assistants on creation

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -23,7 +23,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "@xpert-ai/chatkit-angular": "~0.4.0",
-    "@xpert-ai/chatkit-ui": "~0.4.10",
+    "@xpert-ai/chatkit-ui": "~0.4.12",
     "@xpert-ai/chatkit-types": "~0.4.6",
     "@xpert-ai/chatkit-web-component": "~0.4.0",
     "@xpert-ai/chatkit-web-shared": "~0.4.1",

--- a/packages/server-ai/src/ai/assistant-request-context.ts
+++ b/packages/server-ai/src/ai/assistant-request-context.ts
@@ -1,0 +1,160 @@
+import {
+    ApiKeyBindingType,
+    IApiKey,
+    IApiPrincipal,
+    IChatConversation,
+    IUser,
+    IXpert,
+    isTenantSharedXpertWorkspace,
+    RequestScopeLevel,
+    SecretTokenBindingType
+} from '@xpert-ai/contracts'
+import { ForbiddenException } from '@nestjs/common'
+import { CommandBus } from '@nestjs/cqrs'
+import { RequestContext } from '@xpert-ai/plugin-sdk'
+import { ChatConversationBindXpertCommand } from '../chat-conversation/commands/bind-xpert.command'
+import { PublishedXpertAccessService, XpertPrincipalService } from '../xpert'
+
+/**
+ * Invariants: authorize the assistant before binding a conversation, preserve
+ * consumer organization scope for tenant-shared assistants, and never rebind
+ * an existing conversation to a different assistant.
+ */
+
+type MutableRequestContextRequest = NonNullable<ReturnType<typeof RequestContext.currentRequest>> & {
+    user?: IUser | IApiPrincipal | null
+}
+
+export async function resolveAssistantForRequest(
+    assistantId: string,
+    publishedXpertAccessService: Pick<PublishedXpertAccessService, 'getAccessiblePublishedXpert'>,
+    xpertPrincipalService?: Pick<XpertPrincipalService, 'ensurePrincipalUser'>
+) {
+    const apiKey = RequestContext.currentApiKey()
+    const apiPrincipal = RequestContext.currentApiPrincipal() as IApiPrincipal | null
+    // USER_XPERT is interactive delegation: preserve the authenticated
+    // business user's permissions and audit identity for the assistant run.
+    const delegatedUser =
+        apiPrincipal?.principalType === 'client_secret' &&
+        apiPrincipal.clientSecretBindingType === SecretTokenBindingType.USER_XPERT
+            ? (RequestContext.currentUser() as IUser | null)
+            : null
+
+    if (apiKey?.type === ApiKeyBindingType.ASSISTANT && apiKey.entityId && apiKey.entityId !== assistantId) {
+        throw new ForbiddenException('API key is not allowed to access this assistant.')
+    }
+
+    const xpert = await publishedXpertAccessService.getAccessiblePublishedXpert(assistantId, {
+        relations: ['user', 'createdBy', 'workspace']
+    })
+
+    if (apiKey?.type === ApiKeyBindingType.WORKSPACE && apiKey.entityId && xpert.workspaceId !== apiKey.entityId) {
+        throw new ForbiddenException('API key is not allowed to access this workspace assistant.')
+    }
+
+    if (delegatedUser) {
+        return {
+            ...xpert,
+            user: delegatedUser,
+            userId: delegatedUser.id
+        }
+    }
+
+    if (xpertPrincipalService) {
+        const principalUser = await xpertPrincipalService.ensurePrincipalUser(xpert)
+        return {
+            ...xpert,
+            user: principalUser,
+            userId: principalUser.id
+        }
+    }
+
+    return xpert
+}
+
+export function applyAssistantScope(xpert: IXpert) {
+    const apiKey = RequestContext.currentApiKey()
+    const keepConsumerOrganizationScope =
+        !xpert.organizationId && RequestContext.isOrganizationScope() && isTenantSharedXpertWorkspace(xpert.workspace)
+
+    if (!keepConsumerOrganizationScope) {
+        applyAssistantScopeToCurrentRequest(xpert.organizationId ?? null)
+    }
+    applyAssistantPrincipalToCurrentRequest(apiKey, xpert.user ?? null)
+}
+
+export function assertConversationAssistantBinding(
+    conversation: Pick<IChatConversation, 'xpertId'>,
+    assistantId: string
+) {
+    if (conversation.xpertId && conversation.xpertId !== assistantId) {
+        throw new ForbiddenException()
+    }
+}
+
+export async function bindConversationAssistantIfUnbound(
+    commandBus: CommandBus,
+    conversation: IChatConversation,
+    assistantId: string
+): Promise<IChatConversation> {
+    assertConversationAssistantBinding(conversation, assistantId)
+    if (conversation.xpertId) {
+        return conversation
+    }
+
+    const persisted = await commandBus.execute(new ChatConversationBindXpertCommand(conversation.id, assistantId))
+    assertConversationAssistantBinding(persisted, assistantId)
+    return persisted
+}
+
+function applyAssistantScopeToCurrentRequest(organizationId?: string | null) {
+    const request = RequestContext.currentRequest() as MutableRequestContextRequest | null
+
+    if (!request?.headers) {
+        return
+    }
+
+    if (organizationId) {
+        request.headers['organization-id'] = organizationId
+        request.headers['x-scope-level'] = RequestScopeLevel.ORGANIZATION
+        return
+    }
+
+    delete request.headers['organization-id']
+    request.headers['x-scope-level'] = RequestScopeLevel.TENANT
+}
+
+function applyAssistantPrincipalToCurrentRequest(
+    apiKey: IApiKey | null | undefined,
+    principalUser: IUser | null | undefined
+) {
+    const request = RequestContext.currentRequest() as MutableRequestContextRequest | null
+    const currentUser = RequestContext.currentUser() as IApiPrincipal | null
+
+    if (!request || !apiKey || !principalUser) {
+        return
+    }
+
+    if (
+        currentUser?.principalType === 'client_secret' &&
+        currentUser.clientSecretBindingType === SecretTokenBindingType.PUBLIC_XPERT
+    ) {
+        return
+    }
+
+    // An explicit x-principal-user-id represents the business user and must not
+    // be overwritten by the assistant technical principal.
+    if (currentUser?.requestedUserId) {
+        return
+    }
+
+    request.user = {
+        ...principalUser,
+        apiKey,
+        ownerUserId: currentUser?.ownerUserId ?? apiKey.createdById ?? principalUser.id ?? null,
+        apiKeyUserId: currentUser?.apiKeyUserId ?? apiKey.userId ?? principalUser.id ?? null,
+        requestedUserId: currentUser?.requestedUserId ?? null,
+        requestedOrganizationId: currentUser?.requestedOrganizationId ?? null,
+        principalType: currentUser?.principalType ?? 'api_key'
+    }
+}

--- a/packages/server-ai/src/ai/commands/handlers/run-create-stream.handler.spec.ts
+++ b/packages/server-ai/src/ai/commands/handlers/run-create-stream.handler.spec.ts
@@ -49,8 +49,11 @@ import {
 } from '@xpert-ai/contracts'
 import { RequestContext } from '@xpert-ai/plugin-sdk'
 import { hydrateSendRequestHumanInput } from '../../../shared/agent/human-input'
+import { ChatConversationBindXpertCommand } from '../../../chat-conversation/commands/bind-xpert.command'
+import { ChatConversationUpsertCommand } from '../../../chat-conversation/commands/upsert.command'
 import { XpertAgentExecutionUpsertCommand } from '../../../xpert-agent-execution/commands/upsert.command'
 import { XpertChatCommand } from '../../../xpert/commands/chat.command'
+import { resolveAssistantForRequest } from '../../assistant-request-context'
 import { normalizeRunStreamMessage, RunCreateStreamHandler, validateRunCreateInput } from './run-create-stream.handler'
 
 const conversation = {
@@ -741,7 +744,7 @@ describe('RunCreateStreamHandler environment resolution', () => {
     })
 })
 
-describe('RunCreateStreamHandler assistant principal', () => {
+describe('assistant request principal', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         ;(RequestContext.currentApiPrincipal as jest.Mock).mockReturnValue(null)
@@ -765,15 +768,9 @@ describe('RunCreateStreamHandler assistant principal', () => {
                 tenantId: 'tenant-1'
             })
         }
-        const handler = new RunCreateStreamHandler(
-            {} as any,
-            {} as any,
-            {} as any,
-            publishedXpertAccessService as any,
-            xpertPrincipalService as any
-        )
-
-        await expect(handler['resolveAssistantForRun']('xpert-1')).resolves.toMatchObject({
+        await expect(
+            resolveAssistantForRequest('xpert-1', publishedXpertAccessService, xpertPrincipalService)
+        ).resolves.toMatchObject({
             id: 'xpert-1',
             userId: 'assistant-user-1',
             user: {
@@ -818,15 +815,9 @@ describe('RunCreateStreamHandler assistant principal', () => {
         const xpertPrincipalService = {
             ensurePrincipalUser: jest.fn()
         }
-        const handler = new RunCreateStreamHandler(
-            {} as any,
-            {} as any,
-            {} as any,
-            publishedXpertAccessService as any,
-            xpertPrincipalService as any
-        )
-
-        await expect(handler['resolveAssistantForRun']('xpert-1')).resolves.toMatchObject({
+        await expect(
+            resolveAssistantForRequest('xpert-1', publishedXpertAccessService, xpertPrincipalService)
+        ).resolves.toMatchObject({
             id: 'xpert-1',
             userId: 'user-1',
             user: currentUser
@@ -961,6 +952,88 @@ describe('RunCreateStreamHandler execute', () => {
                 runId: 'execution-1'
             }
         })
+    })
+
+    it('atomically backfills the assistant on a legacy unbound conversation', async () => {
+        ;(RequestContext.currentApiKey as jest.Mock).mockReturnValue(null)
+        const commandBus = {
+            execute: jest.fn(async (command) => {
+                if (command instanceof ChatConversationBindXpertCommand) {
+                    return {
+                        id: 'conversation-1',
+                        threadId: 'thread-1',
+                        xpertId: 'xpert-1',
+                        options: {}
+                    }
+                }
+
+                if (command instanceof XpertAgentExecutionUpsertCommand) {
+                    return {
+                        id: 'execution-1'
+                    }
+                }
+
+                if (command instanceof XpertChatCommand) {
+                    return EMPTY
+                }
+
+                return null
+            })
+        }
+        const queryBus = {
+            execute: jest.fn(async (query) => {
+                if (query.constructor.name === 'GetChatConversationQuery') {
+                    return {
+                        id: 'conversation-1',
+                        threadId: 'thread-1',
+                        xpertId: null,
+                        options: {}
+                    }
+                }
+
+                return null
+            })
+        }
+        const handler = new RunCreateStreamHandler(
+            commandBus as any,
+            queryBus as any,
+            {
+                findOneForRuntime: jest.fn().mockResolvedValue(undefined)
+            } as any,
+            {
+                getAccessiblePublishedXpert: jest.fn().mockResolvedValue({
+                    id: 'xpert-1',
+                    environmentId: null
+                })
+            } as any
+        )
+
+        await handler.execute({
+            threadId: 'thread-1',
+            runCreate: {
+                assistant_id: 'xpert-1',
+                input: {
+                    action: 'send',
+                    message: {
+                        input: {
+                            input: 'Continue the legacy thread'
+                        }
+                    }
+                }
+            }
+        } as any)
+
+        const bindCommand = commandBus.execute.mock.calls.find(
+            ([command]) => command instanceof ChatConversationBindXpertCommand
+        )?.[0] as ChatConversationBindXpertCommand
+
+        expect(bindCommand).toMatchObject({
+            conversationId: 'conversation-1',
+            xpertId: 'xpert-1'
+        })
+        expect(
+            commandBus.execute.mock.calls.some(([command]) => command instanceof ChatConversationUpsertCommand)
+        ).toBe(false)
     })
 
     it('forwards raw message input to Xpert chat and leaves hydration to downstream handlers', async () => {

--- a/packages/server-ai/src/ai/commands/handlers/run-create-stream.handler.ts
+++ b/packages/server-ai/src/ai/commands/handlers/run-create-stream.handler.ts
@@ -1,19 +1,11 @@
 import {
-    ApiKeyBindingType,
-    IApiKey,
-    IApiPrincipal,
     IChatConversation,
     IEnvironment,
-    IUser,
-    IXpert,
-    isTenantSharedXpertWorkspace,
-    RequestScopeLevel,
-    SecretTokenBindingType,
     TChatRequest as TChatRequestV2,
     XpertAgentExecutionStatusEnum
 } from '@xpert-ai/contracts'
 import { TChatRequest as LegacyTChatRequest } from '@xpert-ai/chatkit-types'
-import { BadRequestException, ForbiddenException, Logger } from '@nestjs/common'
+import { BadRequestException, Logger } from '@nestjs/common'
 import { CommandBus, CommandHandler, ICommandHandler, QueryBus } from '@nestjs/cqrs'
 import { isNil, omitBy } from 'lodash'
 import { map } from 'rxjs/operators'
@@ -27,8 +19,12 @@ import { XpertAgentExecutionUpsertCommand } from '../../../xpert-agent-execution
 import { XpertAgentExecutionOneQuery } from '../../../xpert-agent-execution/queries'
 import { RunCreateStreamCommand } from '../run-create-stream.command'
 import { assertPublicXpertSessionConversationAccess } from '../../public-xpert-principal'
-import { RequestContext } from '@xpert-ai/plugin-sdk'
 import { serializeRunStreamPayload } from '../../../shared/stream/'
+import {
+    applyAssistantScope,
+    bindConversationAssistantIfUnbound,
+    resolveAssistantForRequest
+} from '../../assistant-request-context'
 
 const humanInputSchema = z.object({}).passthrough()
 
@@ -299,10 +295,6 @@ function getRunCreateContext(context: unknown): Record<string, unknown> | undefi
     return context
 }
 
-type MutableRequestContextRequest = NonNullable<ReturnType<typeof RequestContext.currentRequest>> & {
-    user?: IUser | IApiPrincipal | null
-}
-
 export function validateRunCreateInput(
     input: LegacyTChatRequest | TChatRequestV2 | unknown,
     conversation: IChatConversation
@@ -324,69 +316,6 @@ export function validateRunCreateInput(
     } as TChatRequestV2
 }
 
-function applyAssistantScopeToCurrentRequest(organizationId?: string | null) {
-    const request = RequestContext.currentRequest() as MutableRequestContextRequest | null
-
-    if (!request?.headers) {
-        return
-    }
-
-    if (organizationId) {
-        request.headers['organization-id'] = organizationId
-        request.headers['x-scope-level'] = RequestScopeLevel.ORGANIZATION
-        return
-    }
-
-    delete request.headers['organization-id']
-    request.headers['x-scope-level'] = RequestScopeLevel.TENANT
-}
-
-function applyAssistantPrincipalToCurrentRequest(
-    apiKey: IApiKey | null | undefined,
-    principalUser: IUser | null | undefined
-) {
-    const request = RequestContext.currentRequest() as MutableRequestContextRequest | null
-    const currentUser = RequestContext.currentUser() as IApiPrincipal | null
-
-    if (!request || !apiKey || !principalUser) {
-        return
-    }
-
-    if (
-        currentUser?.principalType === 'client_secret' &&
-        currentUser.clientSecretBindingType === SecretTokenBindingType.PUBLIC_XPERT
-    ) {
-        return
-    }
-
-    // An explicit x-principal-user-id represents the business user for this
-    // request and must not be overwritten by the xpert technical principal.
-    if (currentUser?.requestedUserId) {
-        return
-    }
-
-    request.user = {
-        ...principalUser,
-        apiKey,
-        ownerUserId: currentUser?.ownerUserId ?? apiKey.createdById ?? principalUser.id ?? null,
-        apiKeyUserId: currentUser?.apiKeyUserId ?? apiKey.userId ?? principalUser.id ?? null,
-        requestedUserId: currentUser?.requestedUserId ?? null,
-        requestedOrganizationId: currentUser?.requestedOrganizationId ?? null,
-        principalType: currentUser?.principalType ?? 'api_key'
-    }
-}
-
-function applyAssistantScope(xpert: IXpert) {
-    const apiKey = RequestContext.currentApiKey()
-    const keepConsumerOrganizationScope =
-        !xpert.organizationId && RequestContext.isOrganizationScope() && isTenantSharedXpertWorkspace(xpert.workspace)
-
-    if (!keepConsumerOrganizationScope) {
-        applyAssistantScopeToCurrentRequest(xpert.organizationId ?? null)
-    }
-    applyAssistantPrincipalToCurrentRequest(apiKey, (xpert.user as IUser | null | undefined) ?? null)
-}
-
 @CommandHandler(RunCreateStreamCommand)
 export class RunCreateStreamHandler implements ICommandHandler<RunCreateStreamCommand> {
     readonly #logger = new Logger(RunCreateStreamHandler.name)
@@ -398,52 +327,6 @@ export class RunCreateStreamHandler implements ICommandHandler<RunCreateStreamCo
         private readonly publishedXpertAccessService: PublishedXpertAccessService,
         private readonly xpertPrincipalService?: XpertPrincipalService
     ) {}
-
-    private async resolveAssistantForRun(assistantId: string) {
-        const apiKey = RequestContext.currentApiKey()
-        const apiPrincipal = RequestContext.currentApiPrincipal() as IApiPrincipal | null
-        // USER_XPERT is an interactive delegation: run with the authenticated
-        // business user. Other assistant bindings use the stable technical
-        // principal required by background/service execution.
-        const delegatedUser =
-            apiPrincipal?.principalType === 'client_secret' &&
-            apiPrincipal.clientSecretBindingType === SecretTokenBindingType.USER_XPERT
-                ? (RequestContext.currentUser() as IUser | null)
-                : null
-
-        if (apiKey?.type === ApiKeyBindingType.ASSISTANT && apiKey.entityId && apiKey.entityId !== assistantId) {
-            throw new ForbiddenException('API key is not allowed to access this assistant.')
-        }
-
-        const xpert = await this.publishedXpertAccessService.getAccessiblePublishedXpert(assistantId, {
-            relations: ['user', 'createdBy', 'workspace']
-        })
-
-        if (apiKey?.type === ApiKeyBindingType.WORKSPACE && apiKey.entityId && xpert.workspaceId !== apiKey.entityId) {
-            throw new ForbiddenException('API key is not allowed to access this workspace assistant.')
-        }
-
-        if (delegatedUser) {
-            // Do not call ensurePrincipalUser here; doing so would replace the
-            // user's permissions and audit identity with the assistant user.
-            return {
-                ...xpert,
-                user: delegatedUser,
-                userId: delegatedUser.id
-            }
-        }
-
-        if (this.xpertPrincipalService) {
-            const principalUser = await this.xpertPrincipalService.ensurePrincipalUser(xpert as never)
-            return {
-                ...xpert,
-                user: principalUser,
-                userId: principalUser.id
-            }
-        }
-
-        return xpert
-    }
 
     private async resolveRequestEnvironment(
         xpert: { environmentId?: string | null },
@@ -465,21 +348,22 @@ export class RunCreateStreamHandler implements ICommandHandler<RunCreateStreamCo
         const runCreate = command.runCreate
 
         // Find thread (conversation) and assistant (xpert)
-        const conversation = await this.queryBus.execute(new GetChatConversationQuery({ threadId }))
+        let conversation = await this.queryBus.execute(new GetChatConversationQuery({ threadId }))
         assertPublicXpertSessionConversationAccess(conversation)
-        const xpert = await this.resolveAssistantForRun(runCreate.assistant_id)
+        const xpert = await resolveAssistantForRequest(
+            runCreate.assistant_id,
+            this.publishedXpertAccessService,
+            this.xpertPrincipalService
+        )
         applyAssistantScope(xpert)
         const chatRequest = validateRunCreateInput(runCreate.input, conversation)
         const runtimeContext = getRunCreateContext(runCreate.context)
         const environment = await this.resolveRequestEnvironment(xpert, chatRequest, runtimeContext)
 
-        // Update conversation if xpertId is missing or sandboxEnvironmentId needs to be persisted
-        let needsUpdate = false
-        // Update xpert id for chat conversation
-        if (!conversation.xpertId) {
-            conversation.xpertId = xpert.id
-            needsUpdate = true
-        }
+        // Backfill legacy threads independently with a compare-and-set update.
+        conversation = await bindConversationAssistantIfUnbound(this.commandBus, conversation, xpert.id)
+
+        // Persist the sandbox option only when the request changes it.
         if (
             chatRequest.action === 'send' &&
             chatRequest.sandboxEnvironmentId &&
@@ -489,9 +373,6 @@ export class RunCreateStreamHandler implements ICommandHandler<RunCreateStreamCo
                 ...(conversation.options || {}),
                 sandboxEnvironmentId: chatRequest.sandboxEnvironmentId
             }
-            needsUpdate = true
-        }
-        if (needsUpdate) {
             await this.commandBus.execute(new ChatConversationUpsertCommand(conversation))
         }
 

--- a/packages/server-ai/src/ai/commands/handlers/thread-create.handler.spec.ts
+++ b/packages/server-ai/src/ai/commands/handlers/thread-create.handler.spec.ts
@@ -25,6 +25,7 @@ import { Test } from '@nestjs/testing'
 import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import { RequestContext } from '@xpert-ai/plugin-sdk'
 import { ChatConversationBindXpertCommand, ChatConversationUpsertCommand } from '../../../chat-conversation'
+import { ThreadAlreadyExistsException } from '../../../core'
 import { PublishedXpertAccessService, XpertPrincipalService } from '../../../xpert'
 import { ThreadCreateCommand } from '../thread-create.command'
 import { resolveThreadCreateAssistantId, ThreadCreateHandler } from './thread-create.handler'
@@ -55,6 +56,26 @@ describe('ThreadCreateHandler', () => {
     }
 
     let handler: ThreadCreateHandler
+
+    function mockOrganizationRequestForTenantAssistant() {
+        const request = {
+            headers: {
+                'organization-id': 'organization-1',
+                'x-scope-level': 'organization'
+            }
+        }
+        ;(RequestContext.currentRequest as jest.Mock).mockReturnValue(request)
+        jest.mocked(RequestContext.isOrganizationScope).mockReturnValue(true)
+        publishedXpertAccessService.getAccessiblePublishedXpert.mockResolvedValue({
+            id: 'xpert-1',
+            tenantId: 'tenant-1',
+            organizationId: null,
+            workspaceId: 'workspace-1',
+            workspace: null,
+            user: null
+        })
+        return request
+    }
 
     beforeEach(async () => {
         jest.clearAllMocks()
@@ -128,6 +149,61 @@ describe('ThreadCreateHandler', () => {
             xpertId: 'xpert-1'
         })
         expect(result.metadata.assistant_id).toBe('xpert-1')
+    })
+
+    it('checks for an existing thread before switching to the assistant scope', async () => {
+        const request = mockOrganizationRequestForTenantAssistant()
+        queryBus.execute.mockImplementation(async () => {
+            expect(request.headers['organization-id']).toBe('organization-1')
+            expect(request.headers['x-scope-level']).toBe('organization')
+            return {
+                id: 'conversation-1',
+                threadId: 'thread-1',
+                xpertId: null,
+                status: 'idle'
+            }
+        })
+
+        await expect(
+            handler.execute(
+                new ThreadCreateCommand({
+                    assistant_id: 'xpert-1',
+                    thread_id: 'thread-1',
+                    if_exists: 'raise'
+                })
+            )
+        ).rejects.toBeInstanceOf(ThreadAlreadyExistsException)
+
+        expect(commandBus.execute).not.toHaveBeenCalled()
+        expect(request.headers['organization-id']).toBe('organization-1')
+        expect(request.headers['x-scope-level']).toBe('organization')
+    })
+
+    it('checks the assistant scope before creating a thread with an existing thread_id', async () => {
+        const request = mockOrganizationRequestForTenantAssistant()
+        queryBus.execute.mockResolvedValueOnce(null).mockImplementationOnce(async () => {
+            expect(request.headers['organization-id']).toBeUndefined()
+            expect(request.headers['x-scope-level']).toBe('tenant')
+            return {
+                id: 'conversation-1',
+                threadId: 'thread-1',
+                xpertId: 'xpert-1',
+                status: 'idle'
+            }
+        })
+
+        await expect(
+            handler.execute(
+                new ThreadCreateCommand({
+                    assistant_id: 'xpert-1',
+                    thread_id: 'thread-1',
+                    if_exists: 'raise'
+                })
+            )
+        ).rejects.toBeInstanceOf(ThreadAlreadyExistsException)
+
+        expect(queryBus.execute).toHaveBeenCalledTimes(2)
+        expect(commandBus.execute).not.toHaveBeenCalled()
     })
 
     it('backfills an existing unbound thread when if_exists is do_nothing', async () => {

--- a/packages/server-ai/src/ai/commands/handlers/thread-create.handler.spec.ts
+++ b/packages/server-ai/src/ai/commands/handlers/thread-create.handler.spec.ts
@@ -1,0 +1,251 @@
+jest.mock('../../../xpert', () => ({
+    PublishedXpertAccessService: class PublishedXpertAccessService {},
+    XpertPrincipalService: class XpertPrincipalService {}
+}))
+
+jest.mock('@xpert-ai/plugin-sdk', () => {
+    const actual = jest.requireActual('@xpert-ai/plugin-sdk')
+
+    return {
+        ...actual,
+        RequestContext: {
+            currentApiKey: jest.fn(),
+            currentApiPrincipal: jest.fn(),
+            currentRequest: jest.fn(),
+            currentUser: jest.fn(),
+            currentUserId: jest.fn(),
+            isOrganizationScope: jest.fn()
+        }
+    }
+})
+
+import { ApiKeyBindingType, SecretTokenBindingType } from '@xpert-ai/contracts'
+import { BadRequestException, ForbiddenException } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { CommandBus, QueryBus } from '@nestjs/cqrs'
+import { RequestContext } from '@xpert-ai/plugin-sdk'
+import { ChatConversationBindXpertCommand, ChatConversationUpsertCommand } from '../../../chat-conversation'
+import { PublishedXpertAccessService, XpertPrincipalService } from '../../../xpert'
+import { ThreadCreateCommand } from '../thread-create.command'
+import { resolveThreadCreateAssistantId, ThreadCreateHandler } from './thread-create.handler'
+
+describe('resolveThreadCreateAssistantId', () => {
+	it.each([
+		['non-string', 123],
+		['null', null],
+		['empty', ''],
+		['blank', '   ']
+	])('rejects an invalid assistant_id: %s', (_label, assistantId) => {
+		expect(() => resolveThreadCreateAssistantId({ assistant_id: assistantId })).toThrow(BadRequestException)
+	})
+})
+
+describe('ThreadCreateHandler', () => {
+    const commandBus = {
+        execute: jest.fn()
+    }
+    const queryBus = {
+        execute: jest.fn()
+    }
+    const publishedXpertAccessService = {
+        getAccessiblePublishedXpert: jest.fn()
+    }
+    const xpertPrincipalService = {
+        ensurePrincipalUser: jest.fn()
+    }
+
+    let handler: ThreadCreateHandler
+
+    beforeEach(async () => {
+        jest.clearAllMocks()
+        jest.mocked(RequestContext.currentApiKey).mockReturnValue(null)
+        jest.mocked(RequestContext.currentApiPrincipal).mockReturnValue(null)
+        jest.mocked(RequestContext.currentRequest).mockReturnValue(null)
+        jest.mocked(RequestContext.currentUser).mockReturnValue(null)
+        jest.mocked(RequestContext.currentUserId).mockReturnValue('')
+        jest.mocked(RequestContext.isOrganizationScope).mockReturnValue(false)
+
+        publishedXpertAccessService.getAccessiblePublishedXpert.mockResolvedValue({
+            id: 'xpert-1',
+            tenantId: 'tenant-1',
+            organizationId: 'organization-1',
+            workspaceId: 'workspace-1',
+            workspace: null,
+            user: null
+        })
+        xpertPrincipalService.ensurePrincipalUser.mockResolvedValue({
+            id: 'principal-user-1'
+        })
+        queryBus.execute.mockResolvedValue(null)
+        commandBus.execute.mockImplementation(async (command: unknown) => {
+            if (command instanceof ChatConversationBindXpertCommand) {
+                return {
+                    id: command.conversationId,
+                    threadId: 'thread-1',
+                    status: 'idle',
+                    xpertId: command.xpertId
+                }
+            }
+            if (!(command instanceof ChatConversationUpsertCommand)) {
+                throw new Error('Unexpected command')
+            }
+
+            return {
+                id: 'conversation-1',
+                status: 'idle',
+                ...command.entity
+            }
+        })
+
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                ThreadCreateHandler,
+                { provide: CommandBus, useValue: commandBus },
+                { provide: QueryBus, useValue: queryBus },
+                { provide: PublishedXpertAccessService, useValue: publishedXpertAccessService },
+                { provide: XpertPrincipalService, useValue: xpertPrincipalService }
+            ]
+        }).compile()
+
+        handler = moduleRef.get(ThreadCreateHandler)
+    })
+
+    it('writes xpertId when a thread is created with assistant_id', async () => {
+        const result = await handler.execute(
+            new ThreadCreateCommand({
+                assistant_id: 'xpert-1',
+                if_exists: 'raise'
+            })
+        )
+
+        const upsert = commandBus.execute.mock.calls[0]?.[0]
+        expect(upsert).toBeInstanceOf(ChatConversationUpsertCommand)
+        if (!(upsert instanceof ChatConversationUpsertCommand)) {
+            throw new Error('Expected a conversation upsert command')
+        }
+        expect(upsert.entity).toMatchObject({
+            from: 'api',
+            xpertId: 'xpert-1'
+        })
+        expect(result.metadata.assistant_id).toBe('xpert-1')
+    })
+
+    it('backfills an existing unbound thread when if_exists is do_nothing', async () => {
+        queryBus.execute.mockResolvedValue({
+            id: 'conversation-1',
+            threadId: 'thread-1',
+            xpertId: null,
+            status: 'idle'
+        })
+
+        await handler.execute(
+            new ThreadCreateCommand({
+                assistant_id: 'xpert-1',
+                thread_id: 'thread-1',
+                if_exists: 'do_nothing'
+            })
+        )
+
+        const bind = commandBus.execute.mock.calls[0]?.[0]
+        expect(bind).toBeInstanceOf(ChatConversationBindXpertCommand)
+        if (!(bind instanceof ChatConversationBindXpertCommand)) {
+            throw new Error('Expected an atomic conversation binding command')
+        }
+        expect(bind.conversationId).toBe('conversation-1')
+        expect(bind.xpertId).toBe('xpert-1')
+    })
+
+    it('rejects binding another public session user\'s thread', async () => {
+        jest.mocked(RequestContext.currentApiPrincipal).mockReturnValue({
+            id: 'session-user-1',
+            principalType: 'client_secret',
+            clientSecretBindingType: SecretTokenBindingType.PUBLIC_XPERT,
+            apiKey: {
+                id: 'api-key-1',
+                token: 'test-api-key',
+                type: ApiKeyBindingType.ASSISTANT,
+                entityId: 'xpert-1'
+            }
+        })
+        jest.mocked(RequestContext.currentUserId).mockReturnValue('session-user-1')
+        queryBus.execute.mockResolvedValue({
+            id: 'conversation-1',
+            threadId: 'thread-1',
+            createdById: 'session-user-2',
+            xpertId: null,
+            status: 'idle'
+        })
+
+        await expect(
+            handler.execute(
+                new ThreadCreateCommand({
+                    assistant_id: 'xpert-1',
+                    thread_id: 'thread-1',
+                    if_exists: 'do_nothing'
+                })
+            )
+        ).rejects.toBeInstanceOf(ForbiddenException)
+        expect(commandBus.execute).not.toHaveBeenCalled()
+    })
+
+    it('rejects when another assistant wins the atomic binding race', async () => {
+        queryBus.execute.mockResolvedValue({
+            id: 'conversation-1',
+            threadId: 'thread-1',
+            xpertId: null,
+            status: 'idle'
+        })
+        commandBus.execute.mockResolvedValue({
+            id: 'conversation-1',
+            threadId: 'thread-1',
+            xpertId: 'xpert-2',
+            status: 'idle'
+        })
+
+        await expect(
+            handler.execute(
+                new ThreadCreateCommand({
+                    assistant_id: 'xpert-1',
+                    thread_id: 'thread-1',
+                    if_exists: 'do_nothing'
+                })
+            )
+        ).rejects.toBeInstanceOf(ForbiddenException)
+    })
+
+    it('rejects rebinding an existing thread to another assistant', async () => {
+        queryBus.execute.mockResolvedValue({
+            id: 'conversation-1',
+            threadId: 'thread-1',
+            xpertId: 'xpert-2',
+            status: 'idle'
+        })
+
+        await expect(
+            handler.execute(
+                new ThreadCreateCommand({
+                    assistant_id: 'xpert-1',
+                    thread_id: 'thread-1',
+                    if_exists: 'do_nothing'
+                })
+            )
+        ).rejects.toBeInstanceOf(ForbiddenException)
+        expect(commandBus.execute).not.toHaveBeenCalled()
+    })
+
+    it('preserves legacy thread creation when assistant_id is omitted', async () => {
+        await handler.execute(
+            new ThreadCreateCommand({
+                if_exists: 'raise'
+            })
+        )
+
+        expect(publishedXpertAccessService.getAccessiblePublishedXpert).not.toHaveBeenCalled()
+        const upsert = commandBus.execute.mock.calls[0]?.[0]
+        expect(upsert).toBeInstanceOf(ChatConversationUpsertCommand)
+        if (!(upsert instanceof ChatConversationUpsertCommand)) {
+            throw new Error('Expected a conversation upsert command')
+        }
+        expect(upsert.entity.xpertId).toBeUndefined()
+    })
+})

--- a/packages/server-ai/src/ai/commands/handlers/thread-create.handler.ts
+++ b/packages/server-ai/src/ai/commands/handlers/thread-create.handler.ts
@@ -1,19 +1,65 @@
+import { BadRequestException } from '@nestjs/common'
 import { CommandBus, CommandHandler, ICommandHandler, QueryBus } from '@nestjs/cqrs'
+import { t } from 'i18next'
 import { v4 as uuidv4 } from 'uuid'
 import { ChatConversationUpsertCommand, GetChatConversationQuery } from '../../../chat-conversation'
 import { ThreadAlreadyExistsException } from '../../../core'
+import { PublishedXpertAccessService, XpertPrincipalService } from '../../../xpert'
+import {
+	applyAssistantScope,
+	bindConversationAssistantIfUnbound,
+	resolveAssistantForRequest
+} from '../../assistant-request-context'
 import { ThreadDTO } from '../../dto'
+import { assertPublicXpertSessionConversationAccess } from '../../public-xpert-principal'
 import { ThreadCreateCommand } from '../thread-create.command'
+
+type ThreadAssistantInput = {
+	assistant_id?: unknown
+}
+
+function normalizeThreadAssistantId(value: unknown): string | undefined {
+	if (value === undefined) {
+		return undefined
+	}
+	if (typeof value !== 'string' || !value.trim()) {
+		throw new BadRequestException(
+			t('server-ai:Error.InvalidThreadAssistantId', {
+				defaultValue: 'Thread assistant_id must be a non-empty string.'
+			})
+		)
+	}
+
+	return value.trim()
+}
+
+export function resolveThreadCreateAssistantId(input: ThreadAssistantInput): string | undefined {
+	return normalizeThreadAssistantId(input.assistant_id)
+}
 
 @CommandHandler(ThreadCreateCommand)
 export class ThreadCreateHandler implements ICommandHandler<ThreadCreateCommand> {
 	constructor(
 		private readonly commandBus: CommandBus,
-		private readonly queryBus: QueryBus
+		private readonly queryBus: QueryBus,
+		private readonly publishedXpertAccessService: PublishedXpertAccessService,
+		private readonly xpertPrincipalService?: XpertPrincipalService
 	) {}
 
 	public async execute(command: ThreadCreateCommand): Promise<ThreadDTO> {
 		const input = command.input
+		const assistantId = resolveThreadCreateAssistantId(input)
+		const xpert = assistantId
+			? await resolveAssistantForRequest(
+					assistantId,
+					this.publishedXpertAccessService,
+					this.xpertPrincipalService
+				)
+			: null
+		if (xpert) {
+			applyAssistantScope(xpert)
+		}
+
 		let conversation = null
 		if (input.thread_id) {
 			conversation = await this.queryBus.execute(
@@ -21,26 +67,26 @@ export class ThreadCreateHandler implements ICommandHandler<ThreadCreateCommand>
 					threadId: input.thread_id
 				})
 			)
+			if (conversation) {
+				assertPublicXpertSessionConversationAccess(conversation)
 
-			if (input.if_exists === 'raise' && conversation) {
-				throw new ThreadAlreadyExistsException()
-			}
+				if (input.if_exists === 'raise') {
+					throw new ThreadAlreadyExistsException()
+				}
 
-			if (!conversation) {
-				conversation = await this.commandBus.execute(
-					new ChatConversationUpsertCommand({
-						threadId: input.thread_id,
-						title: input.metadata?.title,
-						from: 'api'
-					})
-				)
+				if (xpert) {
+					conversation = await bindConversationAssistantIfUnbound(this.commandBus, conversation, xpert.id)
+				}
 			}
-		} else {
+		}
+
+		if (!conversation) {
 			conversation = await this.commandBus.execute(
 				new ChatConversationUpsertCommand({
-					threadId: uuidv4(),
+					threadId: input.thread_id ?? uuidv4(),
 					title: input.metadata?.title,
-					from: 'api'
+					from: 'api',
+					xpertId: xpert?.id
 				})
 			)
 		}

--- a/packages/server-ai/src/ai/commands/handlers/thread-create.handler.ts
+++ b/packages/server-ai/src/ai/commands/handlers/thread-create.handler.ts
@@ -56,9 +56,6 @@ export class ThreadCreateHandler implements ICommandHandler<ThreadCreateCommand>
 					this.xpertPrincipalService
 				)
 			: null
-		if (xpert) {
-			applyAssistantScope(xpert)
-		}
 
 		let conversation = null
 		if (input.thread_id) {
@@ -73,11 +70,28 @@ export class ThreadCreateHandler implements ICommandHandler<ThreadCreateCommand>
 				if (input.if_exists === 'raise') {
 					throw new ThreadAlreadyExistsException()
 				}
+			}
+		}
 
-				if (xpert) {
-					conversation = await bindConversationAssistantIfUnbound(this.commandBus, conversation, xpert.id)
+		if (xpert) {
+			applyAssistantScope(xpert)
+		}
+		if (!conversation && input.thread_id && xpert) {
+			conversation = await this.queryBus.execute(
+				new GetChatConversationQuery({
+					threadId: input.thread_id
+				})
+			)
+			if (conversation) {
+				assertPublicXpertSessionConversationAccess(conversation)
+
+				if (input.if_exists === 'raise') {
+					throw new ThreadAlreadyExistsException()
 				}
 			}
+		}
+		if (conversation && xpert) {
+			conversation = await bindConversationAssistantIfUnbound(this.commandBus, conversation, xpert.id)
 		}
 
 		if (!conversation) {

--- a/packages/server-ai/src/ai/schemas/agent-protocol-schema.d.ts
+++ b/packages/server-ai/src/ai/schemas/agent-protocol-schema.d.ts
@@ -573,6 +573,12 @@ export interface components {
              */
             thread_id?: string;
             /**
+             * Assistant Id
+             * Format: uuid
+             * @description The assistant to bind to the thread.
+             */
+            assistant_id?: string;
+            /**
              * Metadata
              * @description Metadata to add to thread.
              */

--- a/packages/server-ai/src/ai/schemas/openapi.json
+++ b/packages/server-ai/src/ai/schemas/openapi.json
@@ -1664,6 +1664,12 @@
 						"title": "Thread Id",
 						"description": "The ID of the thread. If not provided, a random UUID will be generated."
 					},
+					"assistant_id": {
+						"type": "string",
+						"format": "uuid",
+						"title": "Assistant Id",
+						"description": "The assistant to bind to the thread."
+					},
 					"metadata": {
 						"type": "object",
 						"title": "Metadata",

--- a/packages/server-ai/src/chat-conversation/commands/bind-xpert.command.ts
+++ b/packages/server-ai/src/chat-conversation/commands/bind-xpert.command.ts
@@ -1,0 +1,10 @@
+import { ICommand } from '@nestjs/cqrs'
+
+export class ChatConversationBindXpertCommand implements ICommand {
+    static readonly type = '[Chat Conversation] Bind Xpert'
+
+    constructor(
+        public readonly conversationId: string,
+        public readonly xpertId: string
+    ) {}
+}

--- a/packages/server-ai/src/chat-conversation/commands/handlers/bind-xpert.handler.spec.ts
+++ b/packages/server-ai/src/chat-conversation/commands/handlers/bind-xpert.handler.spec.ts
@@ -7,7 +7,10 @@ import { ChatConversationBindXpertHandler } from './bind-xpert.handler'
 describe('ChatConversationBindXpertHandler', () => {
     const service = {
         update: jest.fn(),
-        findOne: jest.fn()
+        findOne: jest.fn(),
+        repository: {
+            findOneByOrFail: jest.fn()
+        }
     }
 
     let handler: ChatConversationBindXpertHandler
@@ -15,7 +18,7 @@ describe('ChatConversationBindXpertHandler', () => {
     beforeEach(async () => {
         jest.clearAllMocks()
         service.update.mockResolvedValue({ affected: 1 })
-        service.findOne.mockResolvedValue({
+        service.repository.findOneByOrFail.mockResolvedValue({
             id: 'conversation-1',
             xpertId: 'xpert-1'
         })
@@ -50,12 +53,14 @@ describe('ChatConversationBindXpertHandler', () => {
                 xpertId: 'xpert-1'
             }
         )
-        expect(service.findOne).toHaveBeenCalledWith('conversation-1')
+        expect(service.repository.findOneByOrFail).toHaveBeenCalledWith({
+            id: 'conversation-1'
+        })
     })
 
     it('returns the persisted winner when another request binds first', async () => {
         service.update.mockResolvedValue({ affected: 0 })
-        service.findOne.mockResolvedValue({
+        service.repository.findOneByOrFail.mockResolvedValue({
             id: 'conversation-1',
             xpertId: 'xpert-2'
         })
@@ -66,5 +71,18 @@ describe('ChatConversationBindXpertHandler', () => {
             id: 'conversation-1',
             xpertId: 'xpert-2'
         })
+    })
+
+    it('does not refetch the bound conversation through the switched request scope', async () => {
+        service.findOne.mockRejectedValue(new Error('Conversation is hidden by the current scope'))
+
+        await expect(
+            handler.execute(new ChatConversationBindXpertCommand('conversation-1', 'xpert-1'))
+        ).resolves.toEqual({
+            id: 'conversation-1',
+            xpertId: 'xpert-1'
+        })
+
+        expect(service.findOne).not.toHaveBeenCalled()
     })
 })

--- a/packages/server-ai/src/chat-conversation/commands/handlers/bind-xpert.handler.spec.ts
+++ b/packages/server-ai/src/chat-conversation/commands/handlers/bind-xpert.handler.spec.ts
@@ -1,0 +1,70 @@
+import { Test } from '@nestjs/testing'
+import { IsNull } from 'typeorm'
+import { ChatConversationService } from '../../conversation.service'
+import { ChatConversationBindXpertCommand } from '../bind-xpert.command'
+import { ChatConversationBindXpertHandler } from './bind-xpert.handler'
+
+describe('ChatConversationBindXpertHandler', () => {
+    const service = {
+        update: jest.fn(),
+        findOne: jest.fn()
+    }
+
+    let handler: ChatConversationBindXpertHandler
+
+    beforeEach(async () => {
+        jest.clearAllMocks()
+        service.update.mockResolvedValue({ affected: 1 })
+        service.findOne.mockResolvedValue({
+            id: 'conversation-1',
+            xpertId: 'xpert-1'
+        })
+
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                ChatConversationBindXpertHandler,
+                {
+                    provide: ChatConversationService,
+                    useValue: service
+                }
+            ]
+        }).compile()
+
+        handler = moduleRef.get(ChatConversationBindXpertHandler)
+    })
+
+    it('binds only conversations whose xpertId is still null', async () => {
+        await expect(
+            handler.execute(new ChatConversationBindXpertCommand('conversation-1', 'xpert-1'))
+        ).resolves.toEqual({
+            id: 'conversation-1',
+            xpertId: 'xpert-1'
+        })
+
+        expect(service.update).toHaveBeenCalledWith(
+            {
+                id: 'conversation-1',
+                xpertId: IsNull()
+            },
+            {
+                xpertId: 'xpert-1'
+            }
+        )
+        expect(service.findOne).toHaveBeenCalledWith('conversation-1')
+    })
+
+    it('returns the persisted winner when another request binds first', async () => {
+        service.update.mockResolvedValue({ affected: 0 })
+        service.findOne.mockResolvedValue({
+            id: 'conversation-1',
+            xpertId: 'xpert-2'
+        })
+
+        await expect(
+            handler.execute(new ChatConversationBindXpertCommand('conversation-1', 'xpert-1'))
+        ).resolves.toEqual({
+            id: 'conversation-1',
+            xpertId: 'xpert-2'
+        })
+    })
+})

--- a/packages/server-ai/src/chat-conversation/commands/handlers/bind-xpert.handler.ts
+++ b/packages/server-ai/src/chat-conversation/commands/handlers/bind-xpert.handler.ts
@@ -18,6 +18,8 @@ export class ChatConversationBindXpertHandler implements ICommandHandler<ChatCon
             }
         )
 
-        return this.service.findOne(command.conversationId)
+        return this.service.repository.findOneByOrFail({
+            id: command.conversationId
+        })
     }
 }

--- a/packages/server-ai/src/chat-conversation/commands/handlers/bind-xpert.handler.ts
+++ b/packages/server-ai/src/chat-conversation/commands/handlers/bind-xpert.handler.ts
@@ -1,0 +1,23 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs'
+import { IsNull } from 'typeorm'
+import { ChatConversationService } from '../../conversation.service'
+import { ChatConversationBindXpertCommand } from '../bind-xpert.command'
+
+@CommandHandler(ChatConversationBindXpertCommand)
+export class ChatConversationBindXpertHandler implements ICommandHandler<ChatConversationBindXpertCommand> {
+    constructor(private readonly service: ChatConversationService) {}
+
+    public async execute(command: ChatConversationBindXpertCommand) {
+        await this.service.update(
+            {
+                id: command.conversationId,
+                xpertId: IsNull()
+            },
+            {
+                xpertId: command.xpertId
+            }
+        )
+
+        return this.service.findOne(command.conversationId)
+    }
+}

--- a/packages/server-ai/src/chat-conversation/commands/handlers/index.ts
+++ b/packages/server-ai/src/chat-conversation/commands/handlers/index.ts
@@ -1,4 +1,5 @@
 import { CancelSummaryJobHandler } from './cancel-summary.handler'
+import { ChatConversationBindXpertHandler } from './bind-xpert.handler'
 import { ChatConversationDeleteHandler } from './conversation-delete.handler'
 import { ConvFileDeleteHandler } from './delete-file.handler'
 import { ConvFileGetByPathCommandHandler } from './file-get-by-path.handler'
@@ -10,6 +11,7 @@ import { CancelConversationHandler } from './cancel-conversation.handler'
 
 export const CommandHandlers = [
     ChatConversationUpsertHandler,
+    ChatConversationBindXpertHandler,
     ChatConversationDeleteHandler,
     ScheduleSummaryJobHandler,
     CancelSummaryJobHandler,

--- a/packages/server-ai/src/chat-conversation/commands/index.ts
+++ b/packages/server-ai/src/chat-conversation/commands/index.ts
@@ -1,4 +1,5 @@
 export * from './upsert.command'
+export * from './bind-xpert.command'
 export * from './conversation-delete.command'
 export * from './schedule-summary.command'
 export * from './cancel-summary.command'

--- a/packages/server-ai/src/i18n/en-US.json
+++ b/packages/server-ai/src/i18n/en-US.json
@@ -5,6 +5,7 @@
         "GitIntegrationNotProvided": "Git integration not provided",
         "KBReqVisionModel": "Knowledgebase requires vision model to process images",
         "IntegrationNotFound": "Integration '{{id}}' not found",
+        "InvalidThreadAssistantId": "Thread assistant_id must be a non-empty string.",
         "NoTriggerNodes": "No trigger nodes available to start the agent. Please add a trigger node.",
         "SteerFollowUpTargetNotRunning": "Steer follow-up target execution is no longer running",
         "InconsistentTypes": "Cannot aggregate variables with inconsistent types '{{types}}'. Supported aggregation types: arrays, strings, objects.",

--- a/packages/server-ai/src/i18n/en.json
+++ b/packages/server-ai/src/i18n/en.json
@@ -5,6 +5,7 @@
         "GitIntegrationNotProvided": "Git integration not provided",
         "KBReqVisionModel": "Knowledgebase requires vision model to process images",
         "IntegrationNotFound": "Integration '{{id}}' not found",
+        "InvalidThreadAssistantId": "Thread assistant_id must be a non-empty string.",
         "NoTriggerNodes": "No trigger nodes available to start the agent. Please add a trigger node.",
         "SteerFollowUpTargetNotRunning": "Steer follow-up target execution is no longer running",
         "InconsistentTypes": "Cannot aggregate variables with inconsistent types '{{types}}'. Supported aggregation types: arrays, strings, objects.",

--- a/packages/server-ai/src/i18n/zh-Hans.json
+++ b/packages/server-ai/src/i18n/zh-Hans.json
@@ -5,6 +5,7 @@
         "GitIntegrationNotProvided": "未提供 Git 集成",
         "KBReqVisionModel": "知识库需要视觉模型来处理图像",
         "IntegrationNotFound": "未找到系统集成‘{{id}}’",
+        "InvalidThreadAssistantId": "Thread 的 assistant_id 必须是非空字符串。",
         "NoTriggerNodes": "没有可用的触发节点来启动智能体。请添加一个触发节点。",
         "SteerFollowUpTargetNotRunning": "引导消息的目标执行已不再运行",
         "InconsistentTypes": "无法对类型不一致的变量‘{{types}}’进行聚合。支持的聚合类型：数组、字符串、对象。",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,8 +675,8 @@ importers:
         specifier: ~0.4.6
         version: 0.4.6(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       '@xpert-ai/chatkit-ui':
-        specifier: ~0.4.10
-        version: 0.4.10(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(babel-plugin-macros@3.1.0)(openai@5.23.2(ws@8.21.0)(zod@3.25.67))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(signal-polyfill@0.2.2)(typescript@5.9.3)(vite@7.3.0(@types/node@22.20.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.59.0)(terser@5.46.0)(yaml@2.8.2))
+        specifier: ~0.4.12
+        version: 0.4.12(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(babel-plugin-macros@3.1.0)(openai@5.23.2(ws@8.21.0)(zod@3.25.67))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(signal-polyfill@0.2.2)(typescript@5.9.3)(vite@7.3.0(@types/node@22.20.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.59.0)(terser@5.46.0)(yaml@2.8.2))
       '@xpert-ai/chatkit-web-component':
         specifier: ~0.4.0
         version: 0.4.0(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
@@ -10095,8 +10095,14 @@ packages:
       '@a2ui/lit': ^0.8.1
       '@langchain/core': 0.3.72
 
-  '@xpert-ai/chatkit-ui@0.4.10':
-    resolution: {integrity: sha512-x57x2gaHyu4nGZuziqnGAfFTWqigAF6GRL7oclr83lX00rxSl4l6JUlMpbSYb/HhIXK3/qfqjI4szSYf+3Sp1w==}
+  '@xpert-ai/chatkit-types@0.4.7':
+    resolution: {integrity: sha512-qVH0LCKW+WKBgDkgDKddto201YOUQy0xnYEtgG2oQ3Fdq7mIxJV8HAXKqH2TOB6nLNptcuMF+pGa2g4zFmrRdA==}
+    peerDependencies:
+      '@a2ui/lit': ^0.8.1
+      '@langchain/core': 0.3.72
+
+  '@xpert-ai/chatkit-ui@0.4.12':
+    resolution: {integrity: sha512-nowv8Npx+2uJV8aqGxXNnL2o2ghIIwN1gKmX78mlZqK5r6eN5Ja3H2pUzi4DFhRCBWgiVcGprJgJ5FEBAEmzBA==}
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
@@ -10109,6 +10115,9 @@ packages:
 
   '@xpert-ai/xpert-sdk@0.0.13':
     resolution: {integrity: sha512-hTmO5OLFVqRiZeuUVFAJQUIs3JGeDTTD1HcpqswPiH7BXQ9rNLEEEVFp5c8uk9EOX3SEsyxcRaaNpcOPf/kLXw==}
+
+  '@xpert-ai/xpert-sdk@0.0.15':
+    resolution: {integrity: sha512-l6dRBsmx0R79aygyDrPPeqgf08ABv5XsHYq5fdRuAPJq+df59mR3La4tfRyWW+egL/4aWkYXwtu9ibVu+0iLLA==}
 
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
@@ -33440,7 +33449,12 @@ snapshots:
       '@a2ui/lit': 0.8.3(signal-polyfill@0.2.2)
       '@langchain/core': 0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67))
 
-  '@xpert-ai/chatkit-ui@0.4.10(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(babel-plugin-macros@3.1.0)(openai@5.23.2(ws@8.21.0)(zod@3.25.67))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(signal-polyfill@0.2.2)(typescript@5.9.3)(vite@7.3.0(@types/node@22.20.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.59.0)(terser@5.46.0)(yaml@2.8.2))':
+  '@xpert-ai/chatkit-types@0.4.7(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))':
+    dependencies:
+      '@a2ui/lit': 0.8.3(signal-polyfill@0.2.2)
+      '@langchain/core': 0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67))
+
+  '@xpert-ai/chatkit-ui@0.4.12(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(babel-plugin-macros@3.1.0)(openai@5.23.2(ws@8.21.0)(zod@3.25.67))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(signal-polyfill@0.2.2)(typescript@5.9.3)(vite@7.3.0(@types/node@22.20.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.59.0)(terser@5.46.0)(yaml@2.8.2))':
     dependencies:
       '@fontsource-variable/geist': 5.2.9
       '@fontsource-variable/inter': 5.2.8
@@ -33454,9 +33468,9 @@ snapshots:
       '@radix-ui/react-tooltip': 1.2.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tailwindcss/vite': 4.3.2(vite@7.3.0(@types/node@22.20.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.59.0)(terser@5.46.0)(yaml@2.8.2))
       '@xpert-ai/a2ui-react': 0.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(signal-polyfill@0.2.2)(tailwindcss@4.3.2)
-      '@xpert-ai/chatkit-types': 0.4.6(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
+      '@xpert-ai/chatkit-types': 0.4.7(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       '@xpert-ai/chatkit-web-shared': 0.4.1(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
-      '@xpert-ai/xpert-sdk': 0.0.13
+      '@xpert-ai/xpert-sdk': 0.0.15
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       framer-motion: 12.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -33520,6 +33534,12 @@ snapshots:
       - '@langchain/core'
 
   '@xpert-ai/xpert-sdk@0.0.13':
+    dependencies:
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 9.0.1
+
+  '@xpert-ai/xpert-sdk@0.0.15':
     dependencies:
       p-queue: 6.6.2
       p-retry: 4.6.2


### PR DESCRIPTION
## Summary

This change binds new ChatKit threads to the active assistant at the thread creation boundary.

- Accept and validate `assistant_id` on `POST /api/ai/threads`.
- Authorize the assistant and apply its request scope before creating or reusing a conversation.
- Persist `conversation.xpertId` during creation and use a conditional update when backfilling legacy unbound conversations.
- Reject cross-user public-session reuse and attempts to rebind a conversation to a different assistant.
- Keep first-run backfill for legacy clients while routing it through the same atomic binding rule.
- Upgrade `@xpert-ai/chatkit-ui` to `0.4.12`, which sends the active assistant when creating a thread.

## Problem

A non-project ChatKit conversation could be created without `xpertId`. The first run later backfilled that field, leaving a race where the workspace file panel could request files first and receive `Non-project conversations require xpertId to access workspace files`.

## Scope

The PR contains only assistant-bound thread creation, its compatibility path, protocol/i18n updates, focused tests, and the ChatKit version required to send `assistant_id`. Membership-model and other local work were intentionally excluded.

## Validation

- 3 focused Jest suites passed: 38 tests.
- `git diff --check` passed.
- OpenAPI JSON parsing passed.
- Local Chrome verification confirmed that `POST /api/ai/threads` included `assistant_id`, the created conversation returned the same `xpertId`, and the conversation files endpoint returned 200.

A full build was not used as the acceptance check in the isolated worktree because reusing an external `node_modules` path triggers unrelated TypeScript portability errors in existing `xpert-tool` methods. CI should run the normal full build with a native install.