### PR TITLE
fix: restore referral field on registration

### DIFF
--- a/apps/cloud/src/app/@core/state/referral.service.ts
+++ b/apps/cloud/src/app/@core/state/referral.service.ts
@@ -30,6 +30,10 @@ export class ReferralService {
     return firstValueFrom(this.http.get<IReferralCodeView>(`${this.apiUrl}/me`))
   }
 
+  regenerateMyCode() {
+    return firstValueFrom(this.http.post<IReferralCodeView>(`${this.apiUrl}/me/regenerate`, {}))
+  }
+
   getRelations(query: IReferralRelationQuery) {
     let params = new HttpParams()
     for (const [key, value] of Object.entries(query)) {

--- a/apps/cloud/src/app/auth/accept-invite/accept-invite-form/accept-invite-form.component.html
+++ b/apps/cloud/src/app/auth/accept-invite/accept-invite-form/accept-invite-form.component.html
@@ -25,7 +25,7 @@
 
   @if (referralEnabled) {
     <div>
-      <label>{{ 'PAC.Referral.ReferralCode' | translate: { Default: 'Invitation code (optional)' } }}</label>
+      <label>{{ 'XP.Referral.ReferralCode' | translate: { Default: 'Invitation code (optional)' } }}</label>
       <input
         z-input
         formControlName="referralCode"
@@ -33,20 +33,20 @@
         type="text"
         maxlength="10"
         autocomplete="off"
-        [placeholder]="'PAC.Referral.ReferralCodePlaceholder' | translate: { Default: 'Enter invitation code' }"
+        [placeholder]="'XP.Referral.ReferralCodePlaceholder' | translate: { Default: 'Enter invitation code' }"
         (blur)="validateReferralCode()"
       />
       @if (referralValidationLoading) {
         <span class="mt-1 block text-sm text-text-secondary">
-          {{ 'PAC.Referral.ValidatingReferralCode' | translate: { Default: 'Validating...' } }}
+          {{ 'XP.Referral.ValidatingReferralCode' | translate: { Default: 'Validating...' } }}
         </span>
       } @else if (form.controls.referralCode.hasError('invalidReferralCode')) {
         <span class="mt-1 block text-sm text-text-destructive">
-          {{ 'PAC.Referral.InvalidReferralCode' | translate: { Default: 'The invitation code is invalid.' } }}
+          {{ 'XP.Referral.InvalidReferralCode' | translate: { Default: 'The invitation code is invalid.' } }}
         </span>
       } @else if (referralValid) {
         <span class="mt-1 block text-sm text-text-success">
-          {{ 'PAC.Referral.ValidReferralCode' | translate: { Default: 'Invitation code is valid.' } }}
+          {{ 'XP.Referral.ValidReferralCode' | translate: { Default: 'Invitation code is valid.' } }}
         </span>
       }
     </div>

--- a/apps/cloud/src/app/auth/register/register.component.html
+++ b/apps/cloud/src/app/auth/register/register.component.html
@@ -93,11 +93,43 @@
       }
     </div>
 
+    @if (referralEnabled) {
+      <div>
+        <label for="referral_code" class="block mb-2 text-base font-medium text-text-primary">
+          {{ 'PAC.Referral.ReferralCode' | translate: { Default: 'Invitation code (optional)' } }}
+        </label>
+        <input
+          z-input
+          type="text"
+          name="referral_code"
+          id="referral_code"
+          formControlName="referralCode"
+          class="w-full uppercase"
+          maxlength="10"
+          autocomplete="off"
+          [placeholder]="'PAC.Referral.ReferralCodePlaceholder' | translate: { Default: 'Enter invitation code' }"
+        />
+        @if (referralValidationLoading) {
+          <span class="text-text-secondary text-sm mt-1 block">
+            {{ 'PAC.Referral.ValidatingReferralCode' | translate: { Default: 'Validating...' } }}
+          </span>
+        } @else if (referralCode.hasError('invalidReferralCode')) {
+          <span class="text-text-destructive text-sm mt-1 block">
+            {{ 'PAC.Referral.InvalidReferralCode' | translate: { Default: 'The invitation code is invalid.' } }}
+          </span>
+        } @else if (referralValid) {
+          <span class="text-text-success text-sm mt-1 block">
+            {{ 'PAC.Referral.ValidReferralCode' | translate: { Default: 'Invitation code is valid.' } }}
+          </span>
+        }
+      </div>
+    }
+
     <div class="flex justify-between items-center p-1">
       <button
         type="submit"
         class="btn disabled:btn-disabled btn-primary btn-medium mb-2"
-        [disabled]="form.invalid || loading || submitted"
+        [disabled]="form.invalid || loading || submitted || referralAvailabilityLoading || referralValidationLoading"
       >
         {{ 'AUTH.REGISTER.SUBMIT' | translate: { Default: 'Submit' } }}
       </button>

--- a/apps/cloud/src/app/auth/register/register.component.html
+++ b/apps/cloud/src/app/auth/register/register.component.html
@@ -96,7 +96,7 @@
     @if (referralEnabled) {
       <div>
         <label for="referral_code" class="block mb-2 text-base font-medium text-text-primary">
-          {{ 'PAC.Referral.ReferralCode' | translate: { Default: 'Invitation code (optional)' } }}
+          {{ 'XP.Referral.ReferralCode' | translate: { Default: 'Invitation code (optional)' } }}
         </label>
         <input
           z-input
@@ -107,19 +107,19 @@
           class="w-full uppercase"
           maxlength="10"
           autocomplete="off"
-          [placeholder]="'PAC.Referral.ReferralCodePlaceholder' | translate: { Default: 'Enter invitation code' }"
+          [placeholder]="'XP.Referral.ReferralCodePlaceholder' | translate: { Default: 'Enter invitation code' }"
         />
         @if (referralValidationLoading) {
           <span class="text-text-secondary text-sm mt-1 block">
-            {{ 'PAC.Referral.ValidatingReferralCode' | translate: { Default: 'Validating...' } }}
+            {{ 'XP.Referral.ValidatingReferralCode' | translate: { Default: 'Validating...' } }}
           </span>
         } @else if (referralCode.hasError('invalidReferralCode')) {
           <span class="text-text-destructive text-sm mt-1 block">
-            {{ 'PAC.Referral.InvalidReferralCode' | translate: { Default: 'The invitation code is invalid.' } }}
+            {{ 'XP.Referral.InvalidReferralCode' | translate: { Default: 'The invitation code is invalid.' } }}
           </span>
         } @else if (referralValid) {
           <span class="text-text-success text-sm mt-1 block">
-            {{ 'PAC.Referral.ValidReferralCode' | translate: { Default: 'Invitation code is valid.' } }}
+            {{ 'XP.Referral.ValidReferralCode' | translate: { Default: 'Invitation code is valid.' } }}
           </span>
         }
       </div>

--- a/apps/cloud/src/app/features/setting/account/account.component.html
+++ b/apps/cloud/src/app/features/setting/account/account.component.html
@@ -15,9 +15,9 @@
         (click)="copyReferralCode()"
       >
         @if (referralCodeCopied()) {
-          {{ 'PAC.Referral.Copied' | translate: { Default: 'Copied' } }}
+          {{ 'XP.Referral.Copied' | translate: { Default: 'Copied' } }}
         } @else {
-          {{ 'PAC.Referral.CopyCode' | translate: { Default: 'Copy invitation code' } }}
+          {{ 'XP.Referral.CopyCode' | translate: { Default: 'Copy invitation code' } }}
         }
       </button>
     }

--- a/apps/cloud/src/app/features/setting/account/account.component.html
+++ b/apps/cloud/src/app/features/setting/account/account.component.html
@@ -5,21 +5,40 @@
       [src]="user?.imageUrl || '/assets/images/avatar-default.svg'" alt="{{user | user}}" /> -->
     <div class="text-sm font-medium text-text-primary">{{ user()?.email }}</div>
     @if (canUseReferral() && referralCode()) {
-      <button
-        data-referral-copy
-        z-button
-        zType="link"
-        zSize="sm"
-        type="button"
-        class="h-auto px-0 py-0 text-xs"
-        (click)="copyReferralCode()"
-      >
-        @if (referralCodeCopied()) {
-          {{ 'XP.Referral.Copied' | translate: { Default: 'Copied' } }}
-        } @else {
-          {{ 'XP.Referral.CopyCode' | translate: { Default: 'Copy invitation code' } }}
-        }
-      </button>
+      <div class="flex items-center gap-2">
+        <button
+          data-referral-copy
+          z-button
+          zType="link"
+          zSize="sm"
+          type="button"
+          class="h-auto px-0 py-0 text-xs"
+          [zDisabled]="referralCodeRegenerating()"
+          (click)="copyReferralCode()"
+        >
+          @if (referralCodeCopied()) {
+            {{ 'XP.Referral.Copied' | translate: { Default: 'Copied' } }}
+          } @else {
+            {{ 'XP.Referral.CopyCode' | translate: { Default: 'Copy invitation code' } }}
+          }
+        </button>
+        <button
+          data-referral-regenerate
+          z-button
+          zType="link"
+          zSize="sm"
+          type="button"
+          class="h-auto px-0 py-0 text-xs"
+          [zDisabled]="referralCodeRegenerating()"
+          (click)="regenerateReferralCode()"
+        >
+          @if (referralCodeRegenerating()) {
+            {{ 'XP.Referral.RegeneratingCode' | translate: { Default: 'Regenerating...' } }}
+          } @else {
+            {{ 'XP.Referral.RegenerateCode' | translate: { Default: 'Regenerate invitation code' } }}
+          }
+        </button>
+      </div>
     }
   </div>
 

--- a/apps/cloud/src/app/features/setting/account/account.component.html
+++ b/apps/cloud/src/app/features/setting/account/account.component.html
@@ -4,42 +4,6 @@
     <!-- <img class="avatar w-16 h-16 rounded-full flex"
       [src]="user?.imageUrl || '/assets/images/avatar-default.svg'" alt="{{user | user}}" /> -->
     <div class="text-sm font-medium text-text-primary">{{ user()?.email }}</div>
-    @if (canUseReferral() && referralCode()) {
-      <div class="flex items-center gap-2">
-        <button
-          data-referral-copy
-          z-button
-          zType="link"
-          zSize="sm"
-          type="button"
-          class="h-auto px-0 py-0 text-xs"
-          [zDisabled]="referralCodeRegenerating()"
-          (click)="copyReferralCode()"
-        >
-          @if (referralCodeCopied()) {
-            {{ 'XP.Referral.Copied' | translate: { Default: 'Copied' } }}
-          } @else {
-            {{ 'XP.Referral.CopyCode' | translate: { Default: 'Copy invitation code' } }}
-          }
-        </button>
-        <button
-          data-referral-regenerate
-          z-button
-          zType="link"
-          zSize="sm"
-          type="button"
-          class="h-auto px-0 py-0 text-xs"
-          [zDisabled]="referralCodeRegenerating()"
-          (click)="regenerateReferralCode()"
-        >
-          @if (referralCodeRegenerating()) {
-            {{ 'XP.Referral.RegeneratingCode' | translate: { Default: 'Regenerating...' } }}
-          } @else {
-            {{ 'XP.Referral.RegenerateCode' | translate: { Default: 'Regenerate invitation code' } }}
-          }
-        </button>
-      </div>
-    }
   </div>
 
   <nav
@@ -125,5 +89,41 @@
   class="xp-page-body flex w-full flex-col items-center"
   [@routeAnimations]="o.isActivated && o.activatedRoute.routeConfig.path"
 >
+  @if (rla4.isActive && canUseReferral() && referralCode()) {
+    <div class="flex items-center gap-2">
+      <button
+        data-referral-copy
+        z-button
+        zType="link"
+        zSize="sm"
+        type="button"
+        class="h-auto px-0 py-0 text-base"
+        [zDisabled]="referralCodeRegenerating()"
+        (click)="copyReferralCode()"
+      >
+        @if (referralCodeCopied()) {
+          {{ 'XP.Referral.Copied' | translate: { Default: 'Copied' } }}
+        } @else {
+          {{ 'XP.Referral.CopyCode' | translate: { Default: 'Copy invitation code' } }}
+        }
+      </button>
+      <button
+        data-referral-regenerate
+        z-button
+        zType="link"
+        zSize="sm"
+        type="button"
+        class="h-auto px-0 py-0 text-base"
+        [zDisabled]="referralCodeRegenerating()"
+        (click)="regenerateReferralCode()"
+      >
+        @if (referralCodeRegenerating()) {
+          {{ 'XP.Referral.RegeneratingCode' | translate: { Default: 'Regenerating...' } }}
+        } @else {
+          {{ 'XP.Referral.RegenerateCode' | translate: { Default: 'Regenerate invitation code' } }}
+        }
+      </button>
+    </div>
+  }
   <router-outlet #o="outlet"></router-outlet>
 </z-tab-nav-panel>

--- a/apps/cloud/src/app/features/setting/account/account.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/account/account.component.spec.ts
@@ -1,10 +1,12 @@
 import { DOCUMENT } from '@angular/common'
 import { TestBed } from '@angular/core/testing'
 import { ReferralService } from '@cloud/app/@core/state'
+import { TranslateService } from '@ngx-translate/core'
+import { ZardAlertDialogService } from '@xpert-ai/headless-ui'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { of } from 'rxjs'
-import { MembershipService, Store } from '../../../@core'
+import { MembershipService, Store, ToastrService } from '../../../@core'
 import { XpAccountComponent } from './account.component'
 
 jest.mock('@cloud/app/@core/state', () => ({
@@ -14,6 +16,7 @@ jest.mock('@cloud/app/@core/state', () => ({
 jest.mock('../../../@core', () => ({
   MembershipService: class MembershipService {},
   Store: class Store {},
+  ToastrService: class ToastrService {},
   routeAnimations: []
 }))
 
@@ -30,11 +33,14 @@ describe('XpAccountComponent template', () => {
     const template = readFileSync(join(__dirname, 'account.component.html'), 'utf8')
     const emailIndex = template.indexOf('{{ user()?.email }}')
     const copyActionIndex = template.indexOf('data-referral-copy')
+    const regenerateActionIndex = template.indexOf('data-referral-regenerate')
     const tabNavigationIndex = template.indexOf('<nav')
 
     expect(emailIndex).toBeGreaterThan(-1)
     expect(copyActionIndex).toBeGreaterThan(emailIndex)
     expect(copyActionIndex).toBeLessThan(tabNavigationIndex)
+    expect(regenerateActionIndex).toBeGreaterThan(copyActionIndex)
+    expect(regenerateActionIndex).toBeLessThan(tabNavigationIndex)
     expect(template).not.toContain("['configuration']")
   })
 
@@ -66,6 +72,25 @@ describe('XpAccountComponent template', () => {
           }
         },
         {
+          provide: ZardAlertDialogService,
+          useValue: {
+            confirm: jest.fn(() => of(false))
+          }
+        },
+        {
+          provide: TranslateService,
+          useValue: {
+            instant: jest.fn((key: string) => key)
+          }
+        },
+        {
+          provide: ToastrService,
+          useValue: {
+            success: jest.fn(),
+            error: jest.fn()
+          }
+        },
+        {
           provide: DOCUMENT,
           useValue: {
             defaultView: {
@@ -88,5 +113,138 @@ describe('XpAccountComponent template', () => {
     expect(writeText).toHaveBeenCalledWith('ABC234DEFG')
     expect(component.referralCodeCopied()).toBe(true)
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1500)
+  })
+
+  it('replaces the invitation code only after destructive confirmation', async () => {
+    const regenerateMyCode = jest.fn().mockResolvedValue({ code: 'XYZ234DEFG' })
+    const confirm = jest.fn(() => of(true))
+    const toastr = {
+      success: jest.fn(),
+      error: jest.fn()
+    }
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Store,
+          useValue: {
+            user$: of(null),
+            featureContextHydrated$: of(true),
+            featureContextHydrated: true,
+            hasFeatureEnabled: jest.fn(() => false),
+            hasPermission: jest.fn(() => false)
+          }
+        },
+        {
+          provide: MembershipService,
+          useValue: {
+            hasActiveMembershipInScope: jest.fn(() => of(false))
+          }
+        },
+        {
+          provide: ReferralService,
+          useValue: {
+            getMyCode: jest.fn(),
+            regenerateMyCode
+          }
+        },
+        {
+          provide: ZardAlertDialogService,
+          useValue: {
+            confirm
+          }
+        },
+        {
+          provide: TranslateService,
+          useValue: {
+            instant: jest.fn((key: string) => key)
+          }
+        },
+        {
+          provide: ToastrService,
+          useValue: toastr
+        },
+        {
+          provide: DOCUMENT,
+          useValue: {
+            defaultView: null
+          }
+        }
+      ]
+    })
+    const component = TestBed.runInInjectionContext(() => new XpAccountComponent())
+    component.referralCode.set('ABC234DEFG')
+
+    await component.regenerateReferralCode()
+
+    expect(confirm).toHaveBeenCalledWith(expect.objectContaining({ destructive: true }))
+    expect(regenerateMyCode).toHaveBeenCalledTimes(1)
+    expect(component.referralCode()).toBe('XYZ234DEFG')
+    expect(toastr.success).toHaveBeenCalledWith(
+      'XP.Referral.RegenerateSuccess',
+      expect.objectContaining({ Default: 'Invitation code regenerated.' })
+    )
+  })
+
+  it('keeps the current code when regeneration confirmation is cancelled', async () => {
+    const regenerateMyCode = jest.fn()
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Store,
+          useValue: {
+            user$: of(null),
+            featureContextHydrated$: of(true),
+            featureContextHydrated: true,
+            hasFeatureEnabled: jest.fn(() => false),
+            hasPermission: jest.fn(() => false)
+          }
+        },
+        {
+          provide: MembershipService,
+          useValue: {
+            hasActiveMembershipInScope: jest.fn(() => of(false))
+          }
+        },
+        {
+          provide: ReferralService,
+          useValue: {
+            getMyCode: jest.fn(),
+            regenerateMyCode
+          }
+        },
+        {
+          provide: ZardAlertDialogService,
+          useValue: {
+            confirm: jest.fn(() => of(false))
+          }
+        },
+        {
+          provide: TranslateService,
+          useValue: {
+            instant: jest.fn((key: string) => key)
+          }
+        },
+        {
+          provide: ToastrService,
+          useValue: {
+            success: jest.fn(),
+            error: jest.fn()
+          }
+        },
+        {
+          provide: DOCUMENT,
+          useValue: {
+            defaultView: null
+          }
+        }
+      ]
+    })
+    const component = TestBed.runInInjectionContext(() => new XpAccountComponent())
+    component.referralCode.set('ABC234DEFG')
+
+    await component.regenerateReferralCode()
+
+    expect(regenerateMyCode).not.toHaveBeenCalled()
+    expect(component.referralCode()).toBe('ABC234DEFG')
   })
 })

--- a/apps/cloud/src/app/features/setting/account/account.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/account/account.component.spec.ts
@@ -29,18 +29,20 @@ jest.mock('../../../@shared/user', () => ({
 }))
 
 describe('XpAccountComponent template', () => {
-  it('places the invitation code copy action below the email without a configuration tab', () => {
+  it('places larger invitation code actions above the personal information form', () => {
     const template = readFileSync(join(__dirname, 'account.component.html'), 'utf8')
-    const emailIndex = template.indexOf('{{ user()?.email }}')
     const copyActionIndex = template.indexOf('data-referral-copy')
     const regenerateActionIndex = template.indexOf('data-referral-regenerate')
-    const tabNavigationIndex = template.indexOf('<nav')
+    const tabPanelIndex = template.indexOf('<z-tab-nav-panel')
+    const routerOutletIndex = template.indexOf('<router-outlet')
 
-    expect(emailIndex).toBeGreaterThan(-1)
-    expect(copyActionIndex).toBeGreaterThan(emailIndex)
-    expect(copyActionIndex).toBeLessThan(tabNavigationIndex)
+    expect(copyActionIndex).toBeGreaterThan(tabPanelIndex)
+    expect(routerOutletIndex).toBeGreaterThan(-1)
+    expect(copyActionIndex).toBeLessThan(routerOutletIndex)
     expect(regenerateActionIndex).toBeGreaterThan(copyActionIndex)
-    expect(regenerateActionIndex).toBeLessThan(tabNavigationIndex)
+    expect(template).toContain('rla4.isActive && canUseReferral() && referralCode()')
+    expect(template).toMatch(/data-referral-copy[\s\S]*?class="h-auto px-0 py-0 text-base"/)
+    expect(template).toMatch(/data-referral-regenerate[\s\S]*?class="h-auto px-0 py-0 text-base"/)
     expect(template).not.toContain("['configuration']")
   })
 

--- a/apps/cloud/src/app/features/setting/account/account.component.ts
+++ b/apps/cloud/src/app/features/setting/account/account.component.ts
@@ -3,10 +3,16 @@ import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } 
 import { toSignal } from '@angular/core/rxjs-interop'
 import { ReferralService } from '@cloud/app/@core/state'
 import { AiFeatureEnum, AIPermissionsEnum, FeatureEnum, UserType } from '@xpert-ai/contracts'
-import { ZardButtonComponent, ZardDividerComponent, ZardTabsImports } from '@xpert-ai/headless-ui'
+import {
+  ZardAlertDialogService,
+  ZardButtonComponent,
+  ZardDividerComponent,
+  ZardTabsImports
+} from '@xpert-ai/headless-ui'
 import { RouterModule } from '@angular/router'
-import { TranslateModule } from '@ngx-translate/core'
-import { MembershipService, Store, routeAnimations } from '../../../@core'
+import { TranslateModule, TranslateService } from '@ngx-translate/core'
+import { firstValueFrom } from 'rxjs'
+import { MembershipService, Store, ToastrService, routeAnimations } from '../../../@core'
 import { UserPipe } from '../../../@shared/pipes'
 import { UserAvatarEditorComponent } from '../../../@shared/user'
 
@@ -32,6 +38,9 @@ export class XpAccountComponent {
   private readonly membership = inject(MembershipService)
   private readonly referralService = inject(ReferralService)
   private readonly document = inject(DOCUMENT)
+  private readonly alertDialog = inject(ZardAlertDialogService)
+  private readonly translate = inject(TranslateService)
+  private readonly toastr = inject(ToastrService)
   private referralCodeRequested = false
 
   public readonly user = toSignal(this.store.user$)
@@ -56,6 +65,7 @@ export class XpAccountComponent {
   })
   public readonly referralCode = signal('')
   public readonly referralCodeCopied = signal(false)
+  public readonly referralCodeRegenerating = signal(false)
 
   constructor() {
     effect(() => {
@@ -79,6 +89,48 @@ export class XpAccountComponent {
       this.document.defaultView?.setTimeout(() => this.referralCodeCopied.set(false), 1500)
     } catch {
       this.referralCodeCopied.set(false)
+    }
+  }
+
+  async regenerateReferralCode() {
+    if (!this.referralCode() || this.referralCodeRegenerating()) {
+      return
+    }
+
+    const confirmed = await firstValueFrom(
+      this.alertDialog.confirm({
+        title: this.translate.instant('XP.Referral.RegenerateConfirmTitle', {
+          Default: 'Regenerate invitation code?'
+        }),
+        description: this.translate.instant('XP.Referral.RegenerateConfirmDescription', {
+          Default:
+            'The current invitation code will stop working immediately. Existing invitation relationships will not be changed.'
+        }),
+        actionText: this.translate.instant('XP.Referral.RegenerateCode', {
+          Default: 'Regenerate invitation code'
+        }),
+        cancelText: this.translate.instant('XP.ACTIONS.Cancel', { Default: 'Cancel' }),
+        destructive: true
+      })
+    )
+    if (!confirmed) {
+      return
+    }
+
+    this.referralCodeRegenerating.set(true)
+    try {
+      const result = await this.referralService.regenerateMyCode()
+      this.referralCode.set(result.code)
+      this.referralCodeCopied.set(false)
+      this.toastr.success('XP.Referral.RegenerateSuccess', {
+        Default: 'Invitation code regenerated.'
+      })
+    } catch {
+      this.toastr.error('XP.Referral.RegenerateFailed', 'XP.TOASTR.TITLE.ERROR', {
+        Default: 'Invitation code could not be regenerated.'
+      })
+    } finally {
+      this.referralCodeRegenerating.set(false)
     }
   }
 

--- a/apps/cloud/src/app/features/setting/referrals/referral-http.service.spec.ts
+++ b/apps/cloud/src/app/features/setting/referrals/referral-http.service.spec.ts
@@ -38,4 +38,13 @@ describe('ReferralService invitation tenant context', () => {
     request.flush(true)
     await expect(result).resolves.toBe(true)
   })
+
+  it('regenerates the current account invitation code', async () => {
+    const result = service.regenerateMyCode()
+    const request = httpMock.expectOne('/api/referral/me/regenerate')
+
+    expect(request.request.method).toBe('POST')
+    request.flush({ code: 'XYZ234DEFG' })
+    await expect(result).resolves.toEqual({ code: 'XYZ234DEFG' })
+  })
 })

--- a/apps/cloud/src/app/features/setting/referrals/referral-i18n.spec.ts
+++ b/apps/cloud/src/app/features/setting/referrals/referral-i18n.spec.ts
@@ -4,6 +4,12 @@ import { join } from 'node:path'
 const referralTranslationKeys = [
   'CopyCode',
   'Copied',
+  'RegenerateCode',
+  'RegeneratingCode',
+  'RegenerateConfirmTitle',
+  'RegenerateConfirmDescription',
+  'RegenerateSuccess',
+  'RegenerateFailed',
   'ReferralCode',
   'ReferralCodePlaceholder',
   'ValidatingReferralCode',

--- a/apps/cloud/src/app/features/setting/referrals/referral-i18n.spec.ts
+++ b/apps/cloud/src/app/features/setting/referrals/referral-i18n.spec.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const referralTranslationKeys = [
+  'CopyCode',
+  'Copied',
+  'ReferralCode',
+  'ReferralCodePlaceholder',
+  'ValidatingReferralCode',
+  'InvalidReferralCode',
+  'ValidReferralCode',
+  'Relationships',
+  'RelationshipsDescription',
+  'SearchPlaceholder',
+  'Referrer',
+  'Referred',
+  'UsedCode',
+  'BoundAt',
+  'DeletedAccount',
+  'Empty',
+  'LoadError',
+  'Previous',
+  'Next',
+  'PageSummary'
+]
+
+describe('referral translations', () => {
+  it.each(['en', 'en-US', 'zh-CN', 'zh-Hans', 'zh-Hant'])(
+    'provides every referral message in the XP namespace for %s',
+    (locale) => {
+      const messages = JSON.parse(readFileSync(join(__dirname, '../../../../assets/i18n', `${locale}.json`), 'utf8'))
+
+      referralTranslationKeys.forEach((key) => {
+        expect(messages.XP?.Referral?.[key]).toEqual(expect.any(String))
+      })
+    }
+  )
+
+  it('uses the Chinese copy action instead of the English fallback', () => {
+    const messages = JSON.parse(readFileSync(join(__dirname, '../../../../assets/i18n', 'zh-Hans.json'), 'utf8'))
+
+    expect(messages.XP.Referral.CopyCode).toBe('复制邀请码')
+  })
+})

--- a/apps/cloud/src/app/features/setting/referrals/referrals.component.html
+++ b/apps/cloud/src/app/features/setting/referrals/referrals.component.html
@@ -2,11 +2,11 @@
   <div class="flex flex-wrap items-end justify-between gap-4">
     <div>
       <h1 class="text-2xl font-semibold text-text-primary">
-        {{ 'PAC.Referral.Relationships' | translate: { Default: 'Invitation relationships' } }}
+        {{ 'XP.Referral.Relationships' | translate: { Default: 'Invitation relationships' } }}
       </h1>
       <p class="mt-1 text-sm text-text-secondary">
         {{
-          'PAC.Referral.RelationshipsDescription'
+          'XP.Referral.RelationshipsDescription'
             | translate: { Default: 'Read-only direct account invitation relationships in this tenant.' }
         }}
       </p>
@@ -17,10 +17,10 @@
         z-input
         formControlName="search"
         class="w-72"
-        [placeholder]="'PAC.Referral.SearchPlaceholder' | translate: { Default: 'Search user or code' }"
+        [placeholder]="'XP.Referral.SearchPlaceholder' | translate: { Default: 'Search user or code' }"
       />
       <button z-button zType="secondary" type="submit">
-        {{ 'PAC.ACTIONS.Search' | translate: { Default: 'Search' } }}
+        {{ 'XP.ACTIONS.Search' | translate: { Default: 'Search' } }}
       </button>
     </form>
   </div>
@@ -29,10 +29,10 @@
     <table z-table zSize="compact" class="min-w-[52rem]">
       <thead z-table-header>
         <tr z-table-row>
-          <th z-table-head>{{ 'PAC.Referral.Referrer' | translate: { Default: 'Inviter' } }}</th>
-          <th z-table-head>{{ 'PAC.Referral.Referred' | translate: { Default: 'Invitee' } }}</th>
-          <th z-table-head>{{ 'PAC.Referral.UsedCode' | translate: { Default: 'Used code' } }}</th>
-          <th z-table-head>{{ 'PAC.Referral.BoundAt' | translate: { Default: 'Bound at' } }}</th>
+          <th z-table-head>{{ 'XP.Referral.Referrer' | translate: { Default: 'Inviter' } }}</th>
+          <th z-table-head>{{ 'XP.Referral.Referred' | translate: { Default: 'Invitee' } }}</th>
+          <th z-table-head>{{ 'XP.Referral.UsedCode' | translate: { Default: 'Used code' } }}</th>
+          <th z-table-head>{{ 'XP.Referral.BoundAt' | translate: { Default: 'Bound at' } }}</th>
         </tr>
       </thead>
       <tbody z-table-body>
@@ -59,11 +59,11 @@
           <tr z-table-row>
             <td z-table-cell colspan="4" class="py-10 text-center text-text-secondary">
               @if (loading()) {
-                {{ 'PAC.KEY_WORDS.Loading' | translate: { Default: 'Loading...' } }}
+                {{ 'XP.KEY_WORDS.Loading' | translate: { Default: 'Loading...' } }}
               } @else if (loadFailed()) {
-                {{ 'PAC.Referral.LoadError' | translate: { Default: 'Invitation relationships could not be loaded.' } }}
+                {{ 'XP.Referral.LoadError' | translate: { Default: 'Invitation relationships could not be loaded.' } }}
               } @else {
-                {{ 'PAC.Referral.Empty' | translate: { Default: 'No invitation relationships found.' } }}
+                {{ 'XP.Referral.Empty' | translate: { Default: 'No invitation relationships found.' } }}
               }
             </td>
           </tr>
@@ -75,7 +75,7 @@
   <div class="mt-4 flex items-center justify-end gap-3 text-sm text-text-secondary">
     <span>
       {{
-        'PAC.Referral.PageSummary'
+        'XP.Referral.PageSummary'
           | translate
             : {
                 page: pageIndex() + 1,
@@ -92,7 +92,7 @@
       [zDisabled]="loading() || pageIndex() === 0"
       (click)="previousPage()"
     >
-      {{ 'PAC.Referral.Previous' | translate: { Default: 'Previous' } }}
+      {{ 'XP.Referral.Previous' | translate: { Default: 'Previous' } }}
     </button>
     <button
       z-button
@@ -101,7 +101,7 @@
       [zDisabled]="loading() || pageIndex() + 1 >= pageCount()"
       (click)="nextPage()"
     >
-      {{ 'PAC.Referral.Next' | translate: { Default: 'Next' } }}
+      {{ 'XP.Referral.Next' | translate: { Default: 'Next' } }}
     </button>
   </div>
 </div>

--- a/apps/cloud/src/app/features/setting/referrals/referrals.component.ts
+++ b/apps/cloud/src/app/features/setting/referrals/referrals.component.ts
@@ -85,7 +85,7 @@ export class ReferralRelationsComponent implements OnInit {
 
   accountLabel(account: IReferralRelationView['referrer']) {
     return account.deleted
-      ? this.translateService.instant('PAC.Referral.DeletedAccount', { Default: 'Deleted account' })
+      ? this.translateService.instant('XP.Referral.DeletedAccount', { Default: 'Deleted account' })
       : account.name || account.email || '-'
   }
 }

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -26,6 +26,12 @@
     "Referral": {
       "CopyCode": "Copy invitation code",
       "Copied": "Copied",
+      "RegenerateCode": "Regenerate invitation code",
+      "RegeneratingCode": "Regenerating...",
+      "RegenerateConfirmTitle": "Regenerate invitation code?",
+      "RegenerateConfirmDescription": "The current invitation code will stop working immediately. Existing invitation relationships will not be changed.",
+      "RegenerateSuccess": "Invitation code regenerated.",
+      "RegenerateFailed": "Invitation code could not be regenerated.",
       "ReferralCode": "Invitation code (optional)",
       "ReferralCodePlaceholder": "Enter invitation code",
       "ValidatingReferralCode": "Validating...",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -26,6 +26,12 @@
     "Referral": {
       "CopyCode": "Copy invitation code",
       "Copied": "Copied",
+      "RegenerateCode": "Regenerate invitation code",
+      "RegeneratingCode": "Regenerating...",
+      "RegenerateConfirmTitle": "Regenerate invitation code?",
+      "RegenerateConfirmDescription": "The current invitation code will stop working immediately. Existing invitation relationships will not be changed.",
+      "RegenerateSuccess": "Invitation code regenerated.",
+      "RegenerateFailed": "Invitation code could not be regenerated.",
       "ReferralCode": "Invitation code (optional)",
       "ReferralCodePlaceholder": "Enter invitation code",
       "ValidatingReferralCode": "Validating...",

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -20,6 +20,12 @@
     "Referral": {
       "CopyCode": "复制邀请码",
       "Copied": "已复制",
+      "RegenerateCode": "重新生成邀请码",
+      "RegeneratingCode": "正在重新生成...",
+      "RegenerateConfirmTitle": "重新生成邀请码？",
+      "RegenerateConfirmDescription": "当前邀请码将立即失效，已建立的邀请关系不会受到影响。",
+      "RegenerateSuccess": "邀请码已重新生成。",
+      "RegenerateFailed": "邀请码重新生成失败。",
       "ReferralCode": "邀请码（选填）",
       "ReferralCodePlaceholder": "请输入邀请码",
       "ValidatingReferralCode": "正在验证...",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -231,6 +231,12 @@
     "Referral": {
       "CopyCode": "复制邀请码",
       "Copied": "已复制",
+      "RegenerateCode": "重新生成邀请码",
+      "RegeneratingCode": "正在重新生成...",
+      "RegenerateConfirmTitle": "重新生成邀请码？",
+      "RegenerateConfirmDescription": "当前邀请码将立即失效，已建立的邀请关系不会受到影响。",
+      "RegenerateSuccess": "邀请码已重新生成。",
+      "RegenerateFailed": "邀请码重新生成失败。",
       "ReferralCode": "邀请码（选填）",
       "ReferralCodePlaceholder": "请输入邀请码",
       "ValidatingReferralCode": "正在验证...",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -25,6 +25,12 @@
     "Referral": {
       "CopyCode": "複製邀請碼",
       "Copied": "已複製",
+      "RegenerateCode": "重新產生邀請碼",
+      "RegeneratingCode": "正在重新產生...",
+      "RegenerateConfirmTitle": "重新產生邀請碼？",
+      "RegenerateConfirmDescription": "目前邀請碼將立即失效，已建立的邀請關係不會受到影響。",
+      "RegenerateSuccess": "邀請碼已重新產生。",
+      "RegenerateFailed": "邀請碼重新產生失敗。",
       "ReferralCode": "邀請碼（選填）",
       "ReferralCodePlaceholder": "請輸入邀請碼",
       "ValidatingReferralCode": "正在驗證...",

--- a/packages/server/src/referral/referral-code.subscriber.spec.ts
+++ b/packages/server/src/referral/referral-code.subscriber.spec.ts
@@ -21,7 +21,8 @@ describe('ReferralCodeSubscriber', () => {
 	beforeEach(() => {
 		jest.clearAllMocks()
 		queryBuilder.execute.mockResolvedValue({})
-		repository.findOne.mockResolvedValue({
+		repository.findOne.mockReset()
+		repository.findOne.mockResolvedValueOnce(null).mockResolvedValue({
 			id: 'referral-code-1'
 		})
 	})
@@ -58,7 +59,7 @@ describe('ReferralCodeSubscriber', () => {
 	})
 
 	it('retries when a generated code collides', async () => {
-		repository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({
+		repository.findOne.mockReset().mockResolvedValueOnce(null).mockResolvedValueOnce(null).mockResolvedValueOnce({
 			id: 'referral-code-1'
 		})
 

--- a/packages/server/src/referral/referral-code.subscriber.ts
+++ b/packages/server/src/referral/referral-code.subscriber.ts
@@ -1,18 +1,8 @@
 import { UserType } from '@xpert-ai/contracts'
-import { randomBytes } from 'crypto'
-import { t } from 'i18next'
 import { EntitySubscriberInterface, EventSubscriber, InsertEvent } from 'typeorm'
 import { User } from '../user/user.entity'
+import { ensureReferralCode } from './referral-code'
 import { ReferralCode } from './referral-code.entity'
-
-const REFERRAL_ALPHABET = '23456789ABCDEFGHJKLMNPQRSTUVWXYZ'
-const REFERRAL_CODE_LENGTH = 10
-const MAX_GENERATION_ATTEMPTS = 10
-
-export function generateReferralCode() {
-	const bytes = randomBytes(REFERRAL_CODE_LENGTH)
-	return Array.from(bytes, (byte) => REFERRAL_ALPHABET[byte % REFERRAL_ALPHABET.length]).join('')
-}
 
 @EventSubscriber()
 export class ReferralCodeSubscriber implements EntitySubscriberInterface<User> {
@@ -27,35 +17,6 @@ export class ReferralCodeSubscriber implements EntitySubscriberInterface<User> {
 			return
 		}
 
-		const repository = event.manager.getRepository(ReferralCode)
-		for (let attempt = 0; attempt < MAX_GENERATION_ATTEMPTS; attempt += 1) {
-			await repository
-				.createQueryBuilder()
-				.insert()
-				.into(ReferralCode)
-				.values({
-					tenantId,
-					userId: user.id,
-					code: generateReferralCode()
-				})
-				.orIgnore()
-				.execute()
-
-			const referralCode = await repository.findOne({
-				where: {
-					tenantId,
-					userId: user.id
-				}
-			})
-			if (referralCode) {
-				return
-			}
-		}
-
-		throw new Error(
-			t('server-ai:Error.ReferralCodeGenerationFailed', {
-				defaultValue: 'Unable to generate a unique invitation code.'
-			})
-		)
+		await ensureReferralCode(event.manager.getRepository(ReferralCode), tenantId, user.id)
 	}
 }

--- a/packages/server/src/referral/referral-code.ts
+++ b/packages/server/src/referral/referral-code.ts
@@ -1,0 +1,55 @@
+import { randomBytes } from 'crypto'
+import { t } from 'i18next'
+import { Repository } from 'typeorm'
+import { ReferralCode } from './referral-code.entity'
+
+const REFERRAL_ALPHABET = '23456789ABCDEFGHJKLMNPQRSTUVWXYZ'
+const REFERRAL_CODE_LENGTH = 10
+const MAX_GENERATION_ATTEMPTS = 10
+
+export function generateReferralCode() {
+	const bytes = randomBytes(REFERRAL_CODE_LENGTH)
+	return Array.from(bytes, (byte) => REFERRAL_ALPHABET[byte % REFERRAL_ALPHABET.length]).join('')
+}
+
+export async function ensureReferralCode(repository: Repository<ReferralCode>, tenantId: string, userId: string) {
+	const existingCode = await repository.findOne({
+		where: {
+			tenantId,
+			userId
+		}
+	})
+	if (existingCode) {
+		return existingCode
+	}
+
+	for (let attempt = 0; attempt < MAX_GENERATION_ATTEMPTS; attempt += 1) {
+		await repository
+			.createQueryBuilder()
+			.insert()
+			.into(ReferralCode)
+			.values({
+				tenantId,
+				userId,
+				code: generateReferralCode()
+			})
+			.orIgnore()
+			.execute()
+
+		const referralCode = await repository.findOne({
+			where: {
+				tenantId,
+				userId
+			}
+		})
+		if (referralCode) {
+			return referralCode
+		}
+	}
+
+	throw new Error(
+		t('server-ai:Error.ReferralCodeGenerationFailed', {
+			defaultValue: 'Unable to generate a unique invitation code.'
+		})
+	)
+}

--- a/packages/server/src/referral/referral-code.ts
+++ b/packages/server/src/referral/referral-code.ts
@@ -12,6 +12,37 @@ export function generateReferralCode() {
 	return Array.from(bytes, (byte) => REFERRAL_ALPHABET[byte % REFERRAL_ALPHABET.length]).join('')
 }
 
+export async function regenerateReferralCode(repository: Repository<ReferralCode>, tenantId: string, userId: string) {
+	for (let attempt = 0; attempt < MAX_GENERATION_ATTEMPTS; attempt += 1) {
+		try {
+			return await repository.manager.transaction(async (manager) => {
+				const transactionRepository = manager.getRepository(ReferralCode)
+				const currentCode = await transactionRepository.findOne({
+					where: {
+						tenantId,
+						userId
+					},
+					lock: {
+						mode: 'pessimistic_write'
+					}
+				})
+				if (!currentCode) {
+					return ensureReferralCode(transactionRepository, tenantId, userId)
+				}
+
+				currentCode.code = generateDifferentReferralCode(currentCode.code)
+				return transactionRepository.save(currentCode)
+			})
+		} catch (error) {
+			if (!isUniqueViolation(error)) {
+				throw error
+			}
+		}
+	}
+
+	throw referralCodeGenerationError()
+}
+
 export async function ensureReferralCode(repository: Repository<ReferralCode>, tenantId: string, userId: string) {
 	const existingCode = await repository.findOne({
 		where: {
@@ -47,7 +78,40 @@ export async function ensureReferralCode(repository: Repository<ReferralCode>, t
 		}
 	}
 
-	throw new Error(
+	throw referralCodeGenerationError()
+}
+
+function generateDifferentReferralCode(currentCode: string) {
+	for (let attempt = 0; attempt < MAX_GENERATION_ATTEMPTS; attempt += 1) {
+		const candidate = generateReferralCode()
+		if (candidate !== currentCode) {
+			return candidate
+		}
+	}
+
+	throw referralCodeGenerationError()
+}
+
+function isUniqueViolation(error: unknown) {
+	const code = databaseErrorCode(error)
+	return code === '23505' || code === 'SQLITE_CONSTRAINT'
+}
+
+function databaseErrorCode(error: unknown): string | null {
+	if (typeof error !== 'object' || error === null) {
+		return null
+	}
+	if ('code' in error && typeof error.code === 'string') {
+		return error.code
+	}
+	if ('driverError' in error) {
+		return databaseErrorCode(error.driverError)
+	}
+	return null
+}
+
+function referralCodeGenerationError() {
+	return new Error(
 		t('server-ai:Error.ReferralCodeGenerationFailed', {
 			defaultValue: 'Unable to generate a unique invitation code.'
 		})

--- a/packages/server/src/referral/referral.controller.spec.ts
+++ b/packages/server/src/referral/referral.controller.spec.ts
@@ -12,7 +12,9 @@ import { ReferralController } from './referral.controller'
 describe('ReferralController public endpoints', () => {
 	const referralService = {
 		isFeatureEnabled: jest.fn(),
-		validatePublicCode: jest.fn()
+		validatePublicCode: jest.fn(),
+		getMyCode: jest.fn(),
+		regenerateMyCode: jest.fn()
 	}
 	const validationRateLimitService = {
 		assertAllowed: jest.fn()
@@ -30,6 +32,8 @@ describe('ReferralController public endpoints', () => {
 		})
 		referralService.isFeatureEnabled.mockResolvedValue(true)
 		referralService.validatePublicCode.mockResolvedValue(true)
+		referralService.getMyCode.mockResolvedValue({ code: 'ABC234DEFG' })
+		referralService.regenerateMyCode.mockResolvedValue({ code: 'XYZ234DEFG' })
 	})
 
 	it('reports availability for an anonymous tenant-scoped request', async () => {
@@ -49,5 +53,13 @@ describe('ReferralController public endpoints', () => {
 
 		expect(validationRateLimitService.assertAllowed).toHaveBeenCalledWith('tenant-1', '203.0.113.10')
 		expect(referralService.validatePublicCode).toHaveBeenCalledWith('tenant-1', 'ABC234DEFG')
+	})
+
+	it('regenerates the authenticated account invitation code', async () => {
+		await expect(controller.regenerateMyCode()).resolves.toEqual({
+			code: 'XYZ234DEFG'
+		})
+
+		expect(referralService.regenerateMyCode).toHaveBeenCalledTimes(1)
 	})
 })

--- a/packages/server/src/referral/referral.controller.ts
+++ b/packages/server/src/referral/referral.controller.ts
@@ -6,7 +6,7 @@ import {
 	PermissionsEnum,
 	RolesEnum
 } from '@xpert-ai/contracts'
-import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common'
+import { Controller, Get, Post, Query, Req, UseGuards } from '@nestjs/common'
 import { Request } from 'express'
 import { RequestContext } from '../core/context'
 import { Permissions, Public, Roles } from '../shared/decorators'
@@ -45,6 +45,11 @@ export class ReferralController {
 	@Get('me')
 	async getMyCode(): Promise<IReferralCodeView> {
 		return this.referralService.getMyCode()
+	}
+
+	@Post('me/regenerate')
+	async regenerateMyCode(): Promise<IReferralCodeView> {
+		return this.referralService.regenerateMyCode()
 	}
 
 	@UseGuards(TenantPermissionGuard, RoleGuard, PermissionGuard)

--- a/packages/server/src/referral/referral.service.spec.ts
+++ b/packages/server/src/referral/referral.service.spec.ts
@@ -32,9 +32,20 @@ describe('ReferralService registration binding', () => {
 		orIgnore: jest.fn().mockReturnThis(),
 		execute: jest.fn()
 	}
+	const transactionCodeRepository = {
+		findOne: jest.fn(),
+		save: jest.fn()
+	}
+	const transactionManager = {
+		getRepository: jest.fn(() => transactionCodeRepository)
+	}
+	const repositoryManager = {
+		transaction: jest.fn((callback) => callback(transactionManager))
+	}
 	const codeRepository = {
 		createQueryBuilder: jest.fn((alias?: string) => (alias ? codeQueryBuilder : codeInsertQueryBuilder)),
-		findOne: jest.fn()
+		findOne: jest.fn(),
+		manager: repositoryManager
 	}
 	const relationQueryBuilder = {
 		withDeleted: jest.fn().mockReturnThis(),
@@ -78,6 +89,13 @@ describe('ReferralService registration binding', () => {
 		codeRepository.findOne.mockResolvedValue({
 			code: 'ABC234DEFG'
 		})
+		transactionCodeRepository.findOne.mockResolvedValue({
+			id: 'referral-code-1',
+			tenantId: 'tenant-1',
+			userId: 'user-1',
+			code: 'ABC234DEFG'
+		})
+		transactionCodeRepository.save.mockImplementation(async (entity) => entity)
 		codeQueryBuilder.getOne.mockResolvedValue({
 			code: 'ABC234DEFG',
 			userId: 'referrer-1'
@@ -203,6 +221,44 @@ describe('ReferralService registration binding', () => {
 
 		expect(codeRepository.findOne).not.toHaveBeenCalled()
 		expect(codeInsertQueryBuilder.execute).not.toHaveBeenCalled()
+	})
+
+	it('atomically replaces the current code without changing existing relationships', async () => {
+		const result = await service.regenerateMyCode()
+
+		expect(repositoryManager.transaction).toHaveBeenCalledTimes(1)
+		expect(transactionCodeRepository.findOne).toHaveBeenCalledWith({
+			where: {
+				tenantId: 'tenant-1',
+				userId: 'user-1'
+			},
+			lock: {
+				mode: 'pessimistic_write'
+			}
+		})
+		expect(transactionCodeRepository.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: 'referral-code-1',
+				code: expect.stringMatching(/^[23456789ABCDEFGHJKLMNPQRSTUVWXYZ]{10}$/)
+			})
+		)
+		expect(result.code).not.toBe('ABC234DEFG')
+		expect(relationRepository.save).not.toHaveBeenCalled()
+		expect(relationRepository.createQueryBuilder).not.toHaveBeenCalled()
+	})
+
+	it('retries regeneration in a new transaction when the generated code collides', async () => {
+		repositoryManager.transaction.mockRejectedValueOnce({
+			driverError: {
+				code: '23505'
+			}
+		})
+
+		await expect(service.regenerateMyCode()).resolves.toEqual({
+			code: expect.stringMatching(/^[23456789ABCDEFGHJKLMNPQRSTUVWXYZ]{10}$/)
+		})
+
+		expect(repositoryManager.transaction).toHaveBeenCalledTimes(2)
 	})
 
 	it('returns tenant-scoped deleted account placeholders', async () => {

--- a/packages/server/src/referral/referral.service.spec.ts
+++ b/packages/server/src/referral/referral.service.spec.ts
@@ -2,11 +2,13 @@ jest.mock('../core/context', () => ({
 	RequestContext: {
 		currentTenantId: jest.fn(),
 		currentUserId: jest.fn(),
+		currentUser: jest.fn(),
 		isTenantScope: jest.fn()
 	}
 }))
 
-import { BadRequestException } from '@nestjs/common'
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { UserType } from '@xpert-ai/contracts'
 import { RequestContext } from '../core/context'
 import { FeatureOrganization } from '../feature/feature-organization.entity'
 import { ReferralCode } from './referral-code.entity'
@@ -23,8 +25,16 @@ describe('ReferralService registration binding', () => {
 		andWhere: jest.fn().mockReturnThis(),
 		getOne: jest.fn()
 	}
+	const codeInsertQueryBuilder = {
+		insert: jest.fn().mockReturnThis(),
+		into: jest.fn().mockReturnThis(),
+		values: jest.fn().mockReturnThis(),
+		orIgnore: jest.fn().mockReturnThis(),
+		execute: jest.fn()
+	}
 	const codeRepository = {
-		createQueryBuilder: jest.fn(() => codeQueryBuilder)
+		createQueryBuilder: jest.fn((alias?: string) => (alias ? codeQueryBuilder : codeInsertQueryBuilder)),
+		findOne: jest.fn()
 	}
 	const relationQueryBuilder = {
 		withDeleted: jest.fn().mockReturnThis(),
@@ -64,11 +74,20 @@ describe('ReferralService registration binding', () => {
 		relationRepository.findOne.mockResolvedValue(null)
 		relationRepository.save.mockImplementation(async (entity) => entity)
 		relationQueryBuilder.getManyAndCount.mockResolvedValue([[], 0])
+		codeInsertQueryBuilder.execute.mockResolvedValue({})
+		codeRepository.findOne.mockResolvedValue({
+			code: 'ABC234DEFG'
+		})
 		codeQueryBuilder.getOne.mockResolvedValue({
 			code: 'ABC234DEFG',
 			userId: 'referrer-1'
 		})
 		jest.mocked(RequestContext.currentTenantId).mockReturnValue('tenant-1')
+		jest.mocked(RequestContext.currentUserId).mockReturnValue('user-1')
+		jest.mocked(RequestContext.currentUser).mockReturnValue({
+			id: 'user-1',
+			type: UserType.USER
+		} as never)
 		jest.mocked(RequestContext.isTenantScope).mockReturnValue(true)
 	})
 
@@ -134,6 +153,56 @@ describe('ReferralService registration binding', () => {
 
 		expect(codeRepository.createQueryBuilder).not.toHaveBeenCalled()
 		expect(relationRepository.save).not.toHaveBeenCalled()
+	})
+
+	it('returns the existing invitation code without creating another one', async () => {
+		await expect(service.getMyCode()).resolves.toEqual({
+			code: 'ABC234DEFG'
+		})
+
+		expect(codeInsertQueryBuilder.execute).not.toHaveBeenCalled()
+	})
+
+	it('creates an invitation code on demand when an existing account has none', async () => {
+		codeRepository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({
+			code: 'ABC234DEFG'
+		})
+
+		await expect(service.getMyCode()).resolves.toEqual({
+			code: 'ABC234DEFG'
+		})
+
+		expect(codeInsertQueryBuilder.values).toHaveBeenCalledWith({
+			tenantId: 'tenant-1',
+			userId: 'user-1',
+			code: expect.stringMatching(/^[23456789ABCDEFGHJKLMNPQRSTUVWXYZ]{10}$/)
+		})
+		expect(codeInsertQueryBuilder.orIgnore).toHaveBeenCalled()
+		expect(codeInsertQueryBuilder.execute).toHaveBeenCalledTimes(1)
+	})
+
+	it('retries on-demand generation when a candidate code collides', async () => {
+		codeRepository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null).mockResolvedValueOnce({
+			code: 'ABC234DEFG'
+		})
+
+		await expect(service.getMyCode()).resolves.toEqual({
+			code: 'ABC234DEFG'
+		})
+
+		expect(codeInsertQueryBuilder.execute).toHaveBeenCalledTimes(2)
+	})
+
+	it('does not create invitation codes for communication users on demand', async () => {
+		jest.mocked(RequestContext.currentUser).mockReturnValue({
+			id: 'user-1',
+			type: UserType.COMMUNICATION
+		} as never)
+
+		await expect(service.getMyCode()).rejects.toBeInstanceOf(NotFoundException)
+
+		expect(codeRepository.findOne).not.toHaveBeenCalled()
+		expect(codeInsertQueryBuilder.execute).not.toHaveBeenCalled()
 	})
 
 	it('returns tenant-scoped deleted account placeholders', async () => {

--- a/packages/server/src/referral/referral.service.ts
+++ b/packages/server/src/referral/referral.service.ts
@@ -3,7 +3,8 @@ import {
 	IPagination,
 	IReferralCodeView,
 	IReferralRelationQuery,
-	IReferralRelationView
+	IReferralRelationView,
+	UserType
 } from '@xpert-ai/contracts'
 import { BadRequestException, Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
@@ -11,6 +12,7 @@ import { t } from 'i18next'
 import { EntityManager, IsNull, Repository } from 'typeorm'
 import { RequestContext } from '../core/context'
 import { FeatureOrganization } from '../feature/feature-organization.entity'
+import { ensureReferralCode } from './referral-code'
 import { ReferralCode } from './referral-code.entity'
 import { ReferralRelation } from './referral-relation.entity'
 
@@ -123,20 +125,10 @@ export class ReferralService {
 				})
 			)
 		}
-		const referralCode = await this.referralCodeRepository.findOne({
-			where: {
-				tenantId,
-				userId
-			}
-		})
-
-		if (!referralCode) {
-			throw new NotFoundException(
-				t('server-ai:Error.ReferralCodeNotFound', {
-					defaultValue: 'The invitation code was not found.'
-				})
-			)
+		if (RequestContext.currentUser()?.type === UserType.COMMUNICATION) {
+			throw new NotFoundException()
 		}
+		const referralCode = await ensureReferralCode(this.referralCodeRepository, tenantId, userId)
 
 		return { code: referralCode.code }
 	}

--- a/packages/server/src/referral/referral.service.ts
+++ b/packages/server/src/referral/referral.service.ts
@@ -12,7 +12,7 @@ import { t } from 'i18next'
 import { EntityManager, IsNull, Repository } from 'typeorm'
 import { RequestContext } from '../core/context'
 import { FeatureOrganization } from '../feature/feature-organization.entity'
-import { ensureReferralCode } from './referral-code'
+import { ensureReferralCode, regenerateReferralCode } from './referral-code'
 import { ReferralCode } from './referral-code.entity'
 import { ReferralRelation } from './referral-relation.entity'
 
@@ -117,18 +117,17 @@ export class ReferralService {
 	async getMyCode(): Promise<IReferralCodeView> {
 		const tenantId = this.requireTenantId()
 		await this.assertFeatureEnabled(tenantId)
-		const userId = RequestContext.currentUserId()
-		if (!userId) {
-			throw new UnauthorizedException(
-				t('server-ai:Error.ReferralAuthenticatedUserRequired', {
-					defaultValue: 'Authenticated user is required.'
-				})
-			)
-		}
-		if (RequestContext.currentUser()?.type === UserType.COMMUNICATION) {
-			throw new NotFoundException()
-		}
+		const userId = this.requireReferralUserId()
 		const referralCode = await ensureReferralCode(this.referralCodeRepository, tenantId, userId)
+
+		return { code: referralCode.code }
+	}
+
+	async regenerateMyCode(): Promise<IReferralCodeView> {
+		const tenantId = this.requireTenantId()
+		await this.assertFeatureEnabled(tenantId)
+		const userId = this.requireReferralUserId()
+		const referralCode = await regenerateReferralCode(this.referralCodeRepository, tenantId, userId)
 
 		return { code: referralCode.code }
 	}
@@ -219,6 +218,21 @@ export class ReferralService {
 			)
 		}
 		return tenantId
+	}
+
+	private requireReferralUserId() {
+		const userId = RequestContext.currentUserId()
+		if (!userId) {
+			throw new UnauthorizedException(
+				t('server-ai:Error.ReferralAuthenticatedUserRequired', {
+					defaultValue: 'Authenticated user is required.'
+				})
+			)
+		}
+		if (RequestContext.currentUser()?.type === UserType.COMMUNICATION) {
+			throw new NotFoundException()
+		}
+		return userId
 	}
 
 	private normalizeCode(code?: string) {


### PR DESCRIPTION
## Summary
- restore the referral code field on the public registration form
- reuse the existing referral availability and validation state
- keep submission disabled while referral availability or validation is pending

## Root cause
The referral field was added before the auth code relocation, but its template block was dropped when the relocation branch was merged. The TypeScript behavior remained in place.

## Validation
- Prettier check
- git diff --check
- NX_DAEMON=false corepack pnpm@10.24.0 exec nx build cloud --configuration=production