### PR TITLE
fix: restore empty database onboarding

### DIFF
--- a/apps/api/src/bootstrap/index.ts
+++ b/apps/api/src/bootstrap/index.ts
@@ -20,7 +20,7 @@ import {
   TenantService
 } from '@xpert-ai/server-core'
 import { IPluginConfig } from '@xpert-ai/server-common'
-import { ConflictException, DynamicModule, Logger as NestLogger, Module, Type } from '@nestjs/common'
+import { ConflictException, DynamicModule, Logger as NestLogger, Module, NotFoundException, Type } from '@nestjs/common'
 import { NestFactory, Reflector } from '@nestjs/core'
 import { NestExpressApplication } from '@nestjs/platform-express'
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
@@ -111,7 +111,15 @@ export async function bootstrap(options: { title: string; version: string }) {
   const serverService = app.select(ServerAppModule).get(AppService)
   await serverService.seedDBIfEmpty()
   const tenantService = app.select(ServerAppModule).get(TenantService)
-  setDefaultTenantId((await tenantService.getDefaultTenant())?.id ?? null)
+  let defaultTenantId: string | null = null
+  try {
+    defaultTenantId = (await tenantService.getDefaultTenant())?.id ?? null
+  } catch (error) {
+    if (!(error instanceof NotFoundException)) {
+      throw error
+    }
+  }
+  setDefaultTenantId(defaultTenantId)
   /**
    * Dependency injection with class-validator
    */


### PR DESCRIPTION
## Summary

- restore the empty-database fallback after bootstrap moved out of `packages/analytics`
- allow API startup to continue when the default tenant does not exist yet
- preserve failures for database connectivity and all other unexpected errors

## Root cause

PR #823 added the correct fallback in `packages/analytics/src/bootstrap/index.ts`. Commit `933f360de` later moved bootstrap into `apps/api/src/bootstrap/index.ts` while removing analytics, but copied the previous direct `getDefaultTenant()` call and lost the `NotFoundException` guard. Fresh installations therefore fail before `app.listen()` and cannot reach tenant onboarding.

## Impact

Fresh databases can start the API and reach `/api/tenant/onboard`. Existing installations with a default tenant keep the current behavior.

## Validation

- compared the patch with the original PR #823 implementation
- `nx build api --configuration=production` passed
- repository pre-commit checks passed
- Prettier and `git diff --check` passed

Browser and deployed-image validation were not run.