### PR TITLE
fix: align membership model scope precedence

### DIFF
--- a/apps/cloud/src/app/features/setting/membership/membership.component.html
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.html
@@ -1042,7 +1042,7 @@
     <z-card-content class="flex flex-col gap-4 p-4">
       <form
         [formGroup]="memberFilterForm"
-        class="grid gap-3 rounded-lg bg-components-panel-bg p-4 md:grid-cols-2 xl:grid-cols-[minmax(14rem,2fr)_minmax(9rem,1fr)_minmax(10rem,1fr)_minmax(12rem,1fr)_auto]"
+        class="grid gap-3 rounded-lg bg-components-panel-bg p-4 md:grid-cols-2 xl:grid-cols-[minmax(14rem,1fr)_minmax(9rem,1fr)_minmax(10rem,1fr)_minmax(12rem,1fr)]"
         (ngSubmit)="applyMemberFilters()"
       >
         <z-form-field class="w-full">
@@ -1085,13 +1085,17 @@
             }
           </z-select>
         </z-form-field>
-        <z-form-field class="w-full">
+        <z-form-field class="w-full min-w-0">
           <z-form-label>
             {{ 'XP.Membership.ExpiringBefore' | translate: { Default: 'Expiring before' } }}
           </z-form-label>
-          <z-date-picker class="w-full" zFormat="yyyy-MM-dd" formControlName="expiringBefore" />
+          <z-date-picker
+            class="w-full min-w-0 [&>button]:min-w-0"
+            zFormat="yyyy-MM-dd"
+            formControlName="expiringBefore"
+          />
         </z-form-field>
-        <div class="flex items-end justify-end gap-2 px-3 pb-3 xl:ml-2">
+        <div class="col-span-full flex justify-end gap-2">
           <button z-button zType="default" type="submit" [disabled]="adminMembersLoading()">
             {{ 'XP.ACTIONS.Search' | translate: { Default: 'Search' } }}
           </button>

--- a/packages/server-ai/src/copilot/copilot.service.spec.ts
+++ b/packages/server-ai/src/copilot/copilot.service.spec.ts
@@ -53,7 +53,7 @@ describe('CopilotService', () => {
             findModelAccess: jest.fn().mockResolvedValue({
                 tenantId: 'tenant-1',
                 organizationId: 'org-1',
-                membership: {}
+                membership: { plan: {} }
             })
         }
         modelAccessService = {
@@ -199,6 +199,113 @@ describe('CopilotService', () => {
         expect(result).toHaveLength(1)
         expect(result[0].id).toBe('copilot-2')
         expect(result[0].modelProvider?.id).toBe('tenant-provider')
+    })
+
+    it('keeps an organization membership purchased from the tenant catalog in organization model scope', async () => {
+        membershipService.countEnabledOrganizationCopilots.mockResolvedValue(1)
+        membershipService.findModelAccess.mockResolvedValue({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            membership: {
+                plan: {
+                    catalogSourcePlanId: 'tenant-catalog-plan'
+                }
+            }
+        } as never)
+        repository.find.mockResolvedValue([
+            createCopilot({
+                id: 'organization-copilot',
+                organizationId: 'org-1',
+                role: AiProviderRole.Primary,
+                modelProvider: createProvider({
+                    id: 'organization-provider',
+                    organizationId: 'org-1',
+                    providerName: 'openai'
+                })
+            })
+        ])
+        copilotProviderService.findVisibleByCopilotIds.mockResolvedValue(
+            new Map([
+                [
+                    'organization-copilot',
+                    createProvider({
+                        id: 'organization-provider',
+                        copilotId: 'organization-copilot',
+                        organizationId: 'org-1',
+                        providerName: 'openai'
+                    })
+                ]
+            ])
+        )
+
+        const result = await service.findAllAvailablesCopilots('tenant-1', 'org-1')
+
+        expect(repository.find).toHaveBeenCalledWith({
+            where: [
+                {
+                    tenantId: 'tenant-1',
+                    organizationId: 'org-1',
+                    enabled: true
+                }
+            ],
+            relations: ['modelProvider']
+        })
+        expect(result).toHaveLength(1)
+        expect(result[0].id).toBe('organization-copilot')
+    })
+
+    it('uses tenant catalog copilots for an organization catalog membership without organization models', async () => {
+        membershipService.findModelAccess.mockResolvedValue({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            membership: {
+                plan: {
+                    catalogSourcePlanId: 'tenant-catalog-plan'
+                }
+            }
+        } as never)
+        repository.find.mockResolvedValue([
+            createCopilot({
+                id: 'tenant-copilot',
+                organizationId: null,
+                role: AiProviderRole.Primary,
+                modelProvider: createProvider({
+                    id: 'tenant-provider',
+                    organizationId: null,
+                    providerName: 'deepseek'
+                })
+            })
+        ])
+        copilotProviderService.findVisibleByCopilotIds.mockResolvedValue(
+            new Map([
+                [
+                    'tenant-copilot',
+                    createProvider({
+                        id: 'tenant-provider',
+                        copilotId: 'tenant-copilot',
+                        organizationId: null,
+                        providerName: 'deepseek'
+                    })
+                ]
+            ])
+        )
+
+        const result = await service.findAllAvailablesCopilots('tenant-1', 'org-1')
+
+        expect(membershipService.findModelAccess).toHaveBeenCalledWith({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1'
+        })
+        expect(repository.find).toHaveBeenCalledWith({
+            where: [
+                expect.objectContaining({
+                    tenantId: 'tenant-1',
+                    enabled: true
+                })
+            ],
+            relations: ['modelProvider']
+        })
+        expect(result.map((copilot) => copilot.id)).toEqual(['tenant-copilot'])
     })
 
     it('uses only tenant-global copilots when no organization scope is provided', async () => {
@@ -375,7 +482,7 @@ describe('CopilotService', () => {
             role: AiProviderRole.Primary
         })
 
-        expect(membershipService.countEnabledOrganizationCopilots).not.toHaveBeenCalled()
+        expect(membershipService.countEnabledOrganizationCopilots).toHaveBeenCalledWith('tenant-1', 'org-1')
         expect(membershipService.ensureScopeInitialized).not.toHaveBeenCalled()
         expect(membershipService.findModelAccess).not.toHaveBeenCalled()
         expect(repository.find).toHaveBeenCalledTimes(1)
@@ -398,13 +505,9 @@ describe('CopilotService', () => {
         expect(result.map((copilot) => copilot.id)).toEqual(['org-copilot'])
     })
 
-    it('lists direct organization copilots together with tenant plan copilots', async () => {
+    it('lists only direct organization copilots when organization membership is disabled', async () => {
         membershipService.isMembershipPlanEnabled.mockImplementation(async ({ organizationId }) => !organizationId)
-        membershipService.findModelAccess.mockResolvedValue({
-            tenantId: 'tenant-1',
-            organizationId: null,
-            membership: {}
-        } as never)
+        membershipService.countEnabledOrganizationCopilots.mockResolvedValue(1)
         repository.find.mockResolvedValue([
             createCopilot({
                 id: 'org-copilot',
@@ -419,7 +522,8 @@ describe('CopilotService', () => {
 
         const result = await service.findAllAvailablesCopilots('tenant-1', 'org-1')
 
-        expect(result.map((copilot) => copilot.id)).toEqual(['org-copilot', 'tenant-copilot'])
+        expect(membershipService.findModelAccess).not.toHaveBeenCalled()
+        expect(result.map((copilot) => copilot.id)).toEqual(['org-copilot'])
     })
 
     it('lists only tenant enabled copilots without membership access in tenant scope when membership plans are disabled', async () => {

--- a/packages/server-ai/src/copilot/copilot.service.ts
+++ b/packages/server-ai/src/copilot/copilot.service.ts
@@ -101,17 +101,17 @@ export class CopilotService extends TenantOrganizationAwareCrudService<Copilot> 
         if (!tenantId) {
             return []
         }
-        const [tenantMembershipEnabled, organizationMembershipEnabled] = await Promise.all([
+        const [tenantMembershipEnabled, organizationMembershipEnabled, organizationCopilotCount] = await Promise.all([
             this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
             organizationId
                 ? this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId })
-                : Promise.resolve(false)
+                : Promise.resolve(false),
+            organizationId
+                ? this.membershipService.countEnabledOrganizationCopilots(tenantId, organizationId)
+                : Promise.resolve(0)
         ])
-        if (
-            organizationId &&
-            organizationMembershipEnabled &&
-            (await this.membershipService.countEnabledOrganizationCopilots(tenantId, organizationId)) > 0
-        ) {
+        const organizationModelsConfigured = organizationCopilotCount > 0
+        if (organizationId && organizationMembershipEnabled && organizationModelsConfigured) {
             await this.membershipService.ensureScopeInitialized({
                 tenantId,
                 organizationId,
@@ -119,21 +119,29 @@ export class CopilotService extends TenantOrganizationAwareCrudService<Copilot> 
             })
         }
 
-        const access =
-            organizationMembershipEnabled || tenantMembershipEnabled
-                ? await this.membershipService.findModelAccess({
-                      tenantId,
-                      organizationId
-                  })
-                : null
+        const membershipEnabled = organizationId
+            ? organizationModelsConfigured
+                ? organizationMembershipEnabled
+                : organizationMembershipEnabled || tenantMembershipEnabled
+            : tenantMembershipEnabled
+        const access = membershipEnabled
+            ? await this.membershipService.findModelAccess({
+                  tenantId,
+                  organizationId
+              })
+            : null
         const allowedScopes = new Set<string | null>()
         if (!organizationId) {
             if (!tenantMembershipEnabled || access?.organizationId === null) {
                 allowedScopes.add(null)
             }
+        } else if (organizationModelsConfigured) {
+            if (!organizationMembershipEnabled || access?.organizationId === organizationId) {
+                allowedScopes.add(organizationId)
+            }
         } else if (organizationMembershipEnabled) {
             if (access?.organizationId === organizationId) {
-                allowedScopes.add(organizationId)
+                allowedScopes.add(access.membership.plan.catalogSourcePlanId ? null : organizationId)
             } else if (tenantMembershipEnabled && access?.organizationId === null) {
                 allowedScopes.add(null)
             }

--- a/packages/server-ai/src/membership/membership.service.spec.ts
+++ b/packages/server-ai/src/membership/membership.service.spec.ts
@@ -3267,6 +3267,36 @@ describe('MembershipService', () => {
         ).rejects.toThrow('Copilot model is not available for the current membership plan.')
     })
 
+    it('allows tenant copilots for an organization membership purchased from the tenant catalog', async () => {
+        const service = createMembershipService({} as never, {} as never, {} as never, {} as never, {} as never)
+        const membership = createMembership({
+            organizationId: 'org-1',
+            pointsUsed: 0,
+            source: MembershipSourceEnum.External,
+            plan: {
+                ...createMembership().plan,
+                organizationId: 'org-1',
+                catalogSourcePlanId: 'tenant-catalog-plan'
+            }
+        } as never)
+        jest.spyOn(service, 'findModelAccess').mockResolvedValue({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            membership
+        })
+
+        await expect(
+            service.assertCanUse({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                copilotOrganizationId: null,
+                userId: 'assistant-tech-user',
+                provider: 'tongyi',
+                model: 'qwen3.6-plus'
+            })
+        ).resolves.toBeUndefined()
+    })
+
     it('rejects models not explicitly allowed by the active membership plan', async () => {
         const service = createMembershipService({} as never, {} as never, {} as never, {} as never, {} as never)
         jest.spyOn(service, 'findModelAccess').mockResolvedValue({

--- a/packages/server-ai/src/membership/membership.service.ts
+++ b/packages/server-ai/src/membership/membership.service.ts
@@ -4813,7 +4813,11 @@ export class MembershipService {
 
     private assertCopilotScopeMatches(access: MembershipModelAccess, copilotOrganizationId?: string | null) {
         const normalizedCopilotOrganizationId = this.normalizeScopeOrganizationId(copilotOrganizationId)
-        if (normalizedCopilotOrganizationId !== access.organizationId) {
+        const usesTenantCatalog =
+            normalizedCopilotOrganizationId === null &&
+            !!access.organizationId &&
+            !!access.membership.plan.catalogSourcePlanId
+        if (normalizedCopilotOrganizationId !== access.organizationId && !usesTenantCatalog) {
             throw new ExceedingLimitException(
                 this.translateMembershipError(
                     'server-ai:Error.CopilotModelUnavailableForMembershipPlan',

--- a/packages/server-ai/src/model-access/model-access.service.spec.ts
+++ b/packages/server-ai/src/model-access/model-access.service.spec.ts
@@ -53,6 +53,7 @@ function createFixture() {
         resolveBillableUserId: jest.fn().mockResolvedValue('creator-user'),
         isMembershipAccessEnabled: jest.fn().mockResolvedValue(true),
         isMembershipPlanEnabled: jest.fn().mockResolvedValue(true),
+        countEnabledOrganizationCopilots: jest.fn().mockResolvedValue(0),
         findModelAccess: jest.fn(),
         isModelAllowed: jest.fn(),
         resolveModelMultiplierForPlan: jest.fn().mockReturnValue(2),
@@ -213,6 +214,20 @@ describe('ModelAccessService model resolution', () => {
         })
     })
 
+    it('blocks tenant models when the organization has configured its own models', async () => {
+        const { input, membershipService, service } = createFixture()
+        membershipService.isMembershipPlanEnabled.mockImplementation(async ({ organizationId }) => !organizationId)
+        membershipService.countEnabledOrganizationCopilots.mockResolvedValue(1)
+
+        await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
+            allowed: false,
+            organizationId: null,
+            scope: ModelAccessOwnershipScopeEnum.Tenant,
+            unavailableReason: ModelAccessUnavailableReasonEnum.FeatureDisabled
+        })
+        expect(membershipService.findModelAccess).not.toHaveBeenCalled()
+    })
+
     it('resolves an organization-scoped provider from the persisted model scope', async () => {
         const { copilotRepository, input, membershipService, providersService, service } = createFixture()
         const organizationProvider = {
@@ -285,6 +300,29 @@ describe('ModelAccessService model resolution', () => {
         })
         expect(result.grantId).toBeUndefined()
         expect(membershipService.resolveModelMultiplierForPlan).toHaveBeenCalledWith(plan, 'openai', 'gpt-4.1')
+    })
+
+    it('uses an organization catalog membership for tenant catalog models', async () => {
+        const { input, membershipService, service } = createFixture()
+        membershipService.isMembershipPlanEnabled.mockImplementation(async ({ organizationId }) => !!organizationId)
+        const plan = {
+            id: 'organization-catalog-plan',
+            catalogSourcePlanId: 'tenant-catalog-plan'
+        }
+        membershipService.findModelAccess.mockResolvedValue({
+            organizationId: 'runtime-org',
+            membership: { planId: 'organization-catalog-plan', plan }
+        })
+        membershipService.isModelAllowed.mockReturnValue(true)
+
+        await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
+            allowed: true,
+            accessSource: ModelAccessSourceEnum.Plan,
+            planId: 'organization-catalog-plan',
+            organizationId: null,
+            scope: ModelAccessOwnershipScopeEnum.Tenant
+        })
+        expect(membershipService.isModelAllowed).toHaveBeenCalledWith(plan, 'openai', 'gpt-4.1')
     })
 
     it('restores the same personal grant after the plan stops including the model', async () => {
@@ -1154,6 +1192,83 @@ describe('ModelAccessService catalog', () => {
                 })
             ]),
             canRequest: true
+        })
+    })
+
+    it('does not include tenant models when an organization has its own membership models', async () => {
+        jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
+        jest.spyOn(RequestContext, 'currentUserId').mockReturnValue('creator-user')
+        jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('org-1')
+        jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(false)
+        const { copilotRepository, membershipService, providersService, queryBus, service } = createFixture()
+        copilotRepository.findOne.mockResolvedValue({
+            id: 'copilot-1',
+            tenantId: 'tenant-1',
+            organizationId: null,
+            name: 'Tenant Provider',
+            enabled: true,
+            modelProvider: {
+                id: 'provider-1',
+                providerName: 'openai',
+                isValid: true
+            }
+        })
+        providersService.getProvider.mockReturnValue({
+            getProviderModels: jest.fn().mockReturnValue([
+                {
+                    model: 'plan-model',
+                    model_type: AiModelTypeEnum.LLM
+                }
+            ]),
+            getProviderSchema: jest.fn().mockReturnValue({
+                provider: 'openai',
+                label: { en_US: 'OpenAI', zh_Hans: 'OpenAI' }
+            })
+        })
+        membershipService.findModelAccess.mockResolvedValue({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            membership: {
+                plan: {
+                    catalogSourcePlanId: 'tenant-catalog-plan',
+                    allowedModels: [{ provider: 'openai', model: 'plan-model' }]
+                }
+            }
+        })
+        membershipService.countEnabledOrganizationCopilots.mockResolvedValue(1)
+        membershipService.isModelAllowed.mockReturnValue(true)
+        queryBus.execute.mockImplementation(async (query: FindCopilotModelsQuery) =>
+            query.type === AiModelTypeEnum.LLM
+                ? [
+                      {
+                          id: 'copilot-1',
+                          organizationId: null,
+                          providerWithModels: {
+                              provider: 'openai',
+                              models: [
+                                  {
+                                      model: 'plan-model',
+                                      model_type: AiModelTypeEnum.LLM
+                                  }
+                              ]
+                          }
+                      }
+                  ]
+                : []
+        )
+
+        await expect(service.getCatalog()).resolves.toMatchObject({
+            items: [
+                expect.objectContaining({
+                    copilotModelId: 'plan-model',
+                    ownershipScope: ModelAccessOwnershipScopeEnum.Tenant,
+                    organizationId: null,
+                    planIncluded: false,
+                    allowed: false,
+                    requestable: false,
+                    unavailableReason: ModelAccessUnavailableReasonEnum.FeatureDisabled
+                })
+            ]
         })
     })
 })

--- a/packages/server-ai/src/model-access/model-access.service.ts
+++ b/packages/server-ai/src/model-access/model-access.service.ts
@@ -96,6 +96,7 @@ enum ModelTargetAccessMode {
 
 type MembershipFeatureState = {
     organizationEnabled: boolean
+    organizationModelsConfigured: boolean
     tenantEnabled: boolean
 }
 
@@ -170,7 +171,8 @@ export class ModelAccessService {
             tenantFeatureEnabled,
             organizationFeatureEnabled,
             tenantMembershipEnabled,
-            organizationMembershipEnabled
+            organizationMembershipEnabled,
+            organizationCopilotCount
         ] = await Promise.all([
             this.loadVisibleCatalogTargets(organizationId),
             this.findUserRequestsForCurrentContext(tenantId, userId, organizationId),
@@ -184,7 +186,10 @@ export class ModelAccessService {
             this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
             organizationId
                 ? this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId })
-                : Promise.resolve(false)
+                : Promise.resolve(false),
+            organizationId
+                ? this.membershipService.countEnabledOrganizationCopilots(tenantId, organizationId)
+                : Promise.resolve(0)
         ])
         let grantStateChanged = false
         for (const grant of initialGrants.filter((item) => item.status === UserModelGrantStatusEnum.Active)) {
@@ -228,6 +233,7 @@ export class ModelAccessService {
                     organizationFeatureEnabled,
                     tenantMembershipEnabled,
                     organizationMembershipEnabled,
+                    organizationModelsConfigured: organizationCopilotCount > 0,
                     runtimeOrganizationId: organizationId
                 })
             )
@@ -1604,12 +1610,14 @@ export class ModelAccessService {
             organizationFeatureEnabled: boolean
             tenantMembershipEnabled: boolean
             organizationMembershipEnabled: boolean
+            organizationModelsConfigured: boolean
             runtimeOrganizationId: string | null
         }
     ): Promise<IModelAccessCatalogItem> {
         const accessMode = this.resolveTargetAccessMode(target, features.runtimeOrganizationId, {
             tenantEnabled: features.tenantMembershipEnabled,
-            organizationEnabled: features.organizationMembershipEnabled
+            organizationEnabled: features.organizationMembershipEnabled,
+            organizationModelsConfigured: features.organizationModelsConfigured
         })
         const planIncluded =
             accessMode === ModelTargetAccessMode.Membership && this.isPlanIncluded(target, membershipAccess)
@@ -2039,10 +2047,14 @@ export class ModelAccessService {
     }
 
     private isPlanIncluded(target: ModelTarget, access: MembershipModelAccess | null) {
+        if (!access) {
+            return false
+        }
+        const scopeMatches =
+            access.organizationId === target.organizationId ||
+            (target.organizationId === null && !!access.organizationId && !!access.membership.plan.catalogSourcePlanId)
         return (
-            !!access &&
-            access.organizationId === target.organizationId &&
-            this.membershipService.isModelAllowed(access.membership.plan, target.provider, target.model)
+            scopeMatches && this.membershipService.isModelAllowed(access.membership.plan, target.provider, target.model)
         )
     }
 
@@ -2050,16 +2062,23 @@ export class ModelAccessService {
         tenantId: string,
         runtimeOrganizationId: string | null
     ): Promise<MembershipFeatureState> {
-        const [tenantEnabled, organizationEnabled] = await Promise.all([
+        const [tenantEnabled, organizationEnabled, organizationCopilotCount] = await Promise.all([
             this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
             runtimeOrganizationId
                 ? this.membershipService.isMembershipPlanEnabled({
                       tenantId,
                       organizationId: runtimeOrganizationId
                   })
-                : Promise.resolve(false)
+                : Promise.resolve(false),
+            runtimeOrganizationId
+                ? this.membershipService.countEnabledOrganizationCopilots(tenantId, runtimeOrganizationId)
+                : Promise.resolve(0)
         ])
-        return { tenantEnabled, organizationEnabled }
+        return {
+            tenantEnabled,
+            organizationEnabled,
+            organizationModelsConfigured: organizationCopilotCount > 0
+        }
     }
 
     private resolveTargetAccessMode(
@@ -2075,7 +2094,12 @@ export class ModelAccessService {
         if (!runtimeOrganizationId) {
             return membershipFeatures.tenantEnabled ? ModelTargetAccessMode.Membership : ModelTargetAccessMode.Direct
         }
-        return membershipFeatures.tenantEnabled ? ModelTargetAccessMode.Membership : ModelTargetAccessMode.Blocked
+        if (membershipFeatures.organizationModelsConfigured) {
+            return ModelTargetAccessMode.Blocked
+        }
+        return membershipFeatures.organizationEnabled || membershipFeatures.tenantEnabled
+            ? ModelTargetAccessMode.Membership
+            : ModelTargetAccessMode.Blocked
     }
 
     private async resolveQuotaReason(access: MembershipModelAccess | null) {


### PR DESCRIPTION
## Summary

- prefer organization-scoped Copilots when an organization has configured its own models
- fall back to tenant catalog Copilots when a catalog-purchased organization membership has no organization models
- keep catalog-purchased membership benefits and usage bound to the purchasing organization while allowing tenant-scoped catalog models
- move membership member-filter actions onto a dedicated row and prevent the date picker from overflowing

## Root cause

Catalog-purchased memberships are persisted in organization scope, while their model catalog and providers remain tenant-scoped. Exact scope matching therefore hid or rejected tenant catalog models. The model list, access catalog, runtime resolution, and membership guard now apply the same organization-first precedence with tenant-catalog fallback.

The member filter also attempted to fit four controls and action buttons into one wide grid row, which squeezed the date picker and action area.

## Validation

- `corepack pnpm nx test server-ai --runInBand --testPathPatterns='(copilot|membership|model-access)\\.service\\.spec\\.ts$'` — 171 tests passed
- targeted ESLint — 0 errors
- pre-commit formatting, hardcoded-color, and TypeORM column checks passed
- `git diff --check origin/develop...HEAD` passed

Browser validation was not run.
