### PR TITLE
[codex] Gate membership initialization by permission

### DIFF
--- a/packages/server-ai/src/copilot/copilot.service.spec.ts
+++ b/packages/server-ai/src/copilot/copilot.service.spec.ts
@@ -38,6 +38,7 @@ describe('CopilotService', () => {
     let service: CopilotService
 
     beforeEach(async () => {
+        jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(true)
         repository = {
             create: jest.fn((entity) => createCopilot(entity)),
             find: jest.fn().mockResolvedValue([]),
@@ -98,6 +99,10 @@ describe('CopilotService', () => {
         }).compile()
 
         service = moduleRef.get(CopilotService)
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
     })
 
     afterEach(async () => {
@@ -373,7 +378,8 @@ describe('CopilotService', () => {
         expect(copilotProviderService.findVisibleByCopilotIds).not.toHaveBeenCalled()
     })
 
-    it('keeps copilots outside the membership access scope unavailable even with configured credentials', async () => {
+    it('keeps copilots outside the membership access scope unavailable to membership managers', async () => {
+        const permissionSpy = jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(true)
         membershipService.findModelAccess.mockResolvedValue({
             tenantId: 'tenant-1',
             organizationId: null,
@@ -414,9 +420,11 @@ describe('CopilotService', () => {
         const result = await service.findAllAvailablesCopilots('tenant-1', 'org-1')
 
         expect(result.map((copilot) => copilot.id)).toEqual(['tenant-copilot'])
+        permissionSpy.mockRestore()
     })
 
-    it('returns no organization copilots with configured credentials when membership access is missing', async () => {
+    it('returns organization copilots with configured credentials directly when membership edit permission is missing', async () => {
+        const permissionSpy = jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(false)
         membershipService.findModelAccess.mockResolvedValue(null)
         repository.find.mockResolvedValue([
             createCopilot({
@@ -440,10 +448,12 @@ describe('CopilotService', () => {
 
         const result = await service.findAllAvailablesCopilots('tenant-1', 'org-1')
 
-        expect(result).toEqual([])
+        expect(result.map((copilot) => copilot.id)).toEqual(['organization-copilot'])
+        permissionSpy.mockRestore()
     })
 
     it('returns no organization copilots without configured credentials when membership access is missing', async () => {
+        const permissionSpy = jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(false)
         membershipService.findModelAccess.mockResolvedValue(null)
         repository.find.mockResolvedValue([
             createCopilot({
@@ -466,6 +476,7 @@ describe('CopilotService', () => {
         )
 
         await expect(service.findAllAvailablesCopilots('tenant-1', 'org-1')).resolves.toEqual([])
+        permissionSpy.mockRestore()
     })
 
     it('lists only direct organization copilots when organization and tenant membership are disabled', async () => {

--- a/packages/server-ai/src/copilot/copilot.service.ts
+++ b/packages/server-ai/src/copilot/copilot.service.ts
@@ -19,6 +19,7 @@ import { MembershipService } from '../membership'
 import { ModelAccessService } from '../model-access'
 import { Copilot } from './copilot.entity'
 import { CopilotDto } from './dto'
+import { usesOrganizationCredentials } from './utils'
 
 export const ProviderRolePriority = [
     AiProviderRole.Embedding,
@@ -123,34 +124,40 @@ export class CopilotService extends TenantOrganizationAwareCrudService<Copilot> 
                   organizationId
               })
             : null
-        const allowedScopes = new Set<string | null>()
+        const membershipAllowedScopes = new Set<string | null>()
         if (!organizationId) {
             if (!tenantMembershipEnabled || access?.organizationId === null) {
-                allowedScopes.add(null)
+                membershipAllowedScopes.add(null)
             }
         } else if (organizationModelsConfigured) {
             if (!organizationMembershipEnabled || access?.organizationId === organizationId) {
-                allowedScopes.add(organizationId)
+                membershipAllowedScopes.add(organizationId)
             }
         } else if (organizationMembershipEnabled) {
             if (access?.organizationId === organizationId) {
-                allowedScopes.add(access.membership.plan.catalogSourcePlanId ? null : organizationId)
+                membershipAllowedScopes.add(access.membership.plan.catalogSourcePlanId ? null : organizationId)
             } else if (tenantMembershipEnabled && access?.organizationId === null) {
-                allowedScopes.add(null)
+                membershipAllowedScopes.add(null)
             }
         } else {
-            allowedScopes.add(organizationId)
+            membershipAllowedScopes.add(organizationId)
             if (tenantMembershipEnabled && access?.organizationId === null) {
-                allowedScopes.add(null)
+                membershipAllowedScopes.add(null)
             }
         }
-        if (!allowedScopes.size) {
+        const allowDirectOrganizationCredentials =
+            !!organizationId && !RequestContext.hasPermission(AIPermissionsEnum.MEMBERSHIP_EDIT, false)
+        const queryScopes = new Set(membershipAllowedScopes)
+        if (allowDirectOrganizationCredentials) {
+            queryScopes.add(organizationId)
+        }
+        if (!queryScopes.size) {
             return []
         }
 
         const resolvedRelations = this.mergeCopilotRelations(relations)
         const baseWhere = { ...(where ?? {}), tenantId, enabled: true }
-        const scopeWhere = Array.from(allowedScopes).map((scopeOrganizationId) => ({
+        const scopeWhere = Array.from(queryScopes).map((scopeOrganizationId) => ({
             ...baseWhere,
             organizationId: scopeOrganizationId ? scopeOrganizationId : IsNull()
         }))
@@ -158,8 +165,15 @@ export class CopilotService extends TenantOrganizationAwareCrudService<Copilot> 
             where: organizationId ? scopeWhere : scopeWhere[0],
             relations: resolvedRelations
         })
-        const scopedItems = items.filter((copilot) => allowedScopes.has(copilot.organizationId ?? null))
-        return this.hydrateVisibleModelProviders(scopedItems, tenantId, organizationId ?? null)
+        const scopedItems = items.filter((copilot) => queryScopes.has(copilot.organizationId ?? null))
+        const hydratedItems = await this.hydrateVisibleModelProviders(scopedItems, tenantId, organizationId ?? null)
+        return hydratedItems.filter((copilot) => {
+            const scopeOrganizationId = copilot.organizationId ?? null
+            return (
+                membershipAllowedScopes.has(scopeOrganizationId) ||
+                (allowDirectOrganizationCredentials && usesOrganizationCredentials(copilot, organizationId))
+            )
+        })
     }
 
     async findAllEnabledCopilotsWithoutMembership(

--- a/packages/server-ai/src/copilot/utils.ts
+++ b/packages/server-ai/src/copilot/utils.ts
@@ -3,3 +3,17 @@ import { ICopilot } from '@xpert-ai/contracts'
 export function getCopilotModel(copilot: ICopilot) {
     return copilot.copilotModel?.model || copilot.copilotModel?.referencedModel?.model
 }
+
+export function usesOrganizationCredentials(
+    copilot: Pick<ICopilot, 'modelProvider'>,
+    organizationId?: string | null
+): boolean {
+    const provider = copilot.modelProvider
+    return !!(
+        organizationId &&
+        provider?.organizationId === organizationId &&
+        provider.isValid !== false &&
+        provider.credentials &&
+        Object.keys(provider.credentials).length
+    )
+}

--- a/packages/server-ai/src/initialization/bootstrap.service.spec.ts
+++ b/packages/server-ai/src/initialization/bootstrap.service.spec.ts
@@ -246,6 +246,7 @@ describe('ServerAIBootstrapService', () => {
             })
         }
         const membershipService = {
+            enqueueOrganizationDefaultMembershipInitialization: jest.fn().mockResolvedValue(false),
             ensureTenantDefaultMembership: jest.fn().mockResolvedValue(null),
             ensureUserAssignedIfScopeInitialized: jest.fn().mockResolvedValue(null),
             revokeOrganizationMembershipForRemovedUser: jest.fn().mockResolvedValue(null)
@@ -314,8 +315,14 @@ describe('ServerAIBootstrapService', () => {
     }
 
     it('keeps organization bootstrap focused on workspace and membership setup', async () => {
-        const { environmentService, service, skillPackageService, skillRepositoryService, workspaceService } =
-            createService()
+        const {
+            environmentService,
+            membershipService,
+            service,
+            skillPackageService,
+            skillRepositoryService,
+            workspaceService
+        } = createService()
 
         const result = await service.bootstrapOrganization({
             organizationId: 'org-1',
@@ -341,6 +348,11 @@ describe('ServerAIBootstrapService', () => {
         expect(environmentService.getDefaultByWorkspace).toHaveBeenCalledWith('workspace-1')
         expect(workspaceService.ensureMember).toHaveBeenCalledWith('workspace-1', 'owner-1')
         expect(workspaceService.ensureMember).toHaveBeenCalledWith('workspace-1', 'member-2')
+        expect(membershipService.enqueueOrganizationDefaultMembershipInitialization).toHaveBeenCalledWith({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            actorUserId: 'owner-1'
+        })
         expect(result).toEqual({
             repositoryIds: []
         })
@@ -923,7 +935,8 @@ connections: []`
     })
 
     it('removes the user from non-personal org workspaces on membership deletion', async () => {
-        const { membershipService, modelAccessService, modelGatewayService, service, workspaceService } = createService()
+        const { membershipService, modelAccessService, modelGatewayService, service, workspaceService } =
+            createService()
 
         await service.cleanupUserInOrganization({
             tenantId: 'tenant-1',

--- a/packages/server-ai/src/initialization/bootstrap.service.ts
+++ b/packages/server-ai/src/initialization/bootstrap.service.ts
@@ -103,6 +103,12 @@ export class ServerAIBootstrapService {
         const organization = await this.organizationService.findOne(event.organizationId)
         const memberIds = await this.userOrganizationService.findUserIdsByOrganization(event.organizationId)
 
+        await this.membershipService.enqueueOrganizationDefaultMembershipInitialization({
+            tenantId: event.tenantId,
+            organizationId: event.organizationId,
+            actorUserId: event.ownerUserId ?? null
+        })
+
         await this.runInOrganizationContext(owner, event.organizationId, async () => {
             const workspace = await this.ensureOrganizationWorkspace(event.organizationId, owner.id)
             await this.ensureDefaultEnvironment(workspace.id)

--- a/packages/server-ai/src/membership/membership-backfill.processor.spec.ts
+++ b/packages/server-ai/src/membership/membership-backfill.processor.spec.ts
@@ -8,11 +8,14 @@ import {
     ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
     ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
     TENANT_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
-    TENANT_DEFAULT_MEMBERSHIP_BACKFILL_JOB
+    TENANT_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
+    TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
+    TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB
 } from './membership-backfill.queue'
 import type {
     OrganizationDefaultMembershipBackfillJob,
-    TenantDefaultMembershipBackfillJob
+    TenantDefaultMembershipBackfillJob,
+    TenantOrganizationDefaultMembershipBackfillJob
 } from './membership-backfill.queue'
 
 describe('MembershipBackfillQueueService', () => {
@@ -48,14 +51,49 @@ describe('MembershipBackfillQueueService', () => {
             queue as unknown as Queue<TenantDefaultMembershipBackfillJob | OrganizationDefaultMembershipBackfillJob>
         )
 
-        await service.enqueueOrganizationDefaultMembershipBackfill('tenant-1', 'org-1', 'user-organization-100')
+        await service.enqueueOrganizationDefaultMembershipBackfill(
+            'tenant-1',
+            'org-1',
+            'admin-1',
+            'user-organization-100'
+        )
 
         expect(queue.add).toHaveBeenCalledWith(
             ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
             {
                 tenantId: 'tenant-1',
                 organizationId: 'org-1',
+                actorUserId: 'admin-1',
                 afterUserOrganizationId: 'user-organization-100'
+            },
+            {
+                attempts: 5,
+                backoff: 10_000,
+                removeOnComplete: true
+            }
+        )
+    })
+
+    it('enqueues retryable tenant organization backfill jobs with the triggering actor', async () => {
+        const queue = {
+            add: jest.fn().mockResolvedValue(undefined)
+        }
+        const service = new MembershipBackfillQueueService(
+            queue as unknown as Queue<
+                | TenantDefaultMembershipBackfillJob
+                | TenantOrganizationDefaultMembershipBackfillJob
+                | OrganizationDefaultMembershipBackfillJob
+            >
+        )
+
+        await service.enqueueTenantOrganizationDefaultMembershipBackfill('tenant-1', 'admin-1', 'org-100')
+
+        expect(queue.add).toHaveBeenCalledWith(
+            TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
+            {
+                tenantId: 'tenant-1',
+                actorUserId: 'admin-1',
+                afterOrganizationId: 'org-100'
             },
             {
                 attempts: 5,
@@ -70,12 +108,19 @@ describe('MembershipBackfillProcessor', () => {
     function createProcessor() {
         const queueService = {
             enqueueTenantDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined),
+            enqueueTenantOrganizationDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined),
             enqueueOrganizationDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined)
         }
         const membershipService = {
+            canInitializeOrganizationDefaultMembership: jest.fn().mockResolvedValue(true),
             backfillTenantDefaultMembershipBatch: jest.fn().mockResolvedValue({
                 scanned: 2,
                 assigned: 2,
+                nextCursor: null
+            }),
+            backfillTenantOrganizationDefaultMembershipBatch: jest.fn().mockResolvedValue({
+                scanned: 2,
+                enqueued: 2,
                 nextCursor: null
             }),
             backfillOrganizationDefaultMembershipBatch: jest.fn().mockResolvedValue({
@@ -101,10 +146,15 @@ describe('MembershipBackfillProcessor', () => {
             featureId: 'feature-1',
             featureCode: AiFeatureEnum.FEATURE_MEMBERSHIP_PLAN,
             previousIsEnabled: false,
-            isEnabled: true
+            isEnabled: true,
+            actorUserId: 'admin-1'
         } as FeatureOrganizationUpdatedEvent)
 
         expect(queueService.enqueueTenantDefaultMembershipBackfill).toHaveBeenCalledWith('tenant-1')
+        expect(queueService.enqueueTenantOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
+            'tenant-1',
+            'admin-1'
+        )
     })
 
     it('enqueues organization backfill when the membership feature becomes enabled', async () => {
@@ -116,10 +166,15 @@ describe('MembershipBackfillProcessor', () => {
             featureId: 'feature-1',
             featureCode: AiFeatureEnum.FEATURE_MEMBERSHIP_PLAN,
             previousIsEnabled: false,
-            isEnabled: true
+            isEnabled: true,
+            actorUserId: 'admin-1'
         } as FeatureOrganizationUpdatedEvent)
 
-        expect(queueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith('tenant-1', 'org-1')
+        expect(queueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
+            'tenant-1',
+            'org-1',
+            'admin-1'
+        )
         expect(queueService.enqueueTenantDefaultMembershipBackfill).not.toHaveBeenCalled()
     })
 
@@ -136,6 +191,25 @@ describe('MembershipBackfillProcessor', () => {
         } as FeatureOrganizationUpdatedEvent)
 
         expect(queueService.enqueueTenantDefaultMembershipBackfill).not.toHaveBeenCalled()
+        expect(queueService.enqueueOrganizationDefaultMembershipBackfill).not.toHaveBeenCalled()
+    })
+
+    it('does not queue organization initialization when the triggering actor lacks edit permission', async () => {
+        const { membershipService, processor, queueService } = createProcessor()
+        membershipService.canInitializeOrganizationDefaultMembership.mockResolvedValue(false)
+
+        await processor.enqueueBackfillWhenFeatureEnabled({
+            tenantId: 'tenant-1',
+            organizationId: null,
+            actorUserId: 'builder-1',
+            featureId: 'feature-1',
+            featureCode: AiFeatureEnum.FEATURE_MEMBERSHIP_PLAN,
+            previousIsEnabled: false,
+            isEnabled: true
+        } as FeatureOrganizationUpdatedEvent)
+
+        expect(queueService.enqueueTenantDefaultMembershipBackfill).toHaveBeenCalledWith('tenant-1')
+        expect(queueService.enqueueTenantOrganizationDefaultMembershipBackfill).not.toHaveBeenCalled()
         expect(queueService.enqueueOrganizationDefaultMembershipBackfill).not.toHaveBeenCalled()
     })
 
@@ -191,6 +265,35 @@ describe('MembershipBackfillProcessor', () => {
         expect(queueService.enqueueTenantDefaultMembershipBackfill).not.toHaveBeenCalled()
     })
 
+    it('processes inherited organizations in bounded batches', async () => {
+        const { membershipService, processor, queueService } = createProcessor()
+        membershipService.backfillTenantOrganizationDefaultMembershipBatch.mockResolvedValue({
+            scanned: TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
+            enqueued: TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
+            nextCursor: 'org-100'
+        })
+
+        await processor.processTenantOrganizationDefaultMembershipBackfill({
+            data: {
+                tenantId: 'tenant-1',
+                actorUserId: 'admin-1',
+                afterOrganizationId: null
+            }
+        } as Job<TenantOrganizationDefaultMembershipBackfillJob>)
+
+        expect(membershipService.backfillTenantOrganizationDefaultMembershipBatch).toHaveBeenCalledWith({
+            tenantId: 'tenant-1',
+            actorUserId: 'admin-1',
+            afterOrganizationId: null,
+            take: TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE
+        })
+        expect(queueService.enqueueTenantOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
+            'tenant-1',
+            'admin-1',
+            'org-100'
+        )
+    })
+
     it('processes one bounded organization batch and enqueues the next cursor', async () => {
         const { membershipService, processor, queueService } = createProcessor()
         membershipService.backfillOrganizationDefaultMembershipBatch.mockResolvedValue({
@@ -203,6 +306,7 @@ describe('MembershipBackfillProcessor', () => {
             data: {
                 tenantId: 'tenant-1',
                 organizationId: 'org-1',
+                actorUserId: 'admin-1',
                 afterUserOrganizationId: null
             }
         } as Job<OrganizationDefaultMembershipBackfillJob>)
@@ -210,12 +314,14 @@ describe('MembershipBackfillProcessor', () => {
         expect(membershipService.backfillOrganizationDefaultMembershipBatch).toHaveBeenCalledWith({
             tenantId: 'tenant-1',
             organizationId: 'org-1',
+            actorUserId: 'admin-1',
             afterUserOrganizationId: null,
             take: ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE
         })
         expect(queueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
             'tenant-1',
             'org-1',
+            'admin-1',
             'user-organization-100'
         )
     })

--- a/packages/server-ai/src/membership/membership-backfill.processor.ts
+++ b/packages/server-ai/src/membership/membership-backfill.processor.ts
@@ -11,15 +11,23 @@ import {
     ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
     ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
     TENANT_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
-    TENANT_DEFAULT_MEMBERSHIP_BACKFILL_JOB
+    TENANT_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
+    TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE,
+    TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB
 } from './membership-backfill.queue'
 import type {
     OrganizationDefaultMembershipBackfillJob,
-    TenantDefaultMembershipBackfillJob
+    TenantDefaultMembershipBackfillJob,
+    TenantOrganizationDefaultMembershipBackfillJob
 } from './membership-backfill.queue'
 import { MembershipService } from './membership.service'
 
 type DefaultMembershipBackfillService = {
+    canInitializeOrganizationDefaultMembership(input: {
+        tenantId: string
+        organizationId?: string | null
+        actorUserId?: string | null
+    }): Promise<boolean>
     backfillTenantDefaultMembershipBatch(input: {
         tenantId: string
         afterUserId?: string | null
@@ -32,11 +40,22 @@ type DefaultMembershipBackfillService = {
     backfillOrganizationDefaultMembershipBatch(input: {
         tenantId: string
         organizationId: string
+        actorUserId: string
         afterUserOrganizationId?: string | null
         take?: number
     }): Promise<{
         scanned: number
         assigned: number
+        nextCursor: string | null
+    }>
+    backfillTenantOrganizationDefaultMembershipBatch(input: {
+        tenantId: string
+        actorUserId: string
+        afterOrganizationId?: string | null
+        take?: number
+    }): Promise<{
+        scanned: number
+        enqueued: number
         nextCursor: string | null
     }>
 }
@@ -59,10 +78,27 @@ export class MembershipBackfillProcessor {
             return
         }
 
+        const canInitializeOrganizations = await this.membershipService.canInitializeOrganizationDefaultMembership({
+            tenantId: event.tenantId,
+            organizationId: event.organizationId,
+            actorUserId: event.actorUserId
+        })
         if (event.organizationId) {
-            await this.queueService.enqueueOrganizationDefaultMembershipBackfill(event.tenantId, event.organizationId)
+            if (event.actorUserId && canInitializeOrganizations) {
+                await this.queueService.enqueueOrganizationDefaultMembershipBackfill(
+                    event.tenantId,
+                    event.organizationId,
+                    event.actorUserId
+                )
+            }
         } else {
             await this.queueService.enqueueTenantDefaultMembershipBackfill(event.tenantId)
+            if (event.actorUserId && canInitializeOrganizations) {
+                await this.queueService.enqueueTenantOrganizationDefaultMembershipBackfill(
+                    event.tenantId,
+                    event.actorUserId
+                )
+            }
         }
     }
 
@@ -83,6 +119,27 @@ export class MembershipBackfillProcessor {
     }
 
     @Process({
+        name: TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
+        concurrency: 2
+    })
+    async processTenantOrganizationDefaultMembershipBackfill(job: Job<TenantOrganizationDefaultMembershipBackfillJob>) {
+        const result = await this.membershipService.backfillTenantOrganizationDefaultMembershipBatch({
+            tenantId: job.data.tenantId,
+            actorUserId: job.data.actorUserId,
+            afterOrganizationId: job.data.afterOrganizationId,
+            take: TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE
+        })
+        if (result.nextCursor) {
+            await this.queueService.enqueueTenantOrganizationDefaultMembershipBackfill(
+                job.data.tenantId,
+                job.data.actorUserId,
+                result.nextCursor
+            )
+        }
+        return result
+    }
+
+    @Process({
         name: ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
         concurrency: 2
     })
@@ -90,6 +147,7 @@ export class MembershipBackfillProcessor {
         const result = await this.membershipService.backfillOrganizationDefaultMembershipBatch({
             tenantId: job.data.tenantId,
             organizationId: job.data.organizationId,
+            actorUserId: job.data.actorUserId,
             afterUserOrganizationId: job.data.afterUserOrganizationId,
             take: ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE
         })
@@ -97,6 +155,7 @@ export class MembershipBackfillProcessor {
             await this.queueService.enqueueOrganizationDefaultMembershipBackfill(
                 job.data.tenantId,
                 job.data.organizationId,
+                job.data.actorUserId,
                 result.nextCursor
             )
         }

--- a/packages/server-ai/src/membership/membership-backfill.queue.ts
+++ b/packages/server-ai/src/membership/membership-backfill.queue.ts
@@ -5,6 +5,8 @@ import type { Queue } from 'bull'
 export const MEMBERSHIP_MAINTENANCE_QUEUE = 'membership-maintenance'
 export const TENANT_DEFAULT_MEMBERSHIP_BACKFILL_JOB = 'tenant-default-membership-backfill'
 export const TENANT_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE = 100
+export const TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB = 'tenant-organization-default-membership-backfill'
+export const TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE = 100
 export const ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB = 'organization-default-membership-backfill'
 export const ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_BATCH_SIZE = 100
 
@@ -16,10 +18,20 @@ export type TenantDefaultMembershipBackfillJob = {
 export type OrganizationDefaultMembershipBackfillJob = {
     tenantId: string
     organizationId: string
+    actorUserId: string
     afterUserOrganizationId: string | null
 }
 
-type MembershipBackfillJob = TenantDefaultMembershipBackfillJob | OrganizationDefaultMembershipBackfillJob
+export type TenantOrganizationDefaultMembershipBackfillJob = {
+    tenantId: string
+    actorUserId: string
+    afterOrganizationId: string | null
+}
+
+type MembershipBackfillJob =
+    | TenantDefaultMembershipBackfillJob
+    | TenantOrganizationDefaultMembershipBackfillJob
+    | OrganizationDefaultMembershipBackfillJob
 
 @Injectable()
 export class MembershipBackfillQueueService {
@@ -46,6 +58,7 @@ export class MembershipBackfillQueueService {
     async enqueueOrganizationDefaultMembershipBackfill(
         tenantId: string,
         organizationId: string,
+        actorUserId: string,
         afterUserOrganizationId: string | null = null
     ) {
         await this.queue.add(
@@ -53,7 +66,28 @@ export class MembershipBackfillQueueService {
             {
                 tenantId,
                 organizationId,
+                actorUserId,
                 afterUserOrganizationId
+            },
+            {
+                attempts: 5,
+                backoff: 10_000,
+                removeOnComplete: true
+            }
+        )
+    }
+
+    async enqueueTenantOrganizationDefaultMembershipBackfill(
+        tenantId: string,
+        actorUserId: string,
+        afterOrganizationId: string | null = null
+    ) {
+        await this.queue.add(
+            TENANT_ORGANIZATION_DEFAULT_MEMBERSHIP_BACKFILL_JOB,
+            {
+                tenantId,
+                actorUserId,
+                afterOrganizationId
             },
             {
                 attempts: 5,

--- a/packages/server-ai/src/membership/membership.service.spec.ts
+++ b/packages/server-ai/src/membership/membership.service.spec.ts
@@ -663,7 +663,22 @@ describe('MembershipService', () => {
                     rolePermissions: [{ permission: AIPermissionsEnum.MEMBERSHIP_USE, enabled: true }]
                 }
             })),
-            find: jest.fn().mockResolvedValue([{ id: 'user-1' }, { id: 'user-2' }])
+            find: jest.fn().mockResolvedValue([
+                {
+                    id: 'user-1',
+                    type: UserType.USER,
+                    role: {
+                        rolePermissions: [{ permission: AIPermissionsEnum.MEMBERSHIP_USE, enabled: true }]
+                    }
+                },
+                {
+                    id: 'user-2',
+                    type: UserType.USER,
+                    role: {
+                        rolePermissions: [{ permission: AIPermissionsEnum.MEMBERSHIP_USE, enabled: true }]
+                    }
+                }
+            ])
         }
         const membershipRepository = {
             createQueryBuilder: jest.fn(() => {
@@ -1962,6 +1977,28 @@ describe('MembershipService', () => {
         })
     })
 
+    it('does not grant the tenant default membership without membership use permission', async () => {
+        const { ledgers, memberships, plans, service, userRepository } = createScopeInitializationHarness()
+        plans.push(createPlan({ id: 'plan-tenant-default' }))
+        userRepository.findOne.mockImplementation(async ({ where }) => ({
+            id: where.id,
+            tenantId: where.tenantId,
+            type: UserType.USER,
+            role: { rolePermissions: [] }
+        }))
+
+        await expect(
+            service.ensureTenantDefaultMembership({
+                tenantId: 'tenant-1',
+                userId: 'trial-user'
+            })
+        ).resolves.toBeNull()
+
+        expect(plans).toHaveLength(1)
+        expect(memberships).toHaveLength(0)
+        expect(ledgers).toHaveLength(0)
+    })
+
     it('does not grant or assign membership plans to technical users', async () => {
         jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
         jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue(null)
@@ -2576,6 +2613,46 @@ describe('MembershipService', () => {
         expect(ledgers).toHaveLength(2)
         expect(firstResult).toEqual({ scanned: 2, assigned: 2, nextCursor: null })
         expect(secondResult).toEqual({ scanned: 2, assigned: 0, nextCursor: null })
+    })
+
+    it('creates the organization default plan but skips members without membership use permission', async () => {
+        const { ledgers, memberships, plans, service, userRepository } = createScopeInitializationHarness()
+        userRepository.find.mockResolvedValue([
+            {
+                id: 'user-1',
+                type: UserType.USER,
+                role: {
+                    rolePermissions: [{ permission: AIPermissionsEnum.MEMBERSHIP_USE, enabled: true }]
+                }
+            },
+            {
+                id: 'user-2',
+                type: UserType.USER,
+                role: { rolePermissions: [] }
+            }
+        ])
+
+        const result = await service.backfillOrganizationDefaultMembershipBatch({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1'
+        })
+
+        expect(plans).toEqual([
+            expect.objectContaining({
+                organizationId: 'org-1',
+                code: 'default',
+                status: MembershipPlanStatusEnum.Active
+            })
+        ])
+        expect(memberships).toEqual([
+            expect.objectContaining({
+                organizationId: 'org-1',
+                userId: 'user-1',
+                source: MembershipSourceEnum.Organization
+            })
+        ])
+        expect(ledgers).toHaveLength(1)
+        expect(result).toEqual({ scanned: 2, assigned: 1, nextCursor: null })
     })
 
     it('does not assign a user who leaves the organization after the batch is scanned', async () => {

--- a/packages/server-ai/src/membership/membership.service.spec.ts
+++ b/packages/server-ai/src/membership/membership.service.spec.ts
@@ -576,6 +576,7 @@ describe('MembershipService', () => {
         }
         const backfillQueueService = {
             enqueueTenantDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined),
+            enqueueTenantOrganizationDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined),
             enqueueOrganizationDefaultMembershipBackfill: jest.fn().mockResolvedValue(undefined)
         }
         const updateBuilder = {
@@ -660,7 +661,12 @@ describe('MembershipService', () => {
                 tenantId: where.tenantId,
                 type: UserType.USER,
                 role: {
-                    rolePermissions: [{ permission: AIPermissionsEnum.MEMBERSHIP_USE, enabled: true }]
+                    rolePermissions: [
+                        { permission: AIPermissionsEnum.MEMBERSHIP_USE, enabled: true },
+                        ...(where.id === 'admin-1'
+                            ? [{ permission: AIPermissionsEnum.MEMBERSHIP_EDIT, enabled: true }]
+                            : [])
+                    ]
                 }
             })),
             find: jest.fn().mockResolvedValue([
@@ -1058,6 +1064,9 @@ describe('MembershipService', () => {
                 }
             })
         }
+        const organizationRepository = {
+            find: jest.fn().mockResolvedValue([{ id: 'org-1' }, { id: 'org-2' }])
+        }
 
         return {
             dataSource,
@@ -1065,6 +1074,7 @@ describe('MembershipService', () => {
             ledgerRepository,
             memberships,
             membershipRepository,
+            organizationRepository,
             userRepository,
             planRepository,
             plans,
@@ -1085,7 +1095,7 @@ describe('MembershipService', () => {
                 featureOrganizationRepository as never,
                 tenantSettingRepository as never,
                 periodRepository as never,
-                undefined,
+                organizationRepository as never,
                 backfillQueueService as never
             )
         }
@@ -1921,6 +1931,29 @@ describe('MembershipService', () => {
         expect(ensureScopeInitialized).not.toHaveBeenCalled()
     })
 
+    it('assigns an initialized organization Default to a user with use permission but no edit permission', async () => {
+        const { memberships, plans, service } = createScopeInitializationHarness()
+        plans.push(
+            createPlan({
+                id: 'plan-org-default',
+                organizationId: 'org-1'
+            })
+        )
+
+        const membership = await service.ensureUserAssignedIfScopeInitialized({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            userId: 'user-1'
+        })
+
+        expect(membership).toMatchObject({
+            organizationId: 'org-1',
+            userId: 'user-1',
+            planId: 'plan-org-default'
+        })
+        expect(memberships).toHaveLength(1)
+    })
+
     it('grants the tenant default membership idempotently without treating an organization membership as tenant-level', async () => {
         const { dataSource, ledgers, ledgerRepository, memberships, membershipRepository, plans, service } =
             createScopeInitializationHarness()
@@ -2495,8 +2528,63 @@ describe('MembershipService', () => {
         expect(ledgerRepository.save).not.toHaveBeenCalled()
         expect(backfillQueueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
             'tenant-1',
-            'org-1'
+            'org-1',
+            'admin-1'
         )
+    })
+
+    it('does not queue organization initialization for an actor without membership edit permission', async () => {
+        const { backfillQueueService, service } = createScopeInitializationHarness()
+
+        await service.ensureScopeInitialized({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            assignedById: 'builder-1'
+        })
+
+        expect(backfillQueueService.enqueueOrganizationDefaultMembershipBackfill).not.toHaveBeenCalled()
+    })
+
+    it('queues new organization initialization only when effective Feature and actor permission are both enabled', async () => {
+        const { backfillQueueService, service } = createScopeInitializationHarness()
+
+        await expect(
+            service.enqueueOrganizationDefaultMembershipInitialization({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                actorUserId: 'admin-1'
+            })
+        ).resolves.toBe(true)
+        await expect(
+            service.enqueueOrganizationDefaultMembershipInitialization({
+                tenantId: 'tenant-1',
+                organizationId: 'org-2',
+                actorUserId: 'builder-1'
+            })
+        ).resolves.toBe(false)
+
+        expect(backfillQueueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledTimes(1)
+        expect(backfillQueueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
+            'tenant-1',
+            'org-1',
+            'admin-1'
+        )
+    })
+
+    it('does not queue new organization initialization when the effective Feature is disabled', async () => {
+        const { backfillQueueService, service } = createScopeInitializationHarness(undefined, () => [
+            { isEnabled: false }
+        ])
+
+        await expect(
+            service.enqueueOrganizationDefaultMembershipInitialization({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                actorUserId: 'admin-1'
+            })
+        ).resolves.toBe(false)
+
+        expect(backfillQueueService.enqueueOrganizationDefaultMembershipBackfill).not.toHaveBeenCalled()
     })
 
     it('initializes tenant scope by enqueueing an idempotent backfill', async () => {
@@ -2563,17 +2651,45 @@ describe('MembershipService', () => {
         expect(secondResult).toEqual({ scanned: 0, assigned: 0, nextCursor: null })
     })
 
+    it('queues inherited organizations in bounded batches after tenant membership Feature activation', async () => {
+        const { backfillQueueService, organizationRepository, service } = createScopeInitializationHarness()
+
+        const result = await service.backfillTenantOrganizationDefaultMembershipBatch({
+            tenantId: 'tenant-1',
+            actorUserId: 'admin-1',
+            take: 1
+        })
+
+        expect(organizationRepository.find).toHaveBeenCalledWith({
+            select: ['id'],
+            where: {
+                tenantId: 'tenant-1',
+                isActive: true
+            },
+            order: { id: 'ASC' },
+            take: 2
+        })
+        expect(backfillQueueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
+            'tenant-1',
+            'org-1',
+            'admin-1'
+        )
+        expect(result).toEqual({ scanned: 1, enqueued: 1, nextCursor: 'org-1' })
+    })
+
     it('creates one default organization plan and backfills active members idempotently', async () => {
         const { ledgers, memberships, plans, service } = createScopeInitializationHarness()
 
         const [firstResult, secondResult] = await Promise.all([
             service.backfillOrganizationDefaultMembershipBatch({
                 tenantId: 'tenant-1',
-                organizationId: 'org-1'
+                organizationId: 'org-1',
+                actorUserId: 'admin-1'
             }),
             service.backfillOrganizationDefaultMembershipBatch({
                 tenantId: 'tenant-1',
-                organizationId: 'org-1'
+                organizationId: 'org-1',
+                actorUserId: 'admin-1'
             })
         ])
 
@@ -2634,7 +2750,8 @@ describe('MembershipService', () => {
 
         const result = await service.backfillOrganizationDefaultMembershipBatch({
             tenantId: 'tenant-1',
-            organizationId: 'org-1'
+            organizationId: 'org-1',
+            actorUserId: 'admin-1'
         })
 
         expect(plans).toEqual([
@@ -2655,6 +2772,29 @@ describe('MembershipService', () => {
         expect(result).toEqual({ scanned: 2, assigned: 1, nextCursor: null })
     })
 
+    it('does not create an organization default plan when the triggering actor cannot edit membership plans', async () => {
+        const { ledgers, memberships, plans, service, userRepository } = createScopeInitializationHarness()
+        userRepository.findOne.mockImplementation(async ({ where }) => ({
+            id: where.id,
+            tenantId: where.tenantId,
+            type: UserType.USER,
+            role: {
+                rolePermissions: [{ permission: AIPermissionsEnum.MEMBERSHIP_USE, enabled: true }]
+            }
+        }))
+
+        const result = await service.backfillOrganizationDefaultMembershipBatch({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            actorUserId: 'builder-1'
+        })
+
+        expect(plans).toHaveLength(0)
+        expect(memberships).toHaveLength(0)
+        expect(ledgers).toHaveLength(0)
+        expect(result).toEqual({ scanned: 0, assigned: 0, nextCursor: null })
+    })
+
     it('does not assign a user who leaves the organization after the batch is scanned', async () => {
         const { memberships, service, userOrganizationRepository } = createScopeInitializationHarness()
         userOrganizationRepository.find
@@ -2666,7 +2806,8 @@ describe('MembershipService', () => {
 
         const result = await service.backfillOrganizationDefaultMembershipBatch({
             tenantId: 'tenant-1',
-            organizationId: 'org-1'
+            organizationId: 'org-1',
+            actorUserId: 'admin-1'
         })
 
         expect(memberships).toEqual([
@@ -2800,7 +2941,8 @@ describe('MembershipService', () => {
         expect(ledgerRepository.save).not.toHaveBeenCalled()
         expect(backfillQueueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
             'tenant-1',
-            'org-1'
+            'org-1',
+            'admin-1'
         )
     })
 
@@ -2817,11 +2959,13 @@ describe('MembershipService', () => {
 
         const beforeBackfill = await service.ensureScopeInitialized({
             tenantId: 'tenant-1',
-            organizationId: 'org-1'
+            organizationId: 'org-1',
+            assignedById: 'admin-1'
         })
         await service.backfillOrganizationDefaultMembershipBatch({
             tenantId: 'tenant-1',
-            organizationId: 'org-1'
+            organizationId: 'org-1',
+            actorUserId: 'admin-1'
         })
         const afterBackfill = await service.getScopeStatus({
             tenantId: 'tenant-1',
@@ -2835,7 +2979,8 @@ describe('MembershipService', () => {
         })
         expect(backfillQueueService.enqueueOrganizationDefaultMembershipBackfill).toHaveBeenCalledWith(
             'tenant-1',
-            'org-1'
+            'org-1',
+            'admin-1'
         )
         expect(catalogClone.isDefault).toBe(false)
         expect(plans).toEqual(
@@ -2928,11 +3073,13 @@ describe('MembershipService', () => {
 
         const firstResult = await service.backfillOrganizationDefaultMembershipBatch({
             tenantId: 'tenant-1',
-            organizationId: 'org-1'
+            organizationId: 'org-1',
+            actorUserId: 'admin-1'
         })
         const secondResult = await service.backfillOrganizationDefaultMembershipBatch({
             tenantId: 'tenant-1',
-            organizationId: 'org-1'
+            organizationId: 'org-1',
+            actorUserId: 'admin-1'
         })
 
         expect(plans).toEqual([
@@ -2989,7 +3136,8 @@ describe('MembershipService', () => {
 
         const result = await service.backfillOrganizationDefaultMembershipBatch({
             tenantId: 'tenant-1',
-            organizationId: 'org-1'
+            organizationId: 'org-1',
+            actorUserId: 'admin-1'
         })
 
         expect(plans).toEqual(

--- a/packages/server-ai/src/membership/membership.service.ts
+++ b/packages/server-ai/src/membership/membership.service.ts
@@ -596,6 +596,9 @@ export class MembershipService {
         if (!scope.organizationId) {
             return null
         }
+        if (!(await this.hasMembershipUsePermission(scope.tenantId, input.userId))) {
+            return null
+        }
         if (!(await this.hasActivePlan(scope.tenantId, scope.organizationId))) {
             return null
         }
@@ -644,7 +647,7 @@ export class MembershipService {
         if (!(await this.isMembershipPlanEnabledForScope(scope, manager))) {
             return null
         }
-        if (!(await this.isMembershipEligibleUser(scope.tenantId, input.userId))) {
+        if (!(await this.hasMembershipUsePermission(scope.tenantId, input.userId))) {
             return null
         }
 
@@ -692,6 +695,7 @@ export class MembershipService {
             return { scanned: 0, assigned: 0, nextCursor: null }
         }
         const userIds = batch.map((user) => user.id)
+        const permittedUserIds = new Set(await this.findMembershipUsePermissionUserIds(input.tenantId, userIds))
         const nextCursor = users.length > take ? userIds[userIds.length - 1] : null
 
         const result = await this.dataSource.transaction(async (manager) => {
@@ -714,7 +718,7 @@ export class MembershipService {
             let created = 0
 
             for (const userId of userIds) {
-                if (existingUserIds.has(userId)) {
+                if (existingUserIds.has(userId) || !permittedUserIds.has(userId)) {
                     continue
                 }
                 const assignment = await this.ensureTenantDefaultMembershipWithPlan(
@@ -781,18 +785,7 @@ export class MembershipService {
         }
 
         const candidateUserIds = Array.from(new Set(batch.map((membership) => membership.userId).filter(Boolean)))
-        const candidateUserIdSet = new Set(candidateUserIds)
-        const users = candidateUserIds.length
-            ? await this.userRepository.find({
-                  select: ['id'],
-                  where: {
-                      tenantId: input.tenantId,
-                      id: In(candidateUserIds),
-                      type: UserType.USER
-                  }
-              })
-            : []
-        const eligibleUserIds = users.map((user) => user.id).filter((userId) => candidateUserIdSet.has(userId))
+        const permittedUserIds = await this.findMembershipUsePermissionUserIds(input.tenantId, candidateUserIds)
         const nextCursor = organizationMemberships.length > take ? (batch[batch.length - 1]?.id ?? null) : null
 
         const result = await this.dataSource.transaction(async (manager) => {
@@ -804,20 +797,20 @@ export class MembershipService {
                 return { assigned: 0, canContinue: false }
             }
 
-            const activeOrganizationMemberships = eligibleUserIds.length
+            const activeOrganizationMemberships = permittedUserIds.length
                 ? await manager.getRepository(UserOrganization).find({
                       select: ['userId'],
                       where: {
                           tenantId: input.tenantId,
                           organizationId: input.organizationId,
-                          userId: In(eligibleUserIds),
+                          userId: In(permittedUserIds),
                           isActive: true
                       }
                   })
                 : []
             const activeUserIds = new Set(activeOrganizationMemberships.map((membership) => membership.userId))
             let created = 0
-            for (const userId of eligibleUserIds) {
+            for (const userId of permittedUserIds) {
                 if (!activeUserIds.has(userId)) {
                     continue
                 }
@@ -3266,7 +3259,8 @@ export class MembershipService {
             return
         }
 
-        const userIds = await this.findActiveOrganizationUserIds(scope.tenantId, scope.organizationId, manager)
+        const activeUserIds = await this.findActiveOrganizationUserIds(scope.tenantId, scope.organizationId, manager)
+        const userIds = await this.findMembershipUsePermissionUserIds(scope.tenantId, activeUserIds)
         if (!userIds.length) {
             return
         }
@@ -3460,6 +3454,26 @@ export class MembershipService {
             where: { tenantId, id: userId },
             relations: ['role', 'role.rolePermissions']
         })
+        return this.userHasMembershipUsePermission(user)
+    }
+
+    private async findMembershipUsePermissionUserIds(tenantId: string, userIds: string[]): Promise<string[]> {
+        if (!userIds.length) {
+            return []
+        }
+
+        const users = await this.userRepository.find({
+            where: {
+                tenantId,
+                id: In(userIds),
+                type: UserType.USER
+            },
+            relations: ['role', 'role.rolePermissions']
+        })
+        return users.filter((user) => this.userHasMembershipUsePermission(user)).map((user) => user.id)
+    }
+
+    private userHasMembershipUsePermission(user: User | null | undefined) {
         return (
             user?.type === UserType.USER &&
             !!user.role?.rolePermissions?.some(

--- a/packages/server-ai/src/membership/membership.service.ts
+++ b/packages/server-ai/src/membership/membership.service.ts
@@ -572,15 +572,19 @@ export class MembershipService {
             await this.enqueueTenantDefaultMembershipBackfill(scope.tenantId)
             return this.buildScopeStatus(scope, manager)
         }
+        const actorUserId = input?.assignedById ?? RequestContext.currentUserId()
+        if (!actorUserId || !(await this.hasMembershipEditPermission(scope.tenantId, actorUserId))) {
+            return this.buildScopeStatus(scope, manager)
+        }
         if (!(await this.hasActivePlan(scope.tenantId, scope.organizationId, manager))) {
-            await this.enqueueOrganizationDefaultMembershipBackfill(scope.tenantId, scope.organizationId)
+            await this.enqueueOrganizationDefaultMembershipBackfill(scope.tenantId, scope.organizationId, actorUserId)
             return this.buildScopeStatus(scope, manager)
         }
 
         const initialize = async (txManager: EntityManager) => {
             const plan = await this.ensureDefaultOrganizationPlan(scope, txManager)
             if (plan) {
-                await this.ensureOrganizationMemberMemberships(scope, plan, input?.assignedById ?? null, txManager)
+                await this.ensureOrganizationMemberMemberships(scope, plan, actorUserId, txManager)
             }
             return this.buildScopeStatus(scope, txManager)
         }
@@ -599,12 +603,62 @@ export class MembershipService {
         if (!(await this.hasMembershipUsePermission(scope.tenantId, input.userId))) {
             return null
         }
-        if (!(await this.hasActivePlan(scope.tenantId, scope.organizationId))) {
+        if (!(await this.isActiveOrganizationMember(scope.tenantId, scope.organizationId, input.userId))) {
             return null
         }
 
-        await this.ensureScopeInitialized(input)
-        return this.findActiveMembership(scope.tenantId, scope.organizationId, input.userId)
+        return this.dataSource.transaction(async (manager) => {
+            if (!(await this.isMembershipPlanEnabledForScope(scope, manager))) {
+                return null
+            }
+            const plan = await this.findDefaultPlan(scope.tenantId, scope.organizationId, manager)
+            if (!plan) {
+                return null
+            }
+            return (
+                await this.ensureOrganizationMemberMembershipWithPlan(
+                    {
+                        tenantId: scope.tenantId,
+                        organizationId: scope.organizationId,
+                        userId: input.userId
+                    },
+                    plan,
+                    input.assignedById ?? input.userId,
+                    manager
+                )
+            ).membership
+        })
+    }
+
+    async enqueueOrganizationDefaultMembershipInitialization(input: {
+        tenantId: string
+        organizationId: string
+        actorUserId?: string | null
+    }): Promise<boolean> {
+        const actorUserId = input.actorUserId ?? null
+        if (!actorUserId || !(await this.canInitializeOrganizationDefaultMembership(input))) {
+            return false
+        }
+
+        await this.enqueueOrganizationDefaultMembershipBackfill(input.tenantId, input.organizationId, actorUserId)
+        return true
+    }
+
+    async canInitializeOrganizationDefaultMembership(input: {
+        tenantId: string
+        organizationId?: string | null
+        actorUserId?: string | null
+    }): Promise<boolean> {
+        const actorUserId = input.actorUserId ?? null
+        if (!actorUserId) {
+            return false
+        }
+        return (
+            (await this.isMembershipPlanEnabledForScope({
+                tenantId: input.tenantId,
+                organizationId: input.organizationId ?? null
+            })) && (await this.hasMembershipEditPermission(input.tenantId, actorUserId))
+        )
     }
 
     async revokeOrganizationMembershipForRemovedUser(input: {
@@ -746,6 +800,7 @@ export class MembershipService {
     async backfillOrganizationDefaultMembershipBatch(input: {
         tenantId: string
         organizationId: string
+        actorUserId: string
         afterUserOrganizationId?: string | null
         take?: number
     }): Promise<{
@@ -756,6 +811,9 @@ export class MembershipService {
         const scope: MembershipScope = {
             tenantId: input.tenantId,
             organizationId: input.organizationId
+        }
+        if (!(await this.hasMembershipEditPermission(input.tenantId, input.actorUserId))) {
+            return { scanned: 0, assigned: 0, nextCursor: null }
         }
         const defaultPlan = await this.dataSource.transaction(async (manager) => {
             if (!(await this.isMembershipPlanEnabledForScope(scope, manager))) {
@@ -838,6 +896,50 @@ export class MembershipService {
         }
     }
 
+    async backfillTenantOrganizationDefaultMembershipBatch(input: {
+        tenantId: string
+        actorUserId: string
+        afterOrganizationId?: string | null
+        take?: number
+    }): Promise<{
+        scanned: number
+        enqueued: number
+        nextCursor: string | null
+    }> {
+        const tenantScope: MembershipScope = { tenantId: input.tenantId, organizationId: null }
+        if (
+            !this.organizationRepository?.find ||
+            !(await this.isMembershipPlanEnabledForScope(tenantScope)) ||
+            !(await this.hasMembershipEditPermission(input.tenantId, input.actorUserId))
+        ) {
+            return { scanned: 0, enqueued: 0, nextCursor: null }
+        }
+
+        const take = Math.min(Math.max(Math.trunc(input.take ?? 100), 1), 500)
+        const organizations = await this.organizationRepository.find({
+            select: ['id'],
+            where: {
+                tenantId: input.tenantId,
+                isActive: true,
+                ...(input.afterOrganizationId ? { id: MoreThan(input.afterOrganizationId) } : {})
+            },
+            order: { id: 'ASC' },
+            take: take + 1
+        })
+        const batch = organizations.slice(0, take)
+        const nextCursor = organizations.length > take ? (batch[batch.length - 1]?.id ?? null) : null
+
+        for (const organization of batch) {
+            await this.enqueueOrganizationDefaultMembershipBackfill(input.tenantId, organization.id, input.actorUserId)
+        }
+
+        return {
+            scanned: batch.length,
+            enqueued: batch.length,
+            nextCursor
+        }
+    }
+
     private async ensureTenantDefaultMembershipWithPlan(
         input: EnsureTenantDefaultMembershipInput,
         plan: MembershipPlan,
@@ -900,13 +1002,28 @@ export class MembershipService {
         await this.backfillQueueService?.enqueueTenantDefaultMembershipBackfill(tenantId)
     }
 
-    private async enqueueOrganizationDefaultMembershipBackfill(tenantId: string, organizationId: string) {
-        await this.backfillQueueService?.enqueueOrganizationDefaultMembershipBackfill(tenantId, organizationId)
+    private async enqueueOrganizationDefaultMembershipBackfill(
+        tenantId: string,
+        organizationId: string,
+        actorUserId: string
+    ) {
+        await this.backfillQueueService?.enqueueOrganizationDefaultMembershipBackfill(
+            tenantId,
+            organizationId,
+            actorUserId
+        )
     }
 
     private async enqueueDefaultMembershipBackfill(scope: MembershipScope) {
         if (scope.organizationId) {
-            await this.enqueueOrganizationDefaultMembershipBackfill(scope.tenantId, scope.organizationId)
+            const actorUserId = RequestContext.currentUserId()
+            if (actorUserId) {
+                await this.enqueueOrganizationDefaultMembershipBackfill(
+                    scope.tenantId,
+                    scope.organizationId,
+                    actorUserId
+                )
+            }
         } else {
             await this.enqueueTenantDefaultMembershipBackfill(scope.tenantId)
         }
@@ -3455,6 +3572,19 @@ export class MembershipService {
             relations: ['role', 'role.rolePermissions']
         })
         return this.userHasMembershipUsePermission(user)
+    }
+
+    private async hasMembershipEditPermission(tenantId: string, userId: string) {
+        const user = await this.userRepository.findOne({
+            where: { tenantId, id: userId },
+            relations: ['role', 'role.rolePermissions']
+        })
+        return (
+            user?.type === UserType.USER &&
+            !!user.role?.rolePermissions?.some(
+                (permission) => permission.enabled && permission.permission === AIPermissionsEnum.MEMBERSHIP_EDIT
+            )
+        )
     }
 
     private async findMembershipUsePermissionUserIds(tenantId: string, userIds: string[]): Promise<string[]> {

--- a/packages/server-ai/src/model-access/model-access.service.spec.ts
+++ b/packages/server-ai/src/model-access/model-access.service.spec.ts
@@ -210,6 +210,118 @@ describe('ModelAccessService organization model configuration', () => {
 })
 
 describe('ModelAccessService model resolution', () => {
+    it('allows an organization model directly when the billable user cannot manage memberships', async () => {
+        const { copilotRepository, input, membershipService, service, userRepository } = createFixture()
+        copilotRepository.findOne.mockResolvedValue({
+            id: 'copilot-1',
+            tenantId: 'tenant-1',
+            organizationId: 'runtime-org',
+            name: 'Organization Provider',
+            enabled: true,
+            modelProvider: {
+                id: 'provider-1',
+                tenantId: 'tenant-1',
+                organizationId: 'runtime-org',
+                providerName: 'openai',
+                credentials: { api_key: 'configured' },
+                isValid: true
+            }
+        })
+        userRepository.findOne.mockResolvedValue({
+            id: 'creator-user',
+            type: UserType.USER,
+            role: { rolePermissions: [] }
+        })
+        membershipService.findModelAccess.mockResolvedValue({
+            organizationId: null,
+            membership: { planId: 'tenant-plan', plan: {} }
+        })
+
+        await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
+            allowed: true,
+            accessSource: ModelAccessSourceEnum.Direct,
+            organizationId: 'runtime-org',
+            scope: ModelAccessOwnershipScopeEnum.Organization
+        })
+        expect(membershipService.findModelAccess).not.toHaveBeenCalled()
+    })
+
+    it('keeps an organization credential model under membership for membership managers', async () => {
+        const { copilotRepository, input, membershipService, service, userRepository } = createFixture()
+        copilotRepository.findOne.mockResolvedValue({
+            id: 'copilot-1',
+            tenantId: 'tenant-1',
+            organizationId: 'runtime-org',
+            name: 'Organization Provider',
+            enabled: true,
+            modelProvider: {
+                id: 'provider-1',
+                tenantId: 'tenant-1',
+                organizationId: 'runtime-org',
+                providerName: 'openai',
+                credentials: { api_key: 'configured' },
+                isValid: true
+            }
+        })
+        userRepository.findOne.mockResolvedValue({
+            id: 'creator-user',
+            type: UserType.USER,
+            role: {
+                rolePermissions: [{ permission: AIPermissionsEnum.MEMBERSHIP_EDIT, enabled: true }]
+            }
+        })
+        const plan = { id: 'organization-plan' }
+        membershipService.findModelAccess.mockResolvedValue({
+            organizationId: 'runtime-org',
+            membership: { planId: 'organization-plan', plan }
+        })
+        membershipService.isModelAllowed.mockReturnValue(true)
+
+        await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
+            allowed: true,
+            accessSource: ModelAccessSourceEnum.Plan,
+            planId: 'organization-plan',
+            organizationId: 'runtime-org'
+        })
+    })
+
+    it('does not use direct access without configured organization credentials', async () => {
+        const { copilotRepository, input, membershipService, service, userRepository } = createFixture()
+        copilotRepository.findOne.mockResolvedValue({
+            id: 'copilot-1',
+            tenantId: 'tenant-1',
+            organizationId: 'runtime-org',
+            name: 'Organization Provider',
+            enabled: true,
+            modelProvider: {
+                id: 'provider-1',
+                tenantId: 'tenant-1',
+                organizationId: 'runtime-org',
+                providerName: 'openai',
+                credentials: {},
+                isValid: true
+            }
+        })
+        userRepository.findOne.mockResolvedValue({
+            id: 'creator-user',
+            type: UserType.USER,
+            role: { rolePermissions: [] }
+        })
+        const plan = { id: 'organization-plan' }
+        membershipService.findModelAccess.mockResolvedValue({
+            organizationId: 'runtime-org',
+            membership: { planId: 'organization-plan', plan }
+        })
+        membershipService.isModelAllowed.mockReturnValue(true)
+
+        await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
+            allowed: true,
+            accessSource: ModelAccessSourceEnum.Plan,
+            planId: 'organization-plan',
+            organizationId: 'runtime-org'
+        })
+    })
+
     it('allows an organization model directly when organization membership is disabled', async () => {
         const { copilotRepository, input, membershipService, service } = createFixture()
         copilotRepository.findOne.mockResolvedValue({

--- a/packages/server-ai/src/model-access/model-access.service.ts
+++ b/packages/server-ai/src/model-access/model-access.service.ts
@@ -43,6 +43,7 @@ import { AIProvidersService } from '../ai-model'
 import { Copilot } from '../copilot/copilot.entity'
 import { CopilotModelCatalogMode, FindCopilotModelsQuery } from '../copilot/queries/copilot-model-find.query'
 import { CopilotWithProviderDto } from '../copilot/dto'
+import { usesOrganizationCredentials } from '../copilot/utils'
 import { CopilotProviderModel } from '../copilot-provider/models/copilot-provider-model.entity'
 import { ExceedingLimitException } from '../core/errors'
 import { MembershipModelAccess, MembershipService } from '../membership/membership.service'
@@ -85,6 +86,7 @@ type ModelTarget = {
     capabilities: ModelFeature[]
     deprecated: boolean
     enabled: boolean
+    usesOrganizationCredentials: boolean
     listedForRequest?: boolean
 }
 
@@ -1196,7 +1198,16 @@ export class ModelAccessService {
         }
 
         const membershipFeatureState = await this.resolveMembershipFeatureState(input.tenantId, runtimeOrganizationId)
-        const accessMode = this.resolveTargetAccessMode(target, runtimeOrganizationId, membershipFeatureState)
+        const canManageMembership =
+            !target.usesOrganizationCredentials || !membershipFeatureState.organizationEnabled
+                ? true
+                : await this.hasUserPermission(input.tenantId, billableUserId, AIPermissionsEnum.MEMBERSHIP_EDIT)
+        const accessMode = this.resolveTargetAccessMode(
+            target,
+            runtimeOrganizationId,
+            membershipFeatureState,
+            canManageMembership
+        )
         if (accessMode === ModelTargetAccessMode.Direct) {
             return {
                 allowed: target.enabled,
@@ -1612,11 +1623,16 @@ export class ModelAccessService {
             runtimeOrganizationId: string | null
         }
     ): Promise<IModelAccessCatalogItem> {
-        const accessMode = this.resolveTargetAccessMode(target, features.runtimeOrganizationId, {
-            tenantEnabled: features.tenantMembershipEnabled,
-            organizationEnabled: features.organizationMembershipEnabled,
-            organizationModelsConfigured: features.organizationModelsConfigured
-        })
+        const accessMode = this.resolveTargetAccessMode(
+            target,
+            features.runtimeOrganizationId,
+            {
+                tenantEnabled: features.tenantMembershipEnabled,
+                organizationEnabled: features.organizationMembershipEnabled,
+                organizationModelsConfigured: features.organizationModelsConfigured
+            },
+            this.userHasPermission(user, AIPermissionsEnum.MEMBERSHIP_EDIT) === true
+        )
         const planIncluded =
             accessMode === ModelTargetAccessMode.Membership && this.isPlanIncluded(target, membershipAccess)
         const grant =
@@ -1820,7 +1836,8 @@ export class ModelAccessService {
                 copilot.enabled === true &&
                 copilot.modelProvider.isValid !== false &&
                 custom?.isValid !== false &&
-                predefined?.deprecated !== true
+                predefined?.deprecated !== true,
+            usesOrganizationCredentials: usesOrganizationCredentials(copilot, organizationId)
         }
     }
 
@@ -2124,12 +2141,16 @@ export class ModelAccessService {
     private resolveTargetAccessMode(
         target: ModelTarget,
         runtimeOrganizationId: string | null,
-        membershipFeatures: MembershipFeatureState
+        membershipFeatures: MembershipFeatureState,
+        canManageMembership: boolean
     ): ModelTargetAccessMode {
         if (target.organizationId) {
-            return membershipFeatures.organizationEnabled
-                ? ModelTargetAccessMode.Membership
-                : ModelTargetAccessMode.Direct
+            if (!membershipFeatures.organizationEnabled) {
+                return ModelTargetAccessMode.Direct
+            }
+            return target.usesOrganizationCredentials && !canManageMembership
+                ? ModelTargetAccessMode.Direct
+                : ModelTargetAccessMode.Membership
         }
         if (!runtimeOrganizationId) {
             return membershipFeatures.tenantEnabled ? ModelTargetAccessMode.Membership : ModelTargetAccessMode.Direct
@@ -2216,6 +2237,14 @@ export class ModelAccessService {
         return user.role?.rolePermissions?.some(
             (rolePermission) => rolePermission.enabled && rolePermission.permission === permission
         )
+    }
+
+    private async hasUserPermission(tenantId: string, userId: string, permission: AIPermissionsEnum) {
+        const user = await this.userRepository.findOne({
+            where: { tenantId, id: userId },
+            relations: ['role', 'role.rolePermissions']
+        })
+        return !!user && this.userHasPermission(user, permission) === true
     }
 
     private async isModelAccessFeatureEnabled(

--- a/packages/server/src/feature/events/feature-organization.updated.event.ts
+++ b/packages/server/src/feature/events/feature-organization.updated.event.ts
@@ -4,6 +4,7 @@ export class FeatureOrganizationUpdatedEvent {
 	constructor(
 		public readonly tenantId: string,
 		public readonly organizationId: string | null,
+		public readonly actorUserId: string | null,
 		public readonly featureId: string,
 		public readonly featureCode: string,
 		public readonly previousIsEnabled: boolean,

--- a/packages/server/src/feature/feature-organization.service.spec.ts
+++ b/packages/server/src/feature/feature-organization.service.spec.ts
@@ -1,6 +1,7 @@
 jest.mock('../core/context', () => ({
 	RequestContext: {
-		currentTenantId: jest.fn(() => 'tenant-1')
+		currentTenantId: jest.fn(() => 'tenant-1'),
+		currentUserId: jest.fn(() => 'admin-1')
 	}
 }))
 
@@ -243,6 +244,7 @@ describe('FeatureOrganizationService', () => {
 			expect.objectContaining({
 				tenantId: 'tenant-1',
 				organizationId: null,
+				actorUserId: 'admin-1',
 				featureId: 'feature-1',
 				featureCode: 'FEATURE_MEMBERSHIP_PLAN',
 				previousIsEnabled: false,

--- a/packages/server/src/feature/feature-organization.service.ts
+++ b/packages/server/src/feature/feature-organization.service.ts
@@ -105,6 +105,7 @@ export class FeatureOrganizationService extends TenantAwareCrudService<FeatureOr
 				new FeatureOrganizationUpdatedEvent(
 					tenantId,
 					isNotEmpty(organizationId) ? organizationId : null,
+					RequestContext.currentUserId() ?? null,
 					featureId,
 					feature.code,
 					previousIsEnabled,


### PR DESCRIPTION
## Summary

- require `MEMBERSHIP_USE` before automatic tenant or organization membership assignment
- filter tenant and organization backfill candidates with one batched permission query
- preserve tenant Feature inheritance and organization Default plan creation

## Problem

When the membership Feature was enabled at tenant level, an organization without its own Feature configuration inherited that setting. Automatic initialization and backfill then assigned the Default membership to every normal user, including roles that did not have permission to use membership features.

This caused trial or otherwise restricted accounts to receive `user_membership` records even though their role could not use membership benefits.

## Root cause

The initialization paths checked whether the target was a normal user and whether the membership Feature and plan were active, but they did not check the target role's `MEMBERSHIP_USE` permission before creating the membership record.

## Fix

Direct tenant and organization initialization now stop when the target user lacks `MEMBERSHIP_USE`. Tenant and organization backfills load permission-bearing users in batches and skip unauthorized candidates. Organization Feature fallback and Default plan creation remain unchanged; only user assignment is gated.

## Validation

- `corepack pnpm exec jest --config packages/server-ai/jest.config.ts --runTestsByPath packages/server-ai/src/membership/membership.service.spec.ts --runInBand` (125 tests passed)
- `corepack pnpm exec nx run server-ai:build --skip-nx-cache`
- Prettier check passed
- `git diff --check` passed
