### PR TITLE
fix: add dedicated plugin marketplace proxy

### DIFF
--- a/.changeset/calm-pandas-proxy.md
+++ b/.changeset/calm-pandas-proxy.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/server-core': patch
+---
+
+Add an optional dedicated proxy for plugin marketplace HTTP requests.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -79,6 +79,7 @@
 		"tslib": "^2.3.0",
 		"typeorm": "^0.3.24",
 		"underscore": "^1.13.1",
+		"undici": "^7.28.0",
 		"unzipper": "^0.12.3",
 		"zod-to-json-schema": "^3.23.2"
 	},

--- a/packages/server/src/plugin/plugin-marketplace.service.spec.ts
+++ b/packages/server/src/plugin/plugin-marketplace.service.spec.ts
@@ -489,6 +489,70 @@ describe('PluginMarketplaceService marketplace trial shortcuts', () => {
 	})
 })
 
+describe('PluginMarketplaceService dedicated proxy', () => {
+	const originalProxyUrl = process.env.XPERT_PLUGIN_MARKETPLACE_PROXY_URL
+
+	afterEach(() => {
+		if (originalProxyUrl === undefined) {
+			delete process.env.XPERT_PLUGIN_MARKETPLACE_PROXY_URL
+		} else {
+			process.env.XPERT_PLUGIN_MARKETPLACE_PROXY_URL = originalProxyUrl
+		}
+		jest.restoreAllMocks()
+	})
+
+	it('routes marketplace HTTP requests through the configured proxy', async () => {
+		process.env.XPERT_PLUGIN_MARKETPLACE_PROXY_URL = 'http://127.0.0.1:7890'
+		const service = new PluginMarketplaceService({} as any, {} as any, [], {} as any)
+		const fetchMarketplaceJson = service as unknown as {
+			fetchJson(url: string): Promise<unknown>
+		}
+		const fetchRegistry = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+			ok: true,
+			json: async () => ({ plugins: [] })
+		} as Response)
+		const registryUrl = 'https://xpert-ai.github.io/xpert-plugin-registry/plugins/index.json'
+
+		await fetchMarketplaceJson.fetchJson(registryUrl)
+
+		expect(fetchRegistry).toHaveBeenCalledWith(
+			registryUrl,
+			expect.objectContaining({ dispatcher: expect.anything() })
+		)
+	})
+
+	it('preserves direct marketplace requests when the proxy is not configured', async () => {
+		delete process.env.XPERT_PLUGIN_MARKETPLACE_PROXY_URL
+		const service = new PluginMarketplaceService({} as any, {} as any, [], {} as any)
+		const fetchMarketplaceJson = service as unknown as {
+			fetchJson(url: string): Promise<unknown>
+		}
+		const fetchRegistry = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+			ok: true,
+			json: async () => ({ plugins: [] })
+		} as Response)
+		const registryUrl = 'https://xpert-ai.github.io/xpert-plugin-registry/plugins/index.json'
+
+		await fetchMarketplaceJson.fetchJson(registryUrl)
+
+		expect(fetchRegistry).toHaveBeenCalledWith(registryUrl)
+	})
+
+	it('rejects invalid proxy protocols without exposing the configured URL', async () => {
+		process.env.XPERT_PLUGIN_MARKETPLACE_PROXY_URL = 'ftp://proxy-user:proxy-secret@127.0.0.1:7890'
+		const service = new PluginMarketplaceService({} as any, {} as any, [], {} as any)
+		const fetchMarketplaceJson = service as unknown as {
+			fetchJson(url: string): Promise<unknown>
+		}
+		const fetchRegistry = jest.spyOn(globalThis, 'fetch')
+
+		await expect(
+			fetchMarketplaceJson.fetchJson('https://xpert-ai.github.io/xpert-plugin-registry/plugins/index.json')
+		).rejects.toThrow('XPERT_PLUGIN_MARKETPLACE_PROXY_URL must be a valid HTTP or HTTPS URL')
+		expect(fetchRegistry).not.toHaveBeenCalled()
+	})
+})
+
 describe('PluginMarketplaceService public marketplace', () => {
 	afterEach(() => {
 		jest.restoreAllMocks()

--- a/packages/server/src/plugin/plugin-marketplace.service.ts
+++ b/packages/server/src/plugin/plugin-marketplace.service.ts
@@ -1,4 +1,12 @@
-import { BadRequestException, ForbiddenException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import {
+	BadRequestException,
+	ForbiddenException,
+	Inject,
+	Injectable,
+	Logger,
+	NotFoundException,
+	type OnModuleDestroy
+} from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import {
 	type I18nObject,
@@ -33,6 +41,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { promisify } from 'node:util'
 import { IsNull, Repository } from 'typeorm'
+import { ProxyAgent, type Dispatcher } from 'undici'
 import { PluginInstanceService } from './plugin-instance.service'
 import {
 	PLUGIN_MARKETPLACE_REGISTRY_SECTIONS,
@@ -127,7 +136,7 @@ export interface PluginMarketplaceDetailQuery extends PluginMarketplaceListQuery
 }
 
 @Injectable()
-export class PluginMarketplaceService {
+export class PluginMarketplaceService implements OnModuleDestroy {
 	private readonly logger = new Logger(PluginMarketplaceService.name)
 	private readonly refreshJobs = new Map<string, Promise<void>>()
 	private readonly npmMetadataCache = new Map<string, { level?: PluginLevel } | null>()
@@ -135,6 +144,8 @@ export class PluginMarketplaceService {
 	private readonly npmBundleManifestCache = new Map<string, XpertPluginBundleManifest | null>()
 	private readonly publicBuiltinSource = this.createBuiltinSourceRecord()
 	private publicBuiltinRefreshJob: Promise<NormalizedMarketplaceCatalog> | null = null
+	private marketplaceProxyAgent: ProxyAgent | null = null
+	private marketplaceProxyConfigurationError: Error | null = null
 
 	constructor(
 		@InjectRepository(PluginMarketplaceSource)
@@ -144,7 +155,13 @@ export class PluginMarketplaceService {
 		@Inject(LOADED_PLUGINS)
 		private readonly loadedPlugins: Array<LoadedPluginRecord>,
 		private readonly pluginInstanceService: PluginInstanceService
-	) {}
+	) {
+		this.configureMarketplaceProxy()
+	}
+
+	async onModuleDestroy() {
+		await this.marketplaceProxyAgent?.close()
+	}
 
 	async listMarketplace(query: PluginMarketplaceListQuery = {}): Promise<PluginMarketplaceResponse> {
 		const sources = await this.getSourceRecords()
@@ -487,7 +504,7 @@ export class PluginMarketplaceService {
 				return null
 			}
 
-			const tarballResponse = await fetch(archive.tarball)
+			const tarballResponse = await this.fetchMarketplaceRequest(archive.tarball)
 			if (!tarballResponse.ok) {
 				throw new Error(`npm tarball returned ${tarballResponse.status}`)
 			}
@@ -512,7 +529,7 @@ export class PluginMarketplaceService {
 		version: string | null
 	): Promise<NpmPackageArchive | null> {
 		const url = `https://registry.npmjs.org/${encodeURIComponent(packageName)}`
-		const metadataResponse = await fetch(url)
+		const metadataResponse = await this.fetchMarketplaceRequest(url)
 		if (!metadataResponse.ok) {
 			throw new Error(`npm registry returned ${metadataResponse.status}`)
 		}
@@ -1877,7 +1894,7 @@ export class PluginMarketplaceService {
 				return null
 			}
 
-			const tarballResponse = await fetch(archive.tarball)
+			const tarballResponse = await this.fetchMarketplaceRequest(archive.tarball)
 			if (!tarballResponse.ok) {
 				throw new Error(`npm tarball returned ${tarballResponse.status}`)
 			}
@@ -2072,7 +2089,7 @@ export class PluginMarketplaceService {
 	private async fetchNpmPackageMetadata(packageName: string): Promise<{ level?: PluginLevel } | null> {
 		const url = `https://registry.npmjs.org/${encodeURIComponent(packageName)}`
 		try {
-			const response = await fetch(url)
+			const response = await this.fetchMarketplaceRequest(url)
 			if (!response.ok) {
 				throw new Error(`npm registry returned ${response.status}`)
 			}
@@ -2119,7 +2136,7 @@ export class PluginMarketplaceService {
 	private async fetchNpmDownloadCount(packageName: string) {
 		const url = `https://api.npmjs.org/downloads/point/last-month/${encodeURIComponent(packageName)}`
 		try {
-			const response = await fetch(url)
+			const response = await this.fetchMarketplaceRequest(url)
 			if (!response.ok) {
 				throw new Error(`npm downloads API returned ${response.status}`)
 			}
@@ -2707,7 +2724,7 @@ export class PluginMarketplaceService {
 	}
 
 	private async fetchJson(url: string) {
-		const response = await fetch(url)
+		const response = await this.fetchMarketplaceRequest(url)
 		if (!response.ok) {
 			throw new BadRequestException(`Failed to fetch marketplace index (${response.status})`)
 		}
@@ -2715,7 +2732,7 @@ export class PluginMarketplaceService {
 	}
 
 	private async tryFetchJson(url: string) {
-		const response = await fetch(url)
+		const response = await this.fetchMarketplaceRequest(url)
 		if (response.status === 404) {
 			return null
 		}
@@ -2723,6 +2740,39 @@ export class PluginMarketplaceService {
 			throw new BadRequestException(`Failed to fetch marketplace index (${response.status})`)
 		}
 		return response.json()
+	}
+
+	private configureMarketplaceProxy() {
+		const configuredUrl = process.env.XPERT_PLUGIN_MARKETPLACE_PROXY_URL?.trim()
+		if (!configuredUrl) {
+			return
+		}
+
+		try {
+			const proxyUrl = new URL(configuredUrl)
+			if (proxyUrl.protocol !== 'http:' && proxyUrl.protocol !== 'https:') {
+				throw new Error('Unsupported proxy protocol')
+			}
+			this.marketplaceProxyAgent = new ProxyAgent(proxyUrl.toString())
+		} catch {
+			this.marketplaceProxyConfigurationError = new Error(
+				'XPERT_PLUGIN_MARKETPLACE_PROXY_URL must be a valid HTTP or HTTPS URL'
+			)
+		}
+	}
+
+	private fetchMarketplaceRequest(input: string | URL | Request, init?: RequestInit) {
+		if (this.marketplaceProxyConfigurationError) {
+			throw this.marketplaceProxyConfigurationError
+		}
+		if (!this.marketplaceProxyAgent) {
+			return init ? fetch(input, init) : fetch(input)
+		}
+
+		return fetch(input, {
+			...(init ?? {}),
+			dispatcher: this.marketplaceProxyAgent
+		} as RequestInit & { dispatcher: Dispatcher })
 	}
 
 	private getLatestCatalogDate(catalogs: NormalizedMarketplaceCatalog[]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1166,6 +1166,9 @@ importers:
       underscore:
         specifier: ^1.13.1
         version: 1.13.7
+      undici:
+        specifier: ^7.28.0
+        version: 7.28.0
       unzipper:
         specifier: ^0.12.3
         version: 0.12.3


### PR DESCRIPTION
## Summary

- add optional `XPERT_PLUGIN_MARKETPLACE_PROXY_URL` support
- route plugin marketplace catalog, GitHub, npm metadata, tarball, and download requests through a shared proxy dispatcher
- preserve the existing direct-fetch behavior when the variable is unset
- validate proxy protocols without exposing configured credentials

## Root cause

The plugin marketplace used Node's global `fetch` without a proxy dispatcher. Setting a proxy address alone therefore did not route marketplace requests through Clash.

## Validation

- `pnpm exec jest --runTestsByPath packages/server/src/plugin/plugin-marketplace.service.spec.ts --runInBand`
- `pnpm nx build server`
- Prettier check
- staged hardcoded-color and TypeORM column checks
- `git diff --check`

The browser was not used for validation.