### PR TITLE
fix: authenticate NsJail CI checkout

### DIFF
--- a/.github/workflows/nsjail-runner-validate.yml
+++ b/.github/workflows/nsjail-runner-validate.yml
@@ -28,10 +28,16 @@ jobs:
     steps:
       - name: Check out repository
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git init .
           git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
-          git fetch --no-tags --depth=1 origin "$GITHUB_REF"
+          basic_credential="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 --wrap=0)"
+          echo "::add-mask::$basic_credential"
+          git -c "http.${GITHUB_SERVER_URL}/.extraheader=AUTHORIZATION: basic ${basic_credential}" \
+            fetch --no-tags --depth=1 origin "$GITHUB_REF"
+          unset basic_credential
           git checkout --detach FETCH_HEAD
 
       - name: Run Runner unit tests


### PR DESCRIPTION
## Summary

- authenticate the manual NsJail CI checkout with the job-scoped GitHub token
- keep credentials out of the remote URL and persistent Git configuration
- mask the derived Basic credential before the fetch

## Why

The manual checkout works anonymously in the public repository, but the same workflow fails before validation when reused by a private repository. Supplying the existing read-only job token makes the workflow portable without changing the Runner validation or image publication behavior.

## Validation

- YAML syntax parsing
- checkout shell block syntax check
- `corepack pnpm run test:nsjail-runner` (42 tests)
- complete diff audit: one workflow file, 7 insertions and 1 deletion
