### PR TITLE
[codex] improve membership initialization and provider refresh

### DIFF
--- a/apps/cloud/src/app/@shared/copilot/copilot-config-form/form.component.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-config-form/form.component.spec.ts
@@ -1,0 +1,72 @@
+jest.mock('echarts/core', () => ({ registerTheme: jest.fn() }))
+
+import { Dialog } from '@angular/cdk/dialog'
+import { TestBed } from '@angular/core/testing'
+import { Subject } from 'rxjs'
+import { CopilotServerService, ToastrService } from '../../../@core'
+import { CopilotConfigFormComponent } from './form.component'
+
+describe('CopilotConfigFormComponent', () => {
+  let component: CopilotConfigFormComponent
+  let dialogClosed: Subject<string | undefined>
+
+  beforeEach(() => {
+    dialogClosed = new Subject<string | undefined>()
+
+    TestBed.configureTestingModule({
+      imports: [CopilotConfigFormComponent],
+      providers: [
+        {
+          provide: CopilotServerService,
+          useValue: {
+            refresh: jest.fn()
+          }
+        },
+        {
+          provide: ToastrService,
+          useValue: {
+            error: jest.fn(),
+            success: jest.fn()
+          }
+        },
+        {
+          provide: Dialog,
+          useValue: {
+            open: jest.fn().mockReturnValue({
+              closed: dialogClosed.asObservable()
+            })
+          }
+        }
+      ]
+    }).overrideComponent(CopilotConfigFormComponent, {
+      set: {
+        imports: [],
+        template: ''
+      }
+    })
+
+    const fixture = TestBed.createComponent(CopilotConfigFormComponent)
+    component = fixture.componentInstance
+  })
+
+  it('notifies its parent after deleting the model provider', () => {
+    const saved = jest.fn()
+    component.saved.subscribe(saved)
+
+    component.removedModelProvider()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+  })
+
+  it('notifies its parent after selecting a model provider', () => {
+    const saved = jest.fn()
+    component.saved.subscribe(saved)
+
+    component.openAiProviders()
+    expect(saved).not.toHaveBeenCalled()
+
+    dialogClosed.next('provider-id')
+
+    expect(saved).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/cloud/src/app/@shared/copilot/copilot-config-form/form.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-config-form/form.component.ts
@@ -120,13 +120,17 @@ export class CopilotConfigFormComponent {
       }
     })
 
-    dialogRef.closed.subscribe(() => {
+    dialogRef.closed.subscribe((copilotProvider) => {
       this.#copilotServer.refresh()
+      if (copilotProvider) {
+        this.saved.emit()
+      }
     })
   }
 
   removedModelProvider() {
     this.#copilotServer.refresh()
+    this.saved.emit()
   }
 
   onAddedModel(model: ICopilotProviderModel) {

--- a/apps/cloud/src/app/features/setting/copilot/basic/basic.component.html
+++ b/apps/cloud/src/app/features/setting/copilot/basic/basic.component.html
@@ -163,7 +163,7 @@
       </z-accordion-description>
     </z-accordion-header>
 
-    <pac-copilot-form [copilot]="primary()" />
+    <pac-copilot-form [copilot]="primary()" (saved)="copilotServer.refresh()" />
   </z-accordion-item>
 
   @for (copilot of copilots(); track copilot.id) {
@@ -257,7 +257,7 @@
         </z-accordion-description>
       </z-accordion-header>
 
-      <pac-copilot-form [copilot]="copilot" />
+      <pac-copilot-form [copilot]="copilot" (saved)="copilotServer.refresh()" />
     </z-accordion-item>
   }
 </z-accordion>

--- a/apps/cloud/src/app/features/setting/copilot/basic/basic.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/copilot/basic/basic.component.spec.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('CopilotBasicComponent', () => {
+  it('refreshes the copilot list when a nested copilot form saves', () => {
+    const template = readFileSync(join(__dirname, 'basic.component.html'), 'utf8')
+    const formTemplate = readFileSync(join(__dirname, '../copilot-form/copilot-form.component.html'), 'utf8')
+
+    expect(formTemplate).toContain('(saved)="saved.emit()"')
+    expect(template.match(/<pac-copilot-form[^>]*\(saved\)="copilotServer\.refresh\(\)"/g) ?? []).toHaveLength(2)
+  })
+})

--- a/apps/cloud/src/app/features/setting/membership/membership.component.html
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.html
@@ -972,7 +972,7 @@
     <z-card-content class="flex flex-col gap-4 p-4">
       <form
         [formGroup]="memberFilterForm"
-        class="grid gap-3 rounded-lg bg-components-panel-bg p-4 md:grid-cols-2 xl:grid-cols-[minmax(14rem,1fr)_12rem_14rem_12rem_auto]"
+        class="grid gap-3 rounded-lg bg-components-panel-bg p-4 md:grid-cols-2 xl:grid-cols-[minmax(14rem,2fr)_minmax(9rem,1fr)_minmax(10rem,1fr)_minmax(12rem,1fr)_auto]"
         (ngSubmit)="applyMemberFilters()"
       >
         <z-form-field class="w-full">
@@ -1021,7 +1021,7 @@
           </z-form-label>
           <z-date-picker class="w-full" zFormat="yyyy-MM-dd" formControlName="expiringBefore" />
         </z-form-field>
-        <div class="flex items-end gap-2">
+        <div class="flex items-end justify-end gap-2 px-3 pb-3 xl:ml-2">
           <button z-button zType="default" type="submit" [disabled]="adminMembersLoading()">
             {{ 'PAC.ACTIONS.Search' | translate: { Default: 'Search' } }}
           </button>
@@ -1107,7 +1107,7 @@
           z-button
           zType="secondary"
           type="button"
-          class="shrink-0"
+          class="shrink-0 xl:mb-3"
           [disabled]="adminMembersLoading() || !selectedUserCount() || (bulkActionRequiresPlan() && !bulkActionForm.controls.planId.value)"
           (click)="applyBulkAction()"
         >

--- a/packages/server-ai/src/membership/membership.service.spec.ts
+++ b/packages/server-ai/src/membership/membership.service.spec.ts
@@ -1970,6 +1970,66 @@ describe('MembershipService', () => {
         expect(memberships).toHaveLength(0)
     })
 
+    it('creates one default tenant plan before backfilling an empty tenant scope', async () => {
+        const { plans, service, userRepository } = createScopeInitializationHarness()
+        userRepository.find.mockResolvedValue([])
+
+        const [firstResult, secondResult] = await Promise.all([
+            service.backfillTenantDefaultMembershipBatch({
+                tenantId: 'tenant-1'
+            }),
+            service.backfillTenantDefaultMembershipBatch({
+                tenantId: 'tenant-1'
+            })
+        ])
+
+        expect(plans).toEqual([
+            expect.objectContaining({
+                tenantId: 'tenant-1',
+                organizationId: null,
+                code: 'default',
+                name: 'Default',
+                status: MembershipPlanStatusEnum.Active,
+                isDefault: true,
+                period: MembershipPeriodEnum.Monthly,
+                includedPoints: 1000,
+                tokensPerPoint: DEFAULT_MEMBERSHIP_TOKENS_PER_POINT,
+                allowedModels: [],
+                modelMultipliers: [],
+                rateLimits: []
+            })
+        ])
+        expect(firstResult).toEqual({ scanned: 0, assigned: 0, nextCursor: null })
+        expect(secondResult).toEqual({ scanned: 0, assigned: 0, nextCursor: null })
+    })
+
+    it('does not replace an existing tenant plan when the scope has no default plan', async () => {
+        const { memberships, plans, service } = createScopeInitializationHarness()
+        plans.push(
+            createPlan({
+                id: 'plan-custom',
+                code: 'custom',
+                name: 'Custom',
+                isDefault: false
+            })
+        )
+
+        const result = await service.backfillTenantDefaultMembershipBatch({
+            tenantId: 'tenant-1'
+        })
+
+        expect(plans).toEqual([
+            expect.objectContaining({
+                id: 'plan-custom',
+                code: 'custom',
+                name: 'Custom',
+                isDefault: false
+            })
+        ])
+        expect(memberships).toHaveLength(0)
+        expect(result).toEqual({ scanned: 0, assigned: 0, nextCursor: null })
+    })
+
     it('backfills one tenant batch without replacing existing memberships or repeating eligibility queries', async () => {
         const { memberships, membershipRepository, plans, service, userRepository } = createScopeInitializationHarness()
         plans.push(createPlan({ id: 'plan-tenant-default' }))

--- a/packages/server-ai/src/membership/membership.service.ts
+++ b/packages/server-ai/src/membership/membership.service.ts
@@ -628,6 +628,10 @@ export class MembershipService {
             tenantId: input.tenantId,
             organizationId: null
         }
+        const defaultPlan = await this.ensureDefaultTenantPlanForEmptyScope(input.tenantId)
+        if (!defaultPlan) {
+            return { scanned: 0, assigned: 0, nextCursor: null }
+        }
         const take = Math.min(Math.max(Math.trunc(input.take ?? 100), 1), 500)
         const users = await this.userRepository.find({
             select: ['id'],
@@ -751,6 +755,59 @@ export class MembershipService {
 
     private async enqueueTenantDefaultMembershipBackfill(tenantId: string) {
         await this.backfillQueueService?.enqueueTenantDefaultMembershipBackfill(tenantId)
+    }
+
+    private async ensureDefaultTenantPlanForEmptyScope(tenantId: string): Promise<MembershipPlan | null> {
+        const scope: MembershipScope = { tenantId, organizationId: null }
+        return this.dataSource.transaction(async (manager) => {
+            await this.acquireTenantDefaultPlanInitializationLock(manager, tenantId)
+            if (!(await this.isMembershipPlanEnabledForScope(scope, manager))) {
+                return null
+            }
+
+            const defaultPlan = await this.findDefaultPlan(tenantId, null, manager)
+            if (defaultPlan) {
+                return defaultPlan
+            }
+
+            const repository = manager.getRepository(MembershipPlan)
+            const existingPlans = await repository.find({
+                where: this.scopeWhere(tenantId, null),
+                take: 1
+            })
+            if (existingPlans.length) {
+                return null
+            }
+
+            const tokensPerPoint = await this.resolveTenantTokensPerPoint(tenantId)
+            return repository.save(
+                repository.create({
+                    tenantId,
+                    organizationId: null,
+                    code: 'default',
+                    name: DEFAULT_PLAN_NAME,
+                    status: MembershipPlanStatusEnum.Active,
+                    isDefault: true,
+                    period: MembershipPeriodEnum.Monthly,
+                    includedPoints: DEFAULT_INCLUDED_POINTS,
+                    tokensPerPoint,
+                    allowedModels: [],
+                    modelMultipliers: [],
+                    rateLimits: []
+                })
+            )
+        })
+    }
+
+    private async acquireTenantDefaultPlanInitializationLock(manager: EntityManager, tenantId: string) {
+        if (manager.connection.options.type !== 'postgres') {
+            return
+        }
+
+        await manager.query('SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))', [
+            tenantId,
+            'tenant-default-membership-plan'
+        ])
     }
 
     private async acquireTenantDefaultMembershipLock(manager: EntityManager, tenantId: string, userId: string) {


### PR DESCRIPTION
## Summary

- Initialize a tenant-scoped `Default` membership plan before backfilling users when membership is enabled for a completely empty tenant scope.
- Refresh the model provider list immediately after a provider is added or deleted.
- Balance the membership user-filter layout and align its action buttons with the form controls.

## Problem

Tenant membership backfill previously assumed that an active default plan already existed. Enabling membership for a tenant with no plans therefore left the backfill with no plan to assign.

The shared copilot form refreshed its own provider data after provider changes, but the surrounding Basic settings page did not refresh its copilot list. Users had to reload the page to see provider additions or deletions.

The membership user-filter grid assigned all remaining width to the search field and used inconsistent bottom spacing for action buttons.

## Implementation

- Add an empty-scope preflight to tenant membership backfill.
  - Serialize default-plan initialization with a PostgreSQL transaction-scoped advisory lock.
  - Recheck that membership is enabled after acquiring the lock.
  - Reuse an existing active default plan.
  - Create the monthly `Default` plan only when the tenant has no plans at all.
  - Preserve existing custom plans and existing memberships.
- Emit the existing `saved` output after successful provider selection or deletion.
  - Do not emit when the provider dialog is cancelled.
  - Forward the output through the management copilot form.
  - Refresh the Basic page copilot list through its existing refresh stream.
- Distribute membership filters proportionally and align search, reset, and bulk-action buttons with the existing `z-form-field` spacing.

## Commits

1. `fix: initialize default tenant membership plan`
2. `fix: refresh model providers after changes`
3. `fix: balance membership filter layout`

## Validation

- `packages/server-ai/src/membership/membership.service.spec.ts`
- `packages/server-ai/src/membership/membership-backfill.processor.spec.ts`
  - 2 suites, 101 tests passed
- `apps/cloud/src/app/@shared/copilot/copilot-config-form/form.component.spec.ts`
- `apps/cloud/src/app/features/setting/copilot/basic/basic.component.spec.ts`
  - 2 suites, 3 tests passed
- Cloud development build passed
- `git diff --check` passed

Browser validation was not run; the final UI behavior remains for manual verification.
