### PR TITLE
[codex] fix provider fallback and membership initialization

### DIFF
--- a/packages/server-ai/src/copilot/copilot.controller.ts
+++ b/packages/server-ai/src/copilot/copilot.controller.ts
@@ -155,12 +155,7 @@ export class CopilotController extends CrudController<Copilot> {
 	@Permissions(AIPermissionsEnum.COPILOT_EDIT)
 	@Post('enable/:role')
 	async enableCopilotRole(@Param('role') role: AiProviderRole) {
-		const copilot = await this.service.findOneOrFailByWhereOptions({ role })
-		if (copilot.success) {
-			await this.service.update(copilot.record.id, { enabled: true })
-		} else {
-			await this.service.create({ role, enabled: true })
-		}
+		await this.service.enableRole(role)
 	}
 
 	@UseGuards(PermissionGuard)

--- a/packages/server-ai/src/copilot/copilot.service.spec.ts
+++ b/packages/server-ai/src/copilot/copilot.service.spec.ts
@@ -1,9 +1,9 @@
-import { AiProviderRole } from '@xpert-ai/contracts'
+import { AiProviderRole, AIPermissionsEnum } from '@xpert-ai/contracts'
 import { ConfigService } from '@xpert-ai/server-config'
+import { RequestContext } from '@xpert-ai/server-core'
 import { QueryBus } from '@nestjs/cqrs'
 import { Test, TestingModule } from '@nestjs/testing'
 import { getRepositoryToken } from '@nestjs/typeorm'
-import { Repository } from 'typeorm'
 import { CopilotProvider } from '../copilot-provider/copilot-provider.entity'
 import { CopilotProviderService } from '../copilot-provider/copilot-provider.service'
 import { MembershipService } from '../membership'
@@ -20,25 +20,29 @@ jest.mock('../ai-model', () => ({
 
 describe('CopilotService', () => {
     let moduleRef: TestingModule
-    let repository: jest.Mocked<Pick<Repository<Copilot>, 'find'>>
+    let repository: {
+        create: jest.Mock
+        find: jest.Mock
+        findOneByOrFail: jest.Mock
+        save: jest.Mock
+    }
     let queryBus: jest.Mocked<Pick<QueryBus, 'execute'>>
     let copilotProviderService: jest.Mocked<Pick<CopilotProviderService, 'findVisibleByCopilotIds'>>
     let membershipService: jest.Mocked<
-        Pick<
-            MembershipService,
-            | 'findModelAccess'
-            | 'countEnabledOrganizationCopilots'
-            | 'ensureScopeInitialized'
-            | 'isMembershipPlanEnabled'
-        >
+        Pick<MembershipService, 'findModelAccess' | 'ensureScopeInitialized' | 'isMembershipPlanEnabled'>
     >
-    let modelAccessService: jest.Mocked<Pick<ModelAccessService, 'handleCopilotStateChanged'>>
+    let modelAccessService: jest.Mocked<
+        Pick<ModelAccessService, 'handleCopilotStateChanged' | 'hasConfiguredOrganizationModels'>
+    >
     let configService: jest.Mocked<Pick<ConfigService, 'get'>>
     let service: CopilotService
 
     beforeEach(async () => {
         repository = {
-            find: jest.fn().mockResolvedValue([])
+            create: jest.fn((entity) => createCopilot(entity)),
+            find: jest.fn().mockResolvedValue([]),
+            findOneByOrFail: jest.fn().mockRejectedValue(new Error('not found')),
+            save: jest.fn(async (entity) => entity as Copilot)
         }
         queryBus = {
             execute: jest.fn()
@@ -47,7 +51,6 @@ describe('CopilotService', () => {
             findVisibleByCopilotIds: jest.fn().mockResolvedValue(new Map())
         }
         membershipService = {
-            countEnabledOrganizationCopilots: jest.fn().mockResolvedValue(0),
             ensureScopeInitialized: jest.fn().mockResolvedValue({} as never),
             isMembershipPlanEnabled: jest.fn().mockResolvedValue(true),
             findModelAccess: jest.fn().mockResolvedValue({
@@ -57,7 +60,8 @@ describe('CopilotService', () => {
             })
         }
         modelAccessService = {
-            handleCopilotStateChanged: jest.fn().mockResolvedValue(undefined)
+            handleCopilotStateChanged: jest.fn().mockResolvedValue(undefined),
+            hasConfiguredOrganizationModels: jest.fn().mockResolvedValue(false)
         }
         configService = {
             get: jest.fn().mockReturnValue('http://localhost')
@@ -202,7 +206,7 @@ describe('CopilotService', () => {
     })
 
     it('keeps an organization membership purchased from the tenant catalog in organization model scope', async () => {
-        membershipService.countEnabledOrganizationCopilots.mockResolvedValue(1)
+        modelAccessService.hasConfiguredOrganizationModels.mockResolvedValue(true)
         membershipService.findModelAccess.mockResolvedValue({
             tenantId: 'tenant-1',
             organizationId: 'org-1',
@@ -482,7 +486,7 @@ describe('CopilotService', () => {
             role: AiProviderRole.Primary
         })
 
-        expect(membershipService.countEnabledOrganizationCopilots).toHaveBeenCalledWith('tenant-1', 'org-1')
+        expect(modelAccessService.hasConfiguredOrganizationModels).toHaveBeenCalledWith('tenant-1', 'org-1')
         expect(membershipService.ensureScopeInitialized).not.toHaveBeenCalled()
         expect(membershipService.findModelAccess).not.toHaveBeenCalled()
         expect(repository.find).toHaveBeenCalledTimes(1)
@@ -507,7 +511,7 @@ describe('CopilotService', () => {
 
     it('lists only direct organization copilots when organization membership is disabled', async () => {
         membershipService.isMembershipPlanEnabled.mockImplementation(async ({ organizationId }) => !organizationId)
-        membershipService.countEnabledOrganizationCopilots.mockResolvedValue(1)
+        modelAccessService.hasConfiguredOrganizationModels.mockResolvedValue(true)
         repository.find.mockResolvedValue([
             createCopilot({
                 id: 'org-copilot',
@@ -540,7 +544,7 @@ describe('CopilotService', () => {
             role: AiProviderRole.Secondary
         })
 
-        expect(membershipService.countEnabledOrganizationCopilots).not.toHaveBeenCalled()
+        expect(modelAccessService.hasConfiguredOrganizationModels).not.toHaveBeenCalled()
         expect(membershipService.ensureScopeInitialized).not.toHaveBeenCalled()
         expect(membershipService.findModelAccess).not.toHaveBeenCalled()
         expect(repository.find).toHaveBeenCalledTimes(1)
@@ -562,21 +566,67 @@ describe('CopilotService', () => {
         expect(result).toHaveLength(1)
     })
 
-    it('initializes organization membership before listing local copilots', async () => {
-        membershipService.countEnabledOrganizationCopilots.mockResolvedValue(1)
-        repository.find.mockResolvedValue([])
-        copilotProviderService.findVisibleByCopilotIds.mockResolvedValue(new Map())
-
-        await service.findAllAvailablesCopilots('tenant-1', 'org-1')
-
-        expect(membershipService.ensureScopeInitialized).toHaveBeenCalledWith({
-            tenantId: 'tenant-1',
-            organizationId: 'org-1',
-            assignedById: null
+    describe('organization membership initialization', () => {
+        beforeEach(() => {
+            jest.spyOn(RequestContext, 'isOrganizationScope').mockReturnValue(true)
+            jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
+            jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('org-1')
+            jest.spyOn(RequestContext, 'currentUserId').mockReturnValue('user-1')
+            jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(false)
+            repository.find.mockResolvedValue([])
+            copilotProviderService.findVisibleByCopilotIds.mockResolvedValue(new Map())
         })
-        expect(membershipService.findModelAccess).toHaveBeenCalledWith({
-            tenantId: 'tenant-1',
-            organizationId: 'org-1'
+
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it('allows a Trial user to enable organization Primary without membership edit permission', async () => {
+            await expect(service.enableRole(AiProviderRole.Primary)).resolves.toMatchObject({
+                role: AiProviderRole.Primary,
+                enabled: true
+            })
+
+            expect(repository.save).toHaveBeenCalled()
+            expect(membershipService.ensureScopeInitialized).not.toHaveBeenCalled()
+        })
+
+        it('does not initialize organization membership while listing available copilots', async () => {
+            jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(true)
+
+            await service.findAllAvailablesCopilots('tenant-1', 'org-1')
+
+            expect(membershipService.ensureScopeInitialized).not.toHaveBeenCalled()
+            expect(membershipService.findModelAccess).toHaveBeenCalledWith({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1'
+            })
+        })
+
+        it('initializes organization membership when an authorized manager enables Primary', async () => {
+            jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(true)
+
+            await service.enableRole(AiProviderRole.Primary)
+
+            expect(RequestContext.hasPermission).toHaveBeenCalledWith(AIPermissionsEnum.MEMBERSHIP_EDIT, false)
+            expect(membershipService.isMembershipPlanEnabled).toHaveBeenCalledWith({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1'
+            })
+            expect(membershipService.ensureScopeInitialized).toHaveBeenCalledWith({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                assignedById: 'user-1'
+            })
+        })
+
+        it('does not initialize organization membership when the feature is disabled', async () => {
+            jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(true)
+            membershipService.isMembershipPlanEnabled.mockResolvedValue(false)
+
+            await service.enableRole(AiProviderRole.Primary)
+
+            expect(membershipService.ensureScopeInitialized).not.toHaveBeenCalled()
         })
     })
 })

--- a/packages/server-ai/src/copilot/copilot.service.ts
+++ b/packages/server-ai/src/copilot/copilot.service.ts
@@ -1,4 +1,4 @@
-import { AiProviderRole, IAiProviderEntity, ICopilot } from '@xpert-ai/contracts'
+import { AiProviderRole, AIPermissionsEnum, IAiProviderEntity, ICopilot } from '@xpert-ai/contracts'
 import { DeepPartial } from '@xpert-ai/server-common'
 import { ConfigService } from '@xpert-ai/server-config'
 import {
@@ -101,23 +101,16 @@ export class CopilotService extends TenantOrganizationAwareCrudService<Copilot> 
         if (!tenantId) {
             return []
         }
-        const [tenantMembershipEnabled, organizationMembershipEnabled, organizationCopilotCount] = await Promise.all([
-            this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
-            organizationId
-                ? this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId })
-                : Promise.resolve(false),
-            organizationId
-                ? this.membershipService.countEnabledOrganizationCopilots(tenantId, organizationId)
-                : Promise.resolve(0)
-        ])
-        const organizationModelsConfigured = organizationCopilotCount > 0
-        if (organizationId && organizationMembershipEnabled && organizationModelsConfigured) {
-            await this.membershipService.ensureScopeInitialized({
-                tenantId,
-                organizationId,
-                assignedById: RequestContext.currentUserId()
-            })
-        }
+        const [tenantMembershipEnabled, organizationMembershipEnabled, organizationModelsConfigured] =
+            await Promise.all([
+                this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
+                organizationId
+                    ? this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId })
+                    : Promise.resolve(false),
+                organizationId
+                    ? this.modelAccessService.hasConfiguredOrganizationModels(tenantId, organizationId)
+                    : Promise.resolve(false)
+            ])
 
         const membershipEnabled = organizationId
             ? organizationModelsConfigured
@@ -207,6 +200,41 @@ export class CopilotService extends TenantOrganizationAwareCrudService<Copilot> 
         } else {
             return await this.create(entity)
         }
+    }
+
+    async enableRole(role: AiProviderRole) {
+        const result = await this.findOneOrFailByWhereOptions({ role })
+        const copilot = result.success
+            ? await this.update(result.record.id, { enabled: true })
+            : await this.create({ role, enabled: true })
+
+        if (role === AiProviderRole.Primary) {
+            await this.initializeOrganizationMembership()
+        }
+
+        return copilot
+    }
+
+    private async initializeOrganizationMembership() {
+        const tenantId = RequestContext.currentTenantId()
+        const organizationId = RequestContext.getOrganizationId()
+        if (
+            !tenantId ||
+            !organizationId ||
+            !RequestContext.isOrganizationScope() ||
+            !RequestContext.hasPermission(AIPermissionsEnum.MEMBERSHIP_EDIT, false)
+        ) {
+            return
+        }
+        if (!(await this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId }))) {
+            return
+        }
+
+        await this.membershipService.ensureScopeInitialized({
+            tenantId,
+            organizationId,
+            assignedById: RequestContext.currentUserId()
+        })
     }
 
     async update(id: string, entity: DeepPartial<ICopilot>) {

--- a/packages/server-ai/src/model-access/model-access.service.spec.ts
+++ b/packages/server-ai/src/model-access/model-access.service.spec.ts
@@ -53,7 +53,6 @@ function createFixture() {
         resolveBillableUserId: jest.fn().mockResolvedValue('creator-user'),
         isMembershipAccessEnabled: jest.fn().mockResolvedValue(true),
         isMembershipPlanEnabled: jest.fn().mockResolvedValue(true),
-        countEnabledOrganizationCopilots: jest.fn().mockResolvedValue(0),
         findModelAccess: jest.fn(),
         isModelAllowed: jest.fn(),
         resolveModelMultiplierForPlan: jest.fn().mockReturnValue(2),
@@ -61,6 +60,7 @@ function createFixture() {
         assertCanUse: jest.fn().mockResolvedValue(undefined)
     }
     const copilotRepository = {
+        find: jest.fn().mockResolvedValue([]),
         findOne: jest.fn().mockResolvedValue({
             id: 'copilot-1',
             tenantId: 'tenant-1',
@@ -75,6 +75,7 @@ function createFixture() {
         })
     }
     const providerModelRepository = {
+        find: jest.fn().mockResolvedValue([]),
         findOne: jest.fn().mockResolvedValue(null)
     }
     const grantRepository = {
@@ -171,6 +172,43 @@ function createFixture() {
     }
 }
 
+describe('ModelAccessService organization model configuration', () => {
+    it('ignores an enabled organization Copilot after its Provider has been deleted', async () => {
+        const { copilotRepository, providersService, service } = createFixture()
+        copilotRepository.find.mockResolvedValue([
+            {
+                id: 'copilot-1',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                enabled: true,
+                modelProvider: null
+            }
+        ])
+
+        await expect(service.hasConfiguredOrganizationModels('tenant-1', 'org-1')).resolves.toBe(false)
+        expect(providersService.getProvider).not.toHaveBeenCalled()
+    })
+
+    it('recognizes an enabled organization Copilot with a valid Provider model', async () => {
+        const { copilotRepository, service } = createFixture()
+        copilotRepository.find.mockResolvedValue([
+            {
+                id: 'copilot-1',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                enabled: true,
+                modelProvider: {
+                    id: 'provider-1',
+                    providerName: 'openai',
+                    isValid: true
+                }
+            }
+        ])
+
+        await expect(service.hasConfiguredOrganizationModels('tenant-1', 'org-1')).resolves.toBe(true)
+    })
+})
+
 describe('ModelAccessService model resolution', () => {
     it('allows an organization model directly when organization membership is disabled', async () => {
         const { copilotRepository, input, membershipService, service } = createFixture()
@@ -215,9 +253,21 @@ describe('ModelAccessService model resolution', () => {
     })
 
     it('blocks tenant models when the organization has configured its own models', async () => {
-        const { input, membershipService, service } = createFixture()
+        const { copilotRepository, input, membershipService, service } = createFixture()
         membershipService.isMembershipPlanEnabled.mockImplementation(async ({ organizationId }) => !organizationId)
-        membershipService.countEnabledOrganizationCopilots.mockResolvedValue(1)
+        copilotRepository.find.mockResolvedValue([
+            {
+                id: 'organization-copilot',
+                tenantId: 'tenant-1',
+                organizationId: 'runtime-org',
+                enabled: true,
+                modelProvider: {
+                    id: 'organization-provider',
+                    providerName: 'openai',
+                    isValid: true
+                }
+            }
+        ])
 
         await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
             allowed: false,
@@ -226,6 +276,35 @@ describe('ModelAccessService model resolution', () => {
             unavailableReason: ModelAccessUnavailableReasonEnum.FeatureDisabled
         })
         expect(membershipService.findModelAccess).not.toHaveBeenCalled()
+    })
+
+    it('falls back to tenant membership models when only an empty organization Copilot remains', async () => {
+        const { copilotRepository, input, membershipService, service } = createFixture()
+        copilotRepository.find.mockResolvedValue([
+            {
+                id: 'organization-copilot',
+                tenantId: 'tenant-1',
+                organizationId: 'runtime-org',
+                enabled: true,
+                modelProvider: null
+            }
+        ])
+        membershipService.isMembershipPlanEnabled.mockImplementation(async ({ organizationId }) => !organizationId)
+        membershipService.findModelAccess.mockResolvedValue({
+            organizationId: null,
+            membership: {
+                planId: 'tenant-plan',
+                plan: { id: 'tenant-plan' }
+            }
+        })
+        membershipService.isModelAllowed.mockReturnValue(true)
+
+        await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
+            allowed: true,
+            accessSource: ModelAccessSourceEnum.Plan,
+            organizationId: null,
+            scope: ModelAccessOwnershipScopeEnum.Tenant
+        })
     })
 
     it('resolves an organization-scoped provider from the persisted model scope', async () => {
@@ -1235,7 +1314,19 @@ describe('ModelAccessService catalog', () => {
                 }
             }
         })
-        membershipService.countEnabledOrganizationCopilots.mockResolvedValue(1)
+        copilotRepository.find.mockResolvedValue([
+            {
+                id: 'organization-copilot',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                enabled: true,
+                modelProvider: {
+                    id: 'organization-provider',
+                    providerName: 'openai',
+                    isValid: true
+                }
+            }
+        ])
         membershipService.isModelAllowed.mockReturnValue(true)
         queryBus.execute.mockImplementation(async (query: FindCopilotModelsQuery) =>
             query.type === AiModelTypeEnum.LLM

--- a/packages/server-ai/src/model-access/model-access.service.ts
+++ b/packages/server-ai/src/model-access/model-access.service.ts
@@ -172,7 +172,7 @@ export class ModelAccessService {
             organizationFeatureEnabled,
             tenantMembershipEnabled,
             organizationMembershipEnabled,
-            organizationCopilotCount
+            organizationModelsConfigured
         ] = await Promise.all([
             this.loadVisibleCatalogTargets(organizationId),
             this.findUserRequestsForCurrentContext(tenantId, userId, organizationId),
@@ -187,9 +187,7 @@ export class ModelAccessService {
             organizationId
                 ? this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId })
                 : Promise.resolve(false),
-            organizationId
-                ? this.membershipService.countEnabledOrganizationCopilots(tenantId, organizationId)
-                : Promise.resolve(0)
+            organizationId ? this.hasConfiguredOrganizationModels(tenantId, organizationId) : Promise.resolve(false)
         ])
         let grantStateChanged = false
         for (const grant of initialGrants.filter((item) => item.status === UserModelGrantStatusEnum.Active)) {
@@ -233,7 +231,7 @@ export class ModelAccessService {
                     organizationFeatureEnabled,
                     tenantMembershipEnabled,
                     organizationMembershipEnabled,
-                    organizationModelsConfigured: organizationCopilotCount > 0,
+                    organizationModelsConfigured,
                     runtimeOrganizationId: organizationId
                 })
             )
@@ -2058,11 +2056,53 @@ export class ModelAccessService {
         )
     }
 
+    async hasConfiguredOrganizationModels(tenantId: string, organizationId: string): Promise<boolean> {
+        const copilots = await this.copilotRepository.find({
+            where: {
+                tenantId,
+                organizationId,
+                enabled: true
+            },
+            relations: ['modelProvider']
+        })
+
+        for (const copilot of copilots) {
+            const modelProvider = copilot.modelProvider
+            if (!modelProvider?.id || !modelProvider.providerName || modelProvider.isValid === false) {
+                continue
+            }
+
+            const provider = this.providersService.getProvider(modelProvider.providerName, false, organizationId)
+            if (!provider) {
+                continue
+            }
+
+            if (provider.getProviderModels()?.some((model) => !!model.model && model.deprecated !== true)) {
+                return true
+            }
+            if (copilot.copilotModel?.model) {
+                return true
+            }
+
+            const customModels = await this.providerModelRepository.find({
+                where: {
+                    tenantId,
+                    providerId: modelProvider.id
+                }
+            })
+            if (customModels.some((model) => !!model.modelName && model.isValid !== false)) {
+                return true
+            }
+        }
+
+        return false
+    }
+
     private async resolveMembershipFeatureState(
         tenantId: string,
         runtimeOrganizationId: string | null
     ): Promise<MembershipFeatureState> {
-        const [tenantEnabled, organizationEnabled, organizationCopilotCount] = await Promise.all([
+        const [tenantEnabled, organizationEnabled, organizationModelsConfigured] = await Promise.all([
             this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
             runtimeOrganizationId
                 ? this.membershipService.isMembershipPlanEnabled({
@@ -2071,13 +2111,13 @@ export class ModelAccessService {
                   })
                 : Promise.resolve(false),
             runtimeOrganizationId
-                ? this.membershipService.countEnabledOrganizationCopilots(tenantId, runtimeOrganizationId)
-                : Promise.resolve(0)
+                ? this.hasConfiguredOrganizationModels(tenantId, runtimeOrganizationId)
+                : Promise.resolve(false)
         ])
         return {
             tenantEnabled,
             organizationEnabled,
-            organizationModelsConfigured: organizationCopilotCount > 0
+            organizationModelsConfigured
         }
     }
 


### PR DESCRIPTION
## Problem

Deleting an organization model Provider leaves its enabled Copilot record behind. The previous scope decision counted that row as configured organization models, so tenant membership models remained blocked even though the organization no longer had a usable Provider or model.

The available-model read path also initialized organization membership data. As a result, a read request could write membership state, and enabling Primary could indirectly initialize an organization membership without an explicit permission and feature gate at the action boundary.

## Root cause

Organization model configuration was inferred from the number of enabled organization Copilot rows instead of checking for a usable Provider and model capability. Membership initialization was coupled to `findAllAvailablesCopilots()` instead of the explicit Primary enable action.

## Changes

- Treat organization models as configured only when an enabled Copilot still has a valid Provider plugin and at least one built-in, selected, or valid custom model.
- Allow tenant membership model fallback when Provider deletion leaves only an empty organization Copilot.
- Remove membership initialization from the available-model GET path.
- Delegate `POST /copilot/enable/:role` to `CopilotService.enableRole()`.
- Initialize organization membership after enabling Primary only when the request is in organization scope, the actor has `MEMBERSHIP_EDIT`, and membership plans are enabled for that scope.
- Keep Primary enablement itself protected only by the existing `COPILOT_EDIT` permission, so Trial users can enable Primary without automatically initializing an organization membership.

No `xpert-pro` files are included in this PR.

## Validation

- 4 focused Jest suites passed: 183 tests.
- `corepack pnpm exec tsc --noEmit -p packages/server-ai/tsconfig.lib.json` passed.
- ESLint completed with 0 errors; only 8 existing warnings were reported.
- `git diff --check origin/develop...HEAD` passed.
- Browser validation was not run.
