### PR TITLE
fix: allow onboarding without default tenant

### DIFF
--- a/packages/analytics/src/bootstrap/index.ts
+++ b/packages/analytics/src/bootstrap/index.ts
@@ -20,7 +20,7 @@ import {
 	TenantService
 } from '@xpert-ai/server-core'
 import { IPluginConfig } from '@xpert-ai/server-common'
-import { ConflictException, DynamicModule, Logger as NestLogger, Module, Type } from '@nestjs/common'
+import { ConflictException, DynamicModule, Logger as NestLogger, Module, NotFoundException, Type } from '@nestjs/common'
 import { NestFactory, Reflector } from '@nestjs/core'
 import { NestExpressApplication } from '@nestjs/platform-express'
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
@@ -113,7 +113,15 @@ export async function bootstrap(options: { title: string; version: string }) {
 	const serverService = app.select(ServerAppModule).get(AppService)
 	await serverService.seedDBIfEmpty()
 	const tenantService = app.select(ServerAppModule).get(TenantService)
-	setDefaultTenantId((await tenantService.getDefaultTenant())?.id ?? null)
+	let defaultTenantId: string | null = null
+	try {
+		defaultTenantId = (await tenantService.getDefaultTenant())?.id ?? null
+	} catch (error) {
+		if (!(error instanceof NotFoundException)) {
+			throw error
+		}
+	}
+	setDefaultTenantId(defaultTenantId)
 	const analyticsService = app.select(AnalyticsModule).get(AnalyticsService)
 	await analyticsService.seedDBIfEmpty()
 


### PR DESCRIPTION
## Summary

- allow API bootstrap to continue when the default tenant does not exist yet
- preserve the existing failure behavior for unexpected tenant lookup errors

## Root cause

A fresh database has no `Default Tenant`. API bootstrap called `getDefaultTenant()` before `app.listen()`, and the resulting `NotFoundException` aborted startup. Nginx then returned `502` for API requests, causing the frontend to fall back to `/onboarding/unknown` instead of the normal onboarding flow.

## Impact

Fresh installations can start the API with an empty tenant table and proceed through the existing onboarding flow. Existing deployments with a default tenant keep the same behavior.

## Validation

- `corepack pnpm exec tsc -p packages/analytics/tsconfig.lib.json --noEmit --pretty false`
- `git diff --check origin/develop...HEAD`

Browser and deployed-runtime validation were not performed.