### PR TITLE
[codex] Publish NsJail runner image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,9 @@ jobs:
           - dockerfile: .deploy/webapp/Dockerfile
             image_name: xpert-webapp
             node_options: --max-old-space-size=4096
+          - dockerfile: .deploy/nsjail-runner/Dockerfile
+            image_name: xpert-nsjail-runner
+            node_options: ''
     env:
       DOCKER_TARGET: ${{ github.ref == 'refs/heads/develop' && 'candidate' || 'production' }}
     steps:
@@ -79,7 +82,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.service.dockerfile }}
-          target: ${{ env.DOCKER_TARGET }}
+          target: ${{ matrix.service.image_name != 'xpert-nsjail-runner' && env.DOCKER_TARGET || '' }}
           build-args: |
             NODE_OPTIONS=${{ matrix.service.node_options }}
           platforms: linux/amd64


### PR DESCRIPTION
## Summary

- add `xpert-nsjail-runner` to the existing application image publish matrix
- reuse the existing Docker Hub, GHCR, and Aliyun registry/tag rules
- keep the existing API and Webapp build targets unchanged

## Problem

The NsJail validation workflow only builds a temporary local image for tests. It does not publish a pullable Runner image for deployments such as `xpert-installer`.

## Root cause

The application Docker publish matrix contains only API and Webapp images. It also always passes the `candidate` or `production` build target, while the NsJail Runner Dockerfile has no named target.

## Fix

Add the Runner Dockerfile to the matrix and omit the build target only for `xpert-nsjail-runner`. API and Webapp continue using the existing target selection and publish behavior.

## Validation

- parsed `.github/workflows/docker-publish.yml` as YAML
- validated the Runner matrix entry and target selection structurally
- `corepack pnpm exec prettier --check .github/workflows/docker-publish.yml`
- `git diff --check origin/develop...HEAD`
