### PR TITLE
fix: align trial permissions and membership admin UI

### DIFF
--- a/apps/cloud/src/app/@shared/features/feature-toggle/feature-toggle.component.spec.ts
+++ b/apps/cloud/src/app/@shared/features/feature-toggle/feature-toggle.component.spec.ts
@@ -739,6 +739,24 @@ describe('FeatureToggleComponent', () => {
     })
   })
 
+  it('ships membership purchase feature translations for every supported locale', () => {
+    const locales = [
+      ['en', 'Membership Purchase', 'Enable membership plan and personal point purchases.'],
+      ['en-US', 'Membership Purchase', 'Enable membership plan and personal point purchases.'],
+      ['zh-CN', '会员购买', '启用会员套餐和个人积分购买。'],
+      ['zh-Hans', '会员购买', '启用会员套餐和个人积分购买。'],
+      ['zh-Hant', '會員購買', '啟用會員套餐和個人積分購買。']
+    ]
+
+    locales.forEach(([locale, expectedName, expectedDescription]) => {
+      const messages = JSON.parse(readFileSync(join(__dirname, '../../../../assets/i18n', `${locale}.json`), 'utf8'))
+      const feature = messages.XP?.Feature?.Features?.[AiFeatureEnum.FEATURE_MEMBERSHIP_PURCHASE]
+
+      expect(feature?.Name).toBe(expectedName)
+      expect(feature?.Description).toBe(expectedDescription)
+    })
+  })
+
   it('ships management overview translations for every supported locale', () => {
     const locales = ['en', 'en-US', 'zh-CN', 'zh-Hans', 'zh-Hant']
 

--- a/apps/cloud/src/app/features/setting/users/user-membership/user-membership.component.html
+++ b/apps/cloud/src/app/features/setting/users/user-membership/user-membership.component.html
@@ -106,7 +106,7 @@
               {{ 'XP.Membership.Revoke' | translate: { Default: 'Revoke' } }}
             </button>
           }
-          @if (currentMembership.source !== MembershipSourceEnum.External) {
+          @if (!isExternallyManagedMembership()) {
             <button z-button zType="outline" type="button" [disabled]="loading()" (click)="renew()">
               {{ 'XP.Membership.Renew' | translate: { Default: 'Renew' } }}
             </button>
@@ -366,46 +366,58 @@
       </section>
     }
 
-    <form [formGroup]="assignmentForm" class="flex flex-col gap-3 rounded-lg bg-components-panel-bg p-4">
-      <div class="font-semibold text-text-primary">
-        {{ 'XP.Membership.AssignPlan' | translate: { Default: 'Assign plan' } }}
+    @if (isExternallyManagedMembership()) {
+      <div class="rounded-lg border border-divider-regular bg-components-panel-bg p-4 text-sm text-text-tertiary">
+        {{
+          'XP.Membership.ExternallyManagedMembershipHint'
+            | translate
+              : {
+                  Default: 'This membership is managed by an external workflow and cannot be replaced or renewed here.'
+                }
+        }}
       </div>
-      <div class="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(220px,1fr)_180px_minmax(240px,1fr)_auto]">
-        <z-form-field class="w-full">
-          <z-select class="w-full" formControlName="planId">
-            @for (plan of plans(); track plan.id) {
-              <z-select-item [zValue]="plan.id">{{ plan.name }}</z-select-item>
-            }
-          </z-select>
-        </z-form-field>
-        <z-form-field class="w-full">
-          <z-select class="w-full" formControlName="renewalMode">
-            <z-select-item [zValue]="MembershipRenewalModeEnum.Auto">
-              {{ 'XP.Membership.RenewalModes.auto' | translate: { Default: 'Auto renew' } }}
-            </z-select-item>
-            <z-select-item [zValue]="MembershipRenewalModeEnum.Manual">
-              {{ 'XP.Membership.RenewalModes.manual' | translate: { Default: 'Manual renew' } }}
-            </z-select-item>
-          </z-select>
-        </z-form-field>
-        <z-form-field class="w-full">
-          <input
-            z-input
-            formControlName="note"
-            [placeholder]="'XP.Membership.AssignNote' | translate: { Default: 'Assignment note' }"
-          />
-        </z-form-field>
-        <button
-          z-button
-          zType="default"
-          type="button"
-          [disabled]="loading() || assignmentForm.invalid"
-          (click)="assign()"
-        >
-          {{ 'XP.Membership.Assign' | translate: { Default: 'Assign' } }}
-        </button>
-      </div>
-    </form>
+    } @else {
+      <form [formGroup]="assignmentForm" class="flex flex-col gap-3 rounded-lg bg-components-panel-bg p-4">
+        <div class="font-semibold text-text-primary">
+          {{ 'XP.Membership.AssignPlan' | translate: { Default: 'Assign plan' } }}
+        </div>
+        <div class="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(220px,1fr)_180px_minmax(240px,1fr)_auto]">
+          <z-form-field class="w-full">
+            <z-select class="w-full" formControlName="planId">
+              @for (plan of plans(); track plan.id) {
+                <z-select-item [zValue]="plan.id">{{ plan.name }}</z-select-item>
+              }
+            </z-select>
+          </z-form-field>
+          <z-form-field class="w-full">
+            <z-select class="w-full" formControlName="renewalMode">
+              <z-select-item [zValue]="MembershipRenewalModeEnum.Auto">
+                {{ 'XP.Membership.RenewalModes.auto' | translate: { Default: 'Auto renew' } }}
+              </z-select-item>
+              <z-select-item [zValue]="MembershipRenewalModeEnum.Manual">
+                {{ 'XP.Membership.RenewalModes.manual' | translate: { Default: 'Manual renew' } }}
+              </z-select-item>
+            </z-select>
+          </z-form-field>
+          <z-form-field class="w-full">
+            <input
+              z-input
+              formControlName="note"
+              [placeholder]="'XP.Membership.AssignNote' | translate: { Default: 'Assignment note' }"
+            />
+          </z-form-field>
+          <button
+            z-button
+            zType="default"
+            type="button"
+            [disabled]="loading() || assignmentForm.invalid"
+            (click)="assign()"
+          >
+            {{ 'XP.Membership.Assign' | translate: { Default: 'Assign' } }}
+          </button>
+        </div>
+      </form>
+    }
 
     <section class="grid grid-cols-1 gap-4 xl:grid-cols-2">
       <form [formGroup]="cyclePointsForm" class="flex flex-col gap-3 rounded-lg border border-divider-regular p-4">

--- a/apps/cloud/src/app/features/setting/users/user-membership/user-membership.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/users/user-membership/user-membership.component.spec.ts
@@ -1,6 +1,6 @@
 jest.mock('echarts/core', () => ({ registerTheme: jest.fn() }))
 
-import { TestBed } from '@angular/core/testing'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { TranslateService } from '@ngx-translate/core'
 import {
   AIPermissionsEnum,
@@ -11,10 +11,11 @@ import {
   MembershipPeriodEnum,
   MembershipPeriodStatusEnum,
   MembershipRenewalModeEnum,
-  MembershipSourceEnum
+  MembershipSourceEnum,
+  MembershipStatusEnum
 } from '@xpert-ai/contracts'
 import { ZardAlertDialogService } from '@xpert-ai/headless-ui'
-import { of } from 'rxjs'
+import { NEVER, of } from 'rxjs'
 import { MembershipService, RequestScopeLevel, Store, ToastrService } from '../../../../@core'
 import { UserMembershipComponent } from './user-membership.component'
 
@@ -25,6 +26,7 @@ describe('UserMembershipComponent', () => {
     resumeUser: jest.Mock
     revokeUser: jest.Mock
     renewUser: jest.Mock
+    assignUser: jest.Mock
     cancelAdminUserPeriod: jest.Mock
     getPlans: jest.Mock
     getAdminUsers: jest.Mock
@@ -35,7 +37,25 @@ describe('UserMembershipComponent', () => {
   }
   let alertDialog: { confirm: jest.Mock }
   let store: { activeScope: { level: RequestScopeLevel }; hasPermission: jest.Mock }
+  let fixture: ComponentFixture<UserMembershipComponent>
   let component: UserMembershipComponent
+
+  const createMembership = (overrides: Partial<IUserMembership> = {}): IUserMembership => ({
+    id: 'membership-1',
+    tenantId: 'tenant-1',
+    organizationId: null,
+    userId: 'user-1',
+    planId: 'plan-1',
+    status: MembershipStatusEnum.Active,
+    source: MembershipSourceEnum.Admin,
+    renewalMode: MembershipRenewalModeEnum.Manual,
+    currentPeriodStart: new Date('2030-08-01T00:00:00.000Z'),
+    currentPeriodEnd: new Date('2030-09-01T00:00:00.000Z'),
+    pointsGranted: 100,
+    pointsUsed: 0,
+    pointsTotalUsed: 0,
+    ...overrides
+  })
 
   const createPeriod = (overrides: Partial<IUserMembershipPeriod> = {}): IUserMembershipPeriod => ({
     id: 'period-1',
@@ -69,6 +89,7 @@ describe('UserMembershipComponent', () => {
       resumeUser: jest.fn().mockReturnValue(of(membership)),
       revokeUser: jest.fn().mockReturnValue(of(membership)),
       renewUser: jest.fn().mockReturnValue(of(membership)),
+      assignUser: jest.fn().mockReturnValue(of(membership)),
       cancelAdminUserPeriod: jest.fn().mockReturnValue(of({ id: 'period-1', status: 'cancelled' })),
       getPlans: jest.fn().mockReturnValue(of([])),
       getAdminUsers: jest.fn().mockReturnValue(of({ items: [], total: 0 })),
@@ -92,16 +113,22 @@ describe('UserMembershipComponent', () => {
         { provide: Store, useValue: store },
         { provide: ToastrService, useValue: { error: jest.fn() } },
         { provide: ZardAlertDialogService, useValue: alertDialog },
-        { provide: TranslateService, useValue: { instant: jest.fn((key: string) => key) } }
+        {
+          provide: TranslateService,
+          useValue: {
+            instant: jest.fn((key: string) => key),
+            get: jest.fn((key: string) => of(key)),
+            onTranslationChange: NEVER,
+            onLangChange: NEVER,
+            onFallbackLangChange: NEVER,
+            getCurrentLang: jest.fn(() => 'en'),
+            getFallbackLang: jest.fn(() => 'en')
+          }
+        }
       ]
-    }).overrideComponent(UserMembershipComponent, {
-      set: {
-        imports: [],
-        template: ''
-      }
     })
 
-    const fixture = TestBed.createComponent(UserMembershipComponent)
+    fixture = TestBed.createComponent(UserMembershipComponent)
     component = fixture.componentInstance
     component.userId = 'user-1'
   })
@@ -188,6 +215,67 @@ describe('UserMembershipComponent', () => {
 
     expect(alertDialog.confirm).not.toHaveBeenCalled()
     expect(membershipService.cancelAdminUserPeriod).not.toHaveBeenCalled()
+  })
+
+  it('does not replace a membership marked as externally managed by source', () => {
+    component.membership.set(createMembership({ source: MembershipSourceEnum.External }))
+    component.assignmentForm.patchValue({ planId: 'plan-1' })
+
+    component.assign()
+
+    expect(component.isExternallyManagedMembership()).toBe(true)
+    expect(membershipService.assignUser).not.toHaveBeenCalled()
+  })
+
+  it('does not replace a catalog-managed membership with a regular assignment', () => {
+    component.membership.set(
+      createMembership({
+        plan: { catalogSourcePlanId: 'catalog-plan-1' } as IUserMembership['plan']
+      })
+    )
+    component.assignmentForm.patchValue({ planId: 'plan-1' })
+
+    component.assign()
+
+    expect(component.isExternallyManagedMembership()).toBe(true)
+    expect(membershipService.assignUser).not.toHaveBeenCalled()
+  })
+
+  it('does not renew an externally managed membership', async () => {
+    component.membership.set(createMembership({ source: MembershipSourceEnum.External }))
+    alertDialog.confirm.mockReturnValue(of(true))
+
+    await component.renew()
+
+    expect(alertDialog.confirm).not.toHaveBeenCalled()
+    expect(membershipService.renewUser).not.toHaveBeenCalled()
+  })
+
+  it('shows the external management hint instead of assignment and renewal controls', () => {
+    component.membership.set(createMembership({ source: MembershipSourceEnum.External }))
+
+    fixture.detectChanges()
+
+    const text = fixture.nativeElement.textContent as string
+    const buttonLabels = Array.from(fixture.nativeElement.querySelectorAll('button')).map((button: Element) =>
+      button.textContent?.trim()
+    )
+    expect(text).toContain('XP.Membership.ExternallyManagedMembershipHint')
+    expect(text).not.toContain('XP.Membership.AssignPlan')
+    expect(buttonLabels).not.toContain('XP.Membership.Renew')
+  })
+
+  it('keeps externally priced plans out of regular plan assignment', () => {
+    membershipService.getPlans.mockReturnValue(
+      of([
+        { id: 'plan-free', status: 'active', catalogSourcePlanId: null },
+        { id: 'plan-paid', status: 'active', catalogSourcePlanId: 'catalog-plan-1' }
+      ])
+    )
+
+    component.load()
+
+    expect(component.plans().map(({ id }) => id)).toEqual(['plan-free'])
   })
 
   it('allows membership management only with membership edit permission', () => {

--- a/apps/cloud/src/app/features/setting/users/user-membership/user-membership.component.ts
+++ b/apps/cloud/src/app/features/setting/users/user-membership/user-membership.component.ts
@@ -75,6 +75,10 @@ export class UserMembershipComponent implements OnChanges {
   readonly personalPointsBalance = signal(0)
   readonly auditEntries = signal<IMembershipPointLedger[]>([])
   readonly loading = signal(false)
+  readonly isExternallyManagedMembership = computed(() => {
+    const membership = this.membership()
+    return membership?.source === MembershipSourceEnum.External || !!membership?.plan?.catalogSourcePlanId
+  })
 
   readonly MembershipRenewalModeEnum = MembershipRenewalModeEnum
   readonly MembershipSourceEnum = MembershipSourceEnum
@@ -130,7 +134,7 @@ export class UserMembershipComponent implements OnChanges {
         : of({ balance: 0 })
     }).subscribe({
       next: ({ plans, memberships, scopeMemberships, periods, audit, personalPoints }) => {
-        this.plans.set(plans.filter((plan) => plan.status === 'active'))
+        this.plans.set(plans.filter((plan) => plan.status === 'active' && !plan.catalogSourcePlanId))
         const membership = memberships.items?.[0] ?? null
         this.membership.set(membership)
         this.scopeMemberships.set(scopeMemberships)
@@ -168,6 +172,9 @@ export class UserMembershipComponent implements OnChanges {
   }
 
   assign() {
+    if (this.isExternallyManagedMembership()) {
+      return
+    }
     if (this.assignmentForm.invalid) {
       this.assignmentForm.markAllAsTouched()
       return
@@ -190,6 +197,9 @@ export class UserMembershipComponent implements OnChanges {
   }
 
   async renew() {
+    if (this.isExternallyManagedMembership()) {
+      return
+    }
     if (
       await this.confirmMembershipAction({
         titleKey: 'XP.Membership.RenewConfirmTitle',

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -375,6 +375,10 @@
           "Name": "Membership Plans",
           "Description": "Enable membership plan quotas, point deduction, and usage statistics."
         },
+        "FEATURE_MEMBERSHIP_PURCHASE": {
+          "Name": "Membership Purchase",
+          "Description": "Enable membership plan and personal point purchases."
+        },
         "FEATURE_MODEL_ACCESS_REQUEST": {
           "Name": "Personal Model Access",
           "Description": "Enable personal model access requests and grants."
@@ -1204,6 +1208,7 @@
       "NoUserMembership": "No membership has been created for this user yet.",
       "AssignNote": "Assignment note",
       "AssignPlan": "Assign plan",
+      "ExternallyManagedMembershipHint": "This membership is managed by an external workflow and cannot be replaced or renewed here.",
       "PointDelta": "Point delta",
       "Points": "Points",
       "Increase": "Increase",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -430,6 +430,10 @@
           "Name": "Membership Plans",
           "Description": "Enable membership plan quotas, point deduction, and usage statistics."
         },
+        "FEATURE_MEMBERSHIP_PURCHASE": {
+          "Name": "Membership Purchase",
+          "Description": "Enable membership plan and personal point purchases."
+        },
         "FEATURE_MODEL_ACCESS_REQUEST": {
           "Name": "Personal Model Access",
           "Description": "Enable personal model access requests and grants."
@@ -1684,6 +1688,7 @@
       "NoUserMembership": "No membership has been created for this user yet.",
       "AssignNote": "Assignment note",
       "AssignPlan": "Assign plan",
+      "ExternallyManagedMembershipHint": "This membership is managed by an external workflow and cannot be replaced or renewed here.",
       "PointDelta": "Point delta",
       "Points": "Points",
       "Increase": "Increase",

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -2092,6 +2092,7 @@
       "NoUserMembership": "该用户尚未创建会员。",
       "AssignNote": "分配备注",
       "AssignPlan": "分配套餐",
+      "ExternallyManagedMembershipHint": "该会员由外部流程管理，不能在此覆盖或续期。",
       "PointDelta": "点数调整",
       "Points": "点数",
       "Increase": "上调",
@@ -2805,6 +2806,10 @@
         "FEATURE_COPILOT_MONITORING": {
           "Name": "监测",
           "Description": "查看模型提供商的用户使用量和监测信息"
+        },
+        "FEATURE_MEMBERSHIP_PURCHASE": {
+          "Name": "会员购买",
+          "Description": "启用会员套餐和个人积分购买。"
         },
         "FEATURE_MODEL_ACCESS_REQUEST": {
           "Name": "个人模型授权",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -3600,6 +3600,7 @@
       "NoUserMembership": "该用户尚未创建会员。",
       "AssignNote": "分配备注",
       "AssignPlan": "分配套餐",
+      "ExternallyManagedMembershipHint": "该会员由外部流程管理，不能在此覆盖或续期。",
       "PointDelta": "点数调整",
       "Points": "点数",
       "Increase": "上调",
@@ -4699,6 +4700,10 @@
         "FEATURE_MEMBERSHIP_PLAN": {
           "Name": "会员套餐",
           "Description": "启用会员套餐配额、点数扣减和用量统计规则"
+        },
+        "FEATURE_MEMBERSHIP_PURCHASE": {
+          "Name": "会员购买",
+          "Description": "启用会员套餐和个人积分购买。"
         },
         "FEATURE_MODEL_ACCESS_REQUEST": {
           "Name": "个人模型授权",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -2695,6 +2695,7 @@
       "NoUserMembership": "該用戶尚未創建會員。",
       "AssignNote": "分配備註",
       "AssignPlan": "分配套餐",
+      "ExternallyManagedMembershipHint": "該會員由外部流程管理，不能在此覆蓋或續期。",
       "PointDelta": "點數調整",
       "Points": "點數",
       "Increase": "上調",
@@ -3545,6 +3546,10 @@
         "FEATURE_MEMBERSHIP_PLAN": {
           "Name": "會員套餐",
           "Description": "啟用會員套餐配額、點數扣減和用量統計規則"
+        },
+        "FEATURE_MEMBERSHIP_PURCHASE": {
+          "Name": "會員購買",
+          "Description": "啟用會員套餐和個人積分購買。"
         },
         "FEATURE_MODEL_ACCESS_REQUEST": {
           "Name": "個人模型授權",

--- a/packages/server-ai/src/core/default-role-permissions.spec.ts
+++ b/packages/server-ai/src/core/default-role-permissions.spec.ts
@@ -5,6 +5,17 @@ const permissionsFor = (role: RolesEnum) =>
     DEFAULT_ROLE_PERMISSIONS.find((item) => item.role === role)?.defaultEnabledPermissions ?? []
 
 describe('AI default role permissions', () => {
+    it('grants TRIAL only the selected AI permissions by default', () => {
+        expect([...permissionsFor(RolesEnum.TRIAL)].sort()).toEqual(
+            [
+                AIPermissionsEnum.COPILOT_EDIT,
+                AIPermissionsEnum.MEMBERSHIP_PURCHASE,
+                AIPermissionsEnum.XPERT_EDIT,
+                AIPermissionsEnum.CHAT_VIEW
+            ].sort()
+        )
+    })
+
     it.each([RolesEnum.SUPER_ADMIN, RolesEnum.ADMIN])('allows %s to administer memberships', (role) => {
         expect(permissionsFor(role)).toContain(AIPermissionsEnum.MEMBERSHIP_EDIT)
     })

--- a/packages/server-ai/src/core/default-role-permissions.ts
+++ b/packages/server-ai/src/core/default-role-permissions.ts
@@ -55,7 +55,12 @@ export const DEFAULT_ROLE_PERMISSIONS = [
     },
     {
         role: RolesEnum.TRIAL,
-        defaultEnabledPermissions: [...FULL_AI_PERMISSIONS, ...MEMBER_PURCHASE_PERMISSIONS]
+        defaultEnabledPermissions: [
+            AIPermissionsEnum.COPILOT_EDIT,
+            AIPermissionsEnum.XPERT_EDIT,
+            AIPermissionsEnum.CHAT_VIEW,
+            ...MEMBER_PURCHASE_PERMISSIONS
+        ]
     },
     {
         role: RolesEnum.AI_BUILDER,

--- a/packages/server/src/role-permission/default-role-permissions.spec.ts
+++ b/packages/server/src/role-permission/default-role-permissions.spec.ts
@@ -1,0 +1,21 @@
+import { PermissionsEnum, RolesEnum } from '@xpert-ai/contracts'
+import { DEFAULT_ROLE_PERMISSIONS } from './default-role-permissions'
+
+const permissionsFor = (role: RolesEnum) =>
+	DEFAULT_ROLE_PERMISSIONS.find((item) => item.role === role)?.defaultEnabledPermissions ?? []
+
+describe('default role permissions', () => {
+	it('grants TRIAL only the selected platform permissions by default', () => {
+		expect([...permissionsFor(RolesEnum.TRIAL)].sort()).toEqual(
+			[
+				PermissionsEnum.DATA_SOURCE_EDIT,
+				PermissionsEnum.DATA_SOURCE_VIEW,
+				PermissionsEnum.PROFILE_EDIT,
+				PermissionsEnum.ORG_INVITE_EDIT,
+				PermissionsEnum.INTEGRATION_EDIT,
+				PermissionsEnum.CHANGE_SELECTED_ORGANIZATION,
+				PermissionsEnum.INTEGRATION_VIEW
+			].sort()
+		)
+	})
+})

--- a/packages/server/src/role-permission/default-role-permissions.ts
+++ b/packages/server/src/role-permission/default-role-permissions.ts
@@ -70,31 +70,10 @@ const ADMIN_PLATFORM_PERMISSIONS = [
 const TRIAL_PLATFORM_PERMISSIONS = [
 	...DATA_SOURCE_PLATFORM_PERMISSIONS,
 	PermissionsEnum.PROFILE_EDIT,
-	PermissionsEnum.ADMIN_DASHBOARD_VIEW,
-	PermissionsEnum.ORG_EMPLOYEES_VIEW,
-	PermissionsEnum.ORG_EMPLOYEES_EDIT,
-	PermissionsEnum.ORG_HELP_CENTER_EDIT,
-	PermissionsEnum.ORG_USERS_VIEW,
-	PermissionsEnum.ORG_USERS_EDIT,
-	PermissionsEnum.ALL_ORG_VIEW,
-	PermissionsEnum.ALL_ORG_EDIT,
-	PermissionsEnum.INTEGRATION_VIEW,
+	PermissionsEnum.ORG_INVITE_EDIT,
 	PermissionsEnum.INTEGRATION_EDIT,
 	PermissionsEnum.CHANGE_SELECTED_ORGANIZATION,
-	PermissionsEnum.CHANGE_ROLES_PERMISSIONS,
-	PermissionsEnum.ORG_INVITE_VIEW,
-	PermissionsEnum.ORG_INVITE_EDIT,
-	PermissionsEnum.PUBLIC_PAGE_EDIT,
-	PermissionsEnum.ORG_TAGS_EDIT,
-	PermissionsEnum.VIEW_ALL_EMAILS,
-	PermissionsEnum.VIEW_ALL_EMAIL_TEMPLATES,
-	PermissionsEnum.ORG_CONTACT_EDIT,
-	PermissionsEnum.ORG_CONTACT_VIEW,
-	PermissionsEnum.ORG_DEMO_EDIT,
-	PermissionsEnum.FILE_STORAGE_VIEW,
-	PermissionsEnum.SMS_GATEWAY_VIEW,
-	PermissionsEnum.CUSTOM_SMTP_VIEW,
-	PermissionsEnum.VIEW_ALL_ACCOUNTING_TEMPLATES
+	PermissionsEnum.INTEGRATION_VIEW
 ]
 
 const AI_BUILDER_PLATFORM_PERMISSIONS = [


### PR DESCRIPTION
## Summary
- align TRIAL defaults with the selected 11 platform and AI permissions
- prevent purchased memberships from regular admin assignment and renewal, with matching UI guidance
- add membership purchase translations and focused regression coverage

## Validation
- Cloud: 42 focused tests passed
- Server: 9 focused tests passed
- Server AI: 26 focused tests passed
- git diff --check passed

## Scope
- existing role-permission sync semantics are intentionally unchanged