### PR TITLE
[codex] inherit organization model features from tenant

### DIFF
--- a/libs/apps/state/src/lib/store.service.spec.ts
+++ b/libs/apps/state/src/lib/store.service.spec.ts
@@ -188,18 +188,16 @@ describe('Store', () => {
     expect(store.hasFeatureEnabled(FeatureEnum.FEATURE_EMAIL_TEMPLATE)).toBe(true)
   })
 
-  it('requires an explicit organization toggle for personal model access', () => {
+  it('uses tenant fallback until organization toggle overrides personal model access', () => {
     store.organizationId = 'org-1'
     store.featureTenant = [createFeatureOrganization(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST, true)]
     store.featureOrganizations = []
 
-    expect(store.hasFeatureEnabled(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST)).toBe(false)
-
-    store.featureOrganizations = [
-      createFeatureOrganization(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST, true, 'org-1')
-    ]
-
     expect(store.hasFeatureEnabled(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST)).toBe(true)
+
+    store.featureOrganizations = [createFeatureOrganization(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST, false, 'org-1')]
+
+    expect(store.hasFeatureEnabled(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST)).toBe(false)
   })
 
   it('prefers child feature records when duplicate feature codes exist', () => {

--- a/libs/apps/state/src/lib/store.service.ts
+++ b/libs/apps/state/src/lib/store.service.ts
@@ -45,10 +45,6 @@ function findFeatureOrganizationByCode(
   return matches.find((item) => item.feature.parentId) ?? matches[0]
 }
 
-export function requiresExplicitOrganizationFeatureToggle(feature: string) {
-  return feature === AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST
-}
-
 export interface AppState {
   user: IUser
   userRolePermissions: IRolePermission[]
@@ -494,9 +490,6 @@ export class Store {
     }
 
     const organizationFeature = findFeatureOrganizationByCode(featureOrganizations, feature)
-    if (requiresExplicitOrganizationFeatureToggle(feature)) {
-      return organizationFeature?.isEnabled === true
-    }
     return (organizationFeature ?? tenantFeature)?.isEnabled === true
   }
 

--- a/packages/server-ai/src/model-access/model-access.service.ts
+++ b/packages/server-ai/src/model-access/model-access.service.ts
@@ -2095,15 +2095,7 @@ export class ModelAccessService {
         if (!(await this.membershipService.isMembershipPlanEnabled(targetScope, manager))) {
             return false
         }
-        const repository = manager?.getRepository(FeatureOrganization) ?? this.featureOrganizationRepository
-        const query = repository
-            .createQueryBuilder('featureOrganization')
-            .leftJoinAndSelect('featureOrganization.feature', 'feature')
-            .where('featureOrganization.tenantId = :tenantId', { tenantId: targetScope.tenantId })
-            .andWhere('feature.code = :code', { code: AiFeatureEnum.FEATURE_MODEL_GATEWAY })
-        this.applyScopeFilter(query, 'featureOrganization.organizationId', targetScope.organizationId)
-        const toggle = await query.getOne()
-        return toggle?.isEnabled === true
+        return this.isFeatureEnabledForScope(AiFeatureEnum.FEATURE_MODEL_GATEWAY, targetScope, manager)
     }
 
     private async assertModelGatewayFeatureEnabled(
@@ -2169,15 +2161,39 @@ export class ModelAccessService {
         if (!(await this.membershipService.isMembershipPlanEnabled(scope, manager))) {
             return false
         }
+        return this.isFeatureEnabledForScope(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST, scope, manager)
+    }
+
+    private async isFeatureEnabledForScope(
+        code: AiFeatureEnum,
+        scope: { tenantId: string; organizationId: string | null },
+        manager?: EntityManager
+    ) {
+        const organizationToggle = scope.organizationId
+            ? await this.findFeatureToggle(code, scope.tenantId, scope.organizationId, manager)
+            : null
+        if (organizationToggle) {
+            return organizationToggle.isEnabled === true
+        }
+
+        const tenantToggle = await this.findFeatureToggle(code, scope.tenantId, null, manager)
+        return tenantToggle?.isEnabled === true
+    }
+
+    private async findFeatureToggle(
+        code: AiFeatureEnum,
+        tenantId: string,
+        organizationId: string | null,
+        manager?: EntityManager
+    ) {
         const repository = manager?.getRepository(FeatureOrganization) ?? this.featureOrganizationRepository
         const qb = repository
             .createQueryBuilder('featureOrganization')
             .leftJoinAndSelect('featureOrganization.feature', 'feature')
-            .where('featureOrganization.tenantId = :tenantId', { tenantId: scope.tenantId })
-            .andWhere('feature.code = :code', { code: AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST })
-        this.applyScopeFilter(qb, 'featureOrganization.organizationId', scope.organizationId)
-        const toggle = await qb.getOne()
-        return toggle?.isEnabled === true
+            .where('featureOrganization.tenantId = :tenantId', { tenantId })
+            .andWhere('feature.code = :code', { code })
+        this.applyScopeFilter(qb, 'featureOrganization.organizationId', organizationId)
+        return qb.getOne()
     }
 
     private async assertRequestFeatureEnabled(target: ModelTarget, manager?: EntityManager) {


### PR DESCRIPTION
## Issue

Organization-scoped model access and model API gateway checks required an explicit organization feature record, while the rest of the feature-toggle system uses organization override with tenant fallback. This made the frontend and backend disagree when a tenant enabled a feature but an organization had not configured it.

## Root cause

The frontend store contained a special case that disabled tenant fallback for personal model access. The backend model access service also queried only the exact organization scope for personal model access and the model API gateway.

## Fix

- Remove the frontend exception so organization scope follows the standard organization-first, tenant-fallback behavior.
- Resolve model access and model API gateway feature flags through one backend helper.
- Preserve explicit organization overrides, including an organization-level disabled value.
- Update the existing store test to cover tenant fallback followed by an explicit organization override.

No database schema, feature records, routes, or public request contracts are changed.

## Validation

- `packages/server-ai/src/model-access/model-access.service.spec.ts`: 37 tests passed.
- Prettier check passed for all changed files.
- ESLint passed for the changed test and reported no backend errors.
- `git diff --check` passed.

The Angular store suite could not start in the current checkout because `@angular/core/testing` is unavailable in the local dependency installation.
