### PR TITLE
fix: break plugin marketplace component cycle

### DIFF
--- a/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace.component.html
+++ b/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace.component.html
@@ -277,6 +277,8 @@
                 class="group relative rounded-xl hover:bg-hover-bg"
                 [plugin]="plugin"
                 [publicCatalog]="publicCatalog()"
+                [reloadInstalledPlugins]="reloadInstalledPlugins()"
+                [refreshStrategies]="refreshStrategies()"
                 (pluginInstalled)="markPluginInstalled($event)"
               />
             }

--- a/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace.component.ts
+++ b/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace.component.ts
@@ -101,6 +101,8 @@ export class PluginsMarketplaceComponent {
   readonly i18nService = inject(I18nService)
   readonly i18n = new XpI18nPipe()
   readonly publicCatalog = input(false)
+  readonly reloadInstalledPlugins = input<() => void>(() => undefined)
+  readonly refreshStrategies = input<(() => void) | undefined>()
 
   readonly addSourceDialog = viewChild('addSourceDialog', { read: TemplateRef })
   readonly registryDialog = viewChild('registryDialog', { read: TemplateRef })

--- a/apps/cloud/src/app/features/setting/plugins/plugin/plugin.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/plugins/plugin/plugin.component.spec.ts
@@ -1,0 +1,88 @@
+import { Dialog } from '@angular/cdk/dialog'
+import { TestBed } from '@angular/core/testing'
+import { Router } from '@angular/router'
+import { Store } from '@cloud/app/@core/state'
+import { PLUGIN_LEVEL, RequestScopeLevel } from '@xpert-ai/contracts'
+import { TranslateModule } from '@ngx-translate/core'
+import { of } from 'rxjs'
+import { TPluginWithDownloads } from '../types'
+import { SettingsPluginComponent } from './plugin.component'
+
+describe('SettingsPluginComponent', () => {
+  const reloadInstalledPlugins = jest.fn()
+  const refreshStrategies = jest.fn()
+  const dialog = {
+    open: jest.fn(() => ({
+      closed: of(undefined)
+    }))
+  }
+  const plugin: TPluginWithDownloads = {
+    name: '@xpert-ai/plugin-test',
+    packageName: '@xpert-ai/plugin-test',
+    displayName: 'Test plugin',
+    description: 'Test plugin',
+    version: '1.0.0',
+    level: PLUGIN_LEVEL.ORGANIZATION,
+    category: 'integration',
+    icon: {
+      type: 'font',
+      value: 'ri-puzzle-line'
+    },
+    author: {
+      name: 'XpertAI',
+      url: ''
+    }
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), SettingsPluginComponent],
+      providers: [
+        {
+          provide: Dialog,
+          useValue: dialog
+        },
+        {
+          provide: Router,
+          useValue: {
+            navigate: jest.fn()
+          }
+        },
+        {
+          provide: Store,
+          useValue: {
+            token: 'user-token',
+            scopeLevel: RequestScopeLevel.ORGANIZATION,
+            scopeLevel$: of(RequestScopeLevel.ORGANIZATION)
+          }
+        }
+      ]
+    }).compileComponents()
+  })
+
+  afterEach(() => {
+    TestBed.resetTestingModule()
+    jest.clearAllMocks()
+  })
+
+  it('forwards the installed-plugin and strategy refresh callbacks to the install dialog', () => {
+    const fixture = TestBed.createComponent(SettingsPluginComponent)
+    fixture.componentRef.setInput('plugin', plugin)
+    fixture.componentRef.setInput('reloadInstalledPlugins', reloadInstalledPlugins)
+    fixture.componentRef.setInput('refreshStrategies', refreshStrategies)
+    fixture.detectChanges()
+
+    fixture.componentInstance.install()
+
+    expect(dialog.open).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        data: {
+          plugin,
+          reload: reloadInstalledPlugins,
+          refreshStrategies
+        }
+      })
+    )
+  })
+})

--- a/apps/cloud/src/app/features/setting/plugins/plugin/plugin.component.ts
+++ b/apps/cloud/src/app/features/setting/plugins/plugin/plugin.component.ts
@@ -11,7 +11,6 @@ import { injectScopeLevel, Store } from '@cloud/app/@core/state'
 import { PLUGIN_LEVEL, RequestScopeLevel } from '@xpert-ai/contracts'
 import { PluginInstallComponent, PluginInstallResult } from '../install/install.component'
 import { TPluginWithDownloads } from '../types'
-import { PluginsComponent } from '../plugins.component'
 import { PluginMarketplaceDetailComponent } from '../marketplace/marketplace-detail.component'
 import { pluginMarketplaceDetailCommands } from '../plugin-marketplace-navigation'
 
@@ -24,7 +23,6 @@ import { pluginMarketplaceDetailCommands } from '../plugin-marketplace-navigatio
   animations: [routeAnimations, ...OverlayAnimations]
 })
 export class SettingsPluginComponent {
-  readonly pluginsComponent = inject(PluginsComponent, { optional: true })
   readonly #dialog = inject(Dialog)
   readonly #router = inject(Router)
   readonly #store = inject(Store)
@@ -33,6 +31,8 @@ export class SettingsPluginComponent {
 
   readonly plugin = input<TPluginWithDownloads>()
   readonly publicCatalog = input(false)
+  readonly reloadInstalledPlugins = input<() => void>(() => undefined)
+  readonly refreshStrategies = input<(() => void) | undefined>()
   readonly pluginInstalled = output<TPluginWithDownloads>()
   readonly installed = computed(() => this.plugin()?.installed === true)
   readonly hasMarketplaceDetails = computed(() => !!this.plugin()?.contributions?.length)
@@ -59,14 +59,8 @@ export class SettingsPluginComponent {
       .open(PluginInstallComponent, {
         data: {
           plugin,
-          reload: () => {
-            this.pluginsComponent?.reload()
-          },
-          ...(this.pluginsComponent
-            ? {
-                refreshStrategies: this.pluginsComponent.refreshStrategyCaches.bind(this.pluginsComponent)
-              }
-            : {})
+          reload: this.reloadInstalledPlugins(),
+          refreshStrategies: this.refreshStrategies()
         },
         disableClose: true
       })

--- a/apps/cloud/src/app/features/setting/plugins/plugins-runtime-dependencies.spec.ts
+++ b/apps/cloud/src/app/features/setting/plugins/plugins-runtime-dependencies.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from '@angular/core/testing'
+import { PluginsMarketplaceComponent } from './marketplace/marketplace.component'
+import { PluginsComponent } from './plugins.component'
+
+describe('plugins runtime dependencies', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule()
+  })
+
+  it('resolves the plugins page after the marketplace entry is evaluated first', async () => {
+    expect(PluginsMarketplaceComponent).toBeDefined()
+
+    await expect(
+      TestBed.configureTestingModule({
+        imports: [PluginsComponent]
+      }).compileComponents()
+    ).resolves.toBeUndefined()
+  })
+})

--- a/apps/cloud/src/app/features/setting/plugins/plugins.component.html
+++ b/apps/cloud/src/app/features/setting/plugins/plugins.component.html
@@ -143,7 +143,10 @@
 }
 
 @if (category() === 'marketplace') {
-  <xp-plugins-marketplace />
+  <xp-plugins-marketplace
+    [reloadInstalledPlugins]="reloadInstalledPluginsCallback"
+    [refreshStrategies]="refreshStrategyCachesCallback"
+  />
 } @else {
   <div class="flex flex-col items-start justify-center gap-3 self-stretch px-12 pb-3 pt-1">
     <div class="flex items-center gap-2 self-stretch">

--- a/apps/cloud/src/app/features/setting/plugins/plugins.component.ts
+++ b/apps/cloud/src/app/features/setting/plugins/plugins.component.ts
@@ -101,6 +101,8 @@ export class PluginsComponent {
   readonly #toolsetService = inject(XpertToolsetService)
   readonly runtimeRestart = inject(PluginRuntimeRestartService)
   readonly marketplace = viewChild(PluginsMarketplaceComponent)
+  readonly reloadInstalledPluginsCallback = () => this.reload()
+  readonly refreshStrategyCachesCallback = () => this.refreshStrategyCaches()
   readonly npmInstallDialog = viewChild('npmInstallDialog', { read: TemplateRef })
   readonly localInstallDialog = viewChild('localInstallDialog', { read: TemplateRef })
   readonly archiveInstallDialog = viewChild('archiveInstallDialog', { read: TemplateRef })


### PR DESCRIPTION
## Summary
- remove the child-to-parent `PluginsComponent` injection that completed the marketplace runtime dependency cycle
- pass installed-plugin reload and strategy-cache refresh callbacks through component inputs
- add regression coverage for marketplace-first component evaluation and install-dialog callback forwarding

## Root cause
The standalone component graph formed a runtime cycle:

`PluginsComponent -> PluginsMarketplaceComponent -> SettingsPluginComponent -> PluginsComponent`

When the marketplace entry was evaluated first, Angular could observe incomplete component metadata and fail while resolving the plugins page.

## Testing
- `corepack pnpm exec ngc -p apps/cloud/tsconfig.app.json --noEmit`
- `corepack pnpm exec eslint` on the changed TypeScript files
- `corepack pnpm exec prettier --check` on all changed files
- `corepack pnpm nx test cloud --runInBand --testPathPatterns=apps/cloud/src/app/features/setting/plugins/plugins-runtime-dependencies.spec.ts apps/cloud/src/app/features/setting/plugins/plugin/plugin.component.spec.ts`
- `corepack pnpm nx test cloud --runInBand --testPathPatterns=apps/cloud/src/app/features/setting/plugins/install/install.component.spec.ts`
