### PR TITLE
[codex] allow public artifact embedding

### DIFF
--- a/packages/server-ai/src/artifacts/artifacts.controller.spec.ts
+++ b/packages/server-ai/src/artifacts/artifacts.controller.spec.ts
@@ -37,6 +37,8 @@ describe('Artifact share controllers', () => {
         expect(csp).toContain("form-action 'none'")
         expect(csp).toContain("base-uri 'none'")
         expect(csp).toContain("frame-src 'none'")
+        expect(csp).toContain('frame-ancestors *')
+        expect(csp).not.toContain("frame-ancestors 'none'")
     })
 
     it('redirects an unauthenticated private share to the auth handshake without rendering content', async () => {
@@ -81,6 +83,8 @@ describe('Artifact share controllers', () => {
         expect(csp).not.toContain('script-src')
         expect(csp).toContain("style-src 'unsafe-inline' https:")
         expect(csp).toContain('font-src data: https:')
+        expect(csp).toContain('frame-ancestors *')
+        expect(csp).not.toContain("frame-ancestors 'none'")
     })
 
     it('sets a short-lived HttpOnly share-only cookie and returns the fixed URL', async () => {

--- a/packages/server-ai/src/artifacts/artifacts.controller.ts
+++ b/packages/server-ai/src/artifacts/artifacts.controller.ts
@@ -254,7 +254,7 @@ function buildHtmlCsp(profile?: 'strict' | 'interactive' | null) {
             "frame-src 'none'",
             "base-uri 'none'",
             "form-action 'none'",
-            "frame-ancestors 'none'"
+            'frame-ancestors *'
         ].join('; ')
     }
     return [
@@ -269,7 +269,7 @@ function buildHtmlCsp(profile?: 'strict' | 'interactive' | null) {
         "frame-src 'none'",
         "base-uri 'none'",
         "form-action 'none'",
-        "frame-ancestors 'none'"
+        'frame-ancestors *'
     ].join('; ')
 }
 


### PR DESCRIPTION
## Problem

Public Artifact share responses currently send `frame-ancestors 'none'`, so browsers block the otherwise sandboxed HTML output when it is embedded in an iframe. This prevents public Artifact examples from being shown inside the Xpert website Showcase.

## Root cause

`buildHtmlCsp()` hardcodes `frame-ancestors 'none'` for both strict and interactive HTML profiles.

## Change

- Allow public Artifact HTML to be embedded by any parent origin with `frame-ancestors *`.
- Preserve the existing opaque sandbox and the remaining script, network, object, frame, base URI, and form restrictions.
- Cover both strict and interactive CSP profiles with focused assertions.

## Validation

- `corepack pnpm@10.24.0 exec jest --config packages/server-ai/jest.config.ts packages/server-ai/src/artifacts/artifacts.controller.spec.ts --runInBand`
- `corepack pnpm@10.24.0 exec eslint packages/server-ai/src/artifacts/artifacts.controller.ts packages/server-ai/src/artifacts/artifacts.controller.spec.ts`
- `git diff --check`

## Security impact

Any site can embed a public Artifact after this change. The embedded HTML remains in an opaque sandbox without same-origin access, network connections, nested frames, objects, base URI changes, or form submission.
