### PR TITLE
[codex] Fix numeric z-input values

### DIFF
--- a/packages/ui/src/lib/components/input/input.directive.spec.ts
+++ b/packages/ui/src/lib/components/input/input.directive.spec.ts
@@ -1,0 +1,45 @@
+import { Component } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { FormControl, ReactiveFormsModule } from '@angular/forms'
+
+import { ZardInputDirective } from './input.directive'
+
+@Component({
+  imports: [ReactiveFormsModule, ZardInputDirective],
+  template: `
+    <input z-input type="text" [formControl]="textControl" />
+    <input z-input type="number" [formControl]="numberControl" />
+  `
+})
+class InputHostComponent {
+  readonly textControl = new FormControl('', { nonNullable: true })
+  readonly numberControl = new FormControl<number | null>(null)
+}
+
+describe('ZardInputDirective', () => {
+  it('preserves text values and emits numbers for number inputs', async () => {
+    const fixture = await TestBed.configureTestingModule({
+      imports: [InputHostComponent]
+    }).createComponent(InputHostComponent)
+
+    fixture.detectChanges()
+    await fixture.whenStable()
+
+    const [textInput, numberInput] = Array.from(
+      fixture.nativeElement.querySelectorAll('input') as NodeListOf<HTMLInputElement>
+    )
+
+    textInput.value = '10000'
+    textInput.dispatchEvent(new Event('input'))
+    numberInput.value = '10000'
+    numberInput.dispatchEvent(new Event('input'))
+
+    expect(fixture.componentInstance.textControl.value).toBe('10000')
+    expect(fixture.componentInstance.numberControl.value).toBe(10000)
+
+    numberInput.value = ''
+    numberInput.dispatchEvent(new Event('input'))
+
+    expect(fixture.componentInstance.numberControl.value).toBeNull()
+  })
+})

--- a/packages/ui/src/lib/components/input/input.directive.ts
+++ b/packages/ui/src/lib/components/input/input.directive.ts
@@ -41,14 +41,14 @@ import {
 })
 export class ZardInputDirective implements ControlValueAccessor {
   private readonly elementRef = inject(ElementRef);
-  private onChange: (value: string) => void = () => undefined;
+  private onChange: (value: string | number | null) => void = () => undefined;
   private onTouched: () => void = () => undefined;
 
   readonly class = input<ClassValue>('');
   readonly zBorderless = input(false, { transform: booleanAttribute });
   readonly zSize = input<ZardInputSizeVariants>('default');
   readonly zStatus = input<ZardInputStatusVariants>();
-  readonly value = model<string>('');
+  readonly value = model<string | number>('');
 
   readonly size = linkedSignal<ZardInputSizeVariants>(() => this.zSize());
 
@@ -78,11 +78,11 @@ export class ZardInputDirective implements ControlValueAccessor {
     this.elementRef.nativeElement.disabled = b;
   }
 
-  writeValue(value: string | null | undefined): void {
+  writeValue(value: string | number | null | undefined): void {
     this.value.set(value ?? '');
   }
 
-  registerOnChange(fn: (value: string) => void): void {
+  registerOnChange(fn: (value: string | number | null) => void): void {
     this.onChange = fn;
   }
 
@@ -104,7 +104,7 @@ export class ZardInputDirective implements ControlValueAccessor {
     const el = target as HTMLInputElement | HTMLTextAreaElement | null;
     const value = el?.value ?? '';
     this.value.set(value);
-    this.onChange(value);
+    this.onChange(el instanceof HTMLInputElement && el.type === 'number' ? (value === '' ? null : el.valueAsNumber) : value);
   }
 
   protected markAsTouched(): void {


### PR DESCRIPTION
## Problem

`ZardInputDirective` registers its own `ControlValueAccessor` and forwards `HTMLInputElement.value` unchanged. Browser input values are strings, so `input[z-input][type="number"]` writes strings into Angular forms instead of numbers. Valid numeric form values can then fail server-side number validation.

## Root cause

The custom value accessor overrides Angular's native number value accessor but does not preserve its number and empty-value semantics.

## Fix

- Emit `valueAsNumber` for non-empty `type="number"` inputs.
- Emit `null` when a numeric input is cleared.
- Preserve the existing string behavior for text inputs and textareas.
- Add a focused reactive-forms regression test covering text, numeric, and cleared numeric values.

## Validation

- `NX_DAEMON=false corepack pnpm@10.24.0 exec nx test ui --runInBand` — 31 suites, 130 tests passed.
- `NX_DAEMON=false corepack pnpm@10.24.0 exec nx build ui --configuration=development` — passed.
- Focused input directive test — passed.
- ESLint on both changed files — passed.
- `git diff --check` — passed.

Browser validation was not run.
