### PR TITLE
fix: use NsJail in built-in templates

### DIFF
--- a/packages/server-ai/src/xpert-template/templates/xpert--client-browser-automation-tools.yaml
+++ b/packages/server-ai/src/xpert-template/templates/xpert--client-browser-automation-tools.yaml
@@ -56,7 +56,7 @@ team:
             enabled: false
         sandbox:
             enabled: true
-            provider: local-shell-sandbox
+            provider: nsjail
     version: '1'
     agent:
         key: Agent_vCo6Ic4mHR

--- a/packages/server-ai/src/xpert-template/templates/xpert-filememory-dreamer.yaml
+++ b/packages/server-ai/src/xpert-template/templates/xpert-filememory-dreamer.yaml
@@ -33,7 +33,7 @@ team:
             enabled: true
         sandbox:
             enabled: true
-            provider: local-shell-sandbox
+            provider: nsjail
     version: '3'
     agent:
         key: Agent_vlqADhkkrY

--- a/packages/server-ai/src/xpert-template/templates/xpert-my-claw-xpert.yaml
+++ b/packages/server-ai/src/xpert-template/templates/xpert-my-claw-xpert.yaml
@@ -117,7 +117,7 @@ team:
   features:
     sandbox:
       enabled: true
-      provider: local-shell-sandbox
+      provider: nsjail
   version: "1"
   agent:
     key: Agent_xtcQNJthR8


### PR DESCRIPTION
## Summary

- default FileMemory Dreamer to the NsJail sandbox provider
- default Client browser automation tools to the NsJail sandbox provider
- default Claw Xpert to the NsJail sandbox provider

## Why

These built-in templates still pinned `local-shell-sandbox`, so new template installations preferred direct local execution even after the NsJail provider was added. The templates should express the safer NsJail deployment default.

Existing compatibility behavior is preserved: template installation and DSL import already replace an unavailable configured provider with the first available sandbox provider.

## Validation

- parsed all three YAML files successfully
- confirmed the built-in templates no longer reference `local-shell-sandbox`
- `git diff --check`
- audited the complete PR diff: three files, one provider value per file
