### PR TITLE
[codex] Add verified email SSO provisioning

### DIFF
--- a/apps/cloud/src/app/auth/auth.module.ts
+++ b/apps/cloud/src/app/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { TranslateModule } from '@ngx-translate/core'
 import {
   ZardButtonComponent,
   ZardCheckboxComponent,
+  ZardFormImports,
   ZardInputDirective,
   ZardTabComponent,
   ZardTabGroupComponent
@@ -75,6 +76,7 @@ export function nbOptionsFactory(options) {
     RouterModule,
     XpAuthRoutingModule,
     TranslateModule,
+    ...ZardFormImports,
     ZardButtonComponent,
     ZardInputDirective,
     ZardTabGroupComponent,

--- a/apps/cloud/src/app/auth/i18n/zhHans.ts
+++ b/apps/cloud/src/app/auth/i18n/zhHans.ts
@@ -59,6 +59,17 @@ export const ZhHans = {
       CONFLICT: '绑定冲突，请联系管理员处理。',
       FAIL: '绑定失败，请稍后重试。'
     },
+    SSO_REGISTER: {
+      LOADING: '正在加载 SSO 账号信息...',
+      INVALID_TITLE: '注册会话不可用',
+      INVALID_SESSION: '注册会话无效，请重新发起第三方登录。',
+      BACK_TO_LOGIN: '返回登录页',
+      TITLE: '完成 {{ provider }} 注册',
+      DESCRIPTION: '设置密码以完成 Xpert 账号创建。',
+      VERIFIED_EMAIL: '该邮箱已经通过 {{ provider }} 验证，无法在此修改。',
+      PASSWORD_MIN_LENGTH: '密码至少需要 6 个字符。',
+      SUBMIT: '完成注册并登录'
+    },
     ACCEPT_INVITE: {
       HEADING: '接受 {{ organizationName }} 的邀请',
       SUB_HEADING: '完善注册信息 {{ email }}',

--- a/apps/cloud/src/app/auth/i18n/zhHant.ts
+++ b/apps/cloud/src/app/auth/i18n/zhHant.ts
@@ -59,6 +59,17 @@ export const ZhHant = {
       CONFLICT: '綁定衝突，請聯繫管理員處理。',
       FAIL: '綁定失敗，請稍後重試。'
     },
+    SSO_REGISTER: {
+      LOADING: '正在加載 SSO 賬號信息...',
+      INVALID_TITLE: '註冊會話不可用',
+      INVALID_SESSION: '註冊會話無效，請重新發起第三方登錄。',
+      BACK_TO_LOGIN: '返回登錄頁',
+      TITLE: '完成 {{ provider }} 註冊',
+      DESCRIPTION: '設置密碼以完成 Xpert 賬號創建。',
+      VERIFIED_EMAIL: '該郵箱已經通過 {{ provider }} 驗證，無法在此修改。',
+      PASSWORD_MIN_LENGTH: '密碼至少需要 6 個字符。',
+      SUBMIT: '完成註冊並登錄'
+    },
     ACCEPT_INVITE: {
       HEADING: '接受 {{ organizationName }} 的邀請',
       SUB_HEADING: '完善註冊信息 {{ email }}',

--- a/apps/cloud/src/app/auth/register/register.component.html
+++ b/apps/cloud/src/app/auth/register/register.component.html
@@ -1,142 +1,346 @@
-<form [formGroup]="form" (ngSubmit)="register()" role="form" class="flex flex-col justify-start items-stretch">
-  <div class="flex flex-col justify-start items-stretch p-2 mt-2 gap-2">
-    @if (showMessages.error && errors?.length && !loading) {
-      @for (error of errors; track error; let i = $index) {
+@if (ssoChallengeLoading) {
+  <div class="flex min-h-[20rem] w-full items-center justify-center px-4 py-8 text-sm text-text-secondary">
+    {{ 'Auth.SSO_REGISTER.LOADING' | translate: { Default: 'Loading SSO account information...' } }}
+  </div>
+} @else if (ssoChallengeLoadError) {
+  <div class="flex w-full max-w-md flex-col gap-4 px-2 py-4">
+    <div class="rounded-2xl border border-divider-regular bg-background-default-subtle px-5 py-5">
+      <div class="text-base font-semibold text-text-primary">
+        {{ 'Auth.SSO_REGISTER.INVALID_TITLE' | translate: { Default: 'Registration Session Unavailable' } }}
+      </div>
+      <p class="mt-2 whitespace-pre-line text-sm leading-6 text-text-secondary">
+        {{ ssoChallengeLoadError }}
+      </p>
+    </div>
+
+    <button z-button zFull type="button" class="h-10 text-sm font-medium" (click)="navigateToLogin()">
+      {{ 'Auth.SSO_REGISTER.BACK_TO_LOGIN' | translate: { Default: 'Back to Sign In' } }}
+    </button>
+  </div>
+} @else {
+  <form [formGroup]="form" (ngSubmit)="register()" role="form" class="flex flex-col justify-start items-stretch">
+    <div class="flex flex-col justify-start items-stretch p-2 mt-2 gap-2">
+      @if (showMessages.error && errors?.length && !loading) {
+        @for (error of errors; track error; let i = $index) {
+          <div
+            class="flex items-center gap-2 p-3 mb-2 bg-[var(--color-status-warning-bg)] border border-[var(--color-status-warning-indicator-border)] rounded"
+          >
+            <span class="text-[var(--color-status-warning-fg)] text-sm">{{
+              'Auth.' + error | translate: { Default: error }
+            }}</span>
+            <button
+              type="button"
+              (click)="errors.splice(i, 1)"
+              class="ml-auto text-[var(--color-status-warning-fg)] hover:opacity-70"
+            >
+              <span class="text-lg">×</span>
+            </button>
+          </div>
+        }
+      }
+
+      @for (message of messages; track message; let i = $index) {
         <div
-          class="flex items-center gap-2 p-3 mb-2 bg-[var(--color-status-warning-bg)] border border-[var(--color-status-warning-indicator-border)] rounded"
+          class="flex items-center gap-2 p-3 mb-2 bg-[var(--color-status-success-bg)] border border-[var(--color-status-success-indicator-border)] rounded"
         >
-          <span class="text-[var(--color-status-warning-fg)] text-sm">{{
-            'Auth.' + error | translate: { Default: error }
-          }}</span>
+          <span class="text-[var(--color-status-success-fg)] text-sm">{{ message }}</span>
           <button
             type="button"
-            (click)="errors.splice(i, 1)"
-            class="ml-auto text-[var(--color-status-warning-fg)] hover:opacity-70"
+            (click)="messages.splice(i, 1)"
+            class="ml-auto text-[var(--color-status-success-fg)] hover:opacity-70"
           >
             <span class="text-lg">×</span>
           </button>
         </div>
       }
-    }
 
-    @for (message of messages; track message; let i = $index) {
-      <div
-        class="flex items-center gap-2 p-3 mb-2 bg-[var(--color-status-success-bg)] border border-[var(--color-status-success-indicator-border)] rounded"
-      >
-        <span class="text-[var(--color-status-success-fg)] text-sm">{{ message }}</span>
-        <button
-          type="button"
-          (click)="messages.splice(i, 1)"
-          class="ml-auto text-[var(--color-status-success-fg)] hover:opacity-70"
-        >
-          <span class="text-lg">×</span>
-        </button>
-      </div>
-    }
+      @if (verifiedEmailSignup) {
+        @if (ssoChallenge; as challenge) {
+          <div class="mb-2 flex flex-col items-center gap-3 px-4 py-2 text-center">
+            @if (challenge.avatarUrl) {
+              <img
+                class="h-16 w-16 rounded-full border border-divider-regular object-cover"
+                [src]="challenge.avatarUrl"
+                [alt]="challenge.displayName || providerLabel(challenge.provider)"
+                referrerpolicy="no-referrer"
+              />
+            } @else {
+              <div
+                class="flex h-16 w-16 items-center justify-center rounded-full border border-divider-regular bg-components-card-bg text-lg font-semibold text-text-primary"
+              >
+                {{ providerLabel(challenge.provider).slice(0, 1) }}
+              </div>
+            }
 
-    <div>
-      <label for="email" class="block mb-2 text-base font-medium text-text-primary">
-        {{ 'AUTH.REGISTER.EMAIL' | translate: { Default: 'Email' } }}
-      </label>
-      <input
-        type="email"
-        name="email"
-        id="email"
-        formControlName="email"
-        class="xp-input w-full text-text-primary"
-        [placeholder]="'AUTH.REGISTER.EMAIL' | translate: { Default: 'Email' }"
-      />
-    </div>
+            <div>
+              <div class="text-lg font-semibold text-text-primary">
+                {{
+                  'Auth.SSO_REGISTER.TITLE'
+                    | translate
+                      : {
+                          provider: providerLabel(challenge.provider),
+                          Default: 'Complete ' + providerLabel(challenge.provider) + ' Registration'
+                        }
+                }}
+              </div>
+              @if (challenge.displayName) {
+                <div class="mt-1 text-sm font-medium text-text-primary">{{ challenge.displayName }}</div>
+              }
+              <p class="mt-1 text-sm leading-6 text-text-secondary">
+                {{
+                  'Auth.SSO_REGISTER.DESCRIPTION'
+                    | translate
+                      : {
+                          provider: providerLabel(challenge.provider),
+                          Default: 'Set a password to finish creating your Xpert account.'
+                        }
+                }}
+              </p>
+            </div>
+          </div>
+        }
 
-    <div>
-      <label for="password" class="block mb-2 text-base font-medium text-text-primary">
-        {{ 'AUTH.REGISTER.PASSWORD' | translate: { Default: 'Password' } }}
-      </label>
-      <input
-        type="password"
-        name="password"
-        id="password"
-        formControlName="password"
-        class="xp-input w-full text-text-primary"
-        [placeholder]="'XP.KEY_WORDS.EnterPassword' | translate: { Default: 'Enter password' }"
-      />
-      <div class="my-2 h-1 bg-background-default-subtle rounded-full overflow-hidden">
-        <div
-          class="h-full transition-all duration-300"
-          [style.width.%]="passwordProgressMap[status]?.progress ?? 0"
-          [ngClass]="
-            passwordProgressMap[status]?.color === 'warn'
-              ? 'bg-[var(--color-status-warning-indicator-bg)]'
-              : 'bg-[var(--color-status-success-indicator-bg)]'
-          "
-        ></div>
-      </div>
-    </div>
+        <z-form-field appearance="fill" floatLabel="always" class="w-full">
+          <z-form-label>{{ 'AUTH.REGISTER.EMAIL' | translate: { Default: 'Email' } }}</z-form-label>
+          <input
+            z-input
+            type="email"
+            name="email"
+            id="email"
+            formControlName="email"
+            autocomplete="email"
+            [readonly]="emailLocked"
+            [attr.aria-readonly]="emailLocked"
+          />
+          <z-form-message>
+            {{
+              'Auth.SSO_REGISTER.VERIFIED_EMAIL'
+                | translate
+                  : {
+                      provider: providerLabel(ssoChallenge?.provider),
+                      Default: 'Verified by ' + providerLabel(ssoChallenge?.provider) + ' and cannot be changed here.'
+                    }
+            }}
+          </z-form-message>
+        </z-form-field>
 
-    <div>
-      <label for="confirm_password" class="block mb-2 text-base font-medium text-text-primary">
-        {{ 'AUTH.REGISTER.CONFIRM_PASSWORD' | translate: { Default: 'Confirm Password' } }}
-      </label>
-      <input
-        type="password"
-        name="confirm_password"
-        id="confirm_password"
-        formControlName="confirm"
-        class="xp-input w-full text-text-primary"
-        [placeholder]="'XP.KEY_WORDS.ConfirmPassword' | translate: { Default: 'Confirm password' }"
-      />
+        <z-form-field appearance="fill" floatLabel="always" class="w-full">
+          <z-form-label>{{ 'AUTH.REGISTER.PASSWORD' | translate: { Default: 'Password' } }}</z-form-label>
+          <input
+            z-input
+            type="password"
+            name="password"
+            id="password"
+            formControlName="password"
+            autocomplete="new-password"
+            required
+            [placeholder]="'XP.KEY_WORDS.EnterPassword' | translate: { Default: 'Enter password' }"
+          />
+          @if (password.hasError('minlength') && password.dirty) {
+            <z-form-message zType="error">
+              {{ 'Auth.SSO_REGISTER.PASSWORD_MIN_LENGTH' | translate: { Default: 'Use at least 6 characters.' } }}
+            </z-form-message>
+          }
+        </z-form-field>
 
-      @if (mismatch) {
-        <span class="text-text-destructive text-sm mt-1 block">{{
-          'Auth.Mismatch' | translate: { Default: 'Mismatch' }
-        }}</span>
+        <div class="my-1 h-1 overflow-hidden rounded-full bg-background-default-subtle">
+          <div
+            class="h-full transition-all duration-300"
+            [style.width.%]="passwordProgressMap[status]?.progress ?? 0"
+            [ngClass]="
+              passwordProgressMap[status]?.color === 'warn'
+                ? 'bg-[var(--color-status-warning-indicator-bg)]'
+                : 'bg-[var(--color-status-success-indicator-bg)]'
+            "
+          ></div>
+        </div>
+
+        <z-form-field appearance="fill" floatLabel="always" class="w-full">
+          <z-form-label>{{
+            'AUTH.REGISTER.CONFIRM_PASSWORD' | translate: { Default: 'Confirm Password' }
+          }}</z-form-label>
+          <input
+            z-input
+            type="password"
+            name="confirm_password"
+            id="confirm_password"
+            formControlName="confirm"
+            autocomplete="new-password"
+            required
+            [placeholder]="'XP.KEY_WORDS.ConfirmPassword' | translate: { Default: 'Confirm password' }"
+          />
+          @if (mismatch) {
+            <z-form-message zType="error">{{ 'Auth.Mismatch' | translate: { Default: 'Mismatch' } }}</z-form-message>
+          }
+        </z-form-field>
+      } @else {
+        <div>
+          <label for="email" class="block mb-2 text-base font-medium text-text-primary">
+            {{ 'AUTH.REGISTER.EMAIL' | translate: { Default: 'Email' } }}
+          </label>
+          <input
+            type="email"
+            name="email"
+            id="email"
+            formControlName="email"
+            class="xp-input w-full text-text-primary"
+            [placeholder]="'AUTH.REGISTER.EMAIL' | translate: { Default: 'Email' }"
+          />
+        </div>
+
+        <div>
+          <label for="password" class="block mb-2 text-base font-medium text-text-primary">
+            {{ 'AUTH.REGISTER.PASSWORD' | translate: { Default: 'Password' } }}
+          </label>
+          <input
+            type="password"
+            name="password"
+            id="password"
+            formControlName="password"
+            class="xp-input w-full text-text-primary"
+            [placeholder]="'XP.KEY_WORDS.EnterPassword' | translate: { Default: 'Enter password' }"
+          />
+          <div class="my-2 h-1 bg-background-default-subtle rounded-full overflow-hidden">
+            <div
+              class="h-full transition-all duration-300"
+              [style.width.%]="passwordProgressMap[status]?.progress ?? 0"
+              [ngClass]="
+                passwordProgressMap[status]?.color === 'warn'
+                  ? 'bg-[var(--color-status-warning-indicator-bg)]'
+                  : 'bg-[var(--color-status-success-indicator-bg)]'
+              "
+            ></div>
+          </div>
+        </div>
+
+        <div>
+          <label for="confirm_password" class="block mb-2 text-base font-medium text-text-primary">
+            {{ 'AUTH.REGISTER.CONFIRM_PASSWORD' | translate: { Default: 'Confirm Password' } }}
+          </label>
+          <input
+            type="password"
+            name="confirm_password"
+            id="confirm_password"
+            formControlName="confirm"
+            class="xp-input w-full text-text-primary"
+            [placeholder]="'XP.KEY_WORDS.ConfirmPassword' | translate: { Default: 'Confirm password' }"
+          />
+
+          @if (mismatch) {
+            <span class="text-text-destructive text-sm mt-1 block">{{
+              'Auth.Mismatch' | translate: { Default: 'Mismatch' }
+            }}</span>
+          }
+        </div>
+      }
+
+      @if (referralEnabled) {
+        @if (verifiedEmailSignup) {
+          <z-form-field appearance="fill" floatLabel="always" class="w-full">
+            <z-form-label>
+              {{ 'XP.Referral.ReferralCode' | translate: { Default: 'Invitation code (optional)' } }}
+            </z-form-label>
+            <input
+              z-input
+              type="text"
+              name="referral_code"
+              id="referral_code"
+              formControlName="referralCode"
+              class="w-full uppercase"
+              maxlength="10"
+              autocomplete="off"
+              [placeholder]="'XP.Referral.ReferralCodePlaceholder' | translate: { Default: 'Enter invitation code' }"
+            />
+            @if (referralValidationLoading) {
+              <z-form-message>
+                {{ 'XP.Referral.ValidatingReferralCode' | translate: { Default: 'Validating...' } }}
+              </z-form-message>
+            } @else if (referralCode.hasError('invalidReferralCode')) {
+              <z-form-message zType="error">
+                {{ 'XP.Referral.InvalidReferralCode' | translate: { Default: 'The invitation code is invalid.' } }}
+              </z-form-message>
+            } @else if (referralValid) {
+              <z-form-message>
+                {{ 'XP.Referral.ValidReferralCode' | translate: { Default: 'Invitation code is valid.' } }}
+              </z-form-message>
+            }
+          </z-form-field>
+        } @else {
+          <div>
+            <label for="referral_code" class="block mb-2 text-base font-medium text-text-primary">
+              {{ 'XP.Referral.ReferralCode' | translate: { Default: 'Invitation code (optional)' } }}
+            </label>
+            <input
+              z-input
+              type="text"
+              name="referral_code"
+              id="referral_code"
+              formControlName="referralCode"
+              class="w-full uppercase"
+              maxlength="10"
+              autocomplete="off"
+              [placeholder]="'XP.Referral.ReferralCodePlaceholder' | translate: { Default: 'Enter invitation code' }"
+            />
+            @if (referralValidationLoading) {
+              <span class="text-text-secondary text-sm mt-1 block">
+                {{ 'XP.Referral.ValidatingReferralCode' | translate: { Default: 'Validating...' } }}
+              </span>
+            } @else if (referralCode.hasError('invalidReferralCode')) {
+              <span class="text-text-destructive text-sm mt-1 block">
+                {{ 'XP.Referral.InvalidReferralCode' | translate: { Default: 'The invitation code is invalid.' } }}
+              </span>
+            } @else if (referralValid) {
+              <span class="text-text-success text-sm mt-1 block">
+                {{ 'XP.Referral.ValidReferralCode' | translate: { Default: 'Invitation code is valid.' } }}
+              </span>
+            }
+          </div>
+        }
+      }
+
+      @if (verifiedEmailSignup) {
+        <div class="mt-2 flex flex-col gap-3">
+          <button
+            z-button
+            zFull
+            type="submit"
+            class="h-10 text-sm font-medium"
+            [zLoading]="submitted"
+            [disabled]="
+              form.invalid || loading || submitted || referralAvailabilityLoading || referralValidationLoading
+            "
+          >
+            {{ 'Auth.SSO_REGISTER.SUBMIT' | translate: { Default: 'Complete Registration and Sign In' } }}
+          </button>
+
+          <button
+            z-button
+            zFull
+            zType="outline"
+            type="button"
+            class="h-10 text-sm font-medium"
+            (click)="navigateToLogin()"
+          >
+            {{ 'Auth.SSO_REGISTER.BACK_TO_LOGIN' | translate: { Default: 'Back to Sign In' } }}
+          </button>
+        </div>
+      } @else {
+        <div class="flex justify-between items-center p-1">
+          <button
+            type="submit"
+            class="btn disabled:btn-disabled btn-primary btn-medium mb-2"
+            [disabled]="
+              form.invalid || loading || submitted || referralAvailabilityLoading || referralValidationLoading
+            "
+          >
+            {{ 'AUTH.REGISTER.SUBMIT' | translate: { Default: 'Submit' } }}
+          </button>
+
+          <a class="text-[var(--sys-primary)] hover:underline" routerLink="/auth/login">{{
+            'AUTH.REGISTER.SIGN-IN' | translate: { Default: 'Sign-in' }
+          }}</a>
+        </div>
       }
     </div>
-
-    @if (referralEnabled) {
-      <div>
-        <label for="referral_code" class="block mb-2 text-base font-medium text-text-primary">
-          {{ 'XP.Referral.ReferralCode' | translate: { Default: 'Invitation code (optional)' } }}
-        </label>
-        <input
-          z-input
-          type="text"
-          name="referral_code"
-          id="referral_code"
-          formControlName="referralCode"
-          class="w-full uppercase"
-          maxlength="10"
-          autocomplete="off"
-          [placeholder]="'XP.Referral.ReferralCodePlaceholder' | translate: { Default: 'Enter invitation code' }"
-        />
-        @if (referralValidationLoading) {
-          <span class="text-text-secondary text-sm mt-1 block">
-            {{ 'XP.Referral.ValidatingReferralCode' | translate: { Default: 'Validating...' } }}
-          </span>
-        } @else if (referralCode.hasError('invalidReferralCode')) {
-          <span class="text-text-destructive text-sm mt-1 block">
-            {{ 'XP.Referral.InvalidReferralCode' | translate: { Default: 'The invitation code is invalid.' } }}
-          </span>
-        } @else if (referralValid) {
-          <span class="text-text-success text-sm mt-1 block">
-            {{ 'XP.Referral.ValidReferralCode' | translate: { Default: 'Invitation code is valid.' } }}
-          </span>
-        }
-      </div>
-    }
-
-    <div class="flex justify-between items-center p-1">
-      <button
-        type="submit"
-        class="btn disabled:btn-disabled btn-primary btn-medium mb-2"
-        [disabled]="form.invalid || loading || submitted || referralAvailabilityLoading || referralValidationLoading"
-      >
-        {{ 'AUTH.REGISTER.SUBMIT' | translate: { Default: 'Submit' } }}
-      </button>
-
-      <a class="text-[var(--sys-primary)] hover:underline" routerLink="/auth/login">{{
-        'AUTH.REGISTER.SIGN-IN' | translate: { Default: 'Sign-in' }
-      }}</a>
-    </div>
-  </div>
-</form>
+  </form>
+}

--- a/apps/cloud/src/app/auth/register/register.component.html
+++ b/apps/cloud/src/app/auth/register/register.component.html
@@ -18,41 +18,41 @@
     </button>
   </div>
 } @else {
-  <form [formGroup]="form" (ngSubmit)="register()" role="form" class="flex flex-col justify-start items-stretch">
-    <div class="flex flex-col justify-start items-stretch p-2 mt-2 gap-2">
-      @if (showMessages.error && errors?.length && !loading) {
-        @for (error of errors; track error; let i = $index) {
-          <div
-            class="flex items-center gap-2 p-3 mb-2 bg-[var(--color-status-warning-bg)] border border-[var(--color-status-warning-indicator-border)] rounded"
-          >
-            <span class="text-[var(--color-status-warning-fg)] text-sm">{{
-              'Auth.' + error | translate: { Default: error }
-            }}</span>
-            <button
-              type="button"
-              (click)="errors.splice(i, 1)"
-              class="ml-auto text-[var(--color-status-warning-fg)] hover:opacity-70"
-            >
-              <span class="text-lg">×</span>
-            </button>
-          </div>
-        }
-      }
-
-      @for (message of messages; track message; let i = $index) {
+<form [formGroup]="form" (ngSubmit)="register()" role="form" class="flex flex-col justify-start items-stretch">
+  <div class="flex flex-col justify-start items-stretch p-2 mt-2 gap-2">
+    @if (showMessages.error && errors?.length && !loading) {
+      @for (error of errors; track error; let i = $index) {
         <div
-          class="flex items-center gap-2 p-3 mb-2 bg-[var(--color-status-success-bg)] border border-[var(--color-status-success-indicator-border)] rounded"
+          class="flex items-center gap-2 p-3 mb-2 bg-[var(--color-status-warning-bg)] border border-[var(--color-status-warning-indicator-border)] rounded"
         >
-          <span class="text-[var(--color-status-success-fg)] text-sm">{{ message }}</span>
+          <span class="text-[var(--color-status-warning-fg)] text-sm">{{
+            'Auth.' + error | translate: { Default: error }
+          }}</span>
           <button
             type="button"
-            (click)="messages.splice(i, 1)"
-            class="ml-auto text-[var(--color-status-success-fg)] hover:opacity-70"
+            (click)="errors.splice(i, 1)"
+            class="ml-auto text-[var(--color-status-warning-fg)] hover:opacity-70"
           >
             <span class="text-lg">×</span>
           </button>
         </div>
       }
+    }
+
+    @for (message of messages; track message; let i = $index) {
+      <div
+        class="flex items-center gap-2 p-3 mb-2 bg-[var(--color-status-success-bg)] border border-[var(--color-status-success-indicator-border)] rounded"
+      >
+        <span class="text-[var(--color-status-success-fg)] text-sm">{{ message }}</span>
+        <button
+          type="button"
+          (click)="messages.splice(i, 1)"
+          class="ml-auto text-[var(--color-status-success-fg)] hover:opacity-70"
+        >
+          <span class="text-lg">×</span>
+        </button>
+      </div>
+    }
 
       @if (verifiedEmailSignup) {
         @if (ssoChallenge; as challenge) {
@@ -174,67 +174,67 @@
           }
         </z-form-field>
       } @else {
-        <div>
-          <label for="email" class="block mb-2 text-base font-medium text-text-primary">
-            {{ 'AUTH.REGISTER.EMAIL' | translate: { Default: 'Email' } }}
-          </label>
-          <input
-            type="email"
-            name="email"
-            id="email"
-            formControlName="email"
-            class="xp-input w-full text-text-primary"
-            [placeholder]="'AUTH.REGISTER.EMAIL' | translate: { Default: 'Email' }"
-          />
-        </div>
+    <div>
+      <label for="email" class="block mb-2 text-base font-medium text-text-primary">
+        {{ 'AUTH.REGISTER.EMAIL' | translate: { Default: 'Email' } }}
+      </label>
+      <input
+        type="email"
+        name="email"
+        id="email"
+        formControlName="email"
+        class="xp-input w-full text-text-primary"
+        [placeholder]="'AUTH.REGISTER.EMAIL' | translate: { Default: 'Email' }"
+      />
+    </div>
 
-        <div>
-          <label for="password" class="block mb-2 text-base font-medium text-text-primary">
-            {{ 'AUTH.REGISTER.PASSWORD' | translate: { Default: 'Password' } }}
-          </label>
-          <input
-            type="password"
-            name="password"
-            id="password"
-            formControlName="password"
-            class="xp-input w-full text-text-primary"
-            [placeholder]="'XP.KEY_WORDS.EnterPassword' | translate: { Default: 'Enter password' }"
-          />
-          <div class="my-2 h-1 bg-background-default-subtle rounded-full overflow-hidden">
-            <div
-              class="h-full transition-all duration-300"
-              [style.width.%]="passwordProgressMap[status]?.progress ?? 0"
-              [ngClass]="
-                passwordProgressMap[status]?.color === 'warn'
-                  ? 'bg-[var(--color-status-warning-indicator-bg)]'
-                  : 'bg-[var(--color-status-success-indicator-bg)]'
-              "
-            ></div>
-          </div>
-        </div>
+    <div>
+      <label for="password" class="block mb-2 text-base font-medium text-text-primary">
+        {{ 'AUTH.REGISTER.PASSWORD' | translate: { Default: 'Password' } }}
+      </label>
+      <input
+        type="password"
+        name="password"
+        id="password"
+        formControlName="password"
+        class="xp-input w-full text-text-primary"
+        [placeholder]="'XP.KEY_WORDS.EnterPassword' | translate: { Default: 'Enter password' }"
+      />
+      <div class="my-2 h-1 bg-background-default-subtle rounded-full overflow-hidden">
+        <div
+          class="h-full transition-all duration-300"
+          [style.width.%]="passwordProgressMap[status]?.progress ?? 0"
+          [ngClass]="
+            passwordProgressMap[status]?.color === 'warn'
+              ? 'bg-[var(--color-status-warning-indicator-bg)]'
+              : 'bg-[var(--color-status-success-indicator-bg)]'
+          "
+        ></div>
+      </div>
+    </div>
 
-        <div>
-          <label for="confirm_password" class="block mb-2 text-base font-medium text-text-primary">
-            {{ 'AUTH.REGISTER.CONFIRM_PASSWORD' | translate: { Default: 'Confirm Password' } }}
-          </label>
-          <input
-            type="password"
-            name="confirm_password"
-            id="confirm_password"
-            formControlName="confirm"
-            class="xp-input w-full text-text-primary"
-            [placeholder]="'XP.KEY_WORDS.ConfirmPassword' | translate: { Default: 'Confirm password' }"
-          />
+    <div>
+      <label for="confirm_password" class="block mb-2 text-base font-medium text-text-primary">
+        {{ 'AUTH.REGISTER.CONFIRM_PASSWORD' | translate: { Default: 'Confirm Password' } }}
+      </label>
+      <input
+        type="password"
+        name="confirm_password"
+        id="confirm_password"
+        formControlName="confirm"
+        class="xp-input w-full text-text-primary"
+        [placeholder]="'XP.KEY_WORDS.ConfirmPassword' | translate: { Default: 'Confirm password' }"
+      />
 
-          @if (mismatch) {
-            <span class="text-text-destructive text-sm mt-1 block">{{
-              'Auth.Mismatch' | translate: { Default: 'Mismatch' }
-            }}</span>
-          }
-        </div>
+      @if (mismatch) {
+        <span class="text-text-destructive text-sm mt-1 block">{{
+          'Auth.Mismatch' | translate: { Default: 'Mismatch' }
+        }}</span>
+      }
+    </div>
       }
 
-      @if (referralEnabled) {
+    @if (referralEnabled) {
         @if (verifiedEmailSignup) {
           <z-form-field appearance="fill" floatLabel="always" class="w-full">
             <z-form-label>
@@ -266,36 +266,36 @@
             }
           </z-form-field>
         } @else {
-          <div>
-            <label for="referral_code" class="block mb-2 text-base font-medium text-text-primary">
-              {{ 'XP.Referral.ReferralCode' | translate: { Default: 'Invitation code (optional)' } }}
-            </label>
-            <input
-              z-input
-              type="text"
-              name="referral_code"
-              id="referral_code"
-              formControlName="referralCode"
-              class="w-full uppercase"
-              maxlength="10"
-              autocomplete="off"
-              [placeholder]="'XP.Referral.ReferralCodePlaceholder' | translate: { Default: 'Enter invitation code' }"
-            />
-            @if (referralValidationLoading) {
-              <span class="text-text-secondary text-sm mt-1 block">
-                {{ 'XP.Referral.ValidatingReferralCode' | translate: { Default: 'Validating...' } }}
-              </span>
-            } @else if (referralCode.hasError('invalidReferralCode')) {
-              <span class="text-text-destructive text-sm mt-1 block">
-                {{ 'XP.Referral.InvalidReferralCode' | translate: { Default: 'The invitation code is invalid.' } }}
-              </span>
-            } @else if (referralValid) {
-              <span class="text-text-success text-sm mt-1 block">
-                {{ 'XP.Referral.ValidReferralCode' | translate: { Default: 'Invitation code is valid.' } }}
-              </span>
-            }
-          </div>
+      <div>
+        <label for="referral_code" class="block mb-2 text-base font-medium text-text-primary">
+          {{ 'XP.Referral.ReferralCode' | translate: { Default: 'Invitation code (optional)' } }}
+        </label>
+        <input
+          z-input
+          type="text"
+          name="referral_code"
+          id="referral_code"
+          formControlName="referralCode"
+          class="w-full uppercase"
+          maxlength="10"
+          autocomplete="off"
+          [placeholder]="'XP.Referral.ReferralCodePlaceholder' | translate: { Default: 'Enter invitation code' }"
+        />
+        @if (referralValidationLoading) {
+          <span class="text-text-secondary text-sm mt-1 block">
+            {{ 'XP.Referral.ValidatingReferralCode' | translate: { Default: 'Validating...' } }}
+          </span>
+        } @else if (referralCode.hasError('invalidReferralCode')) {
+          <span class="text-text-destructive text-sm mt-1 block">
+            {{ 'XP.Referral.InvalidReferralCode' | translate: { Default: 'The invitation code is invalid.' } }}
+          </span>
+        } @else if (referralValid) {
+          <span class="text-text-success text-sm mt-1 block">
+            {{ 'XP.Referral.ValidReferralCode' | translate: { Default: 'Invitation code is valid.' } }}
+          </span>
         }
+      </div>
+    }
       }
 
       @if (verifiedEmailSignup) {
@@ -325,22 +325,22 @@
           </button>
         </div>
       } @else {
-        <div class="flex justify-between items-center p-1">
-          <button
-            type="submit"
-            class="btn disabled:btn-disabled btn-primary btn-medium mb-2"
+    <div class="flex justify-between items-center p-1">
+      <button
+        type="submit"
+        class="btn disabled:btn-disabled btn-primary btn-medium mb-2"
             [disabled]="
               form.invalid || loading || submitted || referralAvailabilityLoading || referralValidationLoading
             "
-          >
-            {{ 'AUTH.REGISTER.SUBMIT' | translate: { Default: 'Submit' } }}
-          </button>
+      >
+        {{ 'AUTH.REGISTER.SUBMIT' | translate: { Default: 'Submit' } }}
+      </button>
 
-          <a class="text-[var(--sys-primary)] hover:underline" routerLink="/auth/login">{{
-            'AUTH.REGISTER.SIGN-IN' | translate: { Default: 'Sign-in' }
-          }}</a>
-        </div>
-      }
+      <a class="text-[var(--sys-primary)] hover:underline" routerLink="/auth/login">{{
+        'AUTH.REGISTER.SIGN-IN' | translate: { Default: 'Sign-in' }
+      }}</a>
     </div>
-  </form>
+      }
+  </div>
+</form>
 }

--- a/apps/cloud/src/app/auth/register/register.component.spec.ts
+++ b/apps/cloud/src/app/auth/register/register.component.spec.ts
@@ -1,0 +1,337 @@
+import { HttpClient } from '@angular/common/http'
+import { Component } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { ReactiveFormsModule } from '@angular/forms'
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router'
+import { TranslateService } from '@ngx-translate/core'
+import { ReferralService } from '@cloud/app/@core/state'
+import { of, throwError } from 'rxjs'
+import { XP_AUTH_OPTIONS } from '../auth.options'
+import { XpAuthService } from '../services/auth.service'
+import { UserRegisterComponent } from './register.component'
+
+@Component({
+  standalone: false,
+  template: ''
+})
+class TestUserRegisterComponent extends UserRegisterComponent {
+  override redirectToLocation = jest.fn()
+}
+
+describe('UserRegisterComponent SSO registration', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule()
+    jest.clearAllMocks()
+  })
+
+  async function createFixture(
+    challenge: {
+      flow: 'anonymous_bind' | 'verified_email_signup'
+      provider: string
+      email?: string
+      displayName?: string
+      avatarUrl?: string
+      tenantScoped: true
+      expiresAt: string
+    },
+    referralEnabled = true,
+    options: {
+      challengeError?: { error: { message: string } }
+      postError?: { status: number; error: { message: string } }
+      postResult?: { location: string }
+      enablePublicSignup?: boolean
+      providers?: Array<{
+        provider: string
+        displayName: string
+        icon: string
+        order: number
+        startUrl: string
+      }>
+    } = {}
+  ) {
+    const httpClient = {
+      get: jest.fn((url: string) => {
+        if (url === '/api/auth/sso/bind/challenge') {
+          if (options.challengeError) {
+            return throwError(() => options.challengeError)
+          }
+          return of(challenge)
+        }
+        return of({ providers: options.providers ?? [] })
+      }),
+      post: jest.fn(() => {
+        if (options.postResult) {
+          return of(options.postResult)
+        }
+        return throwError(
+          () =>
+            options.postError ?? {
+              error: {
+                message: 'Test stopped before redirect.'
+              }
+            }
+        )
+      })
+    }
+    const referralService = {
+      getAvailability: jest.fn(async () => referralEnabled),
+      validateCode: jest.fn(async () => true)
+    }
+
+    await TestBed.configureTestingModule({
+      declarations: [TestUserRegisterComponent],
+      imports: [ReactiveFormsModule],
+      providers: [
+        { provide: HttpClient, useValue: httpClient },
+        { provide: ReferralService, useValue: referralService },
+        {
+          provide: TranslateService,
+          useValue: {
+            get: jest.fn((key: string) => of(key))
+          }
+        },
+        {
+          provide: XP_AUTH_OPTIONS,
+          useValue: {
+            forms: {
+              register: {
+                enablePublicSignup: options.enablePublicSignup ?? true,
+                redirectDelay: 0,
+                showMessages: {
+                  error: true
+                },
+                strategy: 'email'
+              },
+              login: {
+                socialLinks: []
+              }
+            }
+          }
+        },
+        {
+          provide: XpAuthService,
+          useValue: {
+            register: jest.fn()
+          }
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap: convertToParamMap({ ticket: 'sso-ticket' })
+            }
+          }
+        },
+        {
+          provide: Router,
+          useValue: {
+            navigate: jest.fn(),
+            navigateByUrl: jest.fn()
+          }
+        }
+      ]
+    }).compileComponents()
+
+    const fixture = TestBed.createComponent(TestUserRegisterComponent)
+    fixture.detectChanges()
+    await fixture.whenStable()
+
+    return {
+      component: fixture.componentInstance,
+      httpClient,
+      referralService,
+      router: TestBed.inject(Router)
+    }
+  }
+
+  it('uses the challenge email as a locked value for verified email signup', async () => {
+    const { component, httpClient } = await createFixture({
+      flow: 'verified_email_signup',
+      provider: 'github-sso',
+      email: 'verified@example.com',
+      displayName: 'Octo Cat',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/1',
+      tenantScoped: true,
+      expiresAt: '2026-07-30T12:00:00.000Z'
+    })
+
+    expect(httpClient.get).toHaveBeenCalledWith('/api/auth/sso/bind/challenge', {
+      params: {
+        ticket: 'sso-ticket'
+      }
+    })
+    expect(component.verifiedEmailSignup).toBe(true)
+    expect(component.email.value).toBe('verified@example.com')
+    expect(component.emailLocked).toBe(true)
+    expect(component.ssoChallenge?.displayName).toBe('Octo Cat')
+  })
+
+  it('uses the plugin provider display name for the registration copy and preserves generic fallbacks', async () => {
+    const { component } = await createFixture(
+      {
+        flow: 'verified_email_signup',
+        provider: 'github-sso',
+        email: 'verified@example.com',
+        tenantScoped: true,
+        expiresAt: '2026-07-30T12:00:00.000Z'
+      },
+      true,
+      {
+        providers: [
+          {
+            provider: 'github-sso',
+            displayName: 'GitHub from plugin',
+            icon: '/api/github-identity/icon.svg',
+            order: 110,
+            startUrl: '/api/github-identity/login/start'
+          }
+        ]
+      }
+    )
+
+    expect(component.providerLabel('github-sso')).toBe('GitHub from plugin')
+    expect(component.providerLabel('custom-sso')).toBe('custom-sso')
+    expect(component.providerLabel(' ')).toBe('SSO')
+  })
+
+  it('preserves the existing editable registration form for anonymous binding tickets', async () => {
+    const { component, referralService } = await createFixture({
+      flow: 'anonymous_bind',
+      provider: 'lark',
+      displayName: 'Lark User',
+      tenantScoped: true,
+      expiresAt: '2026-07-30T12:00:00.000Z'
+    })
+
+    expect(component.verifiedEmailSignup).toBe(false)
+    expect(component.emailLocked).toBe(false)
+    expect(component.email.value).toBeNull()
+    expect(referralService.getAvailability).toHaveBeenCalledTimes(1)
+  })
+
+  it('submits the verified challenge email with password and optional referral code', async () => {
+    const { component, httpClient } = await createFixture({
+      flow: 'verified_email_signup',
+      provider: 'github-sso',
+      email: 'verified@example.com',
+      tenantScoped: true,
+      expiresAt: '2026-07-30T12:00:00.000Z'
+    })
+    component.form.patchValue({
+      password: 'strong-password',
+      confirm: 'strong-password',
+      referralCode: 'ABCDEF2345'
+    })
+
+    await component.register()
+
+    expect(httpClient.post).toHaveBeenCalledWith('/api/auth/sso/bind/register', {
+      ticket: 'sso-ticket',
+      email: 'verified@example.com',
+      password: 'strong-password',
+      confirmPassword: 'strong-password',
+      referralCode: 'ABCDEF2345'
+    })
+  })
+
+  it('shows an expired challenge error and keeps registration unavailable', async () => {
+    const { component } = await createFixture(
+      {
+        flow: 'verified_email_signup',
+        provider: 'github-sso',
+        email: 'verified@example.com',
+        tenantScoped: true,
+        expiresAt: '2026-07-30T12:00:00.000Z'
+      },
+      true,
+      {
+        challengeError: {
+          error: {
+            message: 'SSO binding session has expired. Please sign in again.'
+          }
+        }
+      }
+    )
+
+    expect(component.ssoChallenge).toBeNull()
+    expect(component.ssoChallengeLoadError).toBe('SSO binding session has expired. Please sign in again.')
+  })
+
+  it('preserves the ticket and form values after a binding conflict', async () => {
+    const { component } = await createFixture(
+      {
+        flow: 'verified_email_signup',
+        provider: 'github-sso',
+        email: 'verified@example.com',
+        tenantScoped: true,
+        expiresAt: '2026-07-30T12:00:00.000Z'
+      },
+      false,
+      {
+        postError: {
+          status: 409,
+          error: {
+            message: 'This GitHub identity is already bound.'
+          }
+        }
+      }
+    )
+    component.form.patchValue({
+      password: 'strong-password',
+      confirm: 'strong-password'
+    })
+
+    await component.register()
+
+    expect(component.ssoTicket).toBe('sso-ticket')
+    expect(component.password.value).toBe('strong-password')
+    expect(component.confirm.value).toBe('strong-password')
+    expect(component.submitted).toBe(false)
+    expect(component.errors).toEqual(['This GitHub identity is already bound.'])
+  })
+
+  it('redirects to the host-provided sign-in success location after registration', async () => {
+    const { component } = await createFixture(
+      {
+        flow: 'verified_email_signup',
+        provider: 'github-sso',
+        email: 'verified@example.com',
+        tenantScoped: true,
+        expiresAt: '2026-07-30T12:00:00.000Z'
+      },
+      false,
+      {
+        postResult: {
+          location: '/sign-in/success?jwt=token'
+        }
+      }
+    )
+    component.form.patchValue({
+      password: 'strong-password',
+      confirm: 'strong-password'
+    })
+
+    await component.register()
+
+    expect(component.redirectToLocation).toHaveBeenCalledWith('/sign-in/success?jwt=token')
+  })
+
+  it('allows a verified signup ticket when public registration is disabled', async () => {
+    const { component, router } = await createFixture(
+      {
+        flow: 'verified_email_signup',
+        provider: 'github-sso',
+        email: 'verified@example.com',
+        tenantScoped: true,
+        expiresAt: '2026-07-30T12:00:00.000Z'
+      },
+      false,
+      {
+        enablePublicSignup: false
+      }
+    )
+
+    expect(component.verifiedEmailSignup).toBe(true)
+    expect(router.navigate).not.toHaveBeenCalledWith(['/auth/login'])
+  })
+})

