### PR TITLE
feat: open marketplace templates from URL

### DIFF
--- a/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace-readme-page.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace-readme-page.component.spec.ts
@@ -1,0 +1,231 @@
+jest.mock('@cloud/app/@core', () => ({
+  getErrorMessage: jest.fn((error: unknown) => (error instanceof Error ? error.message : 'Unknown error'))
+}))
+
+jest.mock('@cloud/app/@core/state', () => {
+  const { inject } = jest.requireActual('@angular/core')
+
+  class PluginAPIService {}
+
+  return {
+    PluginAPIService,
+    injectPluginAPI: () => inject(PluginAPIService)
+  }
+})
+
+jest.mock('@cloud/app/@shared/avatar', () => {
+  return { IconComponent: class IconComponent {} }
+})
+
+jest.mock('@cloud/app/@shared/i18n', () => {
+  class I18nService {}
+
+  return { I18nService }
+})
+
+jest.mock('@xpert-ai/headless-ui', () => {
+  const { signal } = jest.requireActual('@angular/core')
+
+  function myRxResource<TRequest, TValue>(config: {
+    request: () => TRequest | null
+    loader: (options: { request: TRequest }) => { subscribe: (observer: { next: (value: TValue) => void }) => void }
+  }) {
+    const value = signal<TValue | undefined>(undefined)
+    const request = config.request()
+    if (request) {
+      config.loader({ request }).subscribe({ next: (result: TValue) => value.set(result) })
+    }
+    return {
+      value,
+      status: signal('idle'),
+      error: signal(null),
+      reload: jest.fn()
+    }
+  }
+
+  return {
+    myRxResource,
+    XpI18nPipe: class XpI18nPipe {},
+    XpSpinComponent: class XpSpinComponent {},
+    ZardBadgeComponent: class ZardBadgeComponent {},
+    ZardButtonComponent: class ZardButtonComponent {}
+  }
+})
+
+jest.mock('../install/install.component', () => ({
+  PluginInstallComponent: class PluginInstallComponent {}
+}))
+
+jest.mock('../plugin-marketplace-categories', () => ({
+  PLUGIN_MARKETPLACE_TARGET_APP: 'xpert'
+}))
+
+jest.mock('../plugin-marketplace-metadata', () => ({
+  mergeMarketplaceContributions: (contributions: unknown) => contributions ?? []
+}))
+
+jest.mock('./marketplace-detail.component', () => ({
+  PluginMarketplaceDetailComponent: class PluginMarketplaceDetailComponent {}
+}))
+
+jest.mock('../../../xpert/xpert/blank/blank.component', () => {
+  return { XpertNewBlankComponent: class XpertNewBlankComponent {} }
+})
+
+import { Dialog } from '@angular/cdk/dialog'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router'
+import { XpertTypeEnum } from '@xpert-ai/contracts'
+import { PluginAPIService } from '@cloud/app/@core/state'
+import { I18nService } from '@cloud/app/@shared/i18n'
+import { of } from 'rxjs'
+import { XpertNewBlankComponent } from '../../../xpert/xpert/blank/blank.component'
+import { PluginMarketplaceReadmePageComponent } from './marketplace-readme-page.component'
+
+type PluginDetail = {
+  name: string
+  packageName: string
+  displayName: string
+  description: string
+  version: string
+  category: string
+  icon: { type: 'font'; value: string }
+  author: { name: string; url: string }
+  installed: boolean
+  contributions: []
+}
+
+function createPluginDetail(installed = true): PluginDetail {
+  return {
+    name: '@xpert-ai/plugin-docx-editor',
+    packageName: '@xpert-ai/plugin-docx-editor',
+    displayName: 'DOCX Editor',
+    description: 'Review DOCX files.',
+    version: '0.1.0',
+    category: 'middleware',
+    icon: { type: 'font', value: 'ri-file-word-line' },
+    author: { name: 'XpertAI', url: 'https://xpertai.cn' },
+    installed,
+    contributions: []
+  }
+}
+
+async function createComponent(options: { template?: string | null; installed?: boolean } = {}) {
+  const template = options.template === undefined ? 'docx-editor-assistant' : options.template
+  const detail = createPluginDetail(options.installed)
+  const dialog = {
+    open: jest.fn(() => ({
+      closed: of({ xpert: { id: 'agent-1' } })
+    }))
+  }
+  const router = {
+    navigate: jest.fn()
+  }
+  const pluginAPI = {
+    getMarketplacePluginDetail: jest.fn(() => of(detail))
+  }
+  const route = {
+    paramMap: of(convertToParamMap({ scope: 'xpert-ai', packageName: 'plugin-docx-editor' })),
+    queryParamMap: of(convertToParamMap({ action: 'initialize-template', ...(template ? { template } : {}) })),
+    snapshot: {
+      paramMap: convertToParamMap({ scope: 'xpert-ai', packageName: 'plugin-docx-editor' }),
+      queryParamMap: convertToParamMap({ action: 'initialize-template', ...(template ? { template } : {}) })
+    }
+  }
+  const i18n = {
+    language: jest.fn(() => 'zh-Hans'),
+    instant: jest.fn((key: string, values?: { Default?: string }) => values?.Default ?? key)
+  }
+
+  await TestBed.configureTestingModule({
+    providers: [
+      { provide: ActivatedRoute, useValue: route },
+      { provide: Dialog, useValue: dialog },
+      { provide: Router, useValue: router },
+      { provide: PluginAPIService, useValue: pluginAPI },
+      { provide: I18nService, useValue: i18n }
+    ]
+  })
+    .overrideComponent(PluginMarketplaceReadmePageComponent, {
+      set: {
+        imports: [],
+        styles: [],
+        template: ''
+      }
+    })
+    .compileComponents()
+
+  const fixture = TestBed.createComponent(PluginMarketplaceReadmePageComponent)
+  fixture.detectChanges()
+  await fixture.whenStable()
+  fixture.detectChanges()
+
+  return {
+    component: fixture.componentInstance,
+    dialog,
+    fixture,
+    pluginAPI,
+    router
+  } satisfies {
+    component: PluginMarketplaceReadmePageComponent
+    dialog: typeof dialog
+    fixture: ComponentFixture<PluginMarketplaceReadmePageComponent>
+    pluginAPI: typeof pluginAPI
+    router: typeof router
+  }
+}
+
+describe('PluginMarketplaceReadmePageComponent', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule()
+    jest.clearAllMocks()
+  })
+
+  it('opens the requested template once and navigates to the created agent', async () => {
+    const { dialog, fixture, router } = await createComponent()
+
+    fixture.detectChanges()
+
+    expect(dialog.open).toHaveBeenCalledTimes(1)
+    expect(dialog.open).toHaveBeenCalledWith(
+      XpertNewBlankComponent,
+      expect.objectContaining({
+        disableClose: true,
+        data: expect.objectContaining({
+          allowedModes: [XpertTypeEnum.Agent],
+          allowWorkspaceSelection: true,
+          completionMode: 'create',
+          initialStartMode: 'template',
+          initialTemplateId: '@xpert-ai/plugin-docx-editor:docx-editor-assistant',
+          lockStartMode: true,
+          lockType: true,
+          type: XpertTypeEnum.Agent
+        })
+      })
+    )
+    expect(router.navigate).toHaveBeenCalledWith(['/xpert/x/', 'agent-1'])
+  })
+
+  it('keeps a fully qualified template id unchanged', async () => {
+    const { dialog } = await createComponent({ template: '@acme/plugin-docs:document-reviewer' })
+
+    expect(dialog.open).toHaveBeenCalledWith(
+      XpertNewBlankComponent,
+      expect.objectContaining({
+        data: expect.objectContaining({ initialTemplateId: '@acme/plugin-docs:document-reviewer' })
+      })
+    )
+  })
+
+  it('does not open a creation wizard before the plugin is installed', async () => {
+    const { dialog } = await createComponent({ installed: false })
+
+    expect(dialog.open).not.toHaveBeenCalled()
+  })
+
+  it('does not open a creation wizard without a template parameter', async () => {
+    const { dialog } = await createComponent({ template: null })
+
+    expect(dialog.open).not.toHaveBeenCalled()
+  })
+})

--- a/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace-readme-page.component.ts
+++ b/apps/cloud/src/app/features/setting/plugins/marketplace/marketplace-readme-page.component.ts
@@ -1,13 +1,13 @@
 import { Dialog } from '@angular/cdk/dialog'
 import { CommonModule } from '@angular/common'
-import { Component, ElementRef, computed, inject, viewChild } from '@angular/core'
+import { Component, ElementRef, computed, effect, inject, viewChild } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
-import { ActivatedRoute, RouterModule } from '@angular/router'
+import { ActivatedRoute, Router, RouterModule } from '@angular/router'
 import { getErrorMessage } from '@cloud/app/@core'
 import { IconComponent } from '@cloud/app/@shared/avatar'
 import { I18nService } from '@cloud/app/@shared/i18n'
 import { IPluginMarketplaceDetailItem, injectPluginAPI, PluginMarketplaceItem } from '@cloud/app/@core/state'
-import { JSONValue } from '@xpert-ai/contracts'
+import { JSONValue, XpertTypeEnum } from '@xpert-ai/contracts'
 import { ZardBadgeComponent, ZardButtonComponent } from '@xpert-ai/headless-ui'
 import { XpSpinComponent } from '@xpert-ai/headless-ui'
 import { myRxResource, XpI18nPipe } from '@xpert-ai/headless-ui'
@@ -20,6 +20,7 @@ import { pluginNameFromMarketplaceRoute } from '../plugin-marketplace-navigation
 import { getPluginMarketplaceSourceI18nKey, TPluginWithDownloads } from '../types'
 import { PluginMarketplaceDetailComponent } from './marketplace-detail.component'
 import { PLUGIN_MARKETPLACE_TARGET_APP } from '../plugin-marketplace-categories'
+import { BlankXpertWizardResult, XpertNewBlankComponent } from '../../../xpert/xpert/blank/blank.component'
 
 @Component({
   standalone: true,
@@ -41,6 +42,7 @@ import { PLUGIN_MARKETPLACE_TARGET_APP } from '../plugin-marketplace-categories'
 export class PluginMarketplaceReadmePageComponent {
   readonly #route = inject(ActivatedRoute)
   readonly #dialog = inject(Dialog)
+  readonly #router = inject(Router)
   readonly #pluginAPI = injectPluginAPI()
   readonly #i18n = inject(I18nService)
 
@@ -60,6 +62,17 @@ export class PluginMarketplaceReadmePageComponent {
   readonly sourceId = toSignal(this.#route.queryParamMap.pipe(map((params) => params.get('sourceId'))), {
     initialValue: null
   })
+  readonly requestedTemplateName = toSignal(
+    this.#route.queryParamMap.pipe(
+      map((params) => (params.get('action') === 'initialize-template' ? params.get('template') : null))
+    ),
+    {
+      initialValue:
+        this.#route.snapshot.queryParamMap.get('action') === 'initialize-template'
+          ? this.#route.snapshot.queryParamMap.get('template')
+          : null
+    }
+  )
 
   readonly #detail = myRxResource({
     request: () => ({
@@ -87,6 +100,28 @@ export class PluginMarketplaceReadmePageComponent {
     return detail ? toPluginWithDownloads(detail) : null
   })
   readonly hasSetupContent = computed(() => !!this.pluginForDialog()?.contributions?.length)
+  #openedTemplateId: string | null = null
+
+  readonly #openRequestedTemplate = effect(() => {
+    const templateName = this.requestedTemplateName()?.trim()
+    const plugin = this.pluginForDialog()
+    if (!templateName || !plugin?.installed) {
+      return
+    }
+
+    const pluginName = plugin.packageName || plugin.name
+    if (!pluginName) {
+      return
+    }
+
+    const templateId = templateName.includes(':') ? templateName : `${pluginName}:${templateName}`
+    if (this.#openedTemplateId === templateId) {
+      return
+    }
+
+    this.#openedTemplateId = templateId
+    this.openAssistantTemplate(templateId)
+  })
 
   openInstall() {
     const plugin = this.pluginForDialog()
@@ -115,6 +150,28 @@ export class PluginMarketplaceReadmePageComponent {
       },
       backdropClass: 'backdrop-blur-sm-black'
     })
+  }
+
+  private openAssistantTemplate(templateId: string) {
+    this.#dialog
+      .open<BlankXpertWizardResult>(XpertNewBlankComponent, {
+        disableClose: true,
+        data: {
+          type: XpertTypeEnum.Agent,
+          allowedModes: [XpertTypeEnum.Agent],
+          allowWorkspaceSelection: true,
+          initialStartMode: 'template',
+          initialTemplateId: templateId,
+          lockStartMode: true,
+          lockType: true,
+          completionMode: 'create'
+        }
+      })
+      .closed.subscribe((result) => {
+        if (result?.xpert?.id) {
+          this.#router.navigate(['/xpert/x/', result.xpert.id])
+        }
+      })
   }
 
   reload() {


### PR DESCRIPTION
## Summary
- Read marketplace URL parameters for the requested assistant template.
- Open the locked Agent creation wizard after the installed plugin detail resolves.
- Navigate to the newly created Agent after creation completes.

## Validation
- corepack pnpm exec eslint apps/cloud/src/app/features/setting/plugins/marketplace/marketplace-readme-page.component.ts apps/cloud/src/app/features/setting/plugins/marketplace/marketplace-readme-page.component.spec.ts
- corepack pnpm exec jest --config apps/cloud/jest.config.ts --runInBand apps/cloud/src/app/features/setting/plugins/marketplace/marketplace-readme-page.component.spec.ts apps/cloud/src/app/features/setting/plugins/marketplace/marketplace-detail.component.spec.ts
- corepack pnpm nx build cloud --configuration=development