### PR TITLE
[codex] expose public plugin marketplace

### DIFF
--- a/apps/cloud/src/app/@core/state/plugin.service.spec.ts
+++ b/apps/cloud/src/app/@core/state/plugin.service.spec.ts
@@ -1,0 +1,54 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { TestBed } from '@angular/core/testing'
+import { of } from 'rxjs'
+import { PluginAPIService } from './plugin.service'
+import { Store } from './store.service'
+
+describe('PluginAPIService', () => {
+  let service: PluginAPIService
+  let httpMock: HttpTestingController
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        PluginAPIService,
+        {
+          provide: Store,
+          useValue: {
+            selectOrganizationId: () => of(null)
+          }
+        }
+      ]
+    })
+
+    service = TestBed.inject(PluginAPIService)
+    httpMock = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => {
+    httpMock.verify()
+  })
+
+  it('loads the public marketplace through the Xpert backend', () => {
+    const next = jest.fn()
+
+    service.getPublicMarketplace({ targetApp: 'xpert' }).subscribe(next)
+
+    const request = httpMock.expectOne(
+      (candidate) => candidate.url === '/api/plugin/marketplace/public' && candidate.params.get('targetApp') === 'xpert'
+    )
+
+    expect(request.request.method).toBe('GET')
+
+    const response = {
+      updatedAt: null,
+      total: 0,
+      items: [],
+      sources: []
+    }
+    request.flush(response)
+
+    expect(next).toHaveBeenCalledWith(response)
+  })
+})

--- a/apps/cloud/src/app/@core/state/plugin.service.ts
+++ b/apps/cloud/src/app/@core/state/plugin.service.ts
@@ -126,6 +126,17 @@ export class PluginAPIService extends OrganizationBaseCrudService<IPlugin> {
     })
   }
 
+  getPublicMarketplace(params?: { targetApp?: string }) {
+    let httpParams = new HttpParams()
+    if (params?.targetApp) {
+      httpParams = httpParams.set('targetApp', params.targetApp)
+    }
+
+    return this.httpClient.get<IPluginMarketplaceResponse>(`${this.apiBaseUrl}/marketplace/public`, {
+      params: httpParams
+    })
+  }
+
   getMarketplacePluginDetail(params: { name: string; targetApp?: string; sourceId?: string; locale?: string }) {
     let httpParams = new HttpParams().set('name', params.name)
     if (params.targetApp) {

--- a/apps/cloud/src/app/app-routing.module.ts
+++ b/apps/cloud/src/app/app-routing.module.ts
@@ -27,6 +27,13 @@ const routes: Routes = [
     loadChildren: () => import('./xpert/routes').then((m) => m.routes)
   },
   {
+    path: 'plugins/marketplace',
+    loadComponent: () =>
+      import('./plugin-marketplace/public-plugin-marketplace-page.component').then(
+        (m) => m.PublicPluginMarketplacePageComponent
+      )
+  },
+  {
     path: '',
     loadChildren: () => import('./features/features.module').then((m) => m.FeaturesModule)
   },

--- a/apps/cloud/src/app/features/setting/plugins/install/install.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/plugins/install/install.component.spec.ts
@@ -1,0 +1,163 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog'
+import { TestBed } from '@angular/core/testing'
+import { Router } from '@angular/router'
+import { PluginAPIService, Store } from '@cloud/app/@core/state'
+import { PLUGIN_LEVEL, RequestScopeLevel } from '@xpert-ai/contracts'
+import { TranslateModule } from '@ngx-translate/core'
+import { of } from 'rxjs'
+import { PluginRuntimeRestartService } from '../plugin-runtime-restart.service'
+import { PluginInstallComponent } from './install.component'
+
+describe('PluginInstallComponent anonymous flow', () => {
+  const originalFetch = globalThis.fetch
+  const activeScope = {
+    level: RequestScopeLevel.ORGANIZATION,
+    organizationId: 'org-1'
+  }
+  const store = {
+    token: null as string | null,
+    activeScope,
+    scopeLevel: RequestScopeLevel.ORGANIZATION,
+    selectActiveScope: jest.fn(() => of(activeScope)),
+    scopeLevel$: of(RequestScopeLevel.ORGANIZATION)
+  }
+  const pluginAPI = {
+    getByNames: jest.fn(() => of([])),
+    install: jest.fn(() => of({}))
+  }
+  const dialogRef = {
+    close: jest.fn()
+  }
+  const router = {
+    url: '/plugins/marketplace',
+    navigate: jest.fn(() => Promise.resolve(true))
+  }
+  const runtimeRestartFactory = jest.fn(() => ({
+    markRequired: jest.fn(),
+    canRestart: jest.fn(() => false),
+    restartUnavailableMessageKey: jest.fn(() => ''),
+    confirmAndRestart: jest.fn()
+  }))
+
+  beforeEach(async () => {
+    store.token = null
+
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      writable: true,
+      value: jest.fn(() =>
+        Promise.resolve({
+          ok: false
+        } as Response)
+      )
+    })
+
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), PluginInstallComponent],
+      providers: [
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            plugin: {
+              name: '@xpert-ai/plugin-test',
+              packageName: '@xpert-ai/plugin-test',
+              displayName: 'Test plugin',
+              description: 'Test plugin',
+              version: '1.0.0',
+              level: PLUGIN_LEVEL.SYSTEM,
+              category: 'integration',
+              icon: {
+                type: 'font',
+                value: 'ri-puzzle-line'
+              },
+              author: {
+                name: 'XpertAI',
+                url: ''
+              }
+            },
+            reload: jest.fn()
+          }
+        },
+        {
+          provide: DialogRef,
+          useValue: dialogRef
+        },
+        {
+          provide: Store,
+          useValue: store
+        },
+        {
+          provide: PluginAPIService,
+          useValue: pluginAPI
+        },
+        {
+          provide: Router,
+          useValue: router
+        },
+        {
+          provide: PluginRuntimeRestartService,
+          useFactory: runtimeRestartFactory
+        }
+      ]
+    }).compileComponents()
+  })
+
+  afterEach(() => {
+    TestBed.resetTestingModule()
+    if (originalFetch) {
+      Object.defineProperty(globalThis, 'fetch', {
+        configurable: true,
+        writable: true,
+        value: originalFetch
+      })
+    } else {
+      Reflect.deleteProperty(globalThis, 'fetch')
+    }
+    jest.clearAllMocks()
+  })
+
+  it('does not initialize protected plugin state before anonymous confirmation', async () => {
+    const fixture = TestBed.createComponent(PluginInstallComponent)
+    fixture.detectChanges()
+    await fixture.whenStable()
+
+    expect(pluginAPI.getByNames).not.toHaveBeenCalled()
+    expect(runtimeRestartFactory).not.toHaveBeenCalled()
+    expect(fixture.componentInstance.systemPluginUnavailableInCurrentScope()).toBe(false)
+  })
+
+  it('redirects the final install action to login with the authenticated marketplace URL', () => {
+    const fixture = TestBed.createComponent(PluginInstallComponent)
+
+    fixture.componentInstance.install()
+
+    expect(pluginAPI.install).not.toHaveBeenCalled()
+    expect(dialogRef.close).toHaveBeenCalledWith()
+    expect(router.navigate).toHaveBeenCalledWith(['/auth/login'], {
+      queryParams: {
+        returnUrl: '/plugins?category=marketplace'
+      }
+    })
+  })
+
+  it('keeps the existing install request when a token is available', async () => {
+    store.token = 'user-token'
+    const fixture = TestBed.createComponent(PluginInstallComponent)
+    fixture.componentInstance.plugin.update((plugin) => ({
+      ...plugin,
+      level: PLUGIN_LEVEL.ORGANIZATION
+    }))
+    fixture.detectChanges()
+    await fixture.whenStable()
+
+    expect(pluginAPI.getByNames).toHaveBeenCalledWith(['@xpert-ai/plugin-test'])
+
+    fixture.componentInstance.install()
+
+    expect(pluginAPI.install).toHaveBeenCalledWith({
+      pluginName: '@xpert-ai/plugin-test',
+      version: '1.0.0'
+    })
+    expect(router.navigate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/cloud/src/app/features/setting/plugins/install/install.component.ts
+++ b/apps/cloud/src/app/features/setting/plugins/install/install.component.ts
@@ -1,10 +1,11 @@
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog'
 
-import { Component, computed, effect, inject, signal } from '@angular/core'
+import { Component, computed, effect, inject, Injector, signal } from '@angular/core'
 import { FormsModule } from '@angular/forms'
+import { Router } from '@angular/router'
 import { getErrorMessage, injectHelpWebsite } from '@cloud/app/@core'
 import { PluginComponent, TPlugin } from '@cloud/app/@shared/plugins'
-import { injectActiveScope, injectPluginAPI, injectScopeLevel } from '@cloud/app/@core/state'
+import { injectActiveScope, injectPluginAPI, injectScopeLevel, Store } from '@cloud/app/@core/state'
 import { PLUGIN_LEVEL, RequestScopeLevel } from '@xpert-ai/contracts'
 import { XpSpinComponent } from '@xpert-ai/headless-ui'
 import { myRxResource } from '@xpert-ai/headless-ui'
@@ -34,23 +35,26 @@ type PluginInstallDialogData = {
 export class PluginInstallComponent {
   readonly #dialogRef = inject<DialogRef<PluginInstallResult | undefined>>(DialogRef)
   readonly #data = inject<PluginInstallDialogData>(DIALOG_DATA)
+  readonly #injector = inject(Injector)
+  readonly #router = inject(Router)
+  readonly #store = inject(Store)
   readonly installHelpUrl = injectHelpWebsite('/docs/plugin/install')
   readonly pluginAPI = injectPluginAPI()
   readonly #activeScope = injectActiveScope()
   readonly scopeLevel = injectScopeLevel()
-  readonly runtimeRestart = inject(PluginRuntimeRestartService)
 
   readonly plugin = signal(this.#data.plugin)
   readonly pluginName = computed(() => this.plugin()?.name)
   readonly #installedPlugin = myRxResource({
     request: () => {
       return {
+        authenticated: !!this.#store.token,
         scope: this.#activeScope(),
         name: this.pluginName()
       }
     },
     loader: ({ request }) => {
-      return request.name ? this.pluginAPI.getByNames([request.name]) : null
+      return request.authenticated && request.name ? this.pluginAPI.getByNames([request.name]) : null
     }
   })
   readonly installed = computed(() => this.#installedPlugin.value()?.[0])
@@ -59,6 +63,7 @@ export class PluginInstallComponent {
   readonly pluginVersion = computed(() => this.latestVersion() ?? this.plugin()?.version)
   readonly systemPluginUnavailableInCurrentScope = computed(
     () =>
+      !!this.#store.token &&
       (this.plugin()?.level === PLUGIN_LEVEL.SYSTEM || this.plugin()?.level === PLUGIN_LEVEL.TENANT) &&
       this.scopeLevel() !== RequestScopeLevel.TENANT
   )
@@ -101,6 +106,15 @@ export class PluginInstallComponent {
   }
 
   install() {
+    if (!this.#store.token) {
+      const returnUrl = '/plugins?category=marketplace'
+      this.#dialogRef.close()
+      void this.#router.navigate(['/auth/login'], {
+        queryParams: { returnUrl }
+      })
+      return
+    }
+
     if (this.systemPluginUnavailableInCurrentScope()) {
       return
     }
@@ -135,6 +149,10 @@ export class PluginInstallComponent {
   restartNow() {
     this.close()
     setTimeout(() => void this.runtimeRestart.confirmAndRestart())
+  }
+
+  get runtimeRestart() {
+    return this.#injector.get(PluginRuntimeRestartService)
   }
 
   private hasInstalledPlugin() {

--- a/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace.component.html
+++ b/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace.component.html
@@ -72,21 +72,23 @@
         />
       </div>
     </div>
-    <select
-      class="h-11 min-w-[180px] rounded-xl border border-(--border) bg-components-panel-bg-blur px-3 text-sm text-text-secondary shadow-sm outline-none"
-      [(ngModel)]="sourceFilter"
-    >
-      <option value="all">{{ 'XP.Plugin.AllSources' | translate: { Default: 'All sources' } }}</option>
-      @for (source of sources(); track source.id) {
-        <option [value]="source.id">
-          @if (sourceI18nKey(source.id, source.name); as sourceKey) {
-            {{ sourceKey | translate: { Default: source.name } }}
-          } @else {
-            {{ source.name }}
-          }
-        </option>
-      }
-    </select>
+    @if (!publicCatalog()) {
+      <select
+        class="h-11 min-w-[180px] rounded-xl border border-(--border) bg-components-panel-bg-blur px-3 text-sm text-text-secondary shadow-sm outline-none"
+        [(ngModel)]="sourceFilter"
+      >
+        <option value="all">{{ 'XP.Plugin.AllSources' | translate: { Default: 'All sources' } }}</option>
+        @for (source of sources(); track source.id) {
+          <option [value]="source.id">
+            @if (sourceI18nKey(source.id, source.name); as sourceKey) {
+              {{ sourceKey | translate: { Default: source.name } }}
+            } @else {
+              {{ source.name }}
+            }
+          </option>
+        }
+      </select>
+    }
   </div>
 </div>
 
@@ -274,6 +276,7 @@
               <xp-settings-plugin
                 class="group relative rounded-xl hover:bg-hover-bg"
                 [plugin]="plugin"
+                [publicCatalog]="publicCatalog()"
                 (pluginInstalled)="markPluginInstalled($event)"
               />
             }

--- a/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace.component.ts
+++ b/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace.component.ts
@@ -1,6 +1,6 @@
 import { Dialog, DialogRef } from '@angular/cdk/dialog'
 import { CdkMenuModule } from '@angular/cdk/menu'
-import { Component, TemplateRef, computed, effect, inject, model, signal, viewChild } from '@angular/core'
+import { Component, TemplateRef, computed, effect, inject, input, model, signal, viewChild } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { getErrorMessage, injectToastr, routeAnimations } from '@cloud/app/@core'
 import { XpSelectComponent } from '@cloud/app/@shared/common'
@@ -100,6 +100,7 @@ export class PluginsMarketplaceComponent {
   readonly confirmDelete = injectConfirmDelete()
   readonly i18nService = inject(I18nService)
   readonly i18n = new XpI18nPipe()
+  readonly publicCatalog = input(false)
 
   readonly addSourceDialog = viewChild('addSourceDialog', { read: TemplateRef })
   readonly registryDialog = viewChild('registryDialog', { read: TemplateRef })
@@ -109,14 +110,19 @@ export class PluginsMarketplaceComponent {
 
   readonly #marketplace = myRxResource({
     request: () => ({
+      publicCatalog: this.publicCatalog(),
       scope: this.#activeScope(),
       sourceId: this.selectedSourceId()
     }),
     loader: ({ request }) =>
-      this.pluginAPI.getMarketplace({
-        targetApp: PLUGIN_MARKETPLACE_TARGET_APP,
-        ...(request.sourceId ? { sourceId: request.sourceId } : {})
-      })
+      request.publicCatalog
+        ? this.pluginAPI.getPublicMarketplace({
+            targetApp: PLUGIN_MARKETPLACE_TARGET_APP
+          })
+        : this.pluginAPI.getMarketplace({
+            targetApp: PLUGIN_MARKETPLACE_TARGET_APP,
+            ...(request.sourceId ? { sourceId: request.sourceId } : {})
+          })
   })
 
   readonly manifest = this.#marketplace.value
@@ -292,7 +298,9 @@ export class PluginsMarketplaceComponent {
     this.pluginsWithDownloads.update((plugins) =>
       plugins.map((item) => (isSameMarketplacePlugin(item, plugin) ? { ...item, installed: true } : item))
     )
-    this.reload()
+    if (!this.publicCatalog()) {
+      this.reload()
+    }
   }
 
   sourceI18nKey(sourceId?: string | null, sourceName?: string | null) {

--- a/apps/cloud/src/app/features/setting/plugins/plugin/plugin.component.ts
+++ b/apps/cloud/src/app/features/setting/plugins/plugin/plugin.component.ts
@@ -7,7 +7,7 @@ import { TranslateModule } from '@ngx-translate/core'
 import { Dialog } from '@angular/cdk/dialog'
 import { Router } from '@angular/router'
 import { PluginComponent } from '@cloud/app/@shared/plugins'
-import { injectScopeLevel } from '@cloud/app/@core/state'
+import { injectScopeLevel, Store } from '@cloud/app/@core/state'
 import { PLUGIN_LEVEL, RequestScopeLevel } from '@xpert-ai/contracts'
 import { PluginInstallComponent, PluginInstallResult } from '../install/install.component'
 import { TPluginWithDownloads } from '../types'
@@ -24,13 +24,15 @@ import { pluginMarketplaceDetailCommands } from '../plugin-marketplace-navigatio
   animations: [routeAnimations, ...OverlayAnimations]
 })
 export class SettingsPluginComponent {
-  readonly pluginsComponent = inject(PluginsComponent)
+  readonly pluginsComponent = inject(PluginsComponent, { optional: true })
   readonly #dialog = inject(Dialog)
   readonly #router = inject(Router)
+  readonly #store = inject(Store)
   readonly scopeLevel = injectScopeLevel()
   readonly installHelpUrl = injectHelpWebsite('/docs/plugin/install')
 
   readonly plugin = input<TPluginWithDownloads>()
+  readonly publicCatalog = input(false)
   readonly pluginInstalled = output<TPluginWithDownloads>()
   readonly installed = computed(() => this.plugin()?.installed === true)
   readonly hasMarketplaceDetails = computed(() => !!this.plugin()?.contributions?.length)
@@ -39,6 +41,7 @@ export class SettingsPluginComponent {
   readonly systemPluginUnavailableInCurrentScope = computed(
     () =>
       !this.installed() &&
+      (!this.publicCatalog() || !!this.#store.token) &&
       (this.isSystemPlugin() || this.isTenantPlugin()) &&
       this.scopeLevel() !== RequestScopeLevel.TENANT
   )
@@ -56,8 +59,14 @@ export class SettingsPluginComponent {
       .open(PluginInstallComponent, {
         data: {
           plugin,
-          reload: this.pluginsComponent.reload.bind(this.pluginsComponent),
-          refreshStrategies: this.pluginsComponent.refreshStrategyCaches.bind(this.pluginsComponent)
+          reload: () => {
+            this.pluginsComponent?.reload()
+          },
+          ...(this.pluginsComponent
+            ? {
+                refreshStrategies: this.pluginsComponent.refreshStrategyCaches.bind(this.pluginsComponent)
+              }
+            : {})
         },
         disableClose: true
       })
@@ -84,6 +93,11 @@ export class SettingsPluginComponent {
       return
     }
 
+    if (this.publicCatalog()) {
+      this.viewDetails()
+      return
+    }
+
     this.#router.navigate(pluginMarketplaceDetailCommands(plugin.packageName ?? plugin.name), {
       queryParams: {
         ...(plugin.sourceId ? { sourceId: plugin.sourceId } : {})
@@ -97,7 +111,8 @@ export class SettingsPluginComponent {
     }
     this.#dialog.open(PluginMarketplaceDetailComponent, {
       data: {
-        plugin: this.plugin()
+        plugin: this.plugin(),
+        showActions: !this.publicCatalog()
       },
       backdropClass: 'backdrop-blur-sm-black'
     })

--- a/apps/cloud/src/app/plugin-marketplace/public-plugin-marketplace-page.component.ts
+++ b/apps/cloud/src/app/plugin-marketplace/public-plugin-marketplace-page.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core'
+import { PluginsMarketplaceComponent } from '../features/setting/plugins/marketplace/marketplace.component'
+
+@Component({
+  standalone: true,
+  imports: [PluginsMarketplaceComponent],
+  selector: 'xp-public-plugin-marketplace-page',
+  template: '<xp-plugins-marketplace [publicCatalog]="true" />',
+  host: {
+    class: 'flex min-h-0 grow flex-col overflow-auto pt-8'
+  }
+})
+export class PublicPluginMarketplacePageComponent {}

--- a/packages/server/src/plugin/plugin-marketplace.service.spec.ts
+++ b/packages/server/src/plugin/plugin-marketplace.service.spec.ts
@@ -489,6 +489,117 @@ describe('PluginMarketplaceService marketplace trial shortcuts', () => {
 	})
 })
 
+describe('PluginMarketplaceService public marketplace', () => {
+	afterEach(() => {
+		jest.restoreAllMocks()
+	})
+
+	it('returns only the builtin registry catalog without tenant or source state', async () => {
+		const sourceRepository = {
+			find: jest.fn(),
+			findOne: jest.fn(),
+			create: jest.fn(),
+			save: jest.fn()
+		}
+		const registryRepository = {
+			find: jest.fn()
+		}
+		const pluginInstanceService = {
+			findVisibleInOrganization: jest.fn()
+		}
+		type ServiceDependencies = ConstructorParameters<typeof PluginMarketplaceService>
+		const service = new PluginMarketplaceService(
+			sourceRepository as unknown as ServiceDependencies[0],
+			registryRepository as unknown as ServiceDependencies[1],
+			[],
+			pluginInstanceService as unknown as ServiceDependencies[3]
+		)
+		const fetchRegistry = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				updatedAt: '2026-07-30T00:00:00.000Z',
+				plugins: [
+					{
+						name: '@xpert-ai/plugin-public',
+						packageName: '@xpert-ai/plugin-public',
+						displayName: 'Public Plugin',
+						description: 'Visible in the public marketplace',
+						targetApps: ['xpert'],
+						sourceId: 'builtin-default',
+						sourceName: 'Xpert Plugin Registry',
+						source: {
+							type: 'marketplace',
+							url: 'https://registry.example.test/plugins/index.json'
+						}
+					},
+					{
+						name: '@xpert-ai/plugin-other-app',
+						packageName: '@xpert-ai/plugin-other-app',
+						targetApps: ['data-xpert']
+					}
+				],
+				official: ['@xpert-ai/plugin-public'],
+				partner: [],
+				community: []
+			})
+		} as unknown as Response)
+		const publicService = service as unknown as {
+			listPublicMarketplace(query?: { targetApp?: string }): Promise<{
+				total: number
+				items: Array<Record<string, unknown>>
+				sources: unknown[]
+				errors?: unknown[]
+			}>
+		}
+		const tenantPaths = service as unknown as {
+			getSourceRecords(): Promise<unknown[]>
+			loadPlatformRegistryCatalog(): Promise<unknown>
+			buildInstalledContext(): Promise<unknown>
+		}
+		const listMarketplace = jest.spyOn(service, 'listMarketplace')
+		const getSourceRecords = jest.spyOn(tenantPaths, 'getSourceRecords')
+		const loadPlatformRegistryCatalog = jest.spyOn(tenantPaths, 'loadPlatformRegistryCatalog')
+		const buildInstalledContext = jest.spyOn(tenantPaths, 'buildInstalledContext')
+
+		const response = await publicService.listPublicMarketplace({
+			targetApp: 'xpert'
+		})
+		await publicService.listPublicMarketplace({
+			targetApp: 'xpert'
+		})
+
+		expect(fetchRegistry).toHaveBeenCalledTimes(1)
+		expect(fetchRegistry).toHaveBeenCalledWith(expect.stringContaining('xpert-plugin-registry/plugins/index.json'))
+		expect(response).toEqual(
+			expect.objectContaining({
+				total: 1,
+				sources: [],
+				errors: [],
+				items: [
+					expect.objectContaining({
+						name: '@xpert-ai/plugin-public',
+						installed: false
+					})
+				]
+			})
+		)
+		expect(response.items[0]).not.toHaveProperty('source')
+		expect(response.items[0]).not.toHaveProperty('sourceId')
+		expect(response.items[0]).not.toHaveProperty('sourceName')
+		expect(response.items[0]).not.toHaveProperty('marketplacePlugin')
+		expect(sourceRepository.find).not.toHaveBeenCalled()
+		expect(sourceRepository.findOne).not.toHaveBeenCalled()
+		expect(sourceRepository.create).not.toHaveBeenCalled()
+		expect(sourceRepository.save).not.toHaveBeenCalled()
+		expect(registryRepository.find).not.toHaveBeenCalled()
+		expect(pluginInstanceService.findVisibleInOrganization).not.toHaveBeenCalled()
+		expect(listMarketplace).not.toHaveBeenCalled()
+		expect(getSourceRecords).not.toHaveBeenCalled()
+		expect(loadPlatformRegistryCatalog).not.toHaveBeenCalled()
+		expect(buildInstalledContext).not.toHaveBeenCalled()
+	})
+})
+
 describe('PluginMarketplaceService npm bundle manifest hydration', () => {
 	afterEach(() => {
 		jest.restoreAllMocks()

--- a/packages/server/src/plugin/plugin-marketplace.service.ts
+++ b/packages/server/src/plugin/plugin-marketplace.service.ts
@@ -133,6 +133,8 @@ export class PluginMarketplaceService {
 	private readonly npmMetadataCache = new Map<string, { level?: PluginLevel } | null>()
 	private readonly npmReadmeCache = new Map<string, PluginMarketplaceReadme | null>()
 	private readonly npmBundleManifestCache = new Map<string, XpertPluginBundleManifest | null>()
+	private readonly publicBuiltinSource = this.createBuiltinSourceRecord()
+	private publicBuiltinRefreshJob: Promise<NormalizedMarketplaceCatalog> | null = null
 
 	constructor(
 		@InjectRepository(PluginMarketplaceSource)
@@ -200,6 +202,41 @@ export class PluginMarketplaceService {
 			community: this.mergeCatalogNames(catalogs, 'community'),
 			sources: this.getMarketplaceSourceResponses(sources),
 			errors
+		}
+	}
+
+	async listPublicMarketplace(
+		query: Pick<PluginMarketplaceListQuery, 'targetApp'> = {}
+	): Promise<PluginMarketplaceResponse> {
+		const catalog = await this.loadPublicBuiltinCatalog()
+		const installedContext: InstalledPluginContext = {
+			installedNames: new Set<string>(),
+			loadedMetaByName: new Map<string, PluginMeta>()
+		}
+		const byName = new Map<string, PluginMarketplaceItem>()
+
+		for (const plugin of catalog.plugins) {
+			if (!this.matchesTargetApp(plugin, query.targetApp)) {
+				continue
+			}
+
+			const normalizedName = normalizePluginName(plugin.name)
+			if (!byName.has(normalizedName)) {
+				const item = this.toMarketplaceItem(plugin, query.targetApp, installedContext)
+				byName.set(normalizedName, this.toPublicMarketplaceItem(item))
+			}
+		}
+
+		const items = Array.from(byName.values())
+		return {
+			updatedAt: catalog.updatedAt,
+			total: items.length,
+			items,
+			official: catalog.official,
+			partner: catalog.partner,
+			community: catalog.community,
+			sources: [],
+			errors: []
 		}
 	}
 
@@ -1362,6 +1399,47 @@ export class PluginMarketplaceService {
 		return this.refreshSourceCache(source)
 	}
 
+	private async loadPublicBuiltinCatalog(): Promise<NormalizedMarketplaceCatalog> {
+		const cached = this.publicBuiltinSource.lastCatalog
+		if (cached && !this.isSourceCacheExpired(this.publicBuiltinSource)) {
+			return cached
+		}
+		if (this.publicBuiltinRefreshJob) {
+			return this.publicBuiltinRefreshJob
+		}
+
+		const refreshJob = this.refreshPublicBuiltinCatalog(cached)
+		this.publicBuiltinRefreshJob = refreshJob
+		try {
+			return await refreshJob
+		} finally {
+			if (this.publicBuiltinRefreshJob === refreshJob) {
+				this.publicBuiltinRefreshJob = null
+			}
+		}
+	}
+
+	private async refreshPublicBuiltinCatalog(
+		cached: NormalizedMarketplaceCatalog | null
+	): Promise<NormalizedMarketplaceCatalog> {
+		try {
+			const raw = await this.fetchJson(this.publicBuiltinSource.url)
+			const catalog = this.normalizeCatalog(raw, this.publicBuiltinSource)
+			this.publicBuiltinSource.lastCatalog = catalog
+			this.publicBuiltinSource.lastIndexStatus = 'success'
+			this.publicBuiltinSource.lastIndexedAt = new Date()
+			this.publicBuiltinSource.lastIndexError = null
+			return catalog
+		} catch (error) {
+			this.publicBuiltinSource.lastIndexStatus = 'failed'
+			this.publicBuiltinSource.lastIndexError = this.toErrorMessage(error)
+			if (cached) {
+				return cached
+			}
+			throw error
+		}
+	}
+
 	private isSourceCacheExpired(source: MarketplaceSourceRecord) {
 		const timestamp = this.toTimestamp(source.lastIndexedAt)
 		if (!timestamp) {
@@ -2219,6 +2297,34 @@ export class PluginMarketplaceService {
 			trialShortcuts,
 			operationSummary: this.countOperations(contributions),
 			marketplacePlugin: plugin
+		}
+	}
+
+	private toPublicMarketplaceItem(item: PluginMarketplaceItem): PluginMarketplaceItem {
+		return {
+			name: item.name,
+			packageName: item.packageName,
+			displayName: item.displayName,
+			description: item.description,
+			version: item.version,
+			artifactNamespace: item.artifactNamespace,
+			level: item.level,
+			deprecated: item.deprecated,
+			deprecationMessage: item.deprecationMessage,
+			category: item.category,
+			icon: item.icon,
+			author: item.author,
+			keywords: item.keywords,
+			screenshots: item.screenshots,
+			downloads: item.downloads,
+			installed: false,
+			contributions: item.contributions,
+			defaultPrompt: item.defaultPrompt,
+			trialShortcuts: item.trialShortcuts,
+			operationSummary: item.operationSummary,
+			targetApps: item.targetApps,
+			targetAppMeta: item.targetAppMeta,
+			section: item.section
 		}
 	}
 

--- a/packages/server/src/plugin/plugin.controller.spec.ts
+++ b/packages/server/src/plugin/plugin.controller.spec.ts
@@ -1,4 +1,5 @@
-import { BadRequestException } from '@nestjs/common'
+import { BadRequestException, RequestMethod } from '@nestjs/common'
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -115,6 +116,7 @@ describe('PluginController', () => {
 
 	const pluginMarketplaceService = {
 		listMarketplace: jest.fn(),
+		listPublicMarketplace: jest.fn(),
 		listSources: jest.fn(),
 		createSource: jest.fn(),
 		refreshSources: jest.fn(),
@@ -222,6 +224,30 @@ describe('PluginController', () => {
 		expect((pluginManagementService as any).installPlugin).toHaveBeenCalledWith({
 			pluginName: '@xpert-ai/plugin-org-demo'
 		})
+	})
+
+	it('exposes the builtin marketplace catalog as a public read-only route', async () => {
+		pluginMarketplaceService.listPublicMarketplace.mockResolvedValue({
+			updatedAt: null,
+			total: 0,
+			items: [],
+			sources: [],
+			errors: []
+		})
+
+		await expect(controller.getPublicMarketplace('xpert')).resolves.toEqual(
+			expect.objectContaining({
+				total: 0,
+				items: []
+			})
+		)
+		expect(pluginMarketplaceService.listPublicMarketplace).toHaveBeenCalledWith({
+			targetApp: 'xpert'
+		})
+		expect(Reflect.getMetadata(PATH_METADATA, controller.constructor)).toBe('plugin')
+		expect(Reflect.getMetadata(PATH_METADATA, controller.getPublicMarketplace)).toBe('marketplace/public')
+		expect(Reflect.getMetadata(METHOD_METADATA, controller.getPublicMarketplace)).toBe(RequestMethod.GET)
+		expect(Reflect.getMetadata('isPublic', controller.getPublicMarketplace)).toBe(true)
 	})
 
 	it('returns plugin-managed component definitions for a plugin', async () => {

--- a/packages/server/src/plugin/plugin.controller.ts
+++ b/packages/server/src/plugin/plugin.controller.ts
@@ -60,6 +60,7 @@ import {
 import { GetPluginSkillDocumentQuery, ResolveLatestPluginVersionQuery } from './queries'
 import { UpdatePluginCommand } from './commands'
 import { UploadedPluginArchiveFile } from './plugin-archive'
+import { Public } from '../shared/decorators'
 import { LOADED_PLUGINS, LoadedPluginRecord, PluginInstallInput, normalizePluginName } from './types'
 
 type LoadedPluginScopeState = {
@@ -228,6 +229,12 @@ export class PluginController {
 		@Query('search') search?: string
 	) {
 		return this.pluginMarketplaceService.listMarketplace({ targetApp, sourceId, search })
+	}
+
+	@Get('marketplace/public')
+	@Public()
+	async getPublicMarketplace(@Query('targetApp') targetApp?: string) {
+		return this.pluginMarketplaceService.listPublicMarketplace({ targetApp })
 	}
 
 	@Get('marketplace/sources')


### PR DESCRIPTION
## Summary

This PR adds a read-only plugin marketplace that can be viewed without signing in.

- adds the public `/plugins/marketplace` page
- loads the public catalog through the Xpert backend instead of exposing tenant marketplace APIs
- keeps source management, installed state, plugin details routes, and installation APIs protected
- redirects anonymous users to sign in only when they confirm an installation
- returns signed-in users to `/plugins?category=marketplace`, where the existing scope-aware installation flow continues

## Problem

The existing marketplace is hosted inside the authenticated application shell. As a result, visitors are redirected to sign in before they can see which plugins are available.

The existing marketplace API also combines the builtin registry with tenant sources, platform registry data, and installed plugin state, so it cannot safely be made public as-is.

## Root cause

The page, data source, plugin cards, and installation dialog all assumed an authenticated `PluginsComponent` parent and access to protected organization or tenant state.

## Fix

The frontend now provides a standalone public page that reuses the existing marketplace UI in `publicCatalog` mode. That mode hides source controls, uses a dedicated public API, opens read-only local details, and avoids protected installed-state requests before authentication.

The backend exposes one `@Public()` GET endpoint for the builtin marketplace catalog. It does not read tenant source repositories, platform registry entries, or installed plugin state. The response uses an explicit public field projection and omits source metadata.

The final installation action checks for a token before sending the installation request. Anonymous users are sent to the login page with the authenticated marketplace as the return URL. The installation POST itself remains protected.

## Validation

- Cloud focused Jest: 2 suites, 4 tests passed
- Server focused Jest: 2 suites, 47 tests passed
- Cloud TypeScript `--noEmit` check passed
- Cloud development build passed
- Server build passed
- `git diff --check` passed
- commit hooks passed Prettier, hardcoded color, and TypeORM column checks

Browser validation has not been run and remains pending for manual verification.

## Draft follow-ups

- confirm that `XPERT_PLUGIN_MARKETPLACE_URL` always points to a catalog intended for anonymous exposure, or introduce a separate public registry setting
- add timeout and retry backoff behavior for public registry refreshes
- review the existing trusted inline SVG icon boundary for publicly supplied registry metadata