--- a/apps/cloud/src/app/auth/register/register.component.ts
+++ b/apps/cloud/src/app/auth/register/register.component.ts
@@ -19,6 +19,25 @@ type CompleteSsoBindingResponse = {
   location: string
 }
 
+type SsoRegistrationChallengeBase = {
+  provider: string
+  displayName?: string
+  avatarUrl?: string
+  tenantScoped: true
+  expiresAt: string
+}
+
+type AnonymousSsoRegistrationChallenge = SsoRegistrationChallengeBase & {
+  flow?: 'anonymous_bind'
+}
+
+type VerifiedEmailSignupChallenge = SsoRegistrationChallengeBase & {
+  flow: 'verified_email_signup'
+  email: string
+}
+
+type SsoRegistrationChallengeView = AnonymousSsoRegistrationChallenge | VerifiedEmailSignupChallenge
+
 type SSOProviderDescriptor = {
   provider: string
   displayName: string
@@ -48,6 +67,9 @@ export class UserRegisterComponent implements OnDestroy {
   messages: string[] = []
   socialLinks: NbAuthSocialLink[] = []
   ssoTicket = ''
+  ssoChallenge: SsoRegistrationChallengeView | null = null
+  ssoChallengeLoading = false
+  ssoChallengeLoadError = ''
   enablePublicSignup = true
   referralEnabled = false
   referralAvailabilityLoading = true
@@ -89,6 +111,7 @@ export class UserRegisterComponent implements OnDestroy {
     this.strategy = this.getConfigValue('forms.register.strategy')
     this.socialLinks = this.getConfigValue('forms.login.socialLinks')
     this.ssoTicket = this.route.snapshot.queryParamMap.get('ticket')?.trim() ?? ''
+    this.ssoChallengeLoading = Boolean(this.ssoTicket)
     const queryReferralCode = this.route.snapshot.queryParamMap.get('ref')?.trim() ?? ''
     if (queryReferralCode) {
       saveRegistrationReferralCode(queryReferralCode)
@@ -97,6 +120,9 @@ export class UserRegisterComponent implements OnDestroy {
     this.enablePublicSignup = this.getConfigValue('forms.register.enablePublicSignup') !== false
     void this.loadReferralAvailability()
     void this.loadSsoProviders()
+    if (this.ssoTicket) {
+      void this.loadSsoRegistrationChallenge()
+    }
 
     if (!this.ssoTicket && !this.enablePublicSignup) {
       void this.router.navigate(['/auth/login'])
@@ -116,6 +142,12 @@ export class UserRegisterComponent implements OnDestroy {
   }
   get referralCode(): AbstractControl {
     return this.form.controls.referralCode
+  }
+  get verifiedEmailSignup(): boolean {
+    return this.ssoChallenge?.flow === 'verified_email_signup'
+  }
+  get emailLocked(): boolean {
+    return this.verifiedEmailSignup
   }
   get mobile(): AbstractControl {
     return this.form.controls.mobile
@@ -190,6 +222,9 @@ export class UserRegisterComponent implements OnDestroy {
 
   async register(): Promise<void> {
     this.errors = this.messages = []
+    if (this.ssoTicket && (!this.ssoChallenge || this.ssoChallengeLoading || this.ssoChallengeLoadError)) {
+      return
+    }
     this.submitted = true
     if (!(await this.validateReferralCode())) {
       this.submitted = false
@@ -211,7 +246,7 @@ export class UserRegisterComponent implements OnDestroy {
         )
 
         clearRegistrationReferralCode()
-        window.location.assign(result.location)
+        this.redirectToLocation(result.location)
         return
       } catch (error) {
         this.submitted = false
@@ -304,6 +339,62 @@ export class UserRegisterComponent implements OnDestroy {
     const code = this.referralCode.value?.trim()
     saveRegistrationReferralCode(this.referralEnabled ? code : '')
     window.location.assign(new URL(provider.startUrl, window.location.origin).toString())
+  }
+
+  navigateToLogin(): void {
+    void this.router.navigate(['/auth/login'])
+  }
+
+  protected redirectToLocation(location: string): void {
+    window.location.assign(location)
+  }
+
+  providerLabel(provider?: string | null): string {
+    const providerId = provider?.trim()
+    if (!providerId) {
+      return 'SSO'
+    }
+
+    const displayName = this.ssoProviders.find((item) => item.provider === providerId)?.displayName.trim()
+
+    return displayName || providerId
+  }
+
+  private async loadSsoRegistrationChallenge(): Promise<void> {
+    this.ssoChallengeLoading = true
+    this.ssoChallengeLoadError = ''
+    this.ssoChallenge = null
+    this.cdr.markForCheck()
+
+    try {
+      const challenge = await firstValueFrom(
+        this.http.get<SsoRegistrationChallengeView>('/api/auth/sso/bind/challenge', {
+          params: {
+            ticket: this.ssoTicket
+          }
+        })
+      )
+
+      if (challenge.flow === 'verified_email_signup') {
+        const email = challenge.email?.trim().toLowerCase()
+        if (!email) {
+          this.ssoChallengeLoadError = this.getTranslation('Auth.SSO_REGISTER.INVALID_SESSION', {
+            Default: 'This registration session is invalid. Please start SSO sign-in again.'
+          })
+          return
+        }
+        this.email.setValue(email)
+        this.email.markAsPristine()
+        this.email.updateValueAndValidity({ emitEvent: false })
+      }
+
+      this.ssoChallenge = challenge
+    } catch (error) {
+      this.ssoChallengeLoadError = this.resolveErrorMessage(error)
+    } finally {
+      this.ssoChallengeLoading = false
+      this.cdr.markForCheck()
+    }
   }
 
   private async loadReferralAvailability() {

--- a/packages/plugin-sdk/src/lib/core/permissions/bound-identity-login.ts
+++ b/packages/plugin-sdk/src/lib/core/permissions/bound-identity-login.ts
@@ -1,7 +1,7 @@
 import type { IssuedAuthTokens } from './auth-login'
 import type { BasePermission } from './general'
 
-export type BoundIdentityLoginPermissionOperation = 'create'
+export type BoundIdentityLoginPermissionOperation = 'create' | 'provision'
 
 /**
  * Bound identity login permission
@@ -16,8 +16,7 @@ export interface BoundIdentityLoginPermission extends BasePermission {
 /**
  * System token for resolving bound identity login permission service from plugin context.
  */
-export const BOUND_IDENTITY_LOGIN_PERMISSION_SERVICE_TOKEN =
-  'XPERT_PLUGIN_BOUND_IDENTITY_LOGIN_PERMISSION_SERVICE'
+export const BOUND_IDENTITY_LOGIN_PERMISSION_SERVICE_TOKEN = 'XPERT_PLUGIN_BOUND_IDENTITY_LOGIN_PERMISSION_SERVICE'
 
 export interface BoundIdentityLoginInput {
   provider: string
@@ -26,6 +25,28 @@ export interface BoundIdentityLoginInput {
   organizationId?: string | null
 }
 
+export interface VerifiedEmailLoginInput {
+  provider: string
+  subjectId: string
+  tenantId: string
+  verifiedEmail: string
+  displayName?: string
+  avatarUrl?: string
+  profile?: Record<string, unknown>
+  returnTo?: string
+}
+
+export type VerifiedEmailLoginResult =
+  | {
+      status: 'authenticated'
+      tokens: IssuedAuthTokens
+    }
+  | {
+      status: 'registration_required'
+      ticket: string
+    }
+
 export interface BoundIdentityLoginPermissionService {
   loginWithBoundIdentity(input: BoundIdentityLoginInput): Promise<IssuedAuthTokens | null>
+  loginOrPrepareVerifiedEmail(input: VerifiedEmailLoginInput): Promise<VerifiedEmailLoginResult>
 }

--- a/packages/server/src/auth/auth.service.spec.ts
+++ b/packages/server/src/auth/auth.service.spec.ts
@@ -55,7 +55,39 @@ jest.mock('../referral', () => ({
 	ReferralService: class ReferralService {}
 }))
 
+jest.mock('../account-binding/external-identity-binding.entity', () => ({
+	ExternalIdentityBinding: class ExternalIdentityBinding {}
+}))
+
+jest.mock('../role/role.entity', () => ({
+	Role: class Role {}
+}))
+
+jest.mock('../tenant/tenant.entity', () => ({
+	Tenant: class Tenant {}
+}))
+
+jest.mock('../core/context', () => ({
+	RequestContext: {
+		currentUserId: jest.fn()
+	}
+}))
+
+jest.mock('../organization/events', () => ({
+	EVENT_ORGANIZATION_CREATED: 'organization.created',
+	OrganizationCreatedEvent: class OrganizationCreatedEvent {
+		constructor(
+			public readonly tenantId: string,
+			public readonly organizationId: string,
+			public readonly ownerUserId?: string | null
+		) {}
+	}
+}))
+
 const { AuthService } = require('./auth.service')
+const { CurrenciesEnum, DefaultValueDateTypeEnum, UserType, RolesEnum } = require('@xpert-ai/contracts')
+const { RequestContext } = require('../core/context')
+const { EVENT_ORGANIZATION_CREATED } = require('../organization/events')
 
 describe('AuthService', () => {
 	let service: InstanceType<typeof AuthService>
@@ -87,10 +119,38 @@ describe('AuthService', () => {
 	const userRepository = {
 		create: jest.fn((entity) => entity),
 		save: jest.fn(),
-		findOne: jest.fn()
+		findOne: jest.fn(),
+		createQueryBuilder: jest.fn()
 	}
 	const organizationRepository = {
+		findOne: jest.fn(),
+		create: jest.fn((entity) => entity),
+		save: jest.fn()
+	}
+	const tenantRepository = {
 		findOne: jest.fn()
+	}
+	const roleRepository = {
+		findOne: jest.fn()
+	}
+	const bindingRepository = {
+		findOne: jest.fn(),
+		create: jest.fn((entity) => entity),
+		save: jest.fn(async (entity) => ({
+			id: entity.id ?? 'binding-1',
+			...entity
+		}))
+	}
+	const verifiedEmailQueryBuilder = {
+		withDeleted: jest.fn(),
+		where: jest.fn(),
+		andWhere: jest.fn(),
+		orderBy: jest.fn(),
+		take: jest.fn(),
+		getMany: jest.fn()
+	}
+	for (const method of ['withDeleted', 'where', 'andWhere', 'orderBy', 'take'] as const) {
+		verifiedEmailQueryBuilder[method].mockReturnValue(verifiedEmailQueryBuilder)
 	}
 	const manager = {
 		getRepository: jest.fn((entity) => {
@@ -99,6 +159,12 @@ describe('AuthService', () => {
 					return userRepository
 				case 'Organization':
 					return organizationRepository
+				case 'Role':
+					return roleRepository
+				case 'ExternalIdentityBinding':
+					return bindingRepository
+				case 'Tenant':
+					return tenantRepository
 				default:
 					throw new Error(`Unexpected repository: ${entity?.name}`)
 			}
@@ -110,9 +176,13 @@ describe('AuthService', () => {
 	const referralService = {
 		bindRegistration: jest.fn()
 	}
+	const eventEmitter = {
+		emit: jest.fn()
+	}
 
 	beforeEach(() => {
 		jest.clearAllMocks()
+		RequestContext.currentUserId.mockReturnValue(null)
 
 		service = new AuthService(
 			userService as never,
@@ -124,13 +194,31 @@ describe('AuthService', () => {
 			configService as never,
 			commandBus as never,
 			dataSource as never,
-			referralService as never
+			referralService as never,
+			eventEmitter as never
 		)
 
 		userRepository.save.mockImplementation(async (entity) => ({
 			...entity,
 			id: entity.id ?? 'user-1'
 		}))
+		userRepository.createQueryBuilder.mockReturnValue(verifiedEmailQueryBuilder)
+		verifiedEmailQueryBuilder.getMany.mockResolvedValue([])
+		bindingRepository.findOne.mockResolvedValue(null)
+		roleRepository.findOne.mockImplementation(async (options) =>
+			options?.where?.tenantId === 'tenant-1' &&
+			options?.where?.name === RolesEnum.TRIAL &&
+			options?.where?.isSystem === undefined
+				? {
+						id: 'role-trial',
+						name: RolesEnum.TRIAL,
+						isSystem: false
+					}
+				: null
+		)
+		tenantRepository.findOne.mockResolvedValue({
+			id: 'tenant-1'
+		})
 		userRepository.findOne.mockResolvedValueOnce(null).mockResolvedValue({
 			id: 'user-1',
 			email: 'new.user@example.com',
@@ -143,6 +231,10 @@ describe('AuthService', () => {
 			}
 		})
 		organizationRepository.findOne.mockResolvedValue({ id: 'org-default' })
+		organizationRepository.save.mockImplementation(async (entity) => ({
+			...entity,
+			id: entity.id ?? 'org-trial'
+		}))
 		userOrganizationService.ensureMembershipInTransaction.mockResolvedValue({
 			membership: {
 				id: 'membership-1'
@@ -284,6 +376,404 @@ describe('AuthService', () => {
 
 		expect(userOrganizationService.completeMembershipCreation).not.toHaveBeenCalled()
 		expect(emailService.welcomeUser).not.toHaveBeenCalled()
+	})
+
+	it('resolves an existing external binding before considering the current verified email', async () => {
+		bindingRepository.findOne.mockResolvedValueOnce({
+			id: 'binding-1',
+			tenantId: 'tenant-1',
+			provider: 'github-sso',
+			subjectId: '123',
+			userId: 'user-bound',
+			profile: {
+				login: 'old-login'
+			}
+		})
+		userRepository.findOne.mockReset()
+		userRepository.findOne.mockResolvedValue({
+			id: 'user-bound',
+			tenantId: 'tenant-1',
+			type: UserType.USER,
+			hash: 'hashed-password',
+			email: 'old-address@example.com',
+			emailVerified: true
+		})
+
+		await expect(
+			service.resolveOrBindVerifiedEmail({
+				provider: 'github-sso',
+				subjectId: '123',
+				tenantId: 'tenant-1',
+				verifiedEmail: 'new-address@example.com',
+				profile: {
+					login: 'new-login'
+				}
+			})
+		).resolves.toEqual(
+			expect.objectContaining({
+				id: 'user-bound',
+				email: 'old-address@example.com'
+			})
+		)
+		expect(verifiedEmailQueryBuilder.getMany).not.toHaveBeenCalled()
+		expect(bindingRepository.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: 'binding-1',
+				profile: {
+					login: 'new-login'
+				}
+			})
+		)
+		expect(userRepository.save).not.toHaveBeenCalled()
+	})
+
+	it('binds a unique normalized human account and verifies its email without replacing profile data', async () => {
+		const existingUser = {
+			id: 'user-existing',
+			tenantId: 'tenant-1',
+			type: UserType.USER,
+			hash: 'hashed-password',
+			email: 'alice@example.com',
+			emailVerified: false,
+			firstName: 'Local Alice',
+			imageUrl: 'https://local.example.com/alice.png'
+		}
+		verifiedEmailQueryBuilder.getMany.mockResolvedValue([existingUser])
+
+		await expect(
+			service.resolveOrBindVerifiedEmail({
+				provider: 'github-sso',
+				subjectId: '123',
+				tenantId: 'tenant-1',
+				verifiedEmail: ' Alice@Example.com ',
+				displayName: 'GitHub Alice',
+				avatarUrl: 'https://github.example.com/alice.png',
+				profile: {
+					login: 'alice'
+				}
+			})
+		).resolves.toEqual(
+			expect.objectContaining({
+				id: 'user-existing',
+				firstName: 'Local Alice',
+				imageUrl: 'https://local.example.com/alice.png',
+				emailVerified: true
+			})
+		)
+		expect(verifiedEmailQueryBuilder.andWhere).toHaveBeenCalledWith('LOWER(user.email) = :verifiedEmail', {
+			verifiedEmail: 'alice@example.com'
+		})
+		expect(userRepository.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: 'user-existing',
+				emailVerified: true,
+				firstName: 'Local Alice',
+				imageUrl: 'https://local.example.com/alice.png'
+			})
+		)
+		expect(bindingRepository.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tenantId: 'tenant-1',
+				userId: 'user-existing',
+				provider: 'github-sso',
+				subjectId: '123',
+				profile: {
+					login: 'alice'
+				}
+			})
+		)
+	})
+
+	it.each([
+		[
+			'duplicate email accounts',
+			[
+				{
+					id: 'user-1',
+					tenantId: 'tenant-1',
+					type: UserType.USER,
+					hash: 'hash-1'
+				},
+				{
+					id: 'user-2',
+					tenantId: 'tenant-1',
+					type: UserType.USER,
+					hash: 'hash-2'
+				}
+			]
+		],
+		[
+			'a communication account',
+			[
+				{
+					id: 'communication-1',
+					tenantId: 'tenant-1',
+					type: UserType.COMMUNICATION,
+					hash: 'hashed-password'
+				}
+			]
+		]
+	])('rejects %s instead of guessing an account', async (_label, matchingUsers) => {
+		verifiedEmailQueryBuilder.getMany.mockResolvedValue(matchingUsers)
+
+		await expect(
+			service.resolveOrBindVerifiedEmail({
+				provider: 'github-sso',
+				subjectId: '123',
+				tenantId: 'tenant-1',
+				verifiedEmail: 'alice@example.com'
+			})
+		).rejects.toThrow()
+		expect(bindingRepository.save).not.toHaveBeenCalled()
+	})
+
+	it('allows signup when only a soft-deleted account uses the verified email', async () => {
+		verifiedEmailQueryBuilder.getMany.mockResolvedValue([])
+		verifiedEmailQueryBuilder.withDeleted.mockImplementationOnce(() => {
+			verifiedEmailQueryBuilder.getMany.mockResolvedValueOnce([
+				{
+					id: 'deleted-1',
+					tenantId: 'tenant-1',
+					type: UserType.USER,
+					hash: 'hashed-password',
+					deletedAt: new Date()
+				}
+			])
+			return verifiedEmailQueryBuilder
+		})
+
+		await expect(
+			service.resolveOrBindVerifiedEmail({
+				provider: 'github-sso',
+				subjectId: '123',
+				tenantId: 'tenant-1',
+				verifiedEmail: 'deleted@example.com'
+			})
+		).resolves.toBeNull()
+		expect(bindingRepository.save).not.toHaveBeenCalled()
+	})
+
+	it('creates a verified TRIAL account with its own organization, membership, referral, and binding', async () => {
+		userRepository.findOne.mockReset()
+		const transactionOrder: string[] = []
+		organizationRepository.save.mockImplementation(async (entity) => {
+			transactionOrder.push('organization')
+			return {
+				...entity,
+				id: 'org-trial'
+			}
+		})
+		userRepository.save.mockImplementation(async (entity) => {
+			transactionOrder.push('user')
+			return {
+				...entity,
+				id: 'github-user-1'
+			}
+		})
+		userOrganizationService.ensureMembershipInTransaction.mockImplementation(async () => {
+			transactionOrder.push('membership')
+			return {
+				membership: {
+					id: 'membership-1'
+				},
+				created: true
+			}
+		})
+		referralService.bindRegistration.mockImplementation(async () => {
+			transactionOrder.push('referral')
+		})
+		bindingRepository.save.mockImplementation(async (entity) => {
+			transactionOrder.push('binding')
+			return {
+				id: 'binding-1',
+				...entity
+			}
+		})
+		eventEmitter.emit.mockImplementation(() => {
+			transactionOrder.push('organization-event')
+		})
+		userOrganizationService.completeMembershipCreation.mockImplementation(async () => {
+			transactionOrder.push('membership-event')
+		})
+
+		await expect(
+			service.registerVerifiedExternalIdentity(
+				{
+					provider: 'github-sso',
+					subjectId: '123',
+					tenantId: 'tenant-1',
+					verifiedEmail: ' Alice@Example.com ',
+					displayName: 'Alice',
+					avatarUrl: 'https://example.com/avatar.png',
+					profile: {
+						login: 'alice'
+					},
+					password: 'secret',
+					confirmPassword: 'secret',
+					referralCode: 'ABC234DEFG'
+				},
+				'en-US'
+			)
+		).resolves.toEqual({
+			user: expect.objectContaining({
+				id: 'github-user-1',
+				type: UserType.USER,
+				email: 'alice@example.com',
+				emailVerified: true,
+				firstName: 'Alice',
+				imageUrl: 'https://example.com/avatar.png',
+				hash: 'hashed:secret',
+				role: expect.objectContaining({
+					name: RolesEnum.TRIAL
+				})
+			}),
+			created: true
+		})
+
+		expect(roleRepository.findOne).toHaveBeenCalledWith({
+			where: {
+				tenantId: 'tenant-1',
+				name: RolesEnum.TRIAL
+			}
+		})
+		expect(tenantRepository.findOne).toHaveBeenCalledWith({
+			select: {
+				id: true
+			},
+			where: {
+				id: 'tenant-1'
+			},
+			lock: {
+				mode: 'pessimistic_write'
+			}
+		})
+		expect(organizationRepository.create).toHaveBeenCalledWith({
+			name: 'Alice',
+			tenantId: 'tenant-1',
+			currency: CurrenciesEnum.CNY,
+			defaultValueDateType: DefaultValueDateTypeEnum.TODAY,
+			isDefault: false,
+			isActive: true,
+			show_profits: false,
+			show_bonuses_paid: false,
+			show_income: false,
+			show_total_hours: false,
+			show_projects_count: true,
+			show_minimum_project_size: true,
+			show_clients_count: true,
+			show_clients: true,
+			show_employees_count: true
+		})
+		expect(organizationRepository.findOne).not.toHaveBeenCalled()
+		expect(userOrganizationService.ensureMembershipInTransaction).toHaveBeenCalledWith(manager, {
+			organizationId: 'org-trial',
+			tenantId: 'tenant-1',
+			userId: 'github-user-1'
+		})
+		expect(referralService.bindRegistration).toHaveBeenCalledWith(manager, {
+			tenantId: 'tenant-1',
+			referredUserId: 'github-user-1',
+			referralCode: 'ABC234DEFG'
+		})
+		expect(bindingRepository.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tenantId: 'tenant-1',
+				userId: 'github-user-1',
+				provider: 'github-sso',
+				subjectId: '123'
+			})
+		)
+		expect(eventEmitter.emit).toHaveBeenCalledWith(
+			EVENT_ORGANIZATION_CREATED,
+			expect.objectContaining({
+				tenantId: 'tenant-1',
+				organizationId: 'org-trial',
+				ownerUserId: 'github-user-1'
+			})
+		)
+		expect(userOrganizationService.completeMembershipCreation).toHaveBeenCalledWith({
+			organizationId: 'org-trial',
+			tenantId: 'tenant-1',
+			userId: 'github-user-1'
+		})
+		expect(transactionOrder).toEqual([
+			'organization',
+			'user',
+			'membership',
+			'referral',
+			'binding',
+			'organization-event',
+			'membership-event'
+		])
+	})
+
+	it('uses an account created during completion and ignores password and referral persistence', async () => {
+		const racedUser = {
+			id: 'raced-user',
+			tenantId: 'tenant-1',
+			type: UserType.USER,
+			hash: 'existing-hash',
+			email: 'alice@example.com',
+			emailVerified: true
+		}
+		verifiedEmailQueryBuilder.getMany.mockResolvedValue([racedUser])
+
+		await expect(
+			service.registerVerifiedExternalIdentity(
+				{
+					provider: 'github-sso',
+					subjectId: '123',
+					tenantId: 'tenant-1',
+					verifiedEmail: 'alice@example.com',
+					password: 'new-secret',
+					confirmPassword: 'new-secret',
+					referralCode: 'ABC234DEFG'
+				},
+				'en-US'
+			)
+		).resolves.toEqual({
+			user: racedUser,
+			created: false
+		})
+
+		expect(roleRepository.findOne).not.toHaveBeenCalled()
+		expect(userRepository.create).not.toHaveBeenCalled()
+		expect(userOrganizationService.ensureMembershipInTransaction).not.toHaveBeenCalled()
+		expect(referralService.bindRegistration).not.toHaveBeenCalled()
+		expect(emailService.welcomeUser).not.toHaveBeenCalled()
+		expect(bindingRepository.save).toHaveBeenCalledTimes(1)
+	})
+
+	it('rejects a short or mismatched password before opening a signup transaction', async () => {
+		dataSource.transaction.mockClear()
+
+		await expect(
+			service.registerVerifiedExternalIdentity(
+				{
+					provider: 'github-sso',
+					subjectId: '123',
+					tenantId: 'tenant-1',
+					verifiedEmail: 'alice@example.com',
+					password: 'short',
+					confirmPassword: 'short'
+				},
+				'en-US'
+			)
+		).rejects.toThrow(/at least 6/)
+		await expect(
+			service.registerVerifiedExternalIdentity(
+				{
+					provider: 'github-sso',
+					subjectId: '123',
+					tenantId: 'tenant-1',
+					verifiedEmail: 'alice@example.com',
+					password: 'secret',
+					confirmPassword: 'different'
+				},
+				'en-US'
+			)
+		).rejects.toThrow(/must match/)
+		expect(dataSource.transaction).not.toHaveBeenCalled()
 	})
 
 	it('issues tokens for an existing user and updates the refresh token', async () => {

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -1,5 +1,6 @@
 import {
 	BadRequestException,
+	ConflictException,
 	ForbiddenException,
 	Injectable,
 	InternalServerErrorException,
@@ -9,9 +10,12 @@ import {
 } from '@nestjs/common'
 import { CommandBus } from '@nestjs/cqrs'
 import { ConfigService } from '@nestjs/config'
+import { EventEmitter2 } from '@nestjs/event-emitter'
 import { InjectRepository } from '@nestjs/typeorm'
 import { buildQueryString } from '@xpert-ai/server-common'
 import {
+	CurrenciesEnum,
+	DefaultValueDateTypeEnum,
 	IChangePasswordRequest,
 	ID,
 	IPasswordReset,
@@ -23,8 +27,10 @@ import {
 	IUserRegistrationInput,
 	LanguagesEnum,
 	mapTranslationLanguage,
-	RolesEnum
+	RolesEnum,
+	UserType
 } from '@xpert-ai/contracts'
+import type { VerifiedEmailLoginInput } from '@xpert-ai/plugin-sdk'
 import { SocialAuthService } from '@xpert-ai/server-auth'
 import { environment as env, environment, IEnvironment } from '@xpert-ai/server-config'
 import bcrypt from 'bcryptjs'
@@ -33,7 +39,7 @@ import { nanoid } from 'nanoid'
 import { I18nService } from 'nestjs-i18n'
 import { JsonWebTokenError, sign, verify } from 'jsonwebtoken'
 import { t } from 'i18next'
-import { DataSource, EntityManager, FindOptionsWhere, Repository } from 'typeorm'
+import { DataSource, EntityManager, FindOptionsWhere, QueryFailedError, Repository } from 'typeorm'
 import { EmailService } from '../email/email.service'
 import { UserOrganizationService } from '../user-organization/user-organization.services'
 import { User } from '../user/user.entity'
@@ -44,6 +50,22 @@ import { RoleService } from '../role/role.service'
 import { OrganizationService } from '../organization/organization.service'
 import { Organization } from '../organization/organization.entity'
 import { ReferralService } from '../referral'
+import { ExternalIdentityBinding } from '../account-binding/external-identity-binding.entity'
+import { Role } from '../role/role.entity'
+import { RequestContext } from '../core/context'
+import { Tenant } from '../tenant/tenant.entity'
+import { EVENT_ORGANIZATION_CREATED, OrganizationCreatedEvent } from '../organization/events'
+
+export interface RegisterVerifiedExternalIdentityInput extends VerifiedEmailLoginInput {
+	password?: string
+	confirmPassword?: string
+	referralCode?: string
+}
+
+export interface RegisterVerifiedExternalIdentityResult {
+	user: User
+	created: boolean
+}
 
 @Injectable()
 export class AuthService extends SocialAuthService {
@@ -62,9 +84,379 @@ export class AuthService extends SocialAuthService {
 		private readonly _configService: ConfigService<IEnvironment>,
 		private readonly commandBus: CommandBus,
 		private readonly dataSource: DataSource,
-		private readonly referralService: ReferralService
+		private readonly referralService: ReferralService,
+		private readonly eventEmitter: EventEmitter2
 	) {
 		super()
+	}
+
+	async resolveOrBindVerifiedEmail(input: VerifiedEmailLoginInput): Promise<User | null> {
+		const normalizedInput = this.normalizeVerifiedEmailLoginInput(input)
+		try {
+			return await this.dataSource.transaction((manager) =>
+				this.resolveOrBindVerifiedEmailWithManager(manager, normalizedInput)
+			)
+		} catch (error) {
+			this.rethrowVerifiedIdentityConflict(error)
+		}
+	}
+
+	async registerVerifiedExternalIdentity(
+		input: RegisterVerifiedExternalIdentityInput,
+		languageCode: LanguagesEnum
+	): Promise<RegisterVerifiedExternalIdentityResult> {
+		const normalizedInput = this.normalizeVerifiedEmailLoginInput(input)
+		const password = this.requireVerifiedSignupValue(input?.password, 'password')
+		const confirmPassword = this.requireVerifiedSignupValue(input?.confirmPassword, 'confirmPassword')
+		if (password.length < 6) {
+			throw new BadRequestException('The password must contain at least 6 characters.')
+		}
+		if (password !== confirmPassword) {
+			throw new BadRequestException('The password and confirmation password must match.')
+		}
+		const hash = await this.getPasswordHash(password)
+
+		let membershipCreation: {
+			organizationId: string
+			tenantId: string
+			userId: string
+		} | null = null
+		let organizationCreation: {
+			tenantId: string
+			organizationId: string
+			ownerUserId: string
+		} | null = null
+		let registrationOrganizationId: string | null = null
+
+		let result: RegisterVerifiedExternalIdentityResult
+		try {
+			result = await this.dataSource.transaction(async (manager) => {
+				const existingUser = await this.resolveOrBindVerifiedEmailWithManager(manager, normalizedInput)
+				if (existingUser) {
+					return {
+						user: existingUser,
+						created: false
+					}
+				}
+
+				const role = await manager.getRepository(Role).findOne({
+					where: {
+						tenantId: normalizedInput.tenantId,
+						name: RolesEnum.TRIAL
+					}
+				})
+				if (!role) {
+					throw new InternalServerErrorException(
+						`The TRIAL role is not configured for tenant '${normalizedInput.tenantId}'.`
+					)
+				}
+
+				const organizationRepository = manager.getRepository(Organization)
+				const organization = await organizationRepository.save(
+					organizationRepository.create({
+						name: normalizedInput.displayName ?? normalizedInput.verifiedEmail,
+						tenantId: normalizedInput.tenantId,
+						currency: CurrenciesEnum.CNY,
+						defaultValueDateType: DefaultValueDateTypeEnum.TODAY,
+						isDefault: false,
+						isActive: true,
+						show_profits: false,
+						show_bonuses_paid: false,
+						show_income: false,
+						show_total_hours: false,
+						show_projects_count: true,
+						show_minimum_project_size: true,
+						show_clients_count: true,
+						show_clients: true,
+						show_employees_count: true
+					})
+				)
+				const resolvedOrganizationId = String(organization.id)
+				registrationOrganizationId = resolvedOrganizationId
+
+				const userRepository = manager.getRepository(User)
+				const user = await userRepository.save(
+					userRepository.create({
+						type: UserType.USER,
+						tenantId: normalizedInput.tenantId,
+						email: normalizedInput.verifiedEmail,
+						emailVerified: true,
+						firstName: this.normalizeOptionalVerifiedIdentityValue(normalizedInput.displayName),
+						imageUrl: this.normalizeOptionalVerifiedIdentityValue(normalizedInput.avatarUrl),
+						hash,
+						role
+					})
+				)
+
+				const membership = await this.userOrganizationService.ensureMembershipInTransaction(manager, {
+					organizationId: resolvedOrganizationId,
+					tenantId: normalizedInput.tenantId,
+					userId: String(user.id)
+				})
+				if (membership.created) {
+					membershipCreation = {
+						organizationId: resolvedOrganizationId,
+						tenantId: normalizedInput.tenantId,
+						userId: String(user.id)
+					}
+				}
+				organizationCreation = {
+					tenantId: normalizedInput.tenantId,
+					organizationId: resolvedOrganizationId,
+					ownerUserId: String(user.id)
+				}
+
+				await this.referralService.bindRegistration(manager, {
+					tenantId: normalizedInput.tenantId,
+					referredUserId: String(user.id),
+					referralCode: input.referralCode
+				})
+
+				await this.createStrictVerifiedIdentityBinding(manager, {
+					...normalizedInput,
+					userId: String(user.id)
+				})
+
+				return {
+					user,
+					created: true
+				}
+			})
+		} catch (error) {
+			this.rethrowVerifiedIdentityConflict(error)
+		}
+
+		if (organizationCreation) {
+			this.eventEmitter.emit(
+				EVENT_ORGANIZATION_CREATED,
+				new OrganizationCreatedEvent(
+					organizationCreation.tenantId,
+					organizationCreation.organizationId,
+					organizationCreation.ownerUserId
+				)
+			)
+		}
+		if (membershipCreation) {
+			await this.userOrganizationService.completeMembershipCreation(membershipCreation)
+		}
+		if (result.created) {
+			this.emailService.welcomeUser(result.user, languageCode, registrationOrganizationId ?? undefined, undefined)
+		}
+		return result
+	}
+
+	private async resolveOrBindVerifiedEmailWithManager(
+		manager: EntityManager,
+		input: VerifiedEmailLoginInput
+	): Promise<User | null> {
+		const bindingRepository = manager.getRepository(ExternalIdentityBinding)
+		const userRepository = manager.getRepository(User)
+		const existingBinding = await bindingRepository.findOne({
+			where: {
+				tenantId: input.tenantId,
+				provider: input.provider,
+				subjectId: input.subjectId
+			}
+		})
+
+		if (existingBinding) {
+			const boundUser = await userRepository.findOne({
+				where: {
+					id: existingBinding.userId,
+					tenantId: input.tenantId
+				},
+				withDeleted: true
+			})
+			this.assertEligibleVerifiedIdentityUser(boundUser)
+
+			if (input.profile !== undefined) {
+				existingBinding.profile = this.normalizeVerifiedIdentityProfile(input.profile) ?? null
+				await bindingRepository.save(existingBinding)
+			}
+			return boundUser
+		}
+
+		await this.lockTenantRegistrationScope(manager, input.tenantId)
+
+		const matchingUsers = await userRepository
+			.createQueryBuilder('user')
+			.where('user.tenantId = :tenantId', { tenantId: input.tenantId })
+			.andWhere('LOWER(user.email) = :verifiedEmail', {
+				verifiedEmail: input.verifiedEmail
+			})
+			.orderBy('user.createdAt', 'ASC')
+			.take(2)
+			.getMany()
+
+		if (matchingUsers.length > 1) {
+			throw new ConflictException('Multiple Xpert accounts use this verified email in the current tenant.')
+		}
+		if (matchingUsers.length === 0) {
+			return null
+		}
+
+		const [matchedUser] = matchingUsers
+		this.assertEligibleVerifiedIdentityUser(matchedUser)
+		const existingUserBinding = await bindingRepository.findOne({
+			where: {
+				tenantId: input.tenantId,
+				provider: input.provider,
+				userId: matchedUser.id
+			}
+		})
+		if (existingUserBinding && existingUserBinding.subjectId !== input.subjectId) {
+			throw new ConflictException(`This Xpert account is already bound to another ${input.provider} identity.`)
+		}
+
+		if (!matchedUser.emailVerified) {
+			matchedUser.emailVerified = true
+			await userRepository.save(matchedUser)
+		}
+		await this.createStrictVerifiedIdentityBinding(manager, {
+			...input,
+			userId: String(matchedUser.id)
+		})
+		return matchedUser
+	}
+
+	private async createStrictVerifiedIdentityBinding(
+		manager: EntityManager,
+		input: VerifiedEmailLoginInput & {
+			userId: string
+		}
+	): Promise<ExternalIdentityBinding> {
+		const bindingRepository = manager.getRepository(ExternalIdentityBinding)
+		const [subjectBinding, userBinding] = await Promise.all([
+			bindingRepository.findOne({
+				where: {
+					tenantId: input.tenantId,
+					provider: input.provider,
+					subjectId: input.subjectId
+				}
+			}),
+			bindingRepository.findOne({
+				where: {
+					tenantId: input.tenantId,
+					provider: input.provider,
+					userId: input.userId
+				}
+			})
+		])
+
+		if (subjectBinding && subjectBinding.userId !== input.userId) {
+			throw new ConflictException(`This ${input.provider} identity is already bound to another Xpert account.`)
+		}
+		if (userBinding && userBinding.subjectId !== input.subjectId) {
+			throw new ConflictException(`This Xpert account is already bound to another ${input.provider} identity.`)
+		}
+
+		const binding = subjectBinding ?? userBinding
+		if (binding) {
+			if (input.profile !== undefined) {
+				binding.profile = this.normalizeVerifiedIdentityProfile(input.profile) ?? null
+				return bindingRepository.save(binding)
+			}
+			return binding
+		}
+
+		return bindingRepository.save(
+			bindingRepository.create({
+				tenantId: input.tenantId,
+				userId: input.userId,
+				provider: input.provider,
+				subjectId: input.subjectId,
+				profile: this.normalizeVerifiedIdentityProfile(input.profile) ?? null,
+				createdById: RequestContext.currentUserId() ?? undefined,
+				updatedById: RequestContext.currentUserId() ?? undefined
+			})
+		)
+	}
+
+	private normalizeVerifiedEmailLoginInput(input: VerifiedEmailLoginInput): VerifiedEmailLoginInput {
+		const provider = this.requireVerifiedSignupValue(input?.provider, 'provider')
+		const subjectId = this.requireVerifiedSignupValue(input?.subjectId, 'subjectId')
+		const tenantId = this.requireVerifiedSignupValue(input?.tenantId, 'tenantId')
+		const verifiedEmail = this.requireVerifiedSignupValue(input?.verifiedEmail, 'verifiedEmail').toLowerCase()
+		if (!verifiedEmail.includes('@') || /\s/.test(verifiedEmail)) {
+			throw new BadRequestException("'verifiedEmail' must be a valid email address.")
+		}
+
+		return {
+			provider,
+			subjectId,
+			tenantId,
+			verifiedEmail,
+			displayName: this.normalizeOptionalVerifiedIdentityValue(input?.displayName),
+			avatarUrl: this.normalizeOptionalVerifiedIdentityValue(input?.avatarUrl),
+			profile: this.normalizeVerifiedIdentityProfile(input?.profile),
+			returnTo: this.normalizeOptionalVerifiedIdentityValue(input?.returnTo)
+		}
+	}
+
+	private assertEligibleVerifiedIdentityUser(user: User | null): asserts user is User {
+		if (
+			!user ||
+			user.deletedAt ||
+			user.type !== UserType.USER ||
+			typeof user.hash !== 'string' ||
+			user.hash.trim().length === 0
+		) {
+			throw new ConflictException(
+				'The verified email or external identity belongs to an account that cannot use SSO login.'
+			)
+		}
+	}
+
+	private requireVerifiedSignupValue(value: string | null | undefined, field: string): string {
+		const normalized = this.normalizeOptionalVerifiedIdentityValue(value)
+		if (!normalized) {
+			throw new BadRequestException(`'${field}' is required.`)
+		}
+		return normalized
+	}
+
+	private normalizeOptionalVerifiedIdentityValue(value: string | null | undefined): string | undefined {
+		return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+	}
+
+	private normalizeVerifiedIdentityProfile(
+		profile: Record<string, unknown> | null | undefined
+	): Record<string, any> | undefined {
+		if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+			return undefined
+		}
+		return JSON.parse(JSON.stringify(profile))
+	}
+
+	private rethrowVerifiedIdentityConflict(error: unknown): never {
+		if (
+			error instanceof QueryFailedError &&
+			(error as QueryFailedError & { driverError?: { code?: string } }).driverError?.code === '23505'
+		) {
+			throw new ConflictException('The external identity or Xpert account was bound by another request.')
+		}
+		throw error
+	}
+
+	private async lockTenantRegistrationScope(manager: EntityManager, tenantId: string): Promise<void> {
+		const tenant = await manager.getRepository(Tenant).findOne({
+			select: {
+				id: true
+			},
+			where: {
+				id: tenantId
+			},
+			lock: {
+				mode: 'pessimistic_write'
+			}
+		})
+		if (!tenant?.id) {
+			throw new BadRequestException(
+				t('server-ai:Error.RegistrationTenantRequired', {
+					defaultValue: 'Tenant is required for registration.'
+				})
+			)
+		}
 	}
 
 	async validateUser(email: string, password: string): Promise<any> {
@@ -363,6 +755,7 @@ export class AuthService extends SocialAuthService {
 
 		const registration = await this.dataSource.transaction(async (manager) => {
 			const userRepository = manager.getRepository(User)
+			await this.lockTenantRegistrationScope(manager, tenantId)
 			const where: FindOptionsWhere<User>[] = []
 			if (normalizedEmail) {
 				where.push({

--- a/packages/server/src/auth/sso/auth-sso-binding.service.spec.ts
+++ b/packages/server/src/auth/sso/auth-sso-binding.service.spec.ts
@@ -20,6 +20,7 @@ const { RequestContext } = require('../../core/context')
 describe('AuthSsoBindingService', () => {
 	const pendingSsoBindingChallengeService = {
 		get: jest.fn(),
+		consume: jest.fn(),
 		delete: jest.fn().mockResolvedValue(undefined)
 	}
 	const accountBindingService = {
@@ -29,7 +30,8 @@ describe('AuthSsoBindingService', () => {
 	}
 	const authService = {
 		issueTokensForUser: jest.fn(),
-		register: jest.fn()
+		register: jest.fn(),
+		registerVerifiedExternalIdentity: jest.fn()
 	}
 	const userService = {
 		findOneByOptions: jest.fn()
@@ -39,6 +41,9 @@ describe('AuthSsoBindingService', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks()
+		pendingSsoBindingChallengeService.consume.mockImplementation((ticket) =>
+			pendingSsoBindingChallengeService.get(ticket)
+		)
 		RequestContext.currentUserId.mockReturnValue('user-ctx')
 		RequestContext.getScope.mockReturnValue({
 			tenantId: 'tenant-1',
@@ -66,7 +71,32 @@ describe('AuthSsoBindingService', () => {
 		})
 
 		await expect(service.getChallenge('ticket-1')).resolves.toEqual({
+			flow: 'anonymous_bind',
 			provider: 'lark',
+			displayName: 'Alice',
+			avatarUrl: 'https://example.com/avatar.png',
+			tenantScoped: true,
+			expiresAt: '2099-01-01T00:00:00.000Z'
+		})
+	})
+
+	it('returns the trusted email only for a verified-email signup challenge', async () => {
+		pendingSsoBindingChallengeService.get.mockResolvedValue({
+			ticket: 'ticket-1',
+			flow: 'verified_email_signup',
+			provider: 'github-sso',
+			subjectId: '123',
+			tenantId: 'tenant-1',
+			verifiedEmail: 'alice@example.com',
+			displayName: 'Alice',
+			avatarUrl: 'https://example.com/avatar.png',
+			expiresAt: '2099-01-01T00:00:00.000Z'
+		})
+
+		await expect(service.getChallenge('ticket-1')).resolves.toEqual({
+			flow: 'verified_email_signup',
+			provider: 'github-sso',
+			email: 'alice@example.com',
 			displayName: 'Alice',
 			avatarUrl: 'https://example.com/avatar.png',
 			tenantScoped: true,
@@ -224,6 +254,157 @@ describe('AuthSsoBindingService', () => {
 		)
 	})
 
+	it('completes verified-email signup using only the email stored in the ticket', async () => {
+		pendingSsoBindingChallengeService.get.mockResolvedValue({
+			ticket: 'ticket-1',
+			flow: 'verified_email_signup',
+			provider: 'github-sso',
+			subjectId: '123',
+			tenantId: 'tenant-1',
+			verifiedEmail: 'alice@example.com',
+			displayName: 'Alice',
+			avatarUrl: 'https://example.com/avatar.png',
+			profile: {
+				login: 'alice'
+			},
+			returnTo: '/projects/demo',
+			expiresAt: '2099-01-01T00:00:00.000Z'
+		})
+		authService.registerVerifiedExternalIdentity.mockResolvedValue({
+			user: {
+				id: 'user-1'
+			},
+			created: true
+		})
+		authService.issueTokensForUser.mockResolvedValue({
+			jwt: 'jwt-token',
+			refreshToken: 'refresh-token',
+			userId: 'user-1'
+		})
+
+		await expect(
+			service.registerAndBind(
+				{
+					ticket: 'ticket-1',
+					email: 'ALICE@example.com',
+					password: 'secret',
+					confirmPassword: 'secret',
+					referralCode: 'ABC234DEFG'
+				},
+				LanguagesEnum.English
+			)
+		).resolves.toEqual({
+			location:
+				'/sign-in/success?jwt=jwt-token&refreshToken=refresh-token&userId=user-1&returnTo=%2Fprojects%2Fdemo'
+		})
+
+		expect(authService.registerVerifiedExternalIdentity).toHaveBeenCalledWith(
+			{
+				provider: 'github-sso',
+				subjectId: '123',
+				tenantId: 'tenant-1',
+				verifiedEmail: 'alice@example.com',
+				displayName: 'Alice',
+				avatarUrl: 'https://example.com/avatar.png',
+				profile: {
+					login: 'alice'
+				},
+				returnTo: '/projects/demo',
+				password: 'secret',
+				confirmPassword: 'secret',
+				referralCode: 'ABC234DEFG'
+			},
+			LanguagesEnum.English
+		)
+		expect(pendingSsoBindingChallengeService.consume).toHaveBeenCalledWith('ticket-1')
+		expect(authService.issueTokensForUser).toHaveBeenCalledTimes(1)
+	})
+
+	it('rejects a changed email and preserves the verified-email signup ticket', async () => {
+		pendingSsoBindingChallengeService.get.mockResolvedValue({
+			ticket: 'ticket-1',
+			flow: 'verified_email_signup',
+			provider: 'github-sso',
+			subjectId: '123',
+			tenantId: 'tenant-1',
+			verifiedEmail: 'alice@example.com',
+			expiresAt: '2099-01-01T00:00:00.000Z'
+		})
+
+		await expect(
+			service.registerAndBind(
+				{
+					ticket: 'ticket-1',
+					email: 'mallory@example.com',
+					password: 'secret',
+					confirmPassword: 'secret'
+				},
+				LanguagesEnum.English
+			)
+		).rejects.toBeInstanceOf(BadRequestException)
+		expect(authService.registerVerifiedExternalIdentity).not.toHaveBeenCalled()
+		expect(pendingSsoBindingChallengeService.consume).not.toHaveBeenCalled()
+	})
+
+	it('preserves the verified-email signup ticket when registration validation fails', async () => {
+		pendingSsoBindingChallengeService.get.mockResolvedValue({
+			ticket: 'ticket-1',
+			flow: 'verified_email_signup',
+			provider: 'github-sso',
+			subjectId: '123',
+			tenantId: 'tenant-1',
+			verifiedEmail: 'alice@example.com',
+			expiresAt: '2099-01-01T00:00:00.000Z'
+		})
+		authService.registerVerifiedExternalIdentity.mockRejectedValue(
+			new BadRequestException('The invitation code is invalid.')
+		)
+
+		await expect(
+			service.registerAndBind(
+				{
+					ticket: 'ticket-1',
+					password: 'secret',
+					confirmPassword: 'secret',
+					referralCode: 'INVALID'
+				},
+				LanguagesEnum.English
+			)
+		).rejects.toBeInstanceOf(BadRequestException)
+		expect(pendingSsoBindingChallengeService.consume).not.toHaveBeenCalled()
+	})
+
+	it('rejects a concurrent replay before issuing another login token', async () => {
+		pendingSsoBindingChallengeService.get.mockResolvedValue({
+			ticket: 'ticket-1',
+			flow: 'verified_email_signup',
+			provider: 'github-sso',
+			subjectId: '123',
+			tenantId: 'tenant-1',
+			verifiedEmail: 'alice@example.com',
+			expiresAt: '2099-01-01T00:00:00.000Z'
+		})
+		pendingSsoBindingChallengeService.consume.mockResolvedValue(null)
+		authService.registerVerifiedExternalIdentity.mockResolvedValue({
+			user: {
+				id: 'user-1'
+			},
+			created: false
+		})
+
+		await expect(
+			service.registerAndBind(
+				{
+					ticket: 'ticket-1',
+					password: 'secret',
+					confirmPassword: 'secret'
+				},
+				LanguagesEnum.English
+			)
+		).rejects.toBeInstanceOf(BadRequestException)
+		expect(authService.issueTokensForUser).not.toHaveBeenCalled()
+	})
+
 	it('returns a minimal current-user challenge view for the authenticated tenant', async () => {
 		pendingSsoBindingChallengeService.get.mockResolvedValue({
 			ticket: 'ticket-1',
@@ -237,6 +418,7 @@ describe('AuthSsoBindingService', () => {
 		})
 
 		await expect(service.getCurrentUserChallenge('ticket-1')).resolves.toEqual({
+			flow: 'current_user_confirm',
 			provider: 'lark',
 			displayName: 'Alice',
 			avatarUrl: 'https://example.com/avatar.png',

--- a/packages/server/src/auth/sso/auth-sso-binding.service.ts
+++ b/packages/server/src/auth/sso/auth-sso-binding.service.ts
@@ -1,6 +1,5 @@
 import { BadRequestException, ConflictException, Injectable, UnauthorizedException } from '@nestjs/common'
 import { LanguagesEnum } from '@xpert-ai/contracts'
-import type { PendingSsoBindingFlow } from '@xpert-ai/plugin-sdk'
 import bcrypt from 'bcryptjs'
 import { AccountBindingService } from '../../account-binding'
 import { RequestContext } from '../../core/context'
@@ -8,13 +7,16 @@ import { UserService } from '../../user'
 import { AuthService } from '../auth.service'
 import {
 	PendingSsoBindingChallengeRecord,
-	PendingSsoBindingChallengeService
+	PendingSsoBindingChallengeService,
+	PendingSsoChallengeFlow
 } from './pending-sso-binding-challenge.service'
 
 export interface AuthSsoBindChallengeView {
+	flow: PendingSsoChallengeFlow
 	provider: string
 	displayName?: string
 	avatarUrl?: string
+	email?: string
 	tenantScoped: true
 	expiresAt: string
 }
@@ -51,7 +53,7 @@ export class AuthSsoBindingService {
 	) {}
 
 	async getChallenge(ticket?: string): Promise<AuthSsoBindChallengeView> {
-		const challenge = await this.getRequiredChallenge(ticket, 'anonymous_bind')
+		const challenge = await this.getRequiredPublicChallenge(ticket)
 		return this.toChallengeView(challenge)
 	}
 
@@ -114,7 +116,11 @@ export class AuthSsoBindingService {
 		input: RegisterAndBindSsoInput,
 		languageCode: LanguagesEnum
 	): Promise<CompletedSsoBindingResult> {
-		const challenge = await this.getRequiredChallenge(input?.ticket, 'anonymous_bind')
+		const challenge = await this.getRequiredRegistrationChallenge(input?.ticket)
+		if (challenge.flow === 'verified_email_signup') {
+			return this.registerVerifiedEmailIdentity(input, challenge, languageCode)
+		}
+
 		const email = this.requireValue(input?.email, 'email').toLowerCase()
 		const password = this.requireValue(input?.password, 'password')
 		const confirmPassword = this.requireValue(input?.confirmPassword, 'confirmPassword')
@@ -161,7 +167,52 @@ export class AuthSsoBindingService {
 		}
 	}
 
-	private async getRequiredChallenge(ticket: string | undefined, expectedFlow: PendingSsoBindingFlow) {
+	private async registerVerifiedEmailIdentity(
+		input: RegisterAndBindSsoInput,
+		challenge: PendingSsoBindingChallengeRecord,
+		languageCode: LanguagesEnum
+	): Promise<CompletedSsoBindingResult> {
+		const verifiedEmail = this.requireValue(challenge.verifiedEmail ?? undefined, 'verifiedEmail').toLowerCase()
+		const submittedEmail = typeof input?.email === 'string' ? input.email.trim().toLowerCase() : ''
+		if (submittedEmail && submittedEmail !== verifiedEmail) {
+			throw new BadRequestException('The verified email cannot be changed.')
+		}
+
+		const registration = await this.authService.registerVerifiedExternalIdentity(
+			{
+				provider: challenge.provider,
+				subjectId: challenge.subjectId,
+				tenantId: challenge.tenantId,
+				verifiedEmail,
+				displayName: challenge.displayName ?? undefined,
+				avatarUrl: challenge.avatarUrl ?? undefined,
+				profile: challenge.profile ?? undefined,
+				returnTo: challenge.returnTo ?? undefined,
+				password: input.password,
+				confirmPassword: input.confirmPassword,
+				referralCode: input.referralCode
+			},
+			languageCode
+		)
+
+		const consumedChallenge = await this.pendingSsoBindingChallengeService.consume(challenge.ticket)
+		if (
+			!consumedChallenge ||
+			consumedChallenge.flow !== 'verified_email_signup' ||
+			consumedChallenge.provider !== challenge.provider ||
+			consumedChallenge.subjectId !== challenge.subjectId ||
+			consumedChallenge.tenantId !== challenge.tenantId
+		) {
+			throw new BadRequestException('SSO binding session has expired. Please sign in again.')
+		}
+
+		const tokens = await this.authService.issueTokensForUser(registration.user.id)
+		return {
+			location: this.buildSignInSuccessLocation(tokens, challenge.returnTo ?? undefined)
+		}
+	}
+
+	private async getRequiredChallenge(ticket: string | undefined, expectedFlow: PendingSsoChallengeFlow) {
 		const normalizedTicket = this.requireValue(ticket, 'ticket')
 		const challenge = await this.pendingSsoBindingChallengeService.get(normalizedTicket)
 
@@ -174,6 +225,19 @@ export class AuthSsoBindingService {
 		}
 
 		return challenge
+	}
+
+	private async getRequiredPublicChallenge(ticket?: string) {
+		const normalizedTicket = this.requireValue(ticket, 'ticket')
+		const challenge = await this.pendingSsoBindingChallengeService.get(normalizedTicket)
+		if (!challenge || (challenge.flow !== 'anonymous_bind' && challenge.flow !== 'verified_email_signup')) {
+			throw new BadRequestException('SSO binding session has expired. Please sign in again.')
+		}
+		return challenge
+	}
+
+	private async getRequiredRegistrationChallenge(ticket?: string) {
+		return this.getRequiredPublicChallenge(ticket)
 	}
 
 	private async getRequiredCurrentUserChallenge(ticket?: string) {
@@ -194,9 +258,15 @@ export class AuthSsoBindingService {
 
 	private toChallengeView(challenge: PendingSsoBindingChallengeRecord): AuthSsoBindChallengeView {
 		return {
+			flow: challenge.flow,
 			provider: challenge.provider,
 			displayName: challenge.displayName ?? undefined,
 			avatarUrl: challenge.avatarUrl ?? undefined,
+			...(challenge.flow === 'verified_email_signup' && challenge.verifiedEmail
+				? {
+						email: challenge.verifiedEmail
+					}
+				: {}),
 			tenantScoped: true,
 			expiresAt: challenge.expiresAt
 		}

--- a/packages/server/src/auth/sso/pending-sso-binding-challenge.service.spec.ts
+++ b/packages/server/src/auth/sso/pending-sso-binding-challenge.service.spec.ts
@@ -1,86 +1,160 @@
 import { PendingSsoBindingChallengeService } from './pending-sso-binding-challenge.service'
 
 describe('PendingSsoBindingChallengeService', () => {
-  let redisClient: {
-    setEx: jest.Mock
-    get: jest.Mock
-    del: jest.Mock
-    getDel: jest.Mock
-  }
-  let service: PendingSsoBindingChallengeService
+	let redisClient: {
+		setEx: jest.Mock
+		get: jest.Mock
+		del: jest.Mock
+		getDel: jest.Mock
+	}
+	let service: PendingSsoBindingChallengeService
 
-  beforeEach(() => {
-    jest.clearAllMocks()
-    redisClient = {
-      setEx: jest.fn().mockResolvedValue('OK'),
-      get: jest.fn(),
-      del: jest.fn().mockResolvedValue(1),
-      getDel: jest.fn()
-    }
-    service = new PendingSsoBindingChallengeService(redisClient as any)
-  })
+	beforeEach(() => {
+		jest.clearAllMocks()
+		redisClient = {
+			setEx: jest.fn().mockResolvedValue('OK'),
+			get: jest.fn(),
+			del: jest.fn().mockResolvedValue(1),
+			getDel: jest.fn()
+		}
+		service = new PendingSsoBindingChallengeService(redisClient as any)
+	})
 
-  it('creates a challenge and stores it with ttl', async () => {
-    const result = await service.create({
-      provider: 'lark',
-      subjectId: 'union-1',
-      tenantId: 'tenant-1',
-      organizationId: 'org-1',
-      displayName: 'Alice',
-      avatarUrl: 'https://example.com/avatar.png',
-      returnTo: '/workspace'
-    })
+	it('creates a challenge and stores it with ttl', async () => {
+		const result = await service.create({
+			provider: 'lark',
+			subjectId: 'union-1',
+			tenantId: 'tenant-1',
+			organizationId: 'org-1',
+			displayName: 'Alice',
+			avatarUrl: 'https://example.com/avatar.png',
+			returnTo: '/workspace'
+		})
 
-    expect(result.ticket).toMatch(/^[a-f0-9]{32,}$/)
-    expect(redisClient.setEx).toHaveBeenCalledWith(
-      `auth:sso:bind:challenge:${result.ticket}`,
-      600,
-      expect.stringContaining('"flow":"anonymous_bind"')
-    )
-  })
+		expect(result.ticket).toMatch(/^[a-f0-9]{32,}$/)
+		expect(redisClient.setEx).toHaveBeenCalledWith(
+			`auth:sso:bind:challenge:${result.ticket}`,
+			600,
+			expect.stringContaining('"flow":"anonymous_bind"')
+		)
+	})
 
-  it('reads an existing challenge by ticket', async () => {
-    redisClient.get.mockResolvedValue(
-      JSON.stringify({
-        ticket: 'ticket-1',
-        flow: 'current_user_confirm',
-        provider: 'lark',
-        subjectId: 'union-1',
-        tenantId: 'tenant-1',
-        expiresAt: new Date().toISOString()
-      })
-    )
+	it('does not let the public binding flow mint a verified-email signup ticket', async () => {
+		const result = await service.create({
+			flow: 'verified_email_signup',
+			provider: 'github-sso',
+			subjectId: '123',
+			tenantId: 'tenant-1'
+		} as any)
 
-    await expect(service.get('ticket-1')).resolves.toEqual({
-      ticket: 'ticket-1',
-      flow: 'current_user_confirm',
-      provider: 'lark',
-      subjectId: 'union-1',
-      tenantId: 'tenant-1',
-      expiresAt: expect.any(String)
-    })
-  })
+		expect(redisClient.setEx).toHaveBeenCalledWith(
+			`auth:sso:bind:challenge:${result.ticket}`,
+			600,
+			expect.stringContaining('"flow":"anonymous_bind"')
+		)
+	})
 
-  it('consumes an existing challenge with getDel when available', async () => {
-    redisClient.getDel.mockResolvedValue(
-      JSON.stringify({
-        ticket: 'ticket-1',
-        flow: 'current_user_confirm',
-        provider: 'lark',
-        subjectId: 'union-1',
-        tenantId: 'tenant-1',
-        expiresAt: new Date().toISOString()
-      })
-    )
+	it('creates a host-owned verified-email signup challenge with a ten minute ttl', async () => {
+		const result = await service.createVerifiedEmailSignup({
+			provider: 'github-sso',
+			subjectId: '123',
+			tenantId: 'tenant-1',
+			verifiedEmail: ' Alice@Example.com ',
+			displayName: 'Alice',
+			avatarUrl: 'https://avatars.example.com/alice.png',
+			profile: {
+				login: 'alice'
+			},
+			returnTo: '/projects/demo'
+		})
 
-    await expect(service.consume('ticket-1')).resolves.toEqual({
-      ticket: 'ticket-1',
-      flow: 'current_user_confirm',
-      provider: 'lark',
-      subjectId: 'union-1',
-      tenantId: 'tenant-1',
-      expiresAt: expect.any(String)
-    })
-    expect(redisClient.getDel).toHaveBeenCalledWith('auth:sso:bind:challenge:ticket-1')
-  })
+		const [, ttl, serialized] = redisClient.setEx.mock.calls[0]
+		expect(ttl).toBe(600)
+		expect(JSON.parse(serialized)).toEqual(
+			expect.objectContaining({
+				ticket: result.ticket,
+				flow: 'verified_email_signup',
+				provider: 'github-sso',
+				subjectId: '123',
+				tenantId: 'tenant-1',
+				verifiedEmail: 'alice@example.com',
+				displayName: 'Alice',
+				avatarUrl: 'https://avatars.example.com/alice.png',
+				profile: {
+					login: 'alice'
+				},
+				returnTo: '/projects/demo'
+			})
+		)
+	})
+
+	it('rejects an off-site return path for a verified-email signup challenge', async () => {
+		await expect(
+			service.createVerifiedEmailSignup({
+				provider: 'github-sso',
+				subjectId: '123',
+				tenantId: 'tenant-1',
+				verifiedEmail: 'alice@example.com',
+				returnTo: '//evil.example.com'
+			})
+		).rejects.toThrow(/same-origin path/)
+		expect(redisClient.setEx).not.toHaveBeenCalled()
+	})
+
+	it('reads an existing challenge by ticket', async () => {
+		redisClient.get.mockResolvedValue(
+			JSON.stringify({
+				ticket: 'ticket-1',
+				flow: 'current_user_confirm',
+				provider: 'lark',
+				subjectId: 'union-1',
+				tenantId: 'tenant-1',
+				expiresAt: new Date().toISOString()
+			})
+		)
+
+		await expect(service.get('ticket-1')).resolves.toEqual({
+			ticket: 'ticket-1',
+			flow: 'current_user_confirm',
+			provider: 'lark',
+			subjectId: 'union-1',
+			tenantId: 'tenant-1',
+			expiresAt: expect.any(String)
+		})
+	})
+
+	it('consumes an existing challenge with getDel when available', async () => {
+		redisClient.getDel.mockResolvedValue(
+			JSON.stringify({
+				ticket: 'ticket-1',
+				flow: 'current_user_confirm',
+				provider: 'lark',
+				subjectId: 'union-1',
+				tenantId: 'tenant-1',
+				expiresAt: new Date().toISOString()
+			})
+		)
+
+		await expect(service.consume('ticket-1')).resolves.toEqual({
+			ticket: 'ticket-1',
+			flow: 'current_user_confirm',
+			provider: 'lark',
+			subjectId: 'union-1',
+			tenantId: 'tenant-1',
+			expiresAt: expect.any(String)
+		})
+		expect(redisClient.getDel).toHaveBeenCalledWith('auth:sso:bind:challenge:ticket-1')
+	})
+
+	it('refuses a non-atomic consume fallback', async () => {
+		const serviceWithoutGetDel = new PendingSsoBindingChallengeService({
+			setEx: redisClient.setEx,
+			get: redisClient.get,
+			del: redisClient.del
+		} as any)
+
+		await expect(serviceWithoutGetDel.consume('ticket-1')).rejects.toThrow(/atomic getDel/)
+		expect(redisClient.get).not.toHaveBeenCalled()
+		expect(redisClient.del).not.toHaveBeenCalled()
+	})
 })

--- a/packages/server/src/auth/sso/pending-sso-binding-challenge.service.spec.ts
+++ b/packages/server/src/auth/sso/pending-sso-binding-challenge.service.spec.ts
@@ -1,42 +1,42 @@
 import { PendingSsoBindingChallengeService } from './pending-sso-binding-challenge.service'
 
 describe('PendingSsoBindingChallengeService', () => {
-	let redisClient: {
-		setEx: jest.Mock
-		get: jest.Mock
-		del: jest.Mock
-		getDel: jest.Mock
-	}
-	let service: PendingSsoBindingChallengeService
+  let redisClient: {
+    setEx: jest.Mock
+    get: jest.Mock
+    del: jest.Mock
+    getDel: jest.Mock
+  }
+  let service: PendingSsoBindingChallengeService
 
-	beforeEach(() => {
-		jest.clearAllMocks()
-		redisClient = {
-			setEx: jest.fn().mockResolvedValue('OK'),
-			get: jest.fn(),
-			del: jest.fn().mockResolvedValue(1),
-			getDel: jest.fn()
-		}
-		service = new PendingSsoBindingChallengeService(redisClient as any)
-	})
+  beforeEach(() => {
+    jest.clearAllMocks()
+    redisClient = {
+      setEx: jest.fn().mockResolvedValue('OK'),
+      get: jest.fn(),
+      del: jest.fn().mockResolvedValue(1),
+      getDel: jest.fn()
+    }
+    service = new PendingSsoBindingChallengeService(redisClient as any)
+  })
 
-	it('creates a challenge and stores it with ttl', async () => {
-		const result = await service.create({
-			provider: 'lark',
-			subjectId: 'union-1',
-			tenantId: 'tenant-1',
-			organizationId: 'org-1',
-			displayName: 'Alice',
-			avatarUrl: 'https://example.com/avatar.png',
-			returnTo: '/workspace'
-		})
+  it('creates a challenge and stores it with ttl', async () => {
+    const result = await service.create({
+      provider: 'lark',
+      subjectId: 'union-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      displayName: 'Alice',
+      avatarUrl: 'https://example.com/avatar.png',
+      returnTo: '/workspace'
+    })
 
-		expect(result.ticket).toMatch(/^[a-f0-9]{32,}$/)
-		expect(redisClient.setEx).toHaveBeenCalledWith(
-			`auth:sso:bind:challenge:${result.ticket}`,
-			600,
-			expect.stringContaining('"flow":"anonymous_bind"')
-		)
+    expect(result.ticket).toMatch(/^[a-f0-9]{32,}$/)
+    expect(redisClient.setEx).toHaveBeenCalledWith(
+      `auth:sso:bind:challenge:${result.ticket}`,
+      600,
+      expect.stringContaining('"flow":"anonymous_bind"')
+    )
 	})
 
 	it('does not let the public binding flow mint a verified-email signup ticket', async () => {
@@ -99,52 +99,52 @@ describe('PendingSsoBindingChallengeService', () => {
 			})
 		).rejects.toThrow(/same-origin path/)
 		expect(redisClient.setEx).not.toHaveBeenCalled()
-	})
+  })
 
-	it('reads an existing challenge by ticket', async () => {
-		redisClient.get.mockResolvedValue(
-			JSON.stringify({
-				ticket: 'ticket-1',
-				flow: 'current_user_confirm',
-				provider: 'lark',
-				subjectId: 'union-1',
-				tenantId: 'tenant-1',
-				expiresAt: new Date().toISOString()
-			})
-		)
+  it('reads an existing challenge by ticket', async () => {
+    redisClient.get.mockResolvedValue(
+      JSON.stringify({
+        ticket: 'ticket-1',
+        flow: 'current_user_confirm',
+        provider: 'lark',
+        subjectId: 'union-1',
+        tenantId: 'tenant-1',
+        expiresAt: new Date().toISOString()
+      })
+    )
 
-		await expect(service.get('ticket-1')).resolves.toEqual({
-			ticket: 'ticket-1',
-			flow: 'current_user_confirm',
-			provider: 'lark',
-			subjectId: 'union-1',
-			tenantId: 'tenant-1',
-			expiresAt: expect.any(String)
-		})
-	})
+    await expect(service.get('ticket-1')).resolves.toEqual({
+      ticket: 'ticket-1',
+      flow: 'current_user_confirm',
+      provider: 'lark',
+      subjectId: 'union-1',
+      tenantId: 'tenant-1',
+      expiresAt: expect.any(String)
+    })
+  })
 
-	it('consumes an existing challenge with getDel when available', async () => {
-		redisClient.getDel.mockResolvedValue(
-			JSON.stringify({
-				ticket: 'ticket-1',
-				flow: 'current_user_confirm',
-				provider: 'lark',
-				subjectId: 'union-1',
-				tenantId: 'tenant-1',
-				expiresAt: new Date().toISOString()
-			})
-		)
+  it('consumes an existing challenge with getDel when available', async () => {
+    redisClient.getDel.mockResolvedValue(
+      JSON.stringify({
+        ticket: 'ticket-1',
+        flow: 'current_user_confirm',
+        provider: 'lark',
+        subjectId: 'union-1',
+        tenantId: 'tenant-1',
+        expiresAt: new Date().toISOString()
+      })
+    )
 
-		await expect(service.consume('ticket-1')).resolves.toEqual({
-			ticket: 'ticket-1',
-			flow: 'current_user_confirm',
-			provider: 'lark',
-			subjectId: 'union-1',
-			tenantId: 'tenant-1',
-			expiresAt: expect.any(String)
-		})
-		expect(redisClient.getDel).toHaveBeenCalledWith('auth:sso:bind:challenge:ticket-1')
-	})
+    await expect(service.consume('ticket-1')).resolves.toEqual({
+      ticket: 'ticket-1',
+      flow: 'current_user_confirm',
+      provider: 'lark',
+      subjectId: 'union-1',
+      tenantId: 'tenant-1',
+      expiresAt: expect.any(String)
+    })
+    expect(redisClient.getDel).toHaveBeenCalledWith('auth:sso:bind:challenge:ticket-1')
+  })
 
 	it('refuses a non-atomic consume fallback', async () => {
 		const serviceWithoutGetDel = new PendingSsoBindingChallengeService({
@@ -156,5 +156,5 @@ describe('PendingSsoBindingChallengeService', () => {
 		await expect(serviceWithoutGetDel.consume('ticket-1')).rejects.toThrow(/atomic getDel/)
 		expect(redisClient.get).not.toHaveBeenCalled()
 		expect(redisClient.del).not.toHaveBeenCalled()
-	})
+})
 })

--- a/packages/server/src/auth/sso/pending-sso-binding-challenge.service.ts
+++ b/packages/server/src/auth/sso/pending-sso-binding-challenge.service.ts
@@ -1,143 +1,190 @@
 import { randomUUID } from 'crypto'
 import { Inject, Injectable, InternalServerErrorException } from '@nestjs/common'
 import type {
-  CreatePendingBindingInput,
-  CreatedPendingBindingRef,
-  PendingSsoBindingFlow
+	CreatePendingBindingInput,
+	CreatedPendingBindingRef,
+	PendingSsoBindingFlow,
+	VerifiedEmailLoginInput
 } from '@xpert-ai/plugin-sdk'
 import { REDIS_CLIENT } from '../../core/redis/types'
 
 type RedisClientLike = {
-  setEx?: (key: string, seconds: number, value: string) => Promise<unknown>
-  get?: (key: string) => Promise<string | null>
-  del?: (...keys: string[]) => Promise<unknown>
-  getDel?: (key: string) => Promise<string | null>
+	setEx?: (key: string, seconds: number, value: string) => Promise<unknown>
+	get?: (key: string) => Promise<string | null>
+	del?: (...keys: string[]) => Promise<unknown>
+	getDel?: (key: string) => Promise<string | null>
 }
 
 export interface PendingSsoBindingChallengeRecord {
-  ticket: string
-  flow: PendingSsoBindingFlow
-  provider: string
-  subjectId: string
-  tenantId: string
-  organizationId?: string | null
-  displayName?: string | null
-  avatarUrl?: string | null
-  profile?: Record<string, any> | null
-  returnTo?: string | null
-  expiresAt: string
+	ticket: string
+	flow: PendingSsoChallengeFlow
+	provider: string
+	subjectId: string
+	tenantId: string
+	organizationId?: string | null
+	displayName?: string | null
+	avatarUrl?: string | null
+	profile?: Record<string, any> | null
+	verifiedEmail?: string | null
+	returnTo?: string | null
+	expiresAt: string
 }
+
+export type PendingSsoChallengeFlow = PendingSsoBindingFlow | 'verified_email_signup'
 
 const PENDING_SSO_BINDING_PREFIX = 'auth:sso:bind:challenge:'
 const PENDING_SSO_BINDING_TTL_SECONDS = 60 * 10
 
 @Injectable()
 export class PendingSsoBindingChallengeService {
-  constructor(
-    @Inject(REDIS_CLIENT)
-    private readonly redisClient: RedisClientLike
-  ) {}
+	constructor(
+		@Inject(REDIS_CLIENT)
+		private readonly redisClient: RedisClientLike
+	) {}
 
-  async create(input: CreatePendingBindingInput): Promise<CreatedPendingBindingRef> {
-    const provider = this.requireValue(input?.provider, 'provider')
-    const subjectId = this.requireValue(input?.subjectId, 'subjectId')
-    const tenantId = this.requireValue(input?.tenantId, 'tenantId')
-    const ticket = randomUUID().replace(/-/g, '')
-    const expiresAt = new Date(Date.now() + PENDING_SSO_BINDING_TTL_SECONDS * 1000).toISOString()
-    const payload: PendingSsoBindingChallengeRecord = {
-      ticket,
-      flow: this.normalizeFlow(input?.flow),
-      provider,
-      subjectId,
-      tenantId,
-      organizationId: this.normalizeOptionalValue(input?.organizationId),
-      displayName: this.normalizeOptionalValue(input?.displayName),
-      avatarUrl: this.normalizeOptionalValue(input?.avatarUrl),
-      profile: normalizeProfile(input?.profile),
-      returnTo: this.normalizeOptionalValue(input?.returnTo),
-      expiresAt
-    }
+	async create(input: CreatePendingBindingInput): Promise<CreatedPendingBindingRef> {
+		const provider = this.requireValue(input?.provider, 'provider')
+		const subjectId = this.requireValue(input?.subjectId, 'subjectId')
+		const tenantId = this.requireValue(input?.tenantId, 'tenantId')
+		const ticket = randomUUID().replace(/-/g, '')
+		const expiresAt = new Date(Date.now() + PENDING_SSO_BINDING_TTL_SECONDS * 1000).toISOString()
+		const payload: PendingSsoBindingChallengeRecord = {
+			ticket,
+			flow: this.normalizePublicFlow(input?.flow),
+			provider,
+			subjectId,
+			tenantId,
+			organizationId: this.normalizeOptionalValue(input?.organizationId),
+			displayName: this.normalizeOptionalValue(input?.displayName),
+			avatarUrl: this.normalizeOptionalValue(input?.avatarUrl),
+			profile: normalizeProfile(input?.profile),
+			returnTo: this.normalizeOptionalValue(input?.returnTo),
+			expiresAt
+		}
 
-    await this.set(this.buildKey(ticket), payload)
-    return { ticket }
-  }
+		await this.set(this.buildKey(ticket), payload)
+		return { ticket }
+	}
 
-  async get(ticket: string): Promise<PendingSsoBindingChallengeRecord | null> {
-    const normalizedTicket = this.requireValue(ticket, 'ticket')
-    const serialized = await this.redisClient.get?.(this.buildKey(normalizedTicket))
-    return this.parse(serialized)
-  }
+	async createVerifiedEmailSignup(input: VerifiedEmailLoginInput): Promise<CreatedPendingBindingRef> {
+		const provider = this.requireValue(input?.provider, 'provider')
+		const subjectId = this.requireValue(input?.subjectId, 'subjectId')
+		const tenantId = this.requireValue(input?.tenantId, 'tenantId')
+		const verifiedEmail = this.requireValue(input?.verifiedEmail, 'verifiedEmail').toLowerCase()
+		const returnTo = this.normalizeSafeReturnTo(input?.returnTo)
+		const ticket = randomUUID().replace(/-/g, '')
+		const expiresAt = new Date(Date.now() + PENDING_SSO_BINDING_TTL_SECONDS * 1000).toISOString()
+		const payload: PendingSsoBindingChallengeRecord = {
+			ticket,
+			flow: 'verified_email_signup',
+			provider,
+			subjectId,
+			tenantId,
+			displayName: this.normalizeOptionalValue(input?.displayName),
+			avatarUrl: this.normalizeOptionalValue(input?.avatarUrl),
+			profile: normalizeProfile(input?.profile),
+			verifiedEmail,
+			returnTo,
+			expiresAt
+		}
 
-  async consume(ticket: string): Promise<PendingSsoBindingChallengeRecord | null> {
-    const normalizedTicket = this.requireValue(ticket, 'ticket')
-    const key = this.buildKey(normalizedTicket)
+		await this.set(this.buildKey(ticket), payload)
+		return { ticket }
+	}
 
-    if (typeof this.redisClient.getDel === 'function') {
-      return this.parse(await this.redisClient.getDel(key))
-    }
+	async get(ticket: string): Promise<PendingSsoBindingChallengeRecord | null> {
+		const normalizedTicket = this.requireValue(ticket, 'ticket')
+		const serialized = await this.redisClient.get?.(this.buildKey(normalizedTicket))
+		return this.parse(serialized)
+	}
 
-    const serialized = await this.redisClient.get?.(key)
-    if (serialized) {
-      await this.delete(normalizedTicket)
-    }
-    return this.parse(serialized)
-  }
+	async consume(ticket: string): Promise<PendingSsoBindingChallengeRecord | null> {
+		const normalizedTicket = this.requireValue(ticket, 'ticket')
+		const key = this.buildKey(normalizedTicket)
 
-  async delete(ticket: string): Promise<void> {
-    const normalizedTicket = this.requireValue(ticket, 'ticket')
-    await this.redisClient.del?.(this.buildKey(normalizedTicket))
-  }
+		if (typeof this.redisClient.getDel === 'function') {
+			return this.parse(await this.redisClient.getDel(key))
+		}
 
-  private async set(key: string, payload: PendingSsoBindingChallengeRecord): Promise<void> {
-    const serialized = JSON.stringify(payload)
-    if (typeof this.redisClient.setEx !== 'function') {
-      throw new InternalServerErrorException('Redis client does not support setEx for pending SSO binding challenges.')
-    }
-    await this.redisClient.setEx(key, PENDING_SSO_BINDING_TTL_SECONDS, serialized)
-  }
+		throw new InternalServerErrorException(
+			'Redis client does not support atomic getDel for pending SSO binding challenges.'
+		)
+	}
 
-  private buildKey(ticket: string): string {
-    return `${PENDING_SSO_BINDING_PREFIX}${ticket}`
-  }
+	async delete(ticket: string): Promise<void> {
+		const normalizedTicket = this.requireValue(ticket, 'ticket')
+		await this.redisClient.del?.(this.buildKey(normalizedTicket))
+	}
 
-  private parse(serialized: string | null | undefined): PendingSsoBindingChallengeRecord | null {
-    if (!serialized) {
-      return null
-    }
+	private async set(key: string, payload: PendingSsoBindingChallengeRecord): Promise<void> {
+		const serialized = JSON.stringify(payload)
+		if (typeof this.redisClient.setEx !== 'function') {
+			throw new InternalServerErrorException(
+				'Redis client does not support setEx for pending SSO binding challenges.'
+			)
+		}
+		await this.redisClient.setEx(key, PENDING_SSO_BINDING_TTL_SECONDS, serialized)
+	}
 
-    try {
-      const parsed = JSON.parse(serialized) as PendingSsoBindingChallengeRecord
-      if (!parsed?.ticket || !parsed?.provider || !parsed?.subjectId || !parsed?.tenantId) {
-        return null
-      }
-      parsed.flow = this.normalizeFlow(parsed.flow)
-      return parsed
-    } catch {
-      return null
-    }
-  }
+	private buildKey(ticket: string): string {
+		return `${PENDING_SSO_BINDING_PREFIX}${ticket}`
+	}
 
-  private requireValue(value: string | null | undefined, field: string): string {
-    const normalized = this.normalizeOptionalValue(value)
-    if (!normalized) {
-      throw new InternalServerErrorException(`Pending SSO binding challenge field '${field}' is required.`)
-    }
-    return normalized
-  }
+	private parse(serialized: string | null | undefined): PendingSsoBindingChallengeRecord | null {
+		if (!serialized) {
+			return null
+		}
 
-  private normalizeOptionalValue(value: string | null | undefined): string | null {
-    return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
-  }
+		try {
+			const parsed = JSON.parse(serialized) as PendingSsoBindingChallengeRecord
+			if (!parsed?.ticket || !parsed?.provider || !parsed?.subjectId || !parsed?.tenantId) {
+				return null
+			}
+			parsed.flow = this.normalizeStoredFlow(parsed.flow)
+			return parsed
+		} catch {
+			return null
+		}
+	}
 
-  private normalizeFlow(flow: PendingSsoBindingFlow | null | undefined): PendingSsoBindingFlow {
-    return flow === 'current_user_confirm' ? 'current_user_confirm' : 'anonymous_bind'
-  }
+	private requireValue(value: string | null | undefined, field: string): string {
+		const normalized = this.normalizeOptionalValue(value)
+		if (!normalized) {
+			throw new InternalServerErrorException(`Pending SSO binding challenge field '${field}' is required.`)
+		}
+		return normalized
+	}
+
+	private normalizeOptionalValue(value: string | null | undefined): string | null {
+		return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+	}
+
+	private normalizePublicFlow(flow: PendingSsoBindingFlow | null | undefined): PendingSsoBindingFlow {
+		return flow === 'current_user_confirm' ? 'current_user_confirm' : 'anonymous_bind'
+	}
+
+	private normalizeStoredFlow(flow: PendingSsoChallengeFlow | null | undefined): PendingSsoChallengeFlow {
+		return flow === 'verified_email_signup' ? flow : this.normalizePublicFlow(flow)
+	}
+
+	private normalizeSafeReturnTo(value: string | null | undefined): string | null {
+		const returnTo = this.normalizeOptionalValue(value)
+		if (!returnTo) {
+			return null
+		}
+		if (!returnTo.startsWith('/') || returnTo.startsWith('//')) {
+			throw new InternalServerErrorException(
+				"Pending verified-email signup field 'returnTo' must be a same-origin path."
+			)
+		}
+		return returnTo
+	}
 }
 
 function normalizeProfile(profile: Record<string, any> | null | undefined): Record<string, any> | null {
-  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
-    return null
-  }
+	if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+		return null
+	}
 
-  return JSON.parse(JSON.stringify(profile))
+	return JSON.parse(JSON.stringify(profile))
 }

--- a/packages/server/src/auth/sso/pending-sso-binding-challenge.service.ts
+++ b/packages/server/src/auth/sso/pending-sso-binding-challenge.service.ts
@@ -1,33 +1,33 @@
 import { randomUUID } from 'crypto'
 import { Inject, Injectable, InternalServerErrorException } from '@nestjs/common'
 import type {
-	CreatePendingBindingInput,
-	CreatedPendingBindingRef,
+  CreatePendingBindingInput,
+  CreatedPendingBindingRef,
 	PendingSsoBindingFlow,
 	VerifiedEmailLoginInput
 } from '@xpert-ai/plugin-sdk'
 import { REDIS_CLIENT } from '../../core/redis/types'
 
 type RedisClientLike = {
-	setEx?: (key: string, seconds: number, value: string) => Promise<unknown>
-	get?: (key: string) => Promise<string | null>
-	del?: (...keys: string[]) => Promise<unknown>
-	getDel?: (key: string) => Promise<string | null>
+  setEx?: (key: string, seconds: number, value: string) => Promise<unknown>
+  get?: (key: string) => Promise<string | null>
+  del?: (...keys: string[]) => Promise<unknown>
+  getDel?: (key: string) => Promise<string | null>
 }
 
 export interface PendingSsoBindingChallengeRecord {
-	ticket: string
+  ticket: string
 	flow: PendingSsoChallengeFlow
-	provider: string
-	subjectId: string
-	tenantId: string
-	organizationId?: string | null
-	displayName?: string | null
-	avatarUrl?: string | null
-	profile?: Record<string, any> | null
+  provider: string
+  subjectId: string
+  tenantId: string
+  organizationId?: string | null
+  displayName?: string | null
+  avatarUrl?: string | null
+  profile?: Record<string, any> | null
 	verifiedEmail?: string | null
-	returnTo?: string | null
-	expiresAt: string
+  returnTo?: string | null
+  expiresAt: string
 }
 
 export type PendingSsoChallengeFlow = PendingSsoBindingFlow | 'verified_email_signup'
@@ -37,28 +37,28 @@ const PENDING_SSO_BINDING_TTL_SECONDS = 60 * 10
 
 @Injectable()
 export class PendingSsoBindingChallengeService {
-	constructor(
-		@Inject(REDIS_CLIENT)
-		private readonly redisClient: RedisClientLike
-	) {}
+  constructor(
+    @Inject(REDIS_CLIENT)
+    private readonly redisClient: RedisClientLike
+  ) {}
 
-	async create(input: CreatePendingBindingInput): Promise<CreatedPendingBindingRef> {
-		const provider = this.requireValue(input?.provider, 'provider')
-		const subjectId = this.requireValue(input?.subjectId, 'subjectId')
-		const tenantId = this.requireValue(input?.tenantId, 'tenantId')
-		const ticket = randomUUID().replace(/-/g, '')
-		const expiresAt = new Date(Date.now() + PENDING_SSO_BINDING_TTL_SECONDS * 1000).toISOString()
-		const payload: PendingSsoBindingChallengeRecord = {
-			ticket,
+  async create(input: CreatePendingBindingInput): Promise<CreatedPendingBindingRef> {
+    const provider = this.requireValue(input?.provider, 'provider')
+    const subjectId = this.requireValue(input?.subjectId, 'subjectId')
+    const tenantId = this.requireValue(input?.tenantId, 'tenantId')
+    const ticket = randomUUID().replace(/-/g, '')
+    const expiresAt = new Date(Date.now() + PENDING_SSO_BINDING_TTL_SECONDS * 1000).toISOString()
+    const payload: PendingSsoBindingChallengeRecord = {
+      ticket,
 			flow: this.normalizePublicFlow(input?.flow),
-			provider,
-			subjectId,
-			tenantId,
-			organizationId: this.normalizeOptionalValue(input?.organizationId),
-			displayName: this.normalizeOptionalValue(input?.displayName),
-			avatarUrl: this.normalizeOptionalValue(input?.avatarUrl),
-			profile: normalizeProfile(input?.profile),
-			returnTo: this.normalizeOptionalValue(input?.returnTo),
+      provider,
+      subjectId,
+      tenantId,
+      organizationId: this.normalizeOptionalValue(input?.organizationId),
+      displayName: this.normalizeOptionalValue(input?.displayName),
+      avatarUrl: this.normalizeOptionalValue(input?.avatarUrl),
+      profile: normalizeProfile(input?.profile),
+      returnTo: this.normalizeOptionalValue(input?.returnTo),
 			expiresAt
 		}
 
@@ -85,82 +85,82 @@ export class PendingSsoBindingChallengeService {
 			profile: normalizeProfile(input?.profile),
 			verifiedEmail,
 			returnTo,
-			expiresAt
-		}
+      expiresAt
+    }
 
-		await this.set(this.buildKey(ticket), payload)
-		return { ticket }
-	}
+    await this.set(this.buildKey(ticket), payload)
+    return { ticket }
+  }
 
-	async get(ticket: string): Promise<PendingSsoBindingChallengeRecord | null> {
-		const normalizedTicket = this.requireValue(ticket, 'ticket')
-		const serialized = await this.redisClient.get?.(this.buildKey(normalizedTicket))
-		return this.parse(serialized)
-	}
+  async get(ticket: string): Promise<PendingSsoBindingChallengeRecord | null> {
+    const normalizedTicket = this.requireValue(ticket, 'ticket')
+    const serialized = await this.redisClient.get?.(this.buildKey(normalizedTicket))
+    return this.parse(serialized)
+  }
 
-	async consume(ticket: string): Promise<PendingSsoBindingChallengeRecord | null> {
-		const normalizedTicket = this.requireValue(ticket, 'ticket')
-		const key = this.buildKey(normalizedTicket)
+  async consume(ticket: string): Promise<PendingSsoBindingChallengeRecord | null> {
+    const normalizedTicket = this.requireValue(ticket, 'ticket')
+    const key = this.buildKey(normalizedTicket)
 
-		if (typeof this.redisClient.getDel === 'function') {
-			return this.parse(await this.redisClient.getDel(key))
-		}
+    if (typeof this.redisClient.getDel === 'function') {
+      return this.parse(await this.redisClient.getDel(key))
+    }
 
 		throw new InternalServerErrorException(
 			'Redis client does not support atomic getDel for pending SSO binding challenges.'
 		)
-	}
+  }
 
-	async delete(ticket: string): Promise<void> {
-		const normalizedTicket = this.requireValue(ticket, 'ticket')
-		await this.redisClient.del?.(this.buildKey(normalizedTicket))
-	}
+  async delete(ticket: string): Promise<void> {
+    const normalizedTicket = this.requireValue(ticket, 'ticket')
+    await this.redisClient.del?.(this.buildKey(normalizedTicket))
+  }
 
-	private async set(key: string, payload: PendingSsoBindingChallengeRecord): Promise<void> {
-		const serialized = JSON.stringify(payload)
-		if (typeof this.redisClient.setEx !== 'function') {
+  private async set(key: string, payload: PendingSsoBindingChallengeRecord): Promise<void> {
+    const serialized = JSON.stringify(payload)
+    if (typeof this.redisClient.setEx !== 'function') {
 			throw new InternalServerErrorException(
 				'Redis client does not support setEx for pending SSO binding challenges.'
 			)
-		}
-		await this.redisClient.setEx(key, PENDING_SSO_BINDING_TTL_SECONDS, serialized)
-	}
+    }
+    await this.redisClient.setEx(key, PENDING_SSO_BINDING_TTL_SECONDS, serialized)
+  }
 
-	private buildKey(ticket: string): string {
-		return `${PENDING_SSO_BINDING_PREFIX}${ticket}`
-	}
+  private buildKey(ticket: string): string {
+    return `${PENDING_SSO_BINDING_PREFIX}${ticket}`
+  }
 
-	private parse(serialized: string | null | undefined): PendingSsoBindingChallengeRecord | null {
-		if (!serialized) {
-			return null
-		}
+  private parse(serialized: string | null | undefined): PendingSsoBindingChallengeRecord | null {
+    if (!serialized) {
+      return null
+    }
 
-		try {
-			const parsed = JSON.parse(serialized) as PendingSsoBindingChallengeRecord
-			if (!parsed?.ticket || !parsed?.provider || !parsed?.subjectId || !parsed?.tenantId) {
-				return null
-			}
+    try {
+      const parsed = JSON.parse(serialized) as PendingSsoBindingChallengeRecord
+      if (!parsed?.ticket || !parsed?.provider || !parsed?.subjectId || !parsed?.tenantId) {
+        return null
+      }
 			parsed.flow = this.normalizeStoredFlow(parsed.flow)
-			return parsed
-		} catch {
-			return null
-		}
-	}
+      return parsed
+    } catch {
+      return null
+    }
+  }
 
-	private requireValue(value: string | null | undefined, field: string): string {
-		const normalized = this.normalizeOptionalValue(value)
-		if (!normalized) {
-			throw new InternalServerErrorException(`Pending SSO binding challenge field '${field}' is required.`)
-		}
-		return normalized
-	}
+  private requireValue(value: string | null | undefined, field: string): string {
+    const normalized = this.normalizeOptionalValue(value)
+    if (!normalized) {
+      throw new InternalServerErrorException(`Pending SSO binding challenge field '${field}' is required.`)
+    }
+    return normalized
+  }
 
-	private normalizeOptionalValue(value: string | null | undefined): string | null {
-		return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
-	}
+  private normalizeOptionalValue(value: string | null | undefined): string | null {
+    return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+  }
 
 	private normalizePublicFlow(flow: PendingSsoBindingFlow | null | undefined): PendingSsoBindingFlow {
-		return flow === 'current_user_confirm' ? 'current_user_confirm' : 'anonymous_bind'
+    return flow === 'current_user_confirm' ? 'current_user_confirm' : 'anonymous_bind'
 	}
 
 	private normalizeStoredFlow(flow: PendingSsoChallengeFlow | null | undefined): PendingSsoChallengeFlow {
@@ -178,13 +178,13 @@ export class PendingSsoBindingChallengeService {
 			)
 		}
 		return returnTo
-	}
+  }
 }
 
 function normalizeProfile(profile: Record<string, any> | null | undefined): Record<string, any> | null {
-	if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
-		return null
-	}
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    return null
+  }
 
-	return JSON.parse(JSON.stringify(profile))
+  return JSON.parse(JSON.stringify(profile))
 }

--- a/packages/server/src/plugin/permissions/bound-identity-login-permission.spec.ts
+++ b/packages/server/src/plugin/permissions/bound-identity-login-permission.spec.ts
@@ -71,10 +71,10 @@ describe('Bound identity login plugin permissions', () => {
 
 	it('denies calls when bound_identity_login.create is not declared', () => {
 		const guardedService = createGuardedBoundIdentityLoginPermissionService('demo-plugin', service, [
-			{
-				type: 'bound_identity_login',
-				operations: ['read' as any]
-			}
+				{
+					type: 'bound_identity_login',
+					operations: ['read' as any]
+				}
 		] as Permissions)
 
 		expect(() =>
@@ -106,11 +106,11 @@ describe('Bound identity login plugin permissions', () => {
 
 	it('denies calls for undeclared providers', async () => {
 		const guardedService = createGuardedBoundIdentityLoginPermissionService('demo-plugin', service, [
-			{
-				type: 'bound_identity_login',
-				operations: ['create'],
-				providers: ['github']
-			}
+				{
+					type: 'bound_identity_login',
+					operations: ['create'],
+					providers: ['github']
+				}
 		] as Permissions)
 
 		expect(() =>
@@ -137,11 +137,11 @@ describe('Bound identity login plugin permissions', () => {
 
 	it('issues tokens only after resolving the bound user in the host', async () => {
 		const guardedService = createGuardedBoundIdentityLoginPermissionService('demo-plugin', service, [
-			{
-				type: 'bound_identity_login',
-				operations: ['create'],
-				providers: ['lark']
-			}
+				{
+					type: 'bound_identity_login',
+					operations: ['create'],
+					providers: ['lark']
+				}
 		] as Permissions)
 
 		await expect(
@@ -179,7 +179,7 @@ describe('Bound identity login plugin permissions', () => {
 				subjectId: '123',
 				tenantId: 'tenant-1',
 				verifiedEmail: 'alice@example.com'
-			})
+})
 		).toThrow(/without declaring it in 'bound_identity_login.providers'/)
 
 		await expect(

--- a/packages/server/src/plugin/permissions/bound-identity-login-permission.spec.ts
+++ b/packages/server/src/plugin/permissions/bound-identity-login-permission.spec.ts
@@ -13,6 +13,10 @@ describe('Bound identity login plugin permissions', () => {
 	}
 	let authService: {
 		issueTokensForUser: jest.Mock
+		resolveOrBindVerifiedEmail: jest.Mock
+	}
+	let pendingSsoBindingChallengeService: {
+		createVerifiedEmailSignup: jest.Mock
 	}
 	let moduleRef: {
 		get: jest.Mock
@@ -31,6 +35,14 @@ describe('Bound identity login plugin permissions', () => {
 				jwt: 'jwt-token',
 				refreshToken: 'refresh-token',
 				userId: 'user-1'
+			}),
+			resolveOrBindVerifiedEmail: jest.fn().mockResolvedValue({
+				id: 'user-1'
+			})
+		}
+		pendingSsoBindingChallengeService = {
+			createVerifiedEmailSignup: jest.fn().mockResolvedValue({
+				ticket: 'ticket-1'
 			})
 		}
 		moduleRef = {
@@ -42,6 +54,9 @@ describe('Bound identity login plugin permissions', () => {
 				if (tokenName === 'AuthService') {
 					return authService
 				}
+				if (tokenName === 'PendingSsoBindingChallengeService') {
+					return pendingSsoBindingChallengeService
+				}
 				return null
 			})
 		}
@@ -50,25 +65,17 @@ describe('Bound identity login plugin permissions', () => {
 
 	it('blocks token resolution when bound_identity_login permission is not declared', () => {
 		expect(() =>
-			assertPermissionForToken(
-				'demo-plugin',
-				BOUND_IDENTITY_LOGIN_PERMISSION_SERVICE_TOKEN,
-				new Set(['user'])
-			)
+			assertPermissionForToken('demo-plugin', BOUND_IDENTITY_LOGIN_PERMISSION_SERVICE_TOKEN, new Set(['user']))
 		).toThrow(/without declaring 'bound_identity_login' permission/)
 	})
 
 	it('denies calls when bound_identity_login.create is not declared', () => {
-		const guardedService = createGuardedBoundIdentityLoginPermissionService(
-			'demo-plugin',
-			service,
-			[
-				{
-					type: 'bound_identity_login',
-					operations: ['read' as any]
-				}
-			] as Permissions
-		)
+		const guardedService = createGuardedBoundIdentityLoginPermissionService('demo-plugin', service, [
+			{
+				type: 'bound_identity_login',
+				operations: ['read' as any]
+			}
+		] as Permissions)
 
 		expect(() =>
 			guardedService.loginWithBoundIdentity({
@@ -79,18 +86,32 @@ describe('Bound identity login plugin permissions', () => {
 		).toThrow(/operation 'create'/)
 	})
 
+	it('keeps omitted operations backward compatible with create only', () => {
+		const guardedService = createGuardedBoundIdentityLoginPermissionService('demo-plugin', service, [
+			{
+				type: 'bound_identity_login',
+				providers: ['github-sso']
+			}
+		] as Permissions)
+
+		expect(() =>
+			guardedService.loginOrPrepareVerifiedEmail({
+				provider: 'github-sso',
+				subjectId: '123',
+				tenantId: 'tenant-1',
+				verifiedEmail: 'alice@example.com'
+			})
+		).toThrow(/operation 'provision'/)
+	})
+
 	it('denies calls for undeclared providers', async () => {
-		const guardedService = createGuardedBoundIdentityLoginPermissionService(
-			'demo-plugin',
-			service,
-			[
-				{
-					type: 'bound_identity_login',
-					operations: ['create'],
-					providers: ['github']
-				}
-			] as Permissions
-		)
+		const guardedService = createGuardedBoundIdentityLoginPermissionService('demo-plugin', service, [
+			{
+				type: 'bound_identity_login',
+				operations: ['create'],
+				providers: ['github']
+			}
+		] as Permissions)
 
 		expect(() =>
 			guardedService.loginWithBoundIdentity({
@@ -115,17 +136,13 @@ describe('Bound identity login plugin permissions', () => {
 	})
 
 	it('issues tokens only after resolving the bound user in the host', async () => {
-		const guardedService = createGuardedBoundIdentityLoginPermissionService(
-			'demo-plugin',
-			service,
-			[
-				{
-					type: 'bound_identity_login',
-					operations: ['create'],
-					providers: ['lark']
-				}
-			] as Permissions
-		)
+		const guardedService = createGuardedBoundIdentityLoginPermissionService('demo-plugin', service, [
+			{
+				type: 'bound_identity_login',
+				operations: ['create'],
+				providers: ['lark']
+			}
+		] as Permissions)
 
 		await expect(
 			guardedService.loginWithBoundIdentity({
@@ -145,5 +162,70 @@ describe('Bound identity login plugin permissions', () => {
 			subjectId: 'union-1'
 		})
 		expect(authService.issueTokensForUser).toHaveBeenCalledWith('user-1')
+	})
+
+	it('guards the provision method by provider and returns host-issued tokens', async () => {
+		const guardedService = createGuardedBoundIdentityLoginPermissionService('demo-plugin', service, [
+			{
+				type: 'bound_identity_login',
+				operations: ['provision'],
+				providers: ['github-sso']
+			}
+		] as Permissions)
+
+		expect(() =>
+			guardedService.loginOrPrepareVerifiedEmail({
+				provider: 'lark',
+				subjectId: '123',
+				tenantId: 'tenant-1',
+				verifiedEmail: 'alice@example.com'
+			})
+		).toThrow(/without declaring it in 'bound_identity_login.providers'/)
+
+		await expect(
+			guardedService.loginOrPrepareVerifiedEmail({
+				provider: 'github-sso',
+				subjectId: '123',
+				tenantId: 'tenant-1',
+				verifiedEmail: 'alice@example.com'
+			})
+		).resolves.toEqual({
+			status: 'authenticated',
+			tokens: {
+				jwt: 'jwt-token',
+				refreshToken: 'refresh-token',
+				userId: 'user-1'
+			}
+		})
+		expect(authService.resolveOrBindVerifiedEmail).toHaveBeenCalledWith({
+			provider: 'github-sso',
+			subjectId: '123',
+			tenantId: 'tenant-1',
+			verifiedEmail: 'alice@example.com'
+		})
+	})
+
+	it('creates a host-owned signup ticket when no account matches', async () => {
+		authService.resolveOrBindVerifiedEmail.mockResolvedValue(null)
+
+		await expect(
+			service.loginOrPrepareVerifiedEmail({
+				provider: 'github-sso',
+				subjectId: '123',
+				tenantId: 'tenant-1',
+				verifiedEmail: 'alice@example.com',
+				returnTo: '/projects/demo'
+			})
+		).resolves.toEqual({
+			status: 'registration_required',
+			ticket: 'ticket-1'
+		})
+		expect(pendingSsoBindingChallengeService.createVerifiedEmailSignup).toHaveBeenCalledWith({
+			provider: 'github-sso',
+			subjectId: '123',
+			tenantId: 'tenant-1',
+			verifiedEmail: 'alice@example.com',
+			returnTo: '/projects/demo'
+		})
 	})
 })

--- a/packages/server/src/plugin/permissions/bound-identity-login-permission.ts
+++ b/packages/server/src/plugin/permissions/bound-identity-login-permission.ts
@@ -56,8 +56,8 @@ export function createGuardedBoundIdentityLoginPermissionService(
 	permissions: Permissions
 ): BoundIdentityLoginPermissionService {
 	const operationGuardedService = createOperationGuardedPermissionService<
-		BoundIdentityLoginPermissionOperation,
-		BoundIdentityLoginPermissionService
+			BoundIdentityLoginPermissionOperation,
+			BoundIdentityLoginPermissionService
 	>(pluginName, 'bound_identity_login', service, permissions, resolveBoundIdentityLoginOperations)
 	const allowedProviders = resolveAllowedProviders(permissions)
 
@@ -165,7 +165,7 @@ export class PluginBoundIdentityLoginPermissionService implements BoundIdentityL
 			})
 			if (!service) {
 				throw new Error('PendingSsoBindingChallengeService is not available.')
-			}
+}
 			return service
 		} catch {
 			throw new Error('PendingSsoBindingChallengeService is not available.')

--- a/packages/server/src/plugin/permissions/bound-identity-login-permission.ts
+++ b/packages/server/src/plugin/permissions/bound-identity-login-permission.ts
@@ -6,25 +6,31 @@ import {
 	BoundIdentityLoginPermissionOperation,
 	BoundIdentityLoginPermissionService,
 	Permissions,
-	RequirePermissionOperation
+	RequirePermissionOperation,
+	VerifiedEmailLoginInput,
+	VerifiedEmailLoginResult
 } from '@xpert-ai/plugin-sdk'
 import { AccountBindingService } from '../../account-binding/account-binding.service'
 import { AuthService } from '../../auth/auth.service'
-import {
-	createOperationGuardedPermissionService,
-	resolvePermissionOperations
-} from './service-permission-guard'
+import { PendingSsoBindingChallengeService } from '../../auth/sso/pending-sso-binding-challenge.service'
+import { createOperationGuardedPermissionService, resolvePermissionOperations } from './service-permission-guard'
 
-const BOUND_IDENTITY_LOGIN_ALL_OPERATIONS = ['create'] as const
+const BOUND_IDENTITY_LOGIN_DEFAULT_OPERATIONS = ['create'] as const
 
-function resolveBoundIdentityLoginOperations(
-	permissions: Permissions
-): Set<BoundIdentityLoginPermissionOperation> {
+function resolveBoundIdentityLoginOperations(permissions: Permissions): Set<BoundIdentityLoginPermissionOperation> {
+	const permission = permissions.find(
+		(item): item is BoundIdentityLoginPermission => item.type === 'bound_identity_login'
+	)
+	if (!permission?.operations?.length) {
+		return new Set(BOUND_IDENTITY_LOGIN_DEFAULT_OPERATIONS)
+	}
+
 	return resolvePermissionOperations<BoundIdentityLoginPermissionOperation>(
 		permissions,
 		'bound_identity_login',
-		BOUND_IDENTITY_LOGIN_ALL_OPERATIONS,
-		(operation): operation is BoundIdentityLoginPermissionOperation => operation === 'create'
+		BOUND_IDENTITY_LOGIN_DEFAULT_OPERATIONS,
+		(operation): operation is BoundIdentityLoginPermissionOperation =>
+			operation === 'create' || operation === 'provision'
 	)
 }
 
@@ -49,17 +55,10 @@ export function createGuardedBoundIdentityLoginPermissionService(
 	service: BoundIdentityLoginPermissionService,
 	permissions: Permissions
 ): BoundIdentityLoginPermissionService {
-	const operationGuardedService =
-		createOperationGuardedPermissionService<
-			BoundIdentityLoginPermissionOperation,
-			BoundIdentityLoginPermissionService
-		>(
-			pluginName,
-			'bound_identity_login',
-			service,
-			permissions,
-			resolveBoundIdentityLoginOperations
-		)
+	const operationGuardedService = createOperationGuardedPermissionService<
+		BoundIdentityLoginPermissionOperation,
+		BoundIdentityLoginPermissionService
+	>(pluginName, 'bound_identity_login', service, permissions, resolveBoundIdentityLoginOperations)
 	const allowedProviders = resolveAllowedProviders(permissions)
 
 	if (!allowedProviders || allowedProviders.size === 0) {
@@ -69,7 +68,10 @@ export function createGuardedBoundIdentityLoginPermissionService(
 	return new Proxy(operationGuardedService, {
 		get(target, property, receiver) {
 			const value = Reflect.get(target as object, property, receiver)
-			if (typeof value !== 'function' || property !== 'loginWithBoundIdentity') {
+			if (
+				typeof value !== 'function' ||
+				(property !== 'loginWithBoundIdentity' && property !== 'loginOrPrepareVerifiedEmail')
+			) {
 				return value
 			}
 
@@ -88,15 +90,11 @@ export function createGuardedBoundIdentityLoginPermissionService(
 }
 
 @Injectable()
-export class PluginBoundIdentityLoginPermissionService
-	implements BoundIdentityLoginPermissionService
-{
+export class PluginBoundIdentityLoginPermissionService implements BoundIdentityLoginPermissionService {
 	constructor(private readonly moduleRef: ModuleRef) {}
 
 	@RequirePermissionOperation('bound_identity_login', 'create')
-	async loginWithBoundIdentity(
-		input: BoundIdentityLoginInput
-	) {
+	async loginWithBoundIdentity(input: BoundIdentityLoginInput) {
 		const accountBindingService = this.getAccountBindingService()
 		const user = await accountBindingService.resolveUser({
 			tenantId: input?.tenantId,
@@ -110,6 +108,26 @@ export class PluginBoundIdentityLoginPermissionService
 
 		const authService = this.getAuthService()
 		return authService.issueTokensForUser(user.id)
+	}
+
+	@RequirePermissionOperation('bound_identity_login', 'provision')
+	async loginOrPrepareVerifiedEmail(input: VerifiedEmailLoginInput): Promise<VerifiedEmailLoginResult> {
+		const authService = this.getAuthService()
+		const user = await authService.resolveOrBindVerifiedEmail(input)
+
+		if (user?.id) {
+			return {
+				status: 'authenticated',
+				tokens: await authService.issueTokensForUser(user.id)
+			}
+		}
+
+		const pendingSsoBindingChallengeService = this.getPendingSsoBindingChallengeService()
+		const { ticket } = await pendingSsoBindingChallengeService.createVerifiedEmailSignup(input)
+		return {
+			status: 'registration_required',
+			ticket
+		}
 	}
 
 	private getAccountBindingService(): AccountBindingService {
@@ -137,6 +155,20 @@ export class PluginBoundIdentityLoginPermissionService
 			return service
 		} catch {
 			throw new Error('AuthService is not available.')
+		}
+	}
+
+	private getPendingSsoBindingChallengeService(): PendingSsoBindingChallengeService {
+		try {
+			const service = this.moduleRef.get(PendingSsoBindingChallengeService, {
+				strict: false
+			})
+			if (!service) {
+				throw new Error('PendingSsoBindingChallengeService is not available.')
+			}
+			return service
+		} catch {
+			throw new Error('PendingSsoBindingChallengeService is not available.')
 		}
 	}
 }

--- a/packages/server/src/user/user.service.spec.ts
+++ b/packages/server/src/user/user.service.spec.ts
@@ -39,6 +39,10 @@ jest.mock('../feature/feature-organization.entity', () => ({
 	FeatureOrganization: class FeatureOrganization {}
 }))
 
+jest.mock('../account-binding/external-identity-binding.entity', () => ({
+	ExternalIdentityBinding: class ExternalIdentityBinding {}
+}))
+
 jest.mock('./dto', () => ({
 	UserPublicDTO: class UserPublicDTO {
 		constructor(input?: Record<string, unknown>) {
@@ -65,6 +69,8 @@ jest.mock('./events', () => ({
 const { RequestContext } = require('../core/context')
 const { BadRequestException } = require('@nestjs/common')
 const { RolesEnum, UserType } = require('@xpert-ai/contracts')
+const { ExternalIdentityBinding } = require('../account-binding/external-identity-binding.entity')
+const { User } = require('./user.entity')
 const { UserService } = require('./user.service')
 
 describe('UserService', () => {
@@ -74,7 +80,18 @@ describe('UserService', () => {
 		findOne: jest.fn(),
 		createQueryBuilder: jest.fn(),
 		softDelete: jest.fn(),
+		manager: {
+			transaction: jest.fn()
+		}
+	}
+	const transactionalUserRepository = {
+		softDelete: jest.fn()
+	}
+	const externalIdentityBindingRepository = {
 		delete: jest.fn()
+	}
+	const transactionManager = {
+		getRepository: jest.fn()
 	}
 	const emailVerificationRepository = {}
 	const userOrganizationService = {
@@ -100,6 +117,16 @@ describe('UserService', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks()
+		transactionManager.getRepository.mockImplementation((entity) => {
+			if (entity === User) {
+				return transactionalUserRepository
+			}
+			if (entity === ExternalIdentityBinding) {
+				return externalIdentityBindingRepository
+			}
+			throw new Error(`Unexpected transaction repository: ${entity?.name}`)
+		})
+		userRepository.manager.transaction.mockImplementation(async (callback) => callback(transactionManager))
 		RequestContext.currentUserId.mockReturnValue('requester-1')
 		RequestContext.currentTenantId.mockReturnValue('tenant-1')
 		RequestContext.currentRoleId.mockReturnValue('role-1')
@@ -512,7 +539,7 @@ describe('UserService', () => {
 		})
 	})
 
-	it('removes user organizations through the service and emits deletion events before soft deleting the user', async () => {
+	it('removes memberships and external identity bindings before soft deleting the user', async () => {
 		userRepository.findOne.mockResolvedValue({
 			id: 'user-1',
 			tenantId: 'tenant-1',
@@ -528,7 +555,8 @@ describe('UserService', () => {
 			getCount: jest.fn().mockResolvedValue(1)
 		}
 		userRepository.createQueryBuilder.mockReturnValue(queryBuilder)
-		userRepository.softDelete.mockResolvedValue({ affected: 1 })
+		transactionalUserRepository.softDelete.mockResolvedValue({ affected: 1 })
+		externalIdentityBindingRepository.delete.mockResolvedValue({ affected: 1 })
 
 		userOrganizationService.findAll.mockResolvedValue({
 			items: [
@@ -581,7 +609,15 @@ describe('UserService', () => {
 				userId: 'user-1'
 			})
 		)
-		expect(userRepository.softDelete).toHaveBeenCalledWith('user-1')
+		expect(userRepository.manager.transaction).toHaveBeenCalledTimes(1)
+		expect(externalIdentityBindingRepository.delete).toHaveBeenCalledWith({
+			tenantId: 'tenant-1',
+			userId: 'user-1'
+		})
+		expect(transactionalUserRepository.softDelete).toHaveBeenCalledWith({
+			id: 'user-1',
+			tenantId: 'tenant-1'
+		})
 	})
 
 	it('rejects profile updates for technical users', async () => {

--- a/packages/server/src/user/user.service.ts
+++ b/packages/server/src/user/user.service.ts
@@ -47,6 +47,7 @@ import { UserOrganizationService } from '../user-organization/user-organization.
 import { UserOrganization } from '../user-organization/user-organization.entity'
 import { EVENT_USER_ORGANIZATION_DELETED, UserOrganizationDeletedEvent } from './events'
 import { FeatureOrganization } from '../feature/feature-organization.entity'
+import { ExternalIdentityBinding } from '../account-binding/external-identity-binding.entity'
 import {
 	buildCurrentUserFeatureCacheKey,
 	CURRENT_USER_FEATURE_CACHE_TTL_MS,
@@ -715,7 +716,17 @@ export class UserService extends TenantAwareCrudService<User> {
 		const { tenantId } = await this.ensureDeleteWithGuards(id)
 		await this.deleteUserOrganizations(id, tenantId)
 
-		return this.softDelete(id)
+		return this.repository.manager.transaction(async (manager) => {
+			await manager.getRepository(ExternalIdentityBinding).delete({
+				tenantId,
+				userId: id
+			})
+
+			return manager.getRepository(User).softDelete({
+				id,
+				tenantId
+			})
+		})
 	}
 
 	async deleteHardWithGuards(id: string): Promise<DeleteResult> {


### PR DESCRIPTION
## Summary

This PR adds host-owned verified-email provisioning for system SSO plugins.

- Extend `bound_identity_login` with an explicit `provision` operation and a typed authenticated-or-registration-required result.
- Resolve an existing external identity first, then safely bind a unique eligible account by normalized verified email, or create a short-lived host-owned registration ticket.
- Complete new-user registration as a verified `TRIAL` account with its own active organization, membership, optional referral attribution, and external identity binding.
- Add the verified-email registration UI with provider-supplied display names, a read-only trusted email, password confirmation, optional referral code, retryable errors, and host-issued success redirects.
- Remove external identity bindings when an Xpert account is soft-deleted so stale bindings cannot block later registration.

## Problem and root cause

The existing plugin permission only supported login through an already-created binding. A GitHub OAuth plugin could prove a subject ID and verified email, but it had no safe host API for matching an existing tenant account or preparing registration for a new user. Letting the plugin create users, bindings, or tokens directly would bypass tenant account rules and transaction boundaries.

This change keeps the authority in the host. The plugin can submit verified identity facts only when it declares the provider-scoped `provision` operation. The host owns account eligibility checks, binding conflicts, tickets, registration, organizations, referrals, and login token issuance.

## Security and compatibility

- Existing identity bindings take precedence over later email changes.
- Email matching is tenant-scoped, normalized, and limited to one eligible human account.
- Duplicate accounts, ineligible users, and conflicting provider bindings are rejected rather than guessed or replaced.
- Verified-email registration tickets expire after ten minutes, accept only same-origin return paths, and require atomic Redis consumption before a second token can be issued.
- Existing plugins that omit `operations` retain `create` only and do not gain provisioning access.
- No database migration or GitHub access-token storage is introduced.
- Trust-proxy and development `xfwd` changes are not included.
- The changeset is intentionally excluded from this PR.

## Validation

- Server focused suites: 5 suites, 58 tests passed.
- Cloud registration suite: 1 suite, 8 tests passed.
- `plugin-sdk` build passed.
- Cloud development build passed.
- Staged and outgoing diffs passed `git diff --check`.
- Prettier passed for the changed files; the commit hook formatted the final staged files.

Browser automation and real GitHub OAuth were not run. The end-to-end OAuth flow remains for manual acceptance.
