### PR TITLE
[codex] align membership and model access scopes

### DIFF
--- a/apps/cloud/src/app/features/setting/account/available-models.component.html
+++ b/apps/cloud/src/app/features/setting/account/available-models.component.html
@@ -13,7 +13,7 @@
               | translate
                 : {
                     Default:
-                      'Your available models combine plan access with active personal grants in the tenant and current organization.'
+                      'Your available models combine direct access, plan access, and active personal grants in the tenant and current organization.'
                   }
           }}
         </p>
@@ -28,16 +28,16 @@
 
     <section>
       <z-accordion displayDensity="compact">
-        <z-accordion-item zValue="plan-models" class="[&_[data-slot=accordion-body]>div]:px-0">
+        <z-accordion-item zValue="available-models" class="[&_[data-slot=accordion-body]>div]:px-0">
           <z-accordion-header class="px-0">
             <z-accordion-title class="text-base font-semibold text-text-primary">
-              {{ 'PAC.ModelAccess.PlanModels' | translate: { Default: 'Plan models' } }}
+              {{ 'PAC.ModelAccess.AvailableModels' | translate: { Default: 'Available models' } }}
             </z-accordion-title>
             <z-accordion-description class="!flex-none">
-              <z-badge zType="secondary" zShape="pill">{{ planModels().length }}</z-badge>
+              <z-badge zType="secondary" zShape="pill">{{ availableModels().length }}</z-badge>
             </z-accordion-description>
           </z-accordion-header>
-          @if (planModels().length) {
+          @if (availableModels().length) {
             <div class="mb-3 flex justify-end">
               <z-form-field class="w-full sm:max-w-sm">
                 <z-form-label>
@@ -45,7 +45,7 @@
                 </z-form-label>
                 <input
                   z-input
-                  [formControl]="planModelSearchControl"
+                  [formControl]="availableModelSearchControl"
                   [placeholder]="
                     'PAC.ModelGateway.SearchModelsPlaceholder'
                       | translate: { Default: 'Model ID, provider, or model name' }
@@ -53,9 +53,9 @@
                 />
               </z-form-field>
             </div>
-            @if (filteredPlanModels().length) {
+            @if (filteredAvailableModels().length) {
               <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-                @for (item of filteredPlanModels(); track item.key) {
+                @for (item of filteredAvailableModels(); track item.key) {
                   <z-card class="border border-divider-regular bg-components-card-bg shadow-none">
                     <z-card-content class="space-y-3 p-4">
                       <div class="flex items-start justify-between gap-3">
@@ -71,7 +71,10 @@
                       </div>
                       <div class="flex flex-wrap items-center gap-2 text-xs text-text-secondary">
                         <z-badge zType="secondary" zShape="pill">
-                          {{ 'PAC.ModelAccess.Source.plan' | translate: { Default: 'Plan included' } }}
+                          {{
+                            'PAC.ModelAccess.Source.' + item.accessSource
+                              | translate: { Default: item.accessSource ?? 'Plan included' }
+                          }}
                         </z-badge>
                         <span>{{ 'PAC.ModelAccess.Scope.' + item.ownershipScope | translate }}</span>
                       </div>
@@ -95,10 +98,10 @@
           } @else {
             <z-empty
               zIcon="inbox"
-              [zTitle]="'PAC.ModelAccess.NoPlanModels' | translate: { Default: 'No plan models' }"
+              [zTitle]="'PAC.ModelAccess.NoAvailableModels' | translate: { Default: 'No available models' }"
               [zDescription]="
-                'PAC.ModelAccess.NoPlanModelsDescription'
-                  | translate: { Default: 'The current membership plan does not include any models.' }
+                'PAC.ModelAccess.NoAvailableModelsDescription'
+                  | translate: { Default: 'No models are directly available or included in your current plan.' }
               "
             />
           }

--- a/apps/cloud/src/app/features/setting/account/available-models.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/account/available-models.component.spec.ts
@@ -15,10 +15,7 @@ import { ModelAccessService } from '../../../@core/services/model-access.service
 import { ToastrService } from '../../../@core/services/toastr.service'
 import { PACAccountAvailableModelsComponent } from './available-models.component'
 
-function catalogItem(
-  key: string,
-  input: Partial<IModelAccessCatalogItem> = {}
-): IModelAccessCatalogItem {
+function catalogItem(key: string, input: Partial<IModelAccessCatalogItem> = {}): IModelAccessCatalogItem {
   return {
     key,
     channel: ModelAccessChannelEnum.Xpert,
@@ -64,7 +61,7 @@ describe('PACAccountAvailableModelsComponent', () => {
     TestBed.resetTestingModule()
   })
 
-  it('groups available models and searches package models by model and provider labels', () => {
+  it('groups available models and searches plan and direct models by model and provider labels', () => {
     const packageModel = catalogItem('package', {
       planIncluded: true,
       allowed: true,
@@ -76,6 +73,12 @@ describe('PACAccountAvailableModelsComponent', () => {
       accessSource: ModelAccessSourceEnum.Grant,
       grant: activeGrant('granted')
     })
+    const directModel = catalogItem('direct', {
+      allowed: true,
+      accessSource: ModelAccessSourceEnum.Direct,
+      ownershipScope: ModelAccessOwnershipScopeEnum.Organization,
+      modelLabel: { en_US: 'Direct Reasoner' }
+    })
     const requestableModel = catalogItem('requestable', { requestable: true })
 
     TestBed.configureTestingModule({
@@ -84,7 +87,7 @@ describe('PACAccountAvailableModelsComponent', () => {
           provide: ModelAccessService,
           useValue: {
             catalog$: of({
-              items: [packageModel, grantedModel, requestableModel],
+              items: [packageModel, grantedModel, directModel, requestableModel],
               canRequest: true,
               tenantFeatureEnabled: true,
               organizationFeatureEnabled: false
@@ -101,14 +104,17 @@ describe('PACAccountAvailableModelsComponent', () => {
     })
     const component = TestBed.runInInjectionContext(() => new PACAccountAvailableModelsComponent())
 
-    expect(component.planModels()).toEqual([packageModel])
+    expect(component.availableModels()).toEqual([packageModel, directModel])
     expect(component.grantModels()).toEqual([grantedModel])
     expect(component.requestableModels()).toEqual([requestableModel])
 
-    component.planModelSearchControl.setValue('alpha')
-    expect(component.filteredPlanModels()).toEqual([packageModel])
+    component.availableModelSearchControl.setValue('alpha')
+    expect(component.filteredAvailableModels()).toEqual([packageModel])
 
-    component.planModelSearchControl.setValue('missing')
-    expect(component.filteredPlanModels()).toEqual([])
+    component.availableModelSearchControl.setValue('direct reasoner')
+    expect(component.filteredAvailableModels()).toEqual([directModel])
+
+    component.availableModelSearchControl.setValue('missing')
+    expect(component.filteredAvailableModels()).toEqual([])
   })
 })

--- a/apps/cloud/src/app/features/setting/account/available-models.component.ts
+++ b/apps/cloud/src/app/features/setting/account/available-models.component.ts
@@ -68,7 +68,12 @@ export class PACAccountAvailableModelsComponent {
     ),
     { initialValue: undefined }
   )
-  readonly planModels = computed(() => this.state()?.catalog.items.filter((item) => item.planIncluded) ?? [])
+  readonly availableModels = computed(
+    () =>
+      this.state()?.catalog.items.filter(
+        (item) => item.planIncluded || item.accessSource === ModelAccessSourceEnum.Direct
+      ) ?? []
+  )
   readonly grantModels = computed(
     () =>
       this.state()?.catalog.items.filter(
@@ -77,13 +82,13 @@ export class PACAccountAvailableModelsComponent {
       ) ?? []
   )
   readonly requestableModels = computed(() => this.state()?.catalog.items.filter((item) => item.requestable) ?? [])
-  readonly planModelSearchControl = new FormControl('', { nonNullable: true })
-  readonly planModelSearch = toSignal(this.planModelSearchControl.valueChanges.pipe(startWith('')), {
+  readonly availableModelSearchControl = new FormControl('', { nonNullable: true })
+  readonly availableModelSearch = toSignal(this.availableModelSearchControl.valueChanges.pipe(startWith('')), {
     initialValue: ''
   })
-  readonly filteredPlanModels = computed(() => {
-    const search = this.planModelSearch().trim().toLowerCase()
-    const items = this.planModels()
+  readonly filteredAvailableModels = computed(() => {
+    const search = this.availableModelSearch().trim().toLowerCase()
+    const items = this.availableModels()
     if (!search) {
       return items
     }

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -1306,7 +1306,7 @@
     },
     "ModelAccess": {
       "Title": "Model access",
-      "Description": "View the models included in your plan and any additional personal grants.",
+      "Description": "View directly available models, models included in your plan, and any additional personal grants.",
       "Apply": "Apply for model",
       "ApplyTitle": "Apply for model access",
       "ApplyDescription": "Select an available model and explain why you need access.",
@@ -1324,6 +1324,9 @@
       "PlanModels": "Plan models",
       "NoPlanModels": "No plan models",
       "NoPlanModelsDescription": "Your current plan does not include any available models.",
+      "AvailableModels": "Available models",
+      "NoAvailableModels": "No available models",
+      "NoAvailableModelsDescription": "No models are directly available or included in your current plan.",
       "ExtraGrants": "Additional grants",
       "NoGrants": "No personal grants",
       "NoGrantsDescription": "You do not have any additional model grants.",
@@ -1337,7 +1340,8 @@
       "SystemActor": "System",
       "Source": {
         "plan": "Plan included",
-        "grant": "Additional grant"
+        "grant": "Additional grant",
+        "direct": "Direct access"
       },
       "Scope": {
         "tenant": "Tenant scope",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -1796,7 +1796,7 @@
     },
     "ModelAccess": {
       "Title": "Model access",
-      "Description": "View the models included in your plan and any additional personal grants.",
+      "Description": "View directly available models, models included in your plan, and any additional personal grants.",
       "Apply": "Apply for model",
       "ApplyTitle": "Apply for model access",
       "ApplyDescription": "Select an available model and explain why you need access.",
@@ -1814,6 +1814,9 @@
       "PlanModels": "Plan models",
       "NoPlanModels": "No plan models",
       "NoPlanModelsDescription": "Your current plan does not include any available models.",
+      "AvailableModels": "Available models",
+      "NoAvailableModels": "No available models",
+      "NoAvailableModelsDescription": "No models are directly available or included in your current plan.",
       "ExtraGrants": "Additional grants",
       "NoGrants": "No personal grants",
       "NoGrantsDescription": "You do not have any additional model grants.",
@@ -1827,7 +1830,8 @@
       "SystemActor": "System",
       "Source": {
         "plan": "Plan included",
-        "grant": "Additional grant"
+        "grant": "Additional grant",
+        "direct": "Direct access"
       },
       "Scope": {
         "tenant": "Tenant scope",

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -2205,7 +2205,7 @@
     },
     "ModelAccess": {
       "Title": "模型权限",
-      "Description": "查看套餐包含的模型，以及额外获得的个人模型授权。",
+      "Description": "查看直接可用、套餐包含及额外获得个人授权的模型。",
       "Apply": "申请模型",
       "ApplyTitle": "申请模型权限",
       "ApplyDescription": "选择可申请的模型，并说明使用原因。",
@@ -2222,6 +2222,9 @@
       "PlanModels": "套餐模型",
       "NoPlanModels": "暂无套餐模型",
       "NoPlanModelsDescription": "当前套餐未包含可用模型。",
+      "AvailableModels": "可用模型",
+      "NoAvailableModels": "暂无可用模型",
+      "NoAvailableModelsDescription": "当前没有直接可用或套餐包含的模型。",
       "ExtraGrants": "额外授权",
       "NoGrants": "暂无个人授权",
       "NoGrantsDescription": "你还没有获得额外的模型授权。",
@@ -2235,7 +2238,8 @@
       "SystemActor": "系统",
       "Source": {
         "plan": "套餐包含",
-        "grant": "额外授权"
+        "grant": "额外授权",
+        "direct": "直接可用"
       },
       "Scope": {
         "tenant": "租户级",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -3718,7 +3718,7 @@
     },
     "ModelAccess": {
       "Title": "模型权限",
-      "Description": "查看套餐包含的模型，以及额外获得的个人模型授权。",
+      "Description": "查看直接可用、套餐包含及额外获得个人授权的模型。",
       "Apply": "申请模型",
       "ApplyTitle": "申请模型权限",
       "ApplyDescription": "选择可申请的模型，并说明使用原因。",
@@ -3736,6 +3736,9 @@
       "PlanModels": "套餐模型",
       "NoPlanModels": "暂无套餐模型",
       "NoPlanModelsDescription": "当前套餐未包含可用模型。",
+      "AvailableModels": "可用模型",
+      "NoAvailableModels": "暂无可用模型",
+      "NoAvailableModelsDescription": "当前没有直接可用或套餐包含的模型。",
       "ExtraGrants": "额外授权",
       "NoGrants": "暂无个人授权",
       "NoGrantsDescription": "你还没有获得额外的模型授权。",
@@ -3749,7 +3752,8 @@
       "SystemActor": "系统",
       "Source": {
         "plan": "套餐包含",
-        "grant": "额外授权"
+        "grant": "额外授权",
+        "direct": "直接可用"
       },
       "Scope": {
         "tenant": "租户级",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -2814,7 +2814,7 @@
     },
     "ModelAccess": {
       "Title": "模型權限",
-      "Description": "查看方案包含的模型，以及額外取得的個人模型授權。",
+      "Description": "查看直接可用、方案包含及額外取得個人授權的模型。",
       "Apply": "申請模型",
       "ApplyTitle": "申請模型權限",
       "ApplyDescription": "選擇可申請的模型，並說明使用原因。",
@@ -2831,6 +2831,9 @@
       "PlanModels": "方案模型",
       "NoPlanModels": "暫無方案模型",
       "NoPlanModelsDescription": "目前方案未包含可用模型。",
+      "AvailableModels": "可用模型",
+      "NoAvailableModels": "暫無可用模型",
+      "NoAvailableModelsDescription": "目前沒有直接可用或方案包含的模型。",
       "ExtraGrants": "額外授權",
       "NoGrants": "暫無個人授權",
       "NoGrantsDescription": "你尚未取得額外的模型授權。",
@@ -2844,7 +2847,8 @@
       "SystemActor": "系統",
       "Source": {
         "plan": "方案包含",
-        "grant": "額外授權"
+        "grant": "額外授權",
+        "direct": "直接可用"
       },
       "Scope": {
         "tenant": "租戶級",

--- a/packages/contracts/src/ai/model-access.model.ts
+++ b/packages/contracts/src/ai/model-access.model.ts
@@ -27,6 +27,7 @@ export enum ModelAccessChannelEnum {
 }
 
 export enum ModelAccessSourceEnum {
+  Direct = 'direct',
   Plan = 'plan',
   Grant = 'grant'
 }

--- a/packages/server-ai/src/copilot-user/commands/handlers/token-record.handler.spec.ts
+++ b/packages/server-ai/src/copilot-user/commands/handlers/token-record.handler.spec.ts
@@ -1,6 +1,7 @@
 import {
     AiModelTypeEnum,
     IModelAccessResolution,
+    ModelAccessChannelEnum,
     ModelAccessOwnershipScopeEnum,
     ModelAccessSourceEnum
 } from '@xpert-ai/contracts'
@@ -12,6 +13,7 @@ describe('CopilotTokenRecordHandler', () => {
     function grantResolution(overrides: Partial<IModelAccessResolution> = {}): IModelAccessResolution {
         return {
             allowed: true,
+            channel: ModelAccessChannelEnum.Xpert,
             billableUserId: 'creator-user',
             copilotId: 'copilot-1',
             copilotModelId: 'qwen3.6-plus',

--- a/packages/server-ai/src/copilot/copilot.service.spec.ts
+++ b/packages/server-ai/src/copilot/copilot.service.spec.ts
@@ -29,7 +29,7 @@ describe('CopilotService', () => {
             | 'findModelAccess'
             | 'countEnabledOrganizationCopilots'
             | 'ensureScopeInitialized'
-            | 'isMembershipAccessEnabled'
+            | 'isMembershipPlanEnabled'
         >
     >
     let modelAccessService: jest.Mocked<Pick<ModelAccessService, 'handleCopilotStateChanged'>>
@@ -49,7 +49,7 @@ describe('CopilotService', () => {
         membershipService = {
             countEnabledOrganizationCopilots: jest.fn().mockResolvedValue(0),
             ensureScopeInitialized: jest.fn().mockResolvedValue({} as never),
-            isMembershipAccessEnabled: jest.fn().mockResolvedValue(true),
+            isMembershipPlanEnabled: jest.fn().mockResolvedValue(true),
             findModelAccess: jest.fn().mockResolvedValue({
                 tenantId: 'tenant-1',
                 organizationId: 'org-1',
@@ -133,11 +133,7 @@ describe('CopilotService', () => {
                     tenantId: 'tenant-1',
                     organizationId: 'org-1',
                     enabled: true
-                },
-                expect.objectContaining({
-                    tenantId: 'tenant-1',
-                    enabled: true
-                })
+                }
             ],
             relations: ['modelProvider']
         })
@@ -190,16 +186,12 @@ describe('CopilotService', () => {
             throw new Error('Expected organization and tenant candidate scopes')
         }
 
+        expect(firstCall.where).toHaveLength(1)
         expect(firstCall.where[0]).toMatchObject({
             tenantId: 'tenant-1',
-            organizationId: 'org-1',
             enabled: true
         })
-        expect(firstCall.where[1]).toMatchObject({
-            tenantId: 'tenant-1',
-            enabled: true
-        })
-        expect(firstCall.where[1].organizationId).toBeDefined()
+        expect(firstCall.where[0].organizationId).toBeDefined()
         expect(copilotProviderService.findVisibleByCopilotIds).toHaveBeenCalledWith(['copilot-2'], {
             tenantId: 'tenant-1',
             organizationId: 'org-1'
@@ -266,7 +258,7 @@ describe('CopilotService', () => {
         const result = await service.findAllAvailablesCopilots('tenant-1', 'org-1')
 
         expect(result).toEqual([])
-        expect(repository.find).toHaveBeenCalledTimes(1)
+        expect(repository.find).not.toHaveBeenCalled()
         expect(copilotProviderService.findVisibleByCopilotIds).not.toHaveBeenCalled()
     })
 
@@ -365,8 +357,8 @@ describe('CopilotService', () => {
         await expect(service.findAllAvailablesCopilots('tenant-1', 'org-1')).resolves.toEqual([])
     })
 
-    it('lists organization and tenant enabled copilots without membership access when membership plans are disabled', async () => {
-        membershipService.isMembershipAccessEnabled.mockResolvedValue(false)
+    it('lists only direct organization copilots when organization and tenant membership are disabled', async () => {
+        membershipService.isMembershipPlanEnabled.mockResolvedValue(false)
         repository.find.mockResolvedValue([
             createCopilot({
                 id: 'org-copilot',
@@ -392,27 +384,46 @@ describe('CopilotService', () => {
         if (!Array.isArray(where)) {
             throw new Error('Expected organization-scope copilot query to use inherited where objects')
         }
+        expect(where).toHaveLength(1)
         expect(where[0]).toMatchObject({
             tenantId: 'tenant-1',
             organizationId: 'org-1',
             enabled: true,
             role: AiProviderRole.Primary
         })
-        expect(where[1]).toMatchObject({
-            tenantId: 'tenant-1',
-            enabled: true,
-            role: AiProviderRole.Primary
-        })
-        expect(where[1].organizationId).toBeDefined()
-        expect(copilotProviderService.findVisibleByCopilotIds).toHaveBeenCalledWith(['org-copilot', 'tenant-copilot'], {
+        expect(copilotProviderService.findVisibleByCopilotIds).toHaveBeenCalledWith(['org-copilot'], {
             tenantId: 'tenant-1',
             organizationId: 'org-1'
         })
-        expect(result).toHaveLength(2)
+        expect(result.map((copilot) => copilot.id)).toEqual(['org-copilot'])
+    })
+
+    it('lists direct organization copilots together with tenant plan copilots', async () => {
+        membershipService.isMembershipPlanEnabled.mockImplementation(async ({ organizationId }) => !organizationId)
+        membershipService.findModelAccess.mockResolvedValue({
+            tenantId: 'tenant-1',
+            organizationId: null,
+            membership: {}
+        } as never)
+        repository.find.mockResolvedValue([
+            createCopilot({
+                id: 'org-copilot',
+                organizationId: 'org-1'
+            }),
+            createCopilot({
+                id: 'tenant-copilot',
+                organizationId: null
+            })
+        ])
+        copilotProviderService.findVisibleByCopilotIds.mockResolvedValue(new Map())
+
+        const result = await service.findAllAvailablesCopilots('tenant-1', 'org-1')
+
+        expect(result.map((copilot) => copilot.id)).toEqual(['org-copilot', 'tenant-copilot'])
     })
 
     it('lists only tenant enabled copilots without membership access in tenant scope when membership plans are disabled', async () => {
-        membershipService.isMembershipAccessEnabled.mockResolvedValue(false)
+        membershipService.isMembershipPlanEnabled.mockResolvedValue(false)
         repository.find.mockResolvedValue([
             createCopilot({
                 id: 'tenant-copilot',

--- a/packages/server-ai/src/copilot/copilot.service.ts
+++ b/packages/server-ai/src/copilot/copilot.service.ts
@@ -101,11 +101,15 @@ export class CopilotService extends TenantOrganizationAwareCrudService<Copilot> 
         if (!tenantId) {
             return []
         }
-        if (!(await this.membershipService.isMembershipAccessEnabled({ tenantId, organizationId }))) {
-            return this.findAllEnabledCopilotsWithoutMembership(tenantId, organizationId, where, relations)
-        }
+        const [tenantMembershipEnabled, organizationMembershipEnabled] = await Promise.all([
+            this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
+            organizationId
+                ? this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId })
+                : Promise.resolve(false)
+        ])
         if (
             organizationId &&
+            organizationMembershipEnabled &&
             (await this.membershipService.countEnabledOrganizationCopilots(tenantId, organizationId)) > 0
         ) {
             await this.membershipService.ensureScopeInitialized({
@@ -115,28 +119,46 @@ export class CopilotService extends TenantOrganizationAwareCrudService<Copilot> 
             })
         }
 
-        const access = await this.membershipService.findModelAccess({
-            tenantId,
-            organizationId
-        })
-        if (!access && !organizationId) {
+        const access =
+            organizationMembershipEnabled || tenantMembershipEnabled
+                ? await this.membershipService.findModelAccess({
+                      tenantId,
+                      organizationId
+                  })
+                : null
+        const allowedScopes = new Set<string | null>()
+        if (!organizationId) {
+            if (!tenantMembershipEnabled || access?.organizationId === null) {
+                allowedScopes.add(null)
+            }
+        } else if (organizationMembershipEnabled) {
+            if (access?.organizationId === organizationId) {
+                allowedScopes.add(organizationId)
+            } else if (tenantMembershipEnabled && access?.organizationId === null) {
+                allowedScopes.add(null)
+            }
+        } else {
+            allowedScopes.add(organizationId)
+            if (tenantMembershipEnabled && access?.organizationId === null) {
+                allowedScopes.add(null)
+            }
+        }
+        if (!allowedScopes.size) {
             return []
         }
 
         const resolvedRelations = this.mergeCopilotRelations(relations)
         const baseWhere = { ...(where ?? {}), tenantId, enabled: true }
+        const scopeWhere = Array.from(allowedScopes).map((scopeOrganizationId) => ({
+            ...baseWhere,
+            organizationId: scopeOrganizationId ? scopeOrganizationId : IsNull()
+        }))
         const items = await this.repository.find({
-            where: organizationId
-                ? [
-                      { ...baseWhere, organizationId },
-                      { ...baseWhere, organizationId: IsNull() }
-                  ]
-                : { ...baseWhere, organizationId: IsNull() },
+            where: organizationId ? scopeWhere : scopeWhere[0],
             relations: resolvedRelations
         })
-        const hydratedItems = await this.hydrateVisibleModelProviders(items, tenantId, organizationId ?? null)
-
-        return hydratedItems.filter((copilot) => !!access && (copilot.organizationId ?? null) === access.organizationId)
+        const scopedItems = items.filter((copilot) => allowedScopes.has(copilot.organizationId ?? null))
+        return this.hydrateVisibleModelProviders(scopedItems, tenantId, organizationId ?? null)
     }
 
     async findAllEnabledCopilotsWithoutMembership(

--- a/packages/server-ai/src/membership/membership-backfill.processor.spec.ts
+++ b/packages/server-ai/src/membership/membership-backfill.processor.spec.ts
@@ -5,10 +5,15 @@ import { MembershipBackfillProcessor } from './membership-backfill.processor'
 import {
     MembershipBackfillQueueService,
     MEMBERSHIP_MAINTENANCE_QUEUE,
+    ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
+    ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
     TENANT_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
     TENANT_DEFAULT_MEMBERSHIP_BACKFILL_JOB
 } from './membership-backfill.queue'
-import type { TenantDefaultMembershipBackfillJob } from './membership-backfill.queue'
+import type {
+    OrganizationDefaultMembershipBackfillJob,
+    TenantDefaultMembershipBackfillJob
+} from './membership-backfill.queue'
 
 describe('MembershipBackfillQueueService', () => {
     it('enqueues retryable tenant backfill jobs without a deduplication race', async () => {
@@ -16,7 +21,7 @@ describe('MembershipBackfillQueueService', () => {
             add: jest.fn().mockResolvedValue(undefined)
         }
         const service = new MembershipBackfillQueueService(
-            queue as unknown as Queue<TenantDefaultMembershipBackfillJob>
+            queue as unknown as Queue<TenantDefaultMembershipBackfillJob | OrganizationDefaultMembershipBackfillJob>
         )
 
         await service.enqueueTenantDefaultMembershipBackfill('tenant-1', 'user-100')
@@ -34,15 +39,46 @@ describe('MembershipBackfillQueueService', () => {
             }
         )
     })
+
+    it('enqueues retryable organization backfill jobs without a deduplication race', async () => {
+        const queue = {
+            add: jest.fn().mockResolvedValue(undefined)
+        }
+        const service = new MembershipBackfillQueueService(
+            queue as unknown as Queue<TenantDefaultMembershipBackfillJob | OrganizationDefaultMembershipBackfillJob>
+        )
+
+        await service.enqueueOrganizationDefaultMembershipBackfill('tenant-1', 'org-1', 'user-organization-100')
+
+        expect(queue.add).toHaveBeenCalledWith(
+            ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
+            {
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                afterUserOrganizationId: 'user-organization-100'
+            },
+            {
+                attempts: 5,
+                backoff: 10_000,
+                removeOnComplete: true
+            }
+        )
+    })
 })
 
 describe('MembershipBackfillProcessor', () => {
     function createProcessor() {
         const queueService = {
-            enqueueTenantDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined)
+            enqueueTenantDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined),
+            enqueueOrganizationDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined)
         }
         const membershipService = {
             backfillTenantDefaultMembershipBatch: jest.fn().mockResolvedValue({
+                scanned: 2,
+                assigned: 2,
+                nextCursor: null
+            }),
+            backfillOrganizationDefaultMembershipBatch: jest.fn().mockResolvedValue({
                 scanned: 2,
                 assigned: 2,
                 nextCursor: null
@@ -71,7 +107,7 @@ describe('MembershipBackfillProcessor', () => {
         expect(queueService.enqueueTenantDefaultMembershipBackfill).toHaveBeenCalledWith('tenant-1')
     })
 
-    it('ignores non-tenant membership feature transitions', async () => {
+    it('enqueues organization backfill when the membership feature becomes enabled', async () => {
         const { processor, queueService } = createProcessor()
 
         await processor.enqueueBackfillWhenFeatureEnabled({
@@ -82,6 +118,14 @@ describe('MembershipBackfillProcessor', () => {
             previousIsEnabled: false,
             isEnabled: true
         } as FeatureOrganizationUpdatedEvent)
+
+        expect(queueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith('tenant-1', 'org-1')
+        expect(queueService.enqueueTenantDefaultMembershipBackfill).not.toHaveBeenCalled()
+    })
+
+    it('ignores non-membership feature transitions', async () => {
+        const { processor, queueService } = createProcessor()
+
         await processor.enqueueBackfillWhenFeatureEnabled({
             tenantId: 'tenant-1',
             organizationId: null,
@@ -92,6 +136,7 @@ describe('MembershipBackfillProcessor', () => {
         } as FeatureOrganizationUpdatedEvent)
 
         expect(queueService.enqueueTenantDefaultMembershipBackfill).not.toHaveBeenCalled()
+        expect(queueService.enqueueOrganizationDefaultMembershipBackfill).not.toHaveBeenCalled()
     })
 
     it('does not enqueue a backfill when the membership feature becomes disabled', async () => {
@@ -107,6 +152,7 @@ describe('MembershipBackfillProcessor', () => {
         } as FeatureOrganizationUpdatedEvent)
 
         expect(queueService.enqueueTenantDefaultMembershipBackfill).not.toHaveBeenCalled()
+        expect(queueService.enqueueOrganizationDefaultMembershipBackfill).not.toHaveBeenCalled()
     })
 
     it('processes one bounded batch and enqueues the next cursor', async () => {
@@ -143,6 +189,35 @@ describe('MembershipBackfillProcessor', () => {
         } as Job<TenantDefaultMembershipBackfillJob>)
 
         expect(queueService.enqueueTenantDefaultMembershipBackfill).not.toHaveBeenCalled()
+    })
+
+    it('processes one bounded organization batch and enqueues the next cursor', async () => {
+        const { membershipService, processor, queueService } = createProcessor()
+        membershipService.backfillOrganizationDefaultMembershipBatch.mockResolvedValue({
+            scanned: ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
+            assigned: 90,
+            nextCursor: 'user-organization-100'
+        })
+
+        await processor.processOrganizationDefaultMembershipBackfill({
+            data: {
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                afterUserOrganizationId: null
+            }
+        } as Job<OrganizationDefaultMembershipBackfillJob>)
+
+        expect(membershipService.backfillOrganizationDefaultMembershipBatch).toHaveBeenCalledWith({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            afterUserOrganizationId: null,
+            take: ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE
+        })
+        expect(queueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
+            'tenant-1',
+            'org-1',
+            'user-organization-100'
+        )
     })
 
     it('uses the dedicated maintenance queue', () => {

--- a/packages/server-ai/src/membership/membership-backfill.processor.ts
+++ b/packages/server-ai/src/membership/membership-backfill.processor.ts
@@ -8,16 +8,31 @@ import type { Job } from 'bull'
 import {
     MembershipBackfillQueueService,
     MEMBERSHIP_MAINTENANCE_QUEUE,
+    ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
+    ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
     TENANT_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
     TENANT_DEFAULT_MEMBERSHIP_BACKFILL_JOB
 } from './membership-backfill.queue'
-import type { TenantDefaultMembershipBackfillJob } from './membership-backfill.queue'
+import type {
+    OrganizationDefaultMembershipBackfillJob,
+    TenantDefaultMembershipBackfillJob
+} from './membership-backfill.queue'
 import { MembershipService } from './membership.service'
 
-type TenantDefaultMembershipBackfillService = {
+type DefaultMembershipBackfillService = {
     backfillTenantDefaultMembershipBatch(input: {
         tenantId: string
         afterUserId?: string | null
+        take?: number
+    }): Promise<{
+        scanned: number
+        assigned: number
+        nextCursor: string | null
+    }>
+    backfillOrganizationDefaultMembershipBatch(input: {
+        tenantId: string
+        organizationId: string
+        afterUserOrganizationId?: string | null
         take?: number
     }): Promise<{
         scanned: number
@@ -31,13 +46,12 @@ export class MembershipBackfillProcessor {
     constructor(
         private readonly queueService: MembershipBackfillQueueService,
         @Inject(MembershipService)
-        private readonly membershipService: TenantDefaultMembershipBackfillService
+        private readonly membershipService: DefaultMembershipBackfillService
     ) {}
 
     @OnEvent(EVENT_FEATURE_ORGANIZATION_UPDATED)
     async enqueueBackfillWhenFeatureEnabled(event: FeatureOrganizationUpdatedEvent) {
         if (
-            event.organizationId ||
             event.featureCode !== AiFeatureEnum.FEATURE_MEMBERSHIP_PLAN ||
             event.previousIsEnabled ||
             !event.isEnabled
@@ -45,7 +59,11 @@ export class MembershipBackfillProcessor {
             return
         }
 
-        await this.queueService.enqueueTenantDefaultMembershipBackfill(event.tenantId)
+        if (event.organizationId) {
+            await this.queueService.enqueueOrganizationDefaultMembershipBackfill(event.tenantId, event.organizationId)
+        } else {
+            await this.queueService.enqueueTenantDefaultMembershipBackfill(event.tenantId)
+        }
     }
 
     @Process({
@@ -60,6 +78,27 @@ export class MembershipBackfillProcessor {
         })
         if (result.nextCursor) {
             await this.queueService.enqueueTenantDefaultMembershipBackfill(job.data.tenantId, result.nextCursor)
+        }
+        return result
+    }
+
+    @Process({
+        name: ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
+        concurrency: 2
+    })
+    async processOrganizationDefaultMembershipBackfill(job: Job<OrganizationDefaultMembershipBackfillJob>) {
+        const result = await this.membershipService.backfillOrganizationDefaultMembershipBatch({
+            tenantId: job.data.tenantId,
+            organizationId: job.data.organizationId,
+            afterUserOrganizationId: job.data.afterUserOrganizationId,
+            take: ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE
+        })
+        if (result.nextCursor) {
+            await this.queueService.enqueueOrganizationDefaultMembershipBackfill(
+                job.data.tenantId,
+                job.data.organizationId,
+                result.nextCursor
+            )
         }
         return result
     }

--- a/packages/server-ai/src/membership/membership-backfill.queue.ts
+++ b/packages/server-ai/src/membership/membership-backfill.queue.ts
@@ -5,17 +5,27 @@ import type { Queue } from 'bull'
 export const MEMBERSHIP_MAINTENANCE_QUEUE = 'membership-maintenance'
 export const TENANT_DEFAULT_MEMBERSHIP_BACKFILL_JOB = 'tenant-default-membership-backfill'
 export const TENANT_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE = 100
+export const ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB = 'organization-default-membership-backfill'
+export const ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE = 100
 
 export type TenantDefaultMembershipBackfillJob = {
     tenantId: string
     afterUserId: string | null
 }
 
+export type OrganizationDefaultMembershipBackfillJob = {
+    tenantId: string
+    organizationId: string
+    afterUserOrganizationId: string | null
+}
+
+type MembershipBackfillJob = TenantDefaultMembershipBackfillJob | OrganizationDefaultMembershipBackfillJob
+
 @Injectable()
 export class MembershipBackfillQueueService {
     constructor(
         @InjectQueue(MEMBERSHIP_MAINTENANCE_QUEUE)
-        private readonly queue: Queue<TenantDefaultMembershipBackfillJob>
+        private readonly queue: Queue<MembershipBackfillJob>
     ) {}
 
     async enqueueTenantDefaultMembershipBackfill(tenantId: string, afterUserId: string | null = null) {
@@ -24,6 +34,26 @@ export class MembershipBackfillQueueService {
             {
                 tenantId,
                 afterUserId
+            },
+            {
+                attempts: 5,
+                backoff: 10_000,
+                removeOnComplete: true
+            }
+        )
+    }
+
+    async enqueueOrganizationDefaultMembershipBackfill(
+        tenantId: string,
+        organizationId: string,
+        afterUserOrganizationId: string | null = null
+    ) {
+        await this.queue.add(
+            ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
+            {
+                tenantId,
+                organizationId,
+                afterUserOrganizationId
             },
             {
                 attempts: 5,

--- a/packages/server-ai/src/membership/membership.service.spec.ts
+++ b/packages/server-ai/src/membership/membership.service.spec.ts
@@ -258,10 +258,9 @@ describe('MembershipService', () => {
             where: { tenantId: 'tenant-1', isDefault: true },
             select: { id: true, timeZone: true }
         })
-        expect(userQueryBuilder.andWhere).toHaveBeenCalledWith(
-            'membership.currentPeriodEnd <= :expiringBefore',
-            { expiringBefore: new Date('2027-03-14T15:59:59.999Z') }
-        )
+        expect(userQueryBuilder.andWhere).toHaveBeenCalledWith('membership.currentPeriodEnd <= :expiringBefore', {
+            expiringBefore: new Date('2027-03-14T15:59:59.999Z')
+        })
     })
 
     it('calculates fractional points directly from token usage without rounding per call', () => {
@@ -401,7 +400,8 @@ describe('MembershipService', () => {
             )
         }
         const backfillQueueService = {
-            enqueueTenantDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined)
+            enqueueTenantDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined),
+            enqueueOrganizationDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined)
         }
         const updateBuilder = {
             update: jest.fn().mockReturnThis(),
@@ -432,8 +432,8 @@ describe('MembershipService', () => {
                 if (where?.status === MembershipPlanStatusEnum.Active && where?.isDefault === undefined) {
                     return scopedPlans.find((plan) => plan.status === MembershipPlanStatusEnum.Active) ?? null
                 }
-                if (where?.code === 'default-unlimited') {
-                    return scopedPlans.find((plan) => plan.code === 'default-unlimited') ?? null
+                if (where?.code) {
+                    return scopedPlans.find((plan) => plan.code === where.code) ?? null
                 }
                 return null
             }),
@@ -456,7 +456,10 @@ describe('MembershipService', () => {
             })
         }
         const userOrganizationRepository = {
-            find: jest.fn().mockResolvedValue([{ userId: 'user-1' }, { userId: 'user-2' }]),
+            find: jest.fn().mockResolvedValue([
+                { id: 'user-organization-1', userId: 'user-1' },
+                { id: 'user-organization-2', userId: 'user-2' }
+            ]),
             findOne: jest.fn(async ({ where }) =>
                 ['user-1', 'user-2'].includes(where.userId)
                     ? {
@@ -1271,6 +1274,34 @@ describe('MembershipService', () => {
         ).resolves.toBe(false)
     })
 
+    it('keeps explicit tenant scope when the current request belongs to an organization', async () => {
+        const requestedScopes: Array<string | null> = []
+        const featureOrganizationRepository = createMembershipFeatureRepository((organizationId) => {
+            requestedScopes.push(organizationId)
+            return organizationId === 'org-1' ? [{ isEnabled: false }] : [{ isEnabled: true }]
+        }).repository
+        jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('org-1')
+        const service = createMembershipService(
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            undefined,
+            undefined,
+            undefined,
+            featureOrganizationRepository as never
+        )
+
+        await expect(
+            service.isMembershipPlanEnabled({
+                tenantId: 'tenant-1',
+                organizationId: null
+            })
+        ).resolves.toBe(true)
+        expect(requestedScopes).toEqual([null])
+    })
+
     it('uses organization membership plan feature toggles before tenant toggles', async () => {
         const requestedScopes: Array<string | null> = []
         const featureOrganizationRepository = createMembershipFeatureRepository((organizationId) => {
@@ -1376,6 +1407,41 @@ describe('MembershipService', () => {
         expect(findModelAccess).not.toHaveBeenCalled()
     })
 
+    it('allows direct model usage without consulting membership access', async () => {
+        const service = createMembershipService({} as never, {} as never, {} as never, {} as never, {} as never)
+        const isMembershipAccessEnabled = jest.spyOn(service, 'isMembershipAccessEnabled')
+        const findModelAccess = jest.spyOn(service, 'findModelAccess')
+
+        await expect(
+            service.assertCanUse(
+                {
+                    tenantId: 'tenant-1',
+                    organizationId: 'org-1',
+                    copilotOrganizationId: 'org-1',
+                    userId: 'assistant-tech-user',
+                    provider: 'deepseek',
+                    model: 'deepseek-chat'
+                },
+                {
+                    allowed: true,
+                    channel: ModelAccessChannelEnum.Xpert,
+                    billableUserId: 'assistant-tech-user',
+                    copilotId: 'org-copilot',
+                    copilotModelId: 'deepseek-chat',
+                    provider: 'deepseek',
+                    modelType: AiModelTypeEnum.LLM,
+                    model: 'deepseek-chat',
+                    accessSource: ModelAccessSourceEnum.Direct,
+                    multiplier: 1,
+                    scope: ModelAccessOwnershipScopeEnum.Organization,
+                    organizationId: 'org-1'
+                }
+            )
+        ).resolves.toBeUndefined()
+        expect(isMembershipAccessEnabled).not.toHaveBeenCalled()
+        expect(findModelAccess).not.toHaveBeenCalled()
+    })
+
     it('does not record membership usage when membership plan feature is disabled', async () => {
         const dataSource = {
             transaction: jest.fn()
@@ -1404,6 +1470,42 @@ describe('MembershipService', () => {
                 tokenUsed: 1000
             })
         ).resolves.toBeNull()
+        expect(dataSource.transaction).not.toHaveBeenCalled()
+    })
+
+    it('does not record membership usage for direct model access', async () => {
+        const dataSource = {
+            transaction: jest.fn()
+        }
+        const service = createMembershipService(dataSource as never, {} as never, {} as never, {} as never, {} as never)
+        const isMembershipAccessEnabled = jest.spyOn(service, 'isMembershipAccessEnabled')
+
+        await expect(
+            service.recordUsage({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                copilotOrganizationId: 'org-1',
+                userId: 'assistant-tech-user',
+                provider: 'deepseek',
+                model: 'deepseek-chat',
+                tokenUsed: 1000,
+                modelAccess: {
+                    allowed: true,
+                    channel: ModelAccessChannelEnum.Xpert,
+                    billableUserId: 'assistant-tech-user',
+                    copilotId: 'org-copilot',
+                    copilotModelId: 'deepseek-chat',
+                    provider: 'deepseek',
+                    modelType: AiModelTypeEnum.LLM,
+                    model: 'deepseek-chat',
+                    accessSource: ModelAccessSourceEnum.Direct,
+                    multiplier: 1,
+                    scope: ModelAccessOwnershipScopeEnum.Organization,
+                    organizationId: 'org-1'
+                }
+            })
+        ).resolves.toBeNull()
+        expect(isMembershipAccessEnabled).not.toHaveBeenCalled()
         expect(dataSource.transaction).not.toHaveBeenCalled()
     })
 
@@ -1913,9 +2015,17 @@ describe('MembershipService', () => {
         expect(findUsableMembership).toHaveBeenCalledWith('tenant-1', 'org-1', 'assistant-tech-user', undefined, false)
     })
 
-    it('keeps organization initialization on tenant fallback when no active organization plan exists', async () => {
-        const { dataSource, ledgerRepository, memberships, membershipRepository, planRepository, plans, service } =
-            createScopeInitializationHarness()
+    it('queues organization initialization when no active organization plan exists', async () => {
+        const {
+            backfillQueueService,
+            dataSource,
+            ledgerRepository,
+            memberships,
+            membershipRepository,
+            planRepository,
+            plans,
+            service
+        } = createScopeInitializationHarness()
 
         const status = await service.ensureScopeInitialized({
             tenantId: 'tenant-1',
@@ -1937,6 +2047,10 @@ describe('MembershipService', () => {
         expect(planRepository.save).not.toHaveBeenCalled()
         expect(membershipRepository.save).not.toHaveBeenCalled()
         expect(ledgerRepository.save).not.toHaveBeenCalled()
+        expect(backfillQueueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
+            'tenant-1',
+            'org-1'
+        )
     })
 
     it('initializes tenant scope by enqueueing an idempotent backfill', async () => {
@@ -2001,6 +2115,81 @@ describe('MembershipService', () => {
         ])
         expect(firstResult).toEqual({ scanned: 0, assigned: 0, nextCursor: null })
         expect(secondResult).toEqual({ scanned: 0, assigned: 0, nextCursor: null })
+    })
+
+    it('creates one default organization plan and backfills active members idempotently', async () => {
+        const { ledgers, memberships, plans, service } = createScopeInitializationHarness()
+
+        const [firstResult, secondResult] = await Promise.all([
+            service.backfillOrganizationDefaultMembershipBatch({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1'
+            }),
+            service.backfillOrganizationDefaultMembershipBatch({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1'
+            })
+        ])
+
+        expect(plans).toEqual([
+            expect.objectContaining({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                code: 'default',
+                name: 'Default',
+                status: MembershipPlanStatusEnum.Active,
+                isDefault: true,
+                period: MembershipPeriodEnum.Monthly,
+                includedPoints: 1000,
+                tokensPerPoint: DEFAULT_MEMBERSHIP_TOKENS_PER_POINT,
+                allowedModels: [],
+                modelMultipliers: [],
+                rateLimits: []
+            })
+        ])
+        expect(memberships).toHaveLength(2)
+        expect(memberships).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    organizationId: 'org-1',
+                    userId: 'user-1',
+                    planId: 'plan-default',
+                    source: MembershipSourceEnum.Organization
+                }),
+                expect.objectContaining({
+                    organizationId: 'org-1',
+                    userId: 'user-2',
+                    planId: 'plan-default',
+                    source: MembershipSourceEnum.Organization
+                })
+            ])
+        )
+        expect(ledgers).toHaveLength(2)
+        expect(firstResult).toEqual({ scanned: 2, assigned: 2, nextCursor: null })
+        expect(secondResult).toEqual({ scanned: 2, assigned: 0, nextCursor: null })
+    })
+
+    it('does not assign a user who leaves the organization after the batch is scanned', async () => {
+        const { memberships, service, userOrganizationRepository } = createScopeInitializationHarness()
+        userOrganizationRepository.find
+            .mockResolvedValueOnce([
+                { id: 'user-organization-1', userId: 'user-1' },
+                { id: 'user-organization-2', userId: 'user-2' }
+            ])
+            .mockResolvedValueOnce([{ id: 'user-organization-1', userId: 'user-1' }])
+
+        const result = await service.backfillOrganizationDefaultMembershipBatch({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1'
+        })
+
+        expect(memberships).toEqual([
+            expect.objectContaining({
+                organizationId: 'org-1',
+                userId: 'user-1'
+            })
+        ])
+        expect(result).toEqual({ scanned: 2, assigned: 1, nextCursor: null })
     })
 
     it('does not replace an existing tenant plan when the scope has no default plan', async () => {
@@ -2074,9 +2263,17 @@ describe('MembershipService', () => {
         })
     })
 
-    it('does not reactivate an archived default organization plan during initialization', async () => {
-        const { dataSource, ledgerRepository, memberships, membershipRepository, planRepository, plans, service } =
-            createScopeInitializationHarness()
+    it('queues organization initialization when only archived organization plans exist', async () => {
+        const {
+            backfillQueueService,
+            dataSource,
+            ledgerRepository,
+            memberships,
+            membershipRepository,
+            planRepository,
+            plans,
+            service
+        } = createScopeInitializationHarness()
         plans.push({
             id: 'plan-archived',
             tenantId: 'tenant-1',
@@ -2115,6 +2312,126 @@ describe('MembershipService', () => {
         expect(planRepository.save).not.toHaveBeenCalled()
         expect(membershipRepository.save).not.toHaveBeenCalled()
         expect(ledgerRepository.save).not.toHaveBeenCalled()
+        expect(backfillQueueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
+            'tenant-1',
+            'org-1'
+        )
+    })
+
+    it('reactivates an archived Default organization plan and backfills active members idempotently', async () => {
+        const { memberships, planRepository, plans, service } = createScopeInitializationHarness()
+        const archivedPlan = {
+            id: 'plan-archived',
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            code: 'default',
+            name: 'Default',
+            status: MembershipPlanStatusEnum.Archived,
+            isDefault: false,
+            period: MembershipPeriodEnum.Monthly,
+            includedPoints: 1000,
+            tokensPerPoint: 1000,
+            allowedModels: [],
+            modelMultipliers: [],
+            rateLimits: []
+        } as MembershipPlan
+        plans.push(archivedPlan)
+        memberships.push(
+            createMembership({
+                id: 'membership-expired',
+                organizationId: 'org-1',
+                userId: 'user-1',
+                status: MembershipStatusEnum.Expired,
+                planId: archivedPlan.id,
+                plan: archivedPlan
+            })
+        )
+
+        const firstResult = await service.backfillOrganizationDefaultMembershipBatch({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1'
+        })
+        const secondResult = await service.backfillOrganizationDefaultMembershipBatch({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1'
+        })
+
+        expect(plans).toEqual([
+            expect.objectContaining({
+                id: 'plan-archived',
+                code: 'default',
+                name: 'Default',
+                status: MembershipPlanStatusEnum.Active,
+                isDefault: true
+            })
+        ])
+        expect(memberships).toHaveLength(3)
+        expect(memberships).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: 'membership-expired',
+                    userId: 'user-1',
+                    status: MembershipStatusEnum.Expired
+                }),
+                expect.objectContaining({
+                    userId: 'user-1',
+                    status: MembershipStatusEnum.Active,
+                    planId: 'plan-archived'
+                }),
+                expect.objectContaining({
+                    userId: 'user-2',
+                    status: MembershipStatusEnum.Active,
+                    planId: 'plan-archived'
+                })
+            ])
+        )
+        expect(planRepository.save).toHaveBeenCalledTimes(1)
+        expect(firstResult).toEqual({ scanned: 2, assigned: 2, nextCursor: null })
+        expect(secondResult).toEqual({ scanned: 2, assigned: 0, nextCursor: null })
+    })
+
+    it('keeps archived organization plans and creates one active Default plan for backfill', async () => {
+        const { memberships, plans, service } = createScopeInitializationHarness()
+        plans.push({
+            id: 'plan-archived',
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            code: 'legacy',
+            name: 'Legacy',
+            status: MembershipPlanStatusEnum.Archived,
+            isDefault: false,
+            period: MembershipPeriodEnum.Monthly,
+            includedPoints: 500,
+            tokensPerPoint: 1000,
+            allowedModels: [],
+            modelMultipliers: [],
+            rateLimits: []
+        } as MembershipPlan)
+
+        const result = await service.backfillOrganizationDefaultMembershipBatch({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1'
+        })
+
+        expect(plans).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: 'plan-archived',
+                    code: 'legacy',
+                    status: MembershipPlanStatusEnum.Archived,
+                    isDefault: false
+                }),
+                expect.objectContaining({
+                    code: 'default',
+                    name: 'Default',
+                    status: MembershipPlanStatusEnum.Active,
+                    isDefault: true
+                })
+            ])
+        )
+        expect(plans).toHaveLength(2)
+        expect(memberships).toHaveLength(2)
+        expect(result).toEqual({ scanned: 2, assigned: 2, nextCursor: null })
     })
 
     it('initializes organization scope with an existing active plan and active member memberships idempotently', async () => {
@@ -2174,7 +2491,7 @@ describe('MembershipService', () => {
         expect(planRepository.save).toHaveBeenCalledTimes(1)
     })
 
-    it('does not reactivate paused or revoked organization memberships during repair', async () => {
+    it('preserves paused and revoked records while filling missing active organization memberships', async () => {
         const { ledgerRepository, memberships, membershipRepository, plans, service } =
             createScopeInitializationHarness()
         const plan = createPlan({
@@ -2211,10 +2528,16 @@ describe('MembershipService', () => {
         expect(status).toMatchObject({ initialized: true, needsRepair: false, assignedMemberCount: 2 })
         expect(memberships.map((membership) => membership.status)).toEqual([
             MembershipStatusEnum.Paused,
-            MembershipStatusEnum.Expired
+            MembershipStatusEnum.Expired,
+            MembershipStatusEnum.Active
         ])
-        expect(membershipRepository.save).not.toHaveBeenCalled()
-        expect(ledgerRepository.save).not.toHaveBeenCalled()
+        expect(memberships[2]).toMatchObject({
+            userId: 'user-2',
+            planId: plan.id,
+            source: MembershipSourceEnum.Organization
+        })
+        expect(membershipRepository.save).toHaveBeenCalledTimes(1)
+        expect(ledgerRepository.save).toHaveBeenCalledTimes(1)
     })
 
     it('records xpert usage against the xpert creator membership', async () => {

--- a/packages/server-ai/src/membership/membership.service.ts
+++ b/packages/server-ai/src/membership/membership.service.ts
@@ -64,9 +64,8 @@ import { MembershipBackfillQueueService } from './membership-backfill.queue'
 
 const DEFAULT_PLAN_NAME = 'Default'
 const DEFAULT_INCLUDED_POINTS = 1000
-const DEFAULT_UNLIMITED_PLAN_CODE = 'default-unlimited'
-const DEFAULT_UNLIMITED_PLAN_NAME = 'Default Unlimited'
 const DEFAULT_TENANT_PLAN_GRANT_REASON = 'Default tenant plan grant'
+const DEFAULT_ORGANIZATION_PLAN_GRANT_REASON = 'Organization membership initialized'
 const USAGE_HOUR_FORMAT = 'yyyy-MM-dd HH'
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 
@@ -283,8 +282,8 @@ export class MembershipService {
             }
             return manager.getRepository(MembershipPlan).save(plan)
         })
-        if (!organizationId && saved.status === MembershipPlanStatusEnum.Active && saved.isDefault) {
-            await this.enqueueTenantDefaultMembershipBackfill(tenantId)
+        if (saved.status === MembershipPlanStatusEnum.Active && saved.isDefault) {
+            await this.enqueueDefaultMembershipBackfill({ tenantId, organizationId })
         }
         return saved
     }
@@ -380,8 +379,8 @@ export class MembershipService {
                     !wasActiveDefault && saved.status === MembershipPlanStatusEnum.Active && saved.isDefault
             }
         })
-        if (!organizationId && result.becameActiveDefault) {
-            await this.enqueueTenantDefaultMembershipBackfill(tenantId)
+        if (result.becameActiveDefault) {
+            await this.enqueueDefaultMembershipBackfill({ tenantId, organizationId })
         }
         return result.saved
     }
@@ -527,17 +526,23 @@ export class MembershipService {
             }
             return this.buildScopeStatus(scope, manager)
         }
-        if (!(await this.hasActivePlan(scope.tenantId, scope.organizationId, manager))) {
+        if (!scope.organizationId) {
+            if (!(await this.hasActivePlan(scope.tenantId, scope.organizationId, manager))) {
+                return this.buildScopeStatus(scope, manager)
+            }
+            await this.enqueueTenantDefaultMembershipBackfill(scope.tenantId)
             return this.buildScopeStatus(scope, manager)
         }
-        if (!scope.organizationId) {
-            await this.enqueueTenantDefaultMembershipBackfill(scope.tenantId)
+        if (!(await this.hasActivePlan(scope.tenantId, scope.organizationId, manager))) {
+            await this.enqueueOrganizationDefaultMembershipBackfill(scope.tenantId, scope.organizationId)
             return this.buildScopeStatus(scope, manager)
         }
 
         const initialize = async (txManager: EntityManager) => {
             const plan = await this.ensureDefaultOrganizationPlan(scope, txManager)
-            await this.ensureOrganizationMemberMemberships(scope, plan, input?.assignedById ?? null, txManager)
+            if (plan) {
+                await this.ensureOrganizationMemberMemberships(scope, plan, input?.assignedById ?? null, txManager)
+            }
             return this.buildScopeStatus(scope, txManager)
         }
 
@@ -695,6 +700,112 @@ export class MembershipService {
         }
     }
 
+    async backfillOrganizationDefaultMembershipBatch(input: {
+        tenantId: string
+        organizationId: string
+        afterUserOrganizationId?: string | null
+        take?: number
+    }): Promise<{
+        scanned: number
+        assigned: number
+        nextCursor: string | null
+    }> {
+        const scope: MembershipScope = {
+            tenantId: input.tenantId,
+            organizationId: input.organizationId
+        }
+        const defaultPlan = await this.dataSource.transaction(async (manager) => {
+            if (!(await this.isMembershipPlanEnabledForScope(scope, manager))) {
+                return null
+            }
+            return this.ensureDefaultOrganizationPlan(scope, manager)
+        })
+        if (!defaultPlan || !this.userOrganizationRepository?.find) {
+            return { scanned: 0, assigned: 0, nextCursor: null }
+        }
+
+        const take = Math.min(Math.max(Math.trunc(input.take ?? 100), 1), 500)
+        const organizationMemberships = await this.userOrganizationRepository.find({
+            select: ['id', 'userId'],
+            where: {
+                tenantId: input.tenantId,
+                organizationId: input.organizationId,
+                isActive: true,
+                ...(input.afterUserOrganizationId ? { id: MoreThan(input.afterUserOrganizationId) } : {})
+            },
+            order: { id: 'ASC' },
+            take: take + 1
+        })
+        const batch = organizationMemberships.slice(0, take)
+        if (!batch.length) {
+            return { scanned: 0, assigned: 0, nextCursor: null }
+        }
+
+        const candidateUserIds = Array.from(new Set(batch.map((membership) => membership.userId).filter(Boolean)))
+        const candidateUserIdSet = new Set(candidateUserIds)
+        const users = candidateUserIds.length
+            ? await this.userRepository.find({
+                  select: ['id'],
+                  where: {
+                      tenantId: input.tenantId,
+                      id: In(candidateUserIds),
+                      type: UserType.USER
+                  }
+              })
+            : []
+        const eligibleUserIds = users.map((user) => user.id).filter((userId) => candidateUserIdSet.has(userId))
+        const nextCursor = organizationMemberships.length > take ? (batch[batch.length - 1]?.id ?? null) : null
+
+        const result = await this.dataSource.transaction(async (manager) => {
+            if (!(await this.isMembershipPlanEnabledForScope(scope, manager))) {
+                return { assigned: 0, canContinue: false }
+            }
+            const plan = await this.findDefaultPlan(input.tenantId, input.organizationId, manager)
+            if (!plan) {
+                return { assigned: 0, canContinue: false }
+            }
+
+            const activeOrganizationMemberships = eligibleUserIds.length
+                ? await manager.getRepository(UserOrganization).find({
+                      select: ['userId'],
+                      where: {
+                          tenantId: input.tenantId,
+                          organizationId: input.organizationId,
+                          userId: In(eligibleUserIds),
+                          isActive: true
+                      }
+                  })
+                : []
+            const activeUserIds = new Set(activeOrganizationMemberships.map((membership) => membership.userId))
+            let created = 0
+            for (const userId of eligibleUserIds) {
+                if (!activeUserIds.has(userId)) {
+                    continue
+                }
+                const assignment = await this.ensureOrganizationMemberMembershipWithPlan(
+                    {
+                        tenantId: input.tenantId,
+                        organizationId: input.organizationId,
+                        userId
+                    },
+                    plan,
+                    null,
+                    manager
+                )
+                if (assignment.created) {
+                    created++
+                }
+            }
+            return { assigned: created, canContinue: true }
+        })
+
+        return {
+            scanned: batch.length,
+            assigned: result.assigned,
+            nextCursor: result.canContinue ? nextCursor : null
+        }
+    }
+
     private async ensureTenantDefaultMembershipWithPlan(
         input: EnsureTenantDefaultMembershipInput,
         plan: MembershipPlan,
@@ -757,6 +868,18 @@ export class MembershipService {
         await this.backfillQueueService?.enqueueTenantDefaultMembershipBackfill(tenantId)
     }
 
+    private async enqueueOrganizationDefaultMembershipBackfill(tenantId: string, organizationId: string) {
+        await this.backfillQueueService?.enqueueOrganizationDefaultMembershipBackfill(tenantId, organizationId)
+    }
+
+    private async enqueueDefaultMembershipBackfill(scope: MembershipScope) {
+        if (scope.organizationId) {
+            await this.enqueueOrganizationDefaultMembershipBackfill(scope.tenantId, scope.organizationId)
+        } else {
+            await this.enqueueTenantDefaultMembershipBackfill(scope.tenantId)
+        }
+    }
+
     private async ensureDefaultTenantPlanForEmptyScope(tenantId: string): Promise<MembershipPlan | null> {
         const scope: MembershipScope = { tenantId, organizationId: null }
         return this.dataSource.transaction(async (manager) => {
@@ -807,6 +930,21 @@ export class MembershipService {
         await manager.query('SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))', [
             tenantId,
             'tenant-default-membership-plan'
+        ])
+    }
+
+    private async acquireOrganizationDefaultPlanInitializationLock(
+        manager: EntityManager,
+        tenantId: string,
+        organizationId: string
+    ) {
+        if (manager.connection.options.type !== 'postgres') {
+            return
+        }
+
+        await manager.query('SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))', [
+            tenantId,
+            `organization-default-membership-plan:${organizationId}`
         ])
     }
 
@@ -1961,6 +2099,9 @@ export class MembershipService {
         >,
         modelAccess?: IModelAccessResolution
     ): Promise<void> {
+        if (modelAccess?.accessSource === ModelAccessSourceEnum.Direct) {
+            return
+        }
         if (
             !(await this.isMembershipAccessEnabled({
                 tenantId: input.tenantId,
@@ -2011,6 +2152,9 @@ export class MembershipService {
     async recordUsage(input: RecordUsageInput): Promise<MembershipPointLedger | null> {
         const tokenUsed = Math.max(0, Math.trunc(input.tokenUsed ?? 0))
         if (!tokenUsed) {
+            return null
+        }
+        if (input.modelAccess?.accessSource === ModelAccessSourceEnum.Direct) {
             return null
         }
         if (
@@ -2261,11 +2405,7 @@ export class MembershipService {
                 const remaining = pointsUsed - membershipPointsUsed
                 if (remaining > 0) {
                     await this.acquirePersonalPointsLock(manager, input.tenantId, billableUserId)
-                    const personalBalance = await this.getPersonalPointsBalance(
-                        input.tenantId,
-                        billableUserId,
-                        manager
-                    )
+                    const personalBalance = await this.getPersonalPointsBalance(input.tenantId, billableUserId, manager)
                     personalPointsUsed = Math.min(remaining, personalBalance)
                 }
                 membership.pointsUsed = (membership.pointsUsed ?? 0) + membershipPointsUsed
@@ -2370,11 +2510,7 @@ export class MembershipService {
         return Number(((tokenUsed / tokensPerPoint) * Math.max(0, multiplier)).toFixed(10))
     }
 
-    resolveModelMultiplierForPlan(
-        plan: Pick<IMembershipPlan, 'modelMultipliers'>,
-        provider?: string,
-        model?: string
-    ) {
+    resolveModelMultiplierForPlan(plan: Pick<IMembershipPlan, 'modelMultipliers'>, provider?: string, model?: string) {
         return this.resolveModelMultiplier(plan, provider, model)
     }
 
@@ -2688,7 +2824,11 @@ export class MembershipService {
         }
     }
 
-    private async ensureDefaultOrganizationPlan(scope: MembershipScope, manager: EntityManager) {
+    private async ensureDefaultOrganizationPlan(
+        scope: MembershipScope & { organizationId: string },
+        manager: EntityManager
+    ): Promise<MembershipPlan | null> {
+        await this.acquireOrganizationDefaultPlanInitializationLock(manager, scope.tenantId, scope.organizationId)
         const repository = manager.getRepository(MembershipPlan)
         const tokensPerPoint = await this.resolveTenantTokensPerPoint(scope.tenantId)
         const existingDefaultPlan = await this.findDefaultPlan(scope.tenantId, scope.organizationId, manager)
@@ -2712,32 +2852,27 @@ export class MembershipService {
         const archivedDefaultPlan = await repository.findOne({
             where: {
                 ...this.scopeWhere(scope.tenantId, scope.organizationId),
-                code: DEFAULT_UNLIMITED_PLAN_CODE
+                code: 'default'
             }
         })
         if (archivedDefaultPlan) {
             await this.clearDefaultPlan(scope.tenantId, scope.organizationId, manager, archivedDefaultPlan.id)
-            archivedDefaultPlan.name = archivedDefaultPlan.name || DEFAULT_UNLIMITED_PLAN_NAME
             archivedDefaultPlan.status = MembershipPlanStatusEnum.Active
             archivedDefaultPlan.isDefault = true
-            archivedDefaultPlan.includedPoints = null
-            archivedDefaultPlan.tokensPerPoint = tokensPerPoint
-            archivedDefaultPlan.period = archivedDefaultPlan.period || MembershipPeriodEnum.Monthly
-            archivedDefaultPlan.modelMultipliers = archivedDefaultPlan.modelMultipliers ?? []
-            archivedDefaultPlan.rateLimits = archivedDefaultPlan.rateLimits ?? []
             return repository.save(archivedDefaultPlan)
         }
 
         const plan = repository.create({
             tenantId: scope.tenantId,
             organizationId: scope.organizationId,
-            code: DEFAULT_UNLIMITED_PLAN_CODE,
-            name: DEFAULT_UNLIMITED_PLAN_NAME,
+            code: 'default',
+            name: DEFAULT_PLAN_NAME,
             status: MembershipPlanStatusEnum.Active,
             isDefault: true,
             period: MembershipPeriodEnum.Monthly,
-            includedPoints: null,
+            includedPoints: DEFAULT_INCLUDED_POINTS,
             tokensPerPoint,
+            allowedModels: [],
             modelMultipliers: [],
             rateLimits: []
         })
@@ -2760,51 +2895,84 @@ export class MembershipService {
             return
         }
 
-        const repository = manager.getRepository(UserMembership)
-        const existingMemberships = await repository.find({
-            select: ['userId'],
-            where: {
-                ...this.scopeWhere(scope.tenantId, scope.organizationId),
-                userId: In(userIds)
-            }
-        })
-        const existingUserIds = new Set(existingMemberships.map((membership) => membership.userId))
-        const missingUserIds = userIds.filter((userId) => !existingUserIds.has(userId))
-        if (!missingUserIds.length) {
-            return
-        }
-
         const start = new Date()
-        const end = periodEndFor(start, plan.period)
-        for (const userId of missingUserIds) {
-            const membership = await repository.save(
-                repository.create({
+        for (const userId of userIds) {
+            await this.ensureOrganizationMemberMembershipWithPlan(
+                {
                     tenantId: scope.tenantId,
                     organizationId: scope.organizationId,
-                    userId,
-                    planId: plan.id,
-                    status: MembershipStatusEnum.Active,
-                    source: MembershipSourceEnum.Organization,
-                    renewalMode: MembershipRenewalModeEnum.Auto,
-                    currentPeriodStart: start,
-                    currentPeriodEnd: end,
-                    pointsGranted: plan.includedPoints,
-                    pointsUsed: 0,
-                    pointsTotalUsed: 0,
-                    assignedById: assignedById ?? undefined,
-                    note: 'Organization membership initialized'
-                })
+                    userId
+                },
+                plan,
+                assignedById,
+                manager,
+                start
             )
-            await this.createLedger(manager, {
-                tenantId: scope.tenantId,
-                organizationId: scope.organizationId,
-                userId,
-                membershipId: membership.id,
+        }
+    }
+
+    private async ensureOrganizationMemberMembershipWithPlan(
+        input: {
+            tenantId: string
+            organizationId: string
+            userId: string
+        },
+        plan: MembershipPlan,
+        assignedById: string | null,
+        manager: EntityManager,
+        start = new Date()
+    ): Promise<{
+        membership: UserMembership | null
+        created: boolean
+    }> {
+        await this.acquireMembershipAssignmentLock(manager, input.tenantId, input.organizationId, input.userId)
+        const existingMembership = await this.findMembershipForUpdate(
+            input.tenantId,
+            input.organizationId,
+            input.userId,
+            [MembershipStatusEnum.Active, MembershipStatusEnum.Paused],
+            manager
+        )
+        if (existingMembership) {
+            return {
+                membership: existingMembership.status === MembershipStatusEnum.Active ? existingMembership : null,
+                created: false
+            }
+        }
+
+        const repository = manager.getRepository(UserMembership)
+        const membership = await repository.save(
+            repository.create({
+                tenantId: input.tenantId,
+                organizationId: input.organizationId,
+                userId: input.userId,
                 planId: plan.id,
-                source: MembershipLedgerSourceEnum.Assignment,
-                pointsDelta: plan.includedPoints ?? 0,
-                reason: 'Organization membership initialized'
+                status: MembershipStatusEnum.Active,
+                source: MembershipSourceEnum.Organization,
+                renewalMode: MembershipRenewalModeEnum.Auto,
+                currentPeriodStart: start,
+                currentPeriodEnd: periodEndFor(start, plan.period),
+                pointsGranted: plan.includedPoints,
+                pointsUsed: 0,
+                pointsTotalUsed: 0,
+                assignedById: assignedById ?? undefined,
+                note: DEFAULT_ORGANIZATION_PLAN_GRANT_REASON
             })
+        )
+        membership.plan = plan
+        await this.createLedger(manager, {
+            tenantId: input.tenantId,
+            organizationId: input.organizationId,
+            userId: input.userId,
+            membershipId: membership.id,
+            planId: plan.id,
+            source: MembershipLedgerSourceEnum.Assignment,
+            pointsDelta: plan.includedPoints ?? 0,
+            reason: DEFAULT_ORGANIZATION_PLAN_GRANT_REASON
+        })
+        return {
+            membership,
+            created: true
         }
     }
 
@@ -4045,11 +4213,7 @@ export class MembershipService {
         return start
     }
 
-    private resolveModelMultiplier(
-        plan: Pick<IMembershipPlan, 'modelMultipliers'>,
-        provider?: string,
-        model?: string
-    ) {
+    private resolveModelMultiplier(plan: Pick<IMembershipPlan, 'modelMultipliers'>, provider?: string, model?: string) {
         const multiplier = (plan.modelMultipliers ?? []).find((item) => {
             const providerMatches = !item.provider || item.provider === provider
             const modelMatches = !item.model || item.model === model || item.model === '*'
@@ -4498,7 +4662,7 @@ export class MembershipService {
         return {
             tenantId: input?.tenantId ?? this.requireTenant(),
             organizationId: this.normalizeScopeOrganizationId(
-                input?.organizationId ?? RequestContext.getOrganizationId()
+                input?.organizationId !== undefined ? input.organizationId : RequestContext.getOrganizationId()
             )
         }
     }

--- a/packages/server-ai/src/membership/membership.service.ts
+++ b/packages/server-ai/src/membership/membership.service.ts
@@ -2405,7 +2405,11 @@ export class MembershipService {
                 const remaining = pointsUsed - membershipPointsUsed
                 if (remaining > 0) {
                     await this.acquirePersonalPointsLock(manager, input.tenantId, billableUserId)
-                    const personalBalance = await this.getPersonalPointsBalance(input.tenantId, billableUserId, manager)
+                    const personalBalance = await this.getPersonalPointsBalance(
+                        input.tenantId,
+                        billableUserId,
+                        manager
+                    )
                     personalPointsUsed = Math.min(remaining, personalBalance)
                 }
                 membership.pointsUsed = (membership.pointsUsed ?? 0) + membershipPointsUsed
@@ -2510,7 +2514,11 @@ export class MembershipService {
         return Number(((tokenUsed / tokensPerPoint) * Math.max(0, multiplier)).toFixed(10))
     }
 
-    resolveModelMultiplierForPlan(plan: Pick<IMembershipPlan, 'modelMultipliers'>, provider?: string, model?: string) {
+    resolveModelMultiplierForPlan(
+        plan: Pick<IMembershipPlan, 'modelMultipliers'>,
+        provider?: string,
+        model?: string
+    ) {
         return this.resolveModelMultiplier(plan, provider, model)
     }
 
@@ -4213,7 +4221,11 @@ export class MembershipService {
         return start
     }
 
-    private resolveModelMultiplier(plan: Pick<IMembershipPlan, 'modelMultipliers'>, provider?: string, model?: string) {
+    private resolveModelMultiplier(
+        plan: Pick<IMembershipPlan, 'modelMultipliers'>,
+        provider?: string,
+        model?: string
+    ) {
         const multiplier = (plan.modelMultipliers ?? []).find((item) => {
             const providerMatches = !item.provider || item.provider === provider
             const modelMatches = !item.model || item.model === model || item.model === '*'

--- a/packages/server-ai/src/model-access/model-access.service.spec.ts
+++ b/packages/server-ai/src/model-access/model-access.service.spec.ts
@@ -171,6 +171,48 @@ function createFixture() {
 }
 
 describe('ModelAccessService model resolution', () => {
+    it('allows an organization model directly when organization membership is disabled', async () => {
+        const { copilotRepository, input, membershipService, service } = createFixture()
+        copilotRepository.findOne.mockResolvedValue({
+            id: 'copilot-1',
+            tenantId: 'tenant-1',
+            organizationId: 'runtime-org',
+            name: 'Organization Provider',
+            enabled: true,
+            modelProvider: {
+                id: 'provider-1',
+                providerName: 'openai',
+                isValid: true
+            }
+        })
+        membershipService.isMembershipPlanEnabled.mockImplementation(async ({ organizationId }) => !organizationId)
+        membershipService.findModelAccess.mockResolvedValue({
+            organizationId: null,
+            membership: { planId: 'tenant-plan', plan: {} }
+        })
+
+        await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
+            allowed: true,
+            accessSource: 'direct',
+            organizationId: 'runtime-org',
+            scope: ModelAccessOwnershipScopeEnum.Organization
+        })
+        expect(membershipService.findModelAccess).not.toHaveBeenCalled()
+    })
+
+    it('blocks tenant models in an organization when tenant membership is disabled', async () => {
+        const { input, membershipService, service } = createFixture()
+        membershipService.isMembershipAccessEnabled.mockResolvedValue(false)
+        membershipService.isMembershipPlanEnabled.mockResolvedValue(false)
+
+        await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
+            allowed: false,
+            organizationId: null,
+            scope: ModelAccessOwnershipScopeEnum.Tenant,
+            unavailableReason: ModelAccessUnavailableReasonEnum.FeatureDisabled
+        })
+    })
+
     it('resolves an organization-scoped provider from the persisted model scope', async () => {
         const { copilotRepository, input, membershipService, providersService, service } = createFixture()
         const organizationProvider = {
@@ -368,6 +410,54 @@ describe('ModelAccessService model resolution', () => {
         )
     })
 
+    it('uses the current organization membership when a tenant model is used through a personal grant', async () => {
+        const { grantQueryBuilder, input, membershipService, service } = createFixture()
+        grantQueryBuilder.getOne.mockResolvedValue({
+            id: 'grant-1',
+            tenantId: 'tenant-1',
+            organizationId: null,
+            userId: 'creator-user',
+            requestId: 'request-1',
+            copilotId: 'copilot-1',
+            copilotModelId: 'gpt-4.1',
+            modelType: AiModelTypeEnum.LLM,
+            status: UserModelGrantStatusEnum.Active,
+            ownershipScope: ModelAccessOwnershipScopeEnum.Tenant,
+            modelSnapshot: {}
+        })
+        membershipService.findModelAccess.mockResolvedValue({
+            organizationId: 'runtime-org',
+            membership: {
+                planId: 'organization-plan',
+                plan: { id: 'organization-plan' }
+            }
+        })
+        membershipService.isModelAllowed.mockReturnValue(false)
+
+        const resolution = await service.assertCanUseModel(input)
+
+        expect(resolution).toMatchObject({
+            allowed: true,
+            accessSource: ModelAccessSourceEnum.Grant,
+            grantId: 'grant-1',
+            planId: 'organization-plan',
+            multiplier: 1,
+            scope: ModelAccessOwnershipScopeEnum.Tenant,
+            organizationId: null
+        })
+        expect(membershipService.assertCanUse).toHaveBeenCalledWith(
+            {
+                tenantId: 'tenant-1',
+                organizationId: 'runtime-org',
+                copilotOrganizationId: null,
+                userId: 'creator-user',
+                provider: 'openai',
+                model: 'gpt-4.1'
+            },
+            resolution
+        )
+    })
+
     it('uses the exact copilot, model type, and model id when resolving a grant', async () => {
         const { grantQueryBuilder, input, membershipService, service } = createFixture()
         membershipService.findModelAccess.mockResolvedValue(null)
@@ -482,6 +572,64 @@ describe('ModelAccessService model resolution', () => {
 describe('ModelAccessService catalog', () => {
     afterEach(() => {
         jest.restoreAllMocks()
+    })
+
+    it('exposes organization models as direct access when organization membership is disabled', async () => {
+        jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
+        jest.spyOn(RequestContext, 'currentUserId').mockReturnValue('creator-user')
+        jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('org-1')
+        jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(false)
+        const { copilotRepository, membershipService, queryBus, service } = createFixture()
+        copilotRepository.findOne.mockResolvedValue({
+            id: 'copilot-1',
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            name: 'Organization Provider',
+            enabled: true,
+            modelProvider: {
+                id: 'provider-1',
+                providerName: 'openai',
+                isValid: true
+            }
+        })
+        membershipService.findModelAccess.mockResolvedValue(null)
+        membershipService.isMembershipPlanEnabled.mockImplementation(async ({ organizationId }) => !organizationId)
+        queryBus.execute.mockImplementation(async (query: FindCopilotModelsQuery) =>
+            query.type === AiModelTypeEnum.LLM
+                ? [
+                      {
+                          id: 'copilot-1',
+                          organizationId: 'org-1',
+                          providerWithModels: {
+                              provider: 'openai',
+                              models: [
+                                  {
+                                      model: 'gpt-4.1',
+                                      model_type: AiModelTypeEnum.LLM
+                                  }
+                              ]
+                          }
+                      }
+                  ]
+                : []
+        )
+
+        await expect(service.getCatalog()).resolves.toMatchObject({
+            items: [
+                {
+                    copilotId: 'copilot-1',
+                    copilotModelId: 'gpt-4.1',
+                    ownershipScope: ModelAccessOwnershipScopeEnum.Organization,
+                    organizationId: 'org-1',
+                    accessSource: ModelAccessSourceEnum.Direct,
+                    planIncluded: false,
+                    allowed: true,
+                    requestable: false
+                }
+            ],
+            canRequest: false
+        })
+        expect(membershipService.hasConsumableBalance).not.toHaveBeenCalled()
     })
 
     it('automatically exposes tenant chat models for external API application', async () => {
@@ -1208,6 +1356,32 @@ describe('ModelAccessService request scope resolution', () => {
                 ownershipScope: expectedScope
             })
         )
+    })
+
+    it('rejects tenant model applications when tenant membership is disabled', async () => {
+        jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
+        jest.spyOn(RequestContext, 'currentUserId').mockReturnValue('creator-user')
+        jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('org-1')
+        jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
+            id: 'creator-user',
+            tenantId: 'tenant-1',
+            type: UserType.USER
+        })
+        jest.spyOn(RequestContext, 'isTenantScope').mockReturnValue(false)
+        jest.spyOn(RequestContext, 'isOrganizationScope').mockReturnValue(true)
+        jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(false)
+        const { dataSource, membershipService, service } = createFixture()
+        membershipService.isMembershipPlanEnabled.mockImplementation(async ({ organizationId }) => !!organizationId)
+
+        await expect(
+            service.createRequest({
+                copilotId: 'copilot-1',
+                copilotModelId: 'gpt-4.1',
+                modelType: AiModelTypeEnum.LLM,
+                reason: 'Needed from the organization'
+            })
+        ).rejects.toThrow('Personal model access is disabled.')
+        expect(dataSource.transaction).not.toHaveBeenCalled()
     })
 })
 

--- a/packages/server-ai/src/model-access/model-access.service.ts
+++ b/packages/server-ai/src/model-access/model-access.service.ts
@@ -88,6 +88,17 @@ type ModelTarget = {
     listedForRequest?: boolean
 }
 
+enum ModelTargetAccessMode {
+    Direct = 'direct',
+    Membership = 'membership',
+    Blocked = 'blocked'
+}
+
+type MembershipFeatureState = {
+    organizationEnabled: boolean
+    tenantEnabled: boolean
+}
+
 type ResolveModelInput = {
     tenantId: string
     organizationId?: string | null
@@ -157,7 +168,9 @@ export class ModelAccessService {
             initialGrants,
             membershipAccess,
             tenantFeatureEnabled,
-            organizationFeatureEnabled
+            organizationFeatureEnabled,
+            tenantMembershipEnabled,
+            organizationMembershipEnabled
         ] = await Promise.all([
             this.loadVisibleCatalogTargets(organizationId),
             this.findUserRequestsForCurrentContext(tenantId, userId, organizationId),
@@ -167,7 +180,11 @@ export class ModelAccessService {
                 tenantId,
                 organizationId: null
             }),
-            organizationId ? this.isModelAccessFeatureEnabled({ tenantId, organizationId }) : Promise.resolve(false)
+            organizationId ? this.isModelAccessFeatureEnabled({ tenantId, organizationId }) : Promise.resolve(false),
+            this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
+            organizationId
+                ? this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId })
+                : Promise.resolve(false)
         ])
         let grantStateChanged = false
         for (const grant of initialGrants.filter((item) => item.status === UserModelGrantStatusEnum.Active)) {
@@ -208,7 +225,10 @@ export class ModelAccessService {
             targets.map((target) =>
                 this.toCatalogItem(target, user, effectiveRequests, grants, membershipAccess, {
                     tenantFeatureEnabled,
-                    organizationFeatureEnabled
+                    organizationFeatureEnabled,
+                    tenantMembershipEnabled,
+                    organizationMembershipEnabled,
+                    runtimeOrganizationId: organizationId
                 })
             )
         )
@@ -1140,25 +1160,7 @@ export class ModelAccessService {
             xpertId: input.xpertId
         })
         const runtimeOrganizationId = input.organizationId ?? null
-        const membershipEnabled = await this.membershipService.isMembershipAccessEnabled({
-            tenantId: input.tenantId,
-            organizationId: runtimeOrganizationId
-        })
         const fallbackScope = ModelAccessOwnershipScopeEnum.Tenant
-        if (!membershipEnabled) {
-            return {
-                allowed: true,
-                channel: ModelAccessChannelEnum.Xpert,
-                billableUserId,
-                copilotId: input.copilotId,
-                copilotModelId: input.copilotModelId,
-                modelType: input.modelType,
-                accessSource: null,
-                multiplier: 1,
-                scope: fallbackScope,
-                organizationId: null
-            }
-        }
 
         await this.processDueGrants({
             tenantId: input.tenantId,
@@ -1186,6 +1188,47 @@ export class ModelAccessService {
                 scope: grant?.ownershipScope ?? fallbackScope,
                 organizationId: grant?.organizationId ?? null,
                 unavailableReason: ModelAccessUnavailableReasonEnum.ModelDeleted
+            }
+        }
+
+        const membershipFeatureState = await this.resolveMembershipFeatureState(input.tenantId, runtimeOrganizationId)
+        const accessMode = this.resolveTargetAccessMode(target, runtimeOrganizationId, membershipFeatureState)
+        if (accessMode === ModelTargetAccessMode.Direct) {
+            return {
+                allowed: target.enabled,
+                channel: ModelAccessChannelEnum.Xpert,
+                billableUserId,
+                copilotId: target.copilotId,
+                copilotModelId: target.copilotModelId,
+                provider: target.provider,
+                modelType: target.modelType,
+                model: target.model,
+                accessSource: ModelAccessSourceEnum.Direct,
+                multiplier: 1,
+                scope: target.ownershipScope,
+                organizationId: target.organizationId,
+                unavailableReason: target.enabled ? null : ModelAccessUnavailableReasonEnum.ModelDisabled
+            }
+        }
+        if (accessMode === ModelTargetAccessMode.Blocked) {
+            if (grant) {
+                await this.recordGrantAvailability(grant, ModelAccessUnavailableReasonEnum.FeatureDisabled)
+            }
+            return {
+                allowed: false,
+                channel: ModelAccessChannelEnum.Xpert,
+                billableUserId,
+                copilotId: target.copilotId,
+                copilotModelId: target.copilotModelId,
+                provider: target.provider,
+                modelType: target.modelType,
+                model: target.model,
+                accessSource: grant ? ModelAccessSourceEnum.Grant : null,
+                grantId: grant?.id,
+                multiplier: 1,
+                scope: target.ownershipScope,
+                organizationId: target.organizationId,
+                unavailableReason: ModelAccessUnavailableReasonEnum.FeatureDisabled
             }
         }
 
@@ -1556,9 +1599,20 @@ export class ModelAccessService {
         requests: ModelAccessRequest[],
         grants: UserModelGrant[],
         membershipAccess: MembershipModelAccess | null,
-        features: { tenantFeatureEnabled: boolean; organizationFeatureEnabled: boolean }
+        features: {
+            tenantFeatureEnabled: boolean
+            organizationFeatureEnabled: boolean
+            tenantMembershipEnabled: boolean
+            organizationMembershipEnabled: boolean
+            runtimeOrganizationId: string | null
+        }
     ): Promise<IModelAccessCatalogItem> {
-        const planIncluded = this.isPlanIncluded(target, membershipAccess)
+        const accessMode = this.resolveTargetAccessMode(target, features.runtimeOrganizationId, {
+            tenantEnabled: features.tenantMembershipEnabled,
+            organizationEnabled: features.organizationMembershipEnabled
+        })
+        const planIncluded =
+            accessMode === ModelTargetAccessMode.Membership && this.isPlanIncluded(target, membershipAccess)
         const grant =
             grants.find(
                 (item) => this.sameModelTarget(item, target) && item.status === UserModelGrantStatusEnum.Active
@@ -1573,9 +1627,10 @@ export class ModelAccessService {
                 ? features.tenantFeatureEnabled
                 : features.organizationFeatureEnabled
         const manager = this.canManageTargetScope(target)
-        const quotaReason = await this.resolveQuotaReason(membershipAccess)
+        const quotaReason =
+            accessMode === ModelTargetAccessMode.Membership ? await this.resolveQuotaReason(membershipAccess) : null
         const grantUnavailableReason = effectiveGrant
-            ? !featureEnabled
+            ? accessMode === ModelTargetAccessMode.Blocked || !featureEnabled
                 ? ModelAccessUnavailableReasonEnum.FeatureDisabled
                 : !target.enabled
                   ? ModelAccessUnavailableReasonEnum.ModelDisabled
@@ -1599,20 +1654,27 @@ export class ModelAccessService {
             modelLabel: target.modelLabel,
             ownershipScope: target.ownershipScope,
             organizationId: target.organizationId,
-            accessSource: planIncluded
-                ? ModelAccessSourceEnum.Plan
-                : effectiveGrant
-                  ? ModelAccessSourceEnum.Grant
-                  : null,
+            accessSource:
+                accessMode === ModelTargetAccessMode.Direct
+                    ? ModelAccessSourceEnum.Direct
+                    : planIncluded
+                      ? ModelAccessSourceEnum.Plan
+                      : effectiveGrant
+                        ? ModelAccessSourceEnum.Grant
+                        : null,
             grantId: effectiveGrant?.id,
             planIncluded,
             allowed:
-                (planIncluded && target.enabled) ||
-                (!!effectiveGrant &&
-                    (grantUnavailableReason === null ||
-                        grantUnavailableReason === ModelAccessUnavailableReasonEnum.QuotaExhausted ||
-                        grantUnavailableReason === ModelAccessUnavailableReasonEnum.MembershipRequired)),
+                accessMode === ModelTargetAccessMode.Direct
+                    ? target.enabled
+                    : accessMode === ModelTargetAccessMode.Membership &&
+                      ((planIncluded && target.enabled) ||
+                          (!!effectiveGrant &&
+                              (grantUnavailableReason === null ||
+                                  grantUnavailableReason === ModelAccessUnavailableReasonEnum.QuotaExhausted ||
+                                  grantUnavailableReason === ModelAccessUnavailableReasonEnum.MembershipRequired))),
             requestable:
+                accessMode === ModelTargetAccessMode.Membership &&
                 user.type !== UserType.COMMUNICATION &&
                 target.listedForRequest === true &&
                 target.enabled &&
@@ -1622,11 +1684,17 @@ export class ModelAccessService {
                 !effectiveGrant &&
                 !pendingRequest,
             unavailableReason:
-                planIncluded && !target.enabled
-                    ? ModelAccessUnavailableReasonEnum.ModelDisabled
-                    : planIncluded
-                      ? quotaReason
-                      : grantUnavailableReason,
+                accessMode === ModelTargetAccessMode.Direct
+                    ? target.enabled
+                        ? null
+                        : ModelAccessUnavailableReasonEnum.ModelDisabled
+                    : accessMode === ModelTargetAccessMode.Blocked
+                      ? ModelAccessUnavailableReasonEnum.FeatureDisabled
+                      : planIncluded && !target.enabled
+                        ? ModelAccessUnavailableReasonEnum.ModelDisabled
+                        : planIncluded
+                          ? quotaReason
+                          : grantUnavailableReason,
             pendingRequest,
             grant: effectiveGrant
         }
@@ -1976,6 +2044,38 @@ export class ModelAccessService {
             access.organizationId === target.organizationId &&
             this.membershipService.isModelAllowed(access.membership.plan, target.provider, target.model)
         )
+    }
+
+    private async resolveMembershipFeatureState(
+        tenantId: string,
+        runtimeOrganizationId: string | null
+    ): Promise<MembershipFeatureState> {
+        const [tenantEnabled, organizationEnabled] = await Promise.all([
+            this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
+            runtimeOrganizationId
+                ? this.membershipService.isMembershipPlanEnabled({
+                      tenantId,
+                      organizationId: runtimeOrganizationId
+                  })
+                : Promise.resolve(false)
+        ])
+        return { tenantEnabled, organizationEnabled }
+    }
+
+    private resolveTargetAccessMode(
+        target: ModelTarget,
+        runtimeOrganizationId: string | null,
+        membershipFeatures: MembershipFeatureState
+    ): ModelTargetAccessMode {
+        if (target.organizationId) {
+            return membershipFeatures.organizationEnabled
+                ? ModelTargetAccessMode.Membership
+                : ModelTargetAccessMode.Direct
+        }
+        if (!runtimeOrganizationId) {
+            return membershipFeatures.tenantEnabled ? ModelTargetAccessMode.Membership : ModelTargetAccessMode.Direct
+        }
+        return membershipFeatures.tenantEnabled ? ModelTargetAccessMode.Membership : ModelTargetAccessMode.Blocked
     }
 
     private async resolveQuotaReason(access: MembershipModelAccess | null) {


### PR DESCRIPTION
## Summary

This change aligns organization membership initialization, model discovery, and model access with the active tenant/organization scope.

- enqueue an idempotent organization Default membership backfill when organization membership is enabled
- create or select the organization Default plan and assign memberships in bounded batches
- support direct model access when the owning scope's membership feature is disabled, without membership point settlement
- block tenant-owned models in an organization when tenant membership is disabled
- expose the appropriate tenant/organization model providers for the current membership scope
- separate direct/plan access from personal grants on the account available-models page

## User impact

Previously, enabling organization membership did not reliably initialize a Default plan and organization member relationships. Model discovery also mixed provider ownership with the current membership state, which could hide tenant models or expose the wrong provider scope. Direct access needed an explicit source so that disabled membership features did not accidentally trigger point accounting.

The new flow listens for the membership feature transition, queues bounded backfill work, resolves model access as Direct, Plan, Grant, or Blocked, and keeps point settlement out of Direct access.

## Validation

- `git diff --check`
- `NX_DAEMON=false corepack pnpm nx test server-ai --runInBand --testPathPatterns='(model-gateway.service|openai-adapter|openai.controller|model-access.service|model-access.controller|membership.service|membership-backfill.processor|copilot.service|token-record.handler|membership-period-scheduler.service|model-access-scheduler.service|membership.dto|model-access.dto|copilot-model-find.handler).spec.ts$'`
  - 14 suites, 213 tests passed
- `NX_DAEMON=false corepack pnpm nx test cloud --runInBand --testPathPatterns='available-models.component.spec.ts$'`
  - 1 suite, 1 test passed (Nx cache)
- commit hooks: Prettier, hardcoded-color check, and TypeORM column-type check passed

No browser validation was performed.

## Known follow-up validation

The following acceptance items are intentionally not blocking this draft and should be addressed after integration/runtime testing:

- bind tenant-model personal grants to the organization context that requested them, for both Xpert and external API access
- align archived-only organization initialization with the agreed manual-intervention behavior
- report incomplete/missing Default-plan scopes accurately instead of marking them initialized
- prevent deletion of archived plans that still have historical membership, period, or ledger references
- auto-approve model-access administrators' own requests while preserving audit events
- filter the read-only provider model list at model level rather than only provider scope
