### PR TITLE
[codex] sync organization model feature inheritance to develop

### DIFF
--- a/apps/cloud/src/app/@core/state/store.service.spec.ts
+++ b/apps/cloud/src/app/@core/state/store.service.spec.ts
@@ -188,16 +188,16 @@ describe('Store', () => {
     expect(store.hasFeatureEnabled(FeatureEnum.FEATURE_EMAIL_TEMPLATE)).toBe(true)
   })
 
-  it('requires an explicit organization toggle for personal model access', () => {
+  it('uses tenant fallback until organization toggle overrides personal model access', () => {
     store.organizationId = 'org-1'
     store.featureTenant = [createFeatureOrganization(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST, true)]
     store.featureOrganizations = []
 
-    expect(store.hasFeatureEnabled(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST)).toBe(false)
-
-    store.featureOrganizations = [createFeatureOrganization(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST, true, 'org-1')]
-
     expect(store.hasFeatureEnabled(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST)).toBe(true)
+
+    store.featureOrganizations = [createFeatureOrganization(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST, false, 'org-1')]
+
+    expect(store.hasFeatureEnabled(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST)).toBe(false)
   })
 
   it('prefers child feature records when duplicate feature codes exist', () => {

--- a/apps/cloud/src/app/@core/state/store.service.ts
+++ b/apps/cloud/src/app/@core/state/store.service.ts
@@ -42,10 +42,6 @@ function findFeatureOrganizationByCode(
   return matches.find((item) => item.feature.parentId) ?? matches[0]
 }
 
-export function requiresExplicitOrganizationFeatureToggle(feature: string) {
-  return feature === AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST
-}
-
 export interface AppState {
   user: IUser
   userRolePermissions: IRolePermission[]
@@ -473,9 +469,6 @@ export class Store {
     }
 
     const organizationFeature = findFeatureOrganizationByCode(featureOrganizations, feature)
-    if (requiresExplicitOrganizationFeatureToggle(feature)) {
-      return organizationFeature?.isEnabled === true
-    }
     return (organizationFeature ?? tenantFeature)?.isEnabled === true
   }
 

--- a/packages/server-ai/src/model-access/model-access.service.ts
+++ b/packages/server-ai/src/model-access/model-access.service.ts
@@ -2095,15 +2095,7 @@ export class ModelAccessService {
         if (!(await this.membershipService.isMembershipPlanEnabled(targetScope, manager))) {
             return false
         }
-        const repository = manager?.getRepository(FeatureOrganization) ?? this.featureOrganizationRepository
-        const query = repository
-            .createQueryBuilder('featureOrganization')
-            .leftJoinAndSelect('featureOrganization.feature', 'feature')
-            .where('featureOrganization.tenantId = :tenantId', { tenantId: targetScope.tenantId })
-            .andWhere('feature.code = :code', { code: AiFeatureEnum.FEATURE_MODEL_GATEWAY })
-        this.applyScopeFilter(query, 'featureOrganization.organizationId', targetScope.organizationId)
-        const toggle = await query.getOne()
-        return toggle?.isEnabled === true
+        return this.isFeatureEnabledForScope(AiFeatureEnum.FEATURE_MODEL_GATEWAY, targetScope, manager)
     }
 
     private async assertModelGatewayFeatureEnabled(
@@ -2169,15 +2161,39 @@ export class ModelAccessService {
         if (!(await this.membershipService.isMembershipPlanEnabled(scope, manager))) {
             return false
         }
+        return this.isFeatureEnabledForScope(AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST, scope, manager)
+    }
+
+    private async isFeatureEnabledForScope(
+        code: AiFeatureEnum,
+        scope: { tenantId: string; organizationId: string | null },
+        manager?: EntityManager
+    ) {
+        const organizationToggle = scope.organizationId
+            ? await this.findFeatureToggle(code, scope.tenantId, scope.organizationId, manager)
+            : null
+        if (organizationToggle) {
+            return organizationToggle.isEnabled === true
+        }
+
+        const tenantToggle = await this.findFeatureToggle(code, scope.tenantId, null, manager)
+        return tenantToggle?.isEnabled === true
+    }
+
+    private async findFeatureToggle(
+        code: AiFeatureEnum,
+        tenantId: string,
+        organizationId: string | null,
+        manager?: EntityManager
+    ) {
         const repository = manager?.getRepository(FeatureOrganization) ?? this.featureOrganizationRepository
         const qb = repository
             .createQueryBuilder('featureOrganization')
             .leftJoinAndSelect('featureOrganization.feature', 'feature')
-            .where('featureOrganization.tenantId = :tenantId', { tenantId: scope.tenantId })
-            .andWhere('feature.code = :code', { code: AiFeatureEnum.FEATURE_MODEL_ACCESS_REQUEST })
-        this.applyScopeFilter(qb, 'featureOrganization.organizationId', scope.organizationId)
-        const toggle = await qb.getOne()
-        return toggle?.isEnabled === true
+            .where('featureOrganization.tenantId = :tenantId', { tenantId })
+            .andWhere('feature.code = :code', { code })
+        this.applyScopeFilter(qb, 'featureOrganization.organizationId', organizationId)
+        return qb.getOne()
     }
 
     private async assertRequestFeatureEnabled(target: ModelTarget, manager?: EntityManager) {


### PR DESCRIPTION
## Summary
- port the organization-first, tenant-fallback feature behavior from main PR #841 to develop
- keep explicit organization toggles authoritative for personal model access and model gateway
- adapt the frontend Store change to develop's existing file layout

## Why this is isolated
A direct main-to-develop merge conflicts in an unrelated legacy Store test path, so this PR carries only the fix commit already merged through #841.

## Validation
- ModelAccessService spec: 37 passed
- Cloud Store spec: 8 passed
- diff check passed