### PR TITLE
[codex] hydrate image reference workspace paths

### DIFF
--- a/packages/server-ai/src/shared/agent/human-input.ts
+++ b/packages/server-ai/src/shared/agent/human-input.ts
@@ -16,13 +16,15 @@ type CodeReferenceLike = Omit<ChatKitCodeReference, 'type'> & {
 
 type QuoteReferenceLike = ChatKitQuoteReference
 
-type ImageReferenceLike = ChatKitImageReference
+type ImageReferenceLike = ChatKitImageReference & {
+    workspacePath?: string
+}
 
 type ElementReferenceLike = TChatElementReference
 
 type FileElementReferenceLike = TChatFileElementReference
 
-type ReferenceLike = TChatReference
+type ReferenceLike = Exclude<TChatReference, ChatKitImageReference> | ImageReferenceLike
 
 type ReferenceCompositionMode = 'compose' | 'preserve'
 
@@ -325,7 +327,7 @@ function toQuoteReference(reference: QuoteReferenceCandidate): ChatKitQuoteRefer
     }
 }
 
-function toImageReference(reference: ImageReferenceCandidate): ChatKitImageReference {
+function toImageReference(reference: ImageReferenceCandidate): ImageReferenceLike {
     const fileId = toOptionalString(reference.fileId)
     const url = toOptionalString(reference.url)
     const name = toOptionalString(reference.name)
@@ -413,14 +415,14 @@ export function normalizeReferenceLike(value: unknown): ReferenceLike | null {
     return null
 }
 
-export function normalizeReferences(value: unknown): TChatReference[] {
+export function normalizeReferences(value: unknown): ReferenceLike[] {
     if (!Array.isArray(value)) {
         return []
     }
 
     return value
         .map((reference) => normalizeReferenceLike(reference))
-        .filter((reference): reference is TChatReference => reference !== null)
+        .filter((reference): reference is ReferenceLike => reference !== null)
 }
 
 function getCodeReferenceRange(reference: CodeReferenceLike): string {
@@ -465,6 +467,7 @@ function formatImageReference(reference: ImageReferenceLike): string {
     return [
         `[Image] ${reference.label?.trim() || reference.name?.trim() || 'Pasted image'}`,
         ...(summary.length ? [`Metadata: ${summary.join(', ')}`] : []),
+        ...(reference.workspacePath?.trim() ? [`Workspace Path: ${reference.workspacePath.trim()}`] : []),
         ...(reference.url?.trim() ? [`URL: ${reference.url.trim()}`] : []),
         ...(reference.fileId?.trim() ? [`File ID: ${reference.fileId.trim()}`] : []),
         `Text: ${reference.text}`

--- a/packages/server-ai/src/shared/agent/message.spec.ts
+++ b/packages/server-ai/src/shared/agent/message.spec.ts
@@ -17,6 +17,8 @@ jest.mock('@xpert-ai/server-core', () => {
 })
 
 import type { CommandBus, QueryBus } from '@nestjs/cqrs'
+import { GetStorageFileQuery } from '@xpert-ai/server-core'
+import { GetFileAssetByStorageFileQuery } from '../../file-understanding/queries/get-file-asset-by-storage-file.query'
 import { GetFileAssetQuery } from '../../file-understanding/queries/get-file-asset.query'
 import { GetFilePreviewQuery } from '../../file-understanding/queries/get-file-preview.query'
 import { LoadFileCommand } from '../commands'
@@ -287,6 +289,65 @@ describe('createHumanMessage', () => {
                 text: expect.stringContaining('[Image] reference-only.png')
             }
         ])
+    })
+
+    it('overrides client-supplied image workspace paths with the authoritative file asset path', async () => {
+        const workspacePath = '/workspace/sessions/conversation-1/files/asset-1/diagram.png'
+        const clientWorkspacePath = '/workspace/forged/diagram.png'
+        const imageReference = {
+            type: 'image' as const,
+            fileId: 'storage-1',
+            url: 'https://example.com/diagram.png',
+            workspacePath: clientWorkspacePath,
+            name: 'diagram.png',
+            mimeType: 'image/png',
+            text: 'Pasted image: diagram.png'
+        }
+        const queryBus = {
+            execute: jest.fn().mockImplementation(async (query: unknown) => {
+                if (query instanceof GetFileAssetByStorageFileQuery) {
+                    return {
+                        id: 'asset-1',
+                        storageFileId: 'storage-1',
+                        workspacePath
+                    }
+                }
+                if (query instanceof GetStorageFileQuery) {
+                    return [
+                        {
+                            id: 'storage-1',
+                            file: '',
+                            originalName: 'diagram.png',
+                            mimetype: 'image/png',
+                            size: 2048,
+                            storageProvider: 'local'
+                        }
+                    ]
+                }
+                return null
+            })
+        }
+
+        const message = await createHumanMessage(
+            {
+                execute: jest.fn()
+            } as unknown as CommandBus,
+            queryBus as unknown as QueryBus,
+            {
+                human: {
+                    input: 'Animate this image',
+                    references: [imageReference]
+                }
+            },
+            undefined
+        )
+
+        const textPart = (message.content as Array<{ type: string; text?: string }>).find(
+            (part) => part.type === 'text'
+        )
+        expect(textPart?.text).toContain(`Workspace Path: ${workspacePath}`)
+        expect(textPart?.text).not.toContain(clientWorkspacePath)
+        expect(queryBus.execute).toHaveBeenCalledWith(expect.objectContaining({ storageFileId: imageReference.fileId }))
     })
 
     it('adds file understanding cards without inlining preview chunks', async () => {

--- a/packages/server-ai/src/shared/agent/message.ts
+++ b/packages/server-ai/src/shared/agent/message.ts
@@ -125,6 +125,24 @@ function fileAssetUrl(fileAsset?: FileAsset | null) {
     return typeof url === 'string' && url.trim() ? url.trim() : undefined
 }
 
+async function hydrateImageReferenceWorkspacePaths(
+    queryBus: QueryBus,
+    references: ReturnType<typeof normalizeReferences>
+) {
+    return Promise.all(
+        references.map(async (reference) => {
+            if (reference.type !== 'image' || !reference.fileId) {
+                return reference
+            }
+
+            const fileAsset = await queryBus.execute<GetFileAssetByStorageFileQuery, FileAsset | null>(
+                new GetFileAssetByStorageFileQuery(reference.fileId)
+            )
+            return fileAsset?.workspacePath ? { ...reference, workspacePath: fileAsset.workspacePath } : reference
+        })
+    )
+}
+
 async function toImageContentPart(
     file: ResolvedFile,
     attachment?: TXpertAgentOptions['attachment'] | TXpertAgentOptions['vision']
@@ -186,7 +204,7 @@ export async function createHumanMessage(
     const { human } = state
     const agentHuman = await resolvePromptWorkflowHumanInput(queryBus, human, options?.xpert)
     const input = typeof agentHuman?.input === 'string' ? agentHuman.input : JSON.stringify(agentHuman?.input ?? '')
-    const references = normalizeReferences(agentHuman?.references)
+    const references = await hydrateImageReferenceWorkspacePaths(queryBus, normalizeReferences(agentHuman?.references))
     const referencePrompt = buildReferencedPrompt(references)
     const selectedSkillsPrompt = await buildSelectedRuntimeSkillsPrompt(
         queryBus,


### PR DESCRIPTION
## Summary

- resolve pasted-image workspace paths from the authoritative FileAsset using the StorageFile ID
- add the server-derived workspace path to the model-visible image reference description without changing ChatKit public types
- ignore caller-supplied workspace paths and cover the authority boundary with a regression test

## Root cause

Pasted image references carried a StorageFile ID and URL, but the agent prompt did not include the projected workspace path needed by file-aware model and plugin flows. Accepting a workspace path from the request would also let stale or forged client data bypass the authoritative FileAsset lookup.

## Validation

- corepack pnpm exec jest --config packages/server-ai/jest.config.ts --runInBand packages/server-ai/src/shared/agent/message.spec.ts (12 tests passed)
- corepack pnpm exec nx build server-ai
- Prettier check for message.ts and message.spec.ts
- git diff --check