### PR TITLE
fix: normalize OpenAI-compatible message roles

### DIFF
--- a/.changeset/openai-compatible-message-roles.md
+++ b/.changeset/openai-compatible-message-roles.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-sdk': patch
+---
+
+Normalize missing assistant roles in OpenAI-compatible completion responses.

--- a/packages/plugin-sdk/jest.config.ts
+++ b/packages/plugin-sdk/jest.config.ts
@@ -1,9 +1,13 @@
 /* eslint-disable */
 import { readFileSync } from 'fs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const currentDirectory = dirname(fileURLToPath(import.meta.url))
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
-const { exclude: _, ...swcJestConfig } = JSON.parse(readFileSync(`${__dirname}/.swcrc`, 'utf-8'))
+const { exclude: _, ...swcJestConfig } = JSON.parse(readFileSync(`${currentDirectory}/.swcrc`, 'utf-8'))
 
 // disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
 // If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"

--- a/packages/plugin-sdk/src/lib/ai-model/openai-compatible/completions.spec.ts
+++ b/packages/plugin-sdk/src/lib/ai-model/openai-compatible/completions.spec.ts
@@ -1,0 +1,45 @@
+import { ChatOAICompatReasoningModel } from './completions'
+
+class TestChatModel extends ChatOAICompatReasoningModel {
+  convertDelta(delta: Record<string, unknown>, rawResponse: Record<string, unknown>, defaultRole?: string) {
+    return this._convertCompletionsDeltaToBaseMessageChunk(
+      delta,
+      rawResponse as never,
+      defaultRole as Parameters<ChatOAICompatReasoningModel['_convertCompletionsDeltaToBaseMessageChunk']>[2]
+    )
+  }
+
+  convertMessage(message: Record<string, unknown>, rawResponse: Record<string, unknown>) {
+    return this._convertCompletionsMessageToBaseMessage(message as never, rawResponse as never)
+  }
+}
+
+describe('ChatOAICompatReasoningModel', () => {
+  it('treats role-less completion deltas as assistant chunks', () => {
+    const model = new TestChatModel({
+      apiKey: 'test-key',
+      model: 'test-model',
+      configuration: { baseURL: 'https://example.test/v1' }
+    })
+
+    const chunk = model.convertDelta(
+      { content: '' },
+      { id: 'chunk-1', choices: [{ index: 0, delta: { content: '' } }] }
+    )
+
+    expect(chunk._getType()).toBe('ai')
+  })
+
+  it('treats a role-less non-stream completion as an assistant message', () => {
+    const model = new TestChatModel({
+      apiKey: 'test-key',
+      model: 'test-model',
+      configuration: { baseURL: 'https://example.test/v1' }
+    })
+
+    const message = model.convertMessage({ content: 'answer' }, { id: 'response-1', model: 'test-model', choices: [] })
+
+    expect(message._getType()).toBe('ai')
+    expect(message.content).toBe('answer')
+  })
+})

--- a/packages/plugin-sdk/src/lib/ai-model/openai-compatible/completions.ts
+++ b/packages/plugin-sdk/src/lib/ai-model/openai-compatible/completions.ts
@@ -2,7 +2,6 @@ import { ChatOpenAICompletions, ChatOpenAIFields, ClientOptions, OpenAIClient } 
 
 export type TOAIAPICompatLLMParams = ChatOpenAIFields & { configuration: ClientOptions }
 
-
 /**
  * A model extended from ChatOpenAICompletions, compatible with OpenAI-style chat completions,
  * and supports structuring content within `<think>` reasoning tags into the `reasoning_content` field.
@@ -15,49 +14,65 @@ export type TOAIAPICompatLLMParams = ChatOpenAIFields & { configuration: ClientO
  * In this way, the reasoning process in the model output can be separated from the main content, making it easier for subsequent structured processing and display.
  */
 export class ChatOAICompatReasoningModel extends ChatOpenAICompletions {
-	private thinking = false
-	/**
-	 * 
-	 */
-	protected override _convertCompletionsDeltaToBaseMessageChunk(
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		delta: Record<string, any>,
-		rawResponse: OpenAIClient.ChatCompletionChunk,
-		defaultRole?: 'function' | 'user' | 'system' | 'developer' | 'assistant' | 'tool'
-	) {
-		const messageChunk = super._convertCompletionsDeltaToBaseMessageChunk(delta, rawResponse, defaultRole)
-		if (delta['content'] === '<think>') {
-			this.thinking = true
-			messageChunk.content = ''
-		} else if (delta['content'] === '</think>') {
-			this.thinking = false
-			messageChunk.content = ''
-		} else if (this.thinking) {
-			messageChunk.additional_kwargs['reasoning_content'] = messageChunk.content
-			messageChunk.content = ''
-		} else {
-			messageChunk.additional_kwargs['reasoning_content'] = delta['reasoning_content']
-		}
-		return messageChunk
-	}
+  private thinking = false
+  /**
+   *
+   */
+  protected override _convertCompletionsDeltaToBaseMessageChunk(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delta: Record<string, any>,
+    rawResponse: OpenAIClient.ChatCompletionChunk,
+    defaultRole?: 'function' | 'user' | 'system' | 'developer' | 'assistant' | 'tool'
+  ) {
+    // Some OpenAI-compatible providers omit `delta.role` on the final usage
+    // chunk. Without a role, LangChain creates a generic ChatMessageChunk;
+    // persisting that chunk makes the next request contain `role: undefined`.
+    // Treat role-less completion deltas as assistant output so they remain
+    // valid both in the current stream and when the conversation is resumed.
+    const messageChunk = super._convertCompletionsDeltaToBaseMessageChunk(
+      delta,
+      rawResponse,
+      defaultRole ?? 'assistant'
+    )
+    if (delta['content'] === '<think>') {
+      this.thinking = true
+      messageChunk.content = ''
+    } else if (delta['content'] === '</think>') {
+      this.thinking = false
+      messageChunk.content = ''
+    } else if (this.thinking) {
+      messageChunk.additional_kwargs['reasoning_content'] = messageChunk.content
+      messageChunk.content = ''
+    } else {
+      messageChunk.additional_kwargs['reasoning_content'] = delta['reasoning_content']
+    }
+    return messageChunk
+  }
 
-	protected override _convertCompletionsMessageToBaseMessage(
-		message: OpenAIClient.ChatCompletionMessage,
-		rawResponse: OpenAIClient.ChatCompletion
-	) {
-		const langChainMessage = super._convertCompletionsMessageToBaseMessage(message, rawResponse)
-		console.log(langChainMessage.content)
-		
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		if ((message as any).reasoning_content) {
-			langChainMessage.additional_kwargs['reasoning_content'] = (message as any).reasoning_content
-		} else if (typeof langChainMessage.content === 'string') {
-			const match = langChainMessage.content.match(/<think>([\s\S]*?)<\/think>/)
-			if (match) {
-				langChainMessage.additional_kwargs['reasoning_content'] = match[1]
-				langChainMessage.content = langChainMessage.content.replace(match[0], '')
-			}
-		}
-		return langChainMessage
-	}
+  protected override _convertCompletionsMessageToBaseMessage(
+    message: OpenAIClient.ChatCompletionMessage,
+    rawResponse: OpenAIClient.ChatCompletion
+  ) {
+    // Some compatible providers also omit the role on non-stream responses.
+    // Normalize that response before LangChain falls back to a generic
+    // message with role `unknown`.
+    const normalizedMessage = {
+      ...message,
+      role: message.role ?? 'assistant'
+    } as OpenAIClient.ChatCompletionMessage
+    const langChainMessage = super._convertCompletionsMessageToBaseMessage(normalizedMessage, rawResponse)
+    console.log(langChainMessage.content)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((message as any).reasoning_content) {
+      langChainMessage.additional_kwargs['reasoning_content'] = (message as any).reasoning_content
+    } else if (typeof langChainMessage.content === 'string') {
+      const match = langChainMessage.content.match(/<think>([\s\S]*?)<\/think>/)
+      if (match) {
+        langChainMessage.additional_kwargs['reasoning_content'] = match[1]
+        langChainMessage.content = langChainMessage.content.replace(match[0], '')
+      }
+    }
+    return langChainMessage
+  }
 }


### PR DESCRIPTION
## Summary

- Default role-less streaming and non-streaming OpenAI-compatible responses to assistant messages.
- Add focused regression coverage for missing response roles.
- Make the plugin SDK Jest configuration ESM-compatible.
- Add a patch changeset for @xpert-ai/plugin-sdk.

## Testing

- corepack pnpm exec nx test plugin-sdk --testFile=packages/plugin-sdk/src/lib/ai-model/openai-compatible/completions.spec.ts --runInBand
- corepack pnpm exec nx build plugin-sdk --skip-nx-cache