### PR TITLE
fix: include core-js in api runtime

### DIFF
--- a/.deploy/api/package-prod.json
+++ b/.deploy/api/package-prod.json
@@ -20,6 +20,7 @@
     "@swc/helpers": "0.5.3",
     "@xpert-ai/plugin-sdk": "workspace:*",
     "bullmq": "^5.78.1",
+    "core-js": "3.37.1",
     "glob": "^11.0.3",
     "lodash-es": "^4.17.21",
     "idb-keyval": "^6.2.1",


### PR DESCRIPTION
## Summary

- add `core-js` to the production API dependency manifest
- keep the runtime version aligned with `apps/api/package.json`

## Why

The compiled API bundle requires `core-js/actual/structured-clone`, while the production Docker stage installs dependencies from `.deploy/api/package-prod.json`. Without a direct runtime dependency, the API image can crash when no other workspace package installs `core-js` transitively.

## Validation

- parsed both package manifests and verified matching `core-js` versions
- repository pre-commit checks passed
- `git diff --check` passed

No browser validation or full Docker image build was run.