### PR TITLE
feat(ui): refine registration, referrals, and membership management

### DIFF
--- a/apps/cloud/src/app/auth/register/register.component.scss
+++ b/apps/cloud/src/app/auth/register/register.component.scss
@@ -1,4 +1,4 @@
 @reference "../../../styles/tailwind-reference.css";
 :host {
-  @apply w-[368px] flex flex-col max-w-full px-8;
+  @apply w-[368px] flex flex-col max-w-full;
 }

--- a/apps/cloud/src/app/features/setting/membership/membership.component.html
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.html
@@ -11,98 +11,128 @@
       </div>
     </div>
 
-    <button z-button zType="default" type="button" class="self-start lg:self-auto" (click)="create()">
-      <z-icon zType="add"></z-icon>
-      {{ 'XP.Membership.NewPlan' | translate: { Default: 'New plan' } }}
-    </button>
+    @if (activeTab() === 'plans') {
+      <button z-button zType="default" type="button" class="self-start lg:self-auto" (click)="create()">
+        <z-icon zType="add"></z-icon>
+        {{ 'XP.Membership.NewPlan' | translate: { Default: 'New plan' } }}
+      </button>
+    }
   </div>
+
+  <nav
+    z-tab-nav-bar
+    class="xp-tab-nav-bar w-full"
+    color="accent"
+    alignTabs="start"
+    stretchTabs="false"
+    disableRipple
+    [tabPanel]="tabPanel"
+  >
+    <button z-tab-link type="button" [active]="activeTab() === 'plans'" (click)="setActiveTab('plans')">
+      <z-icon zType="credit-card"></z-icon>
+      {{ 'XP.Membership.PlanManagement' | translate: { Default: 'Plan configuration' } }}
+      <span class="text-xs text-text-tertiary">{{ plans().length | number }}</span>
+    </button>
+    <button z-tab-link type="button" [active]="activeTab() === 'users'" (click)="setActiveTab('users')">
+      <z-icon zType="users"></z-icon>
+      {{ 'XP.Membership.UserManagement' | translate: { Default: 'User memberships' } }}
+      <span class="text-xs text-text-tertiary">{{ adminMemberCount() | number }}</span>
+    </button>
+  </nav>
 </div>
 
-<div class="xp-page-body flex min-h-0 flex-1 flex-col gap-4 p-4">
-  @if (scopeStatus(); as status) {
-    <z-card class="border border-divider-regular bg-components-panel-bg shadow-none">
-      <z-card-content class="flex flex-col gap-4 p-4 xl:flex-row xl:items-center xl:justify-between">
-        <div class="min-w-0">
-          <div class="flex flex-wrap items-center gap-2">
-            <span
-              class="flex size-12 shrink-0 items-center justify-center rounded-xl bg-components-card-bg text-text-secondary"
-            >
-              <z-icon [zType]="status.scope === 'organization' ? 'corporate_fare' : 'storage'" class="size-6"></z-icon>
-            </span>
-            <div class="min-w-0">
-              <div class="text-base font-semibold text-text-primary">
+<z-tab-nav-panel #tabPanel class="xp-page-body flex min-h-0 flex-1 flex-col gap-4 p-4">
+  @if (activeTab() === 'plans') {
+    @if (scopeStatus(); as status) {
+      <section class="flex flex-col gap-4 rounded-lg bg-components-panel-bg px-4 py-3 xl:flex-row xl:items-center">
+        <div class="flex min-w-0 flex-1 items-center gap-3">
+          <span
+            class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-components-card-bg text-text-secondary"
+          >
+            <z-icon [zType]="status.scope === 'organization' ? 'corporate_fare' : 'storage'"></z-icon>
+          </span>
+          <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-2">
+              <div class="font-semibold text-text-primary">
                 @if (status.scope === 'organization') {
                   {{ 'XP.Membership.OrganizationScope' | translate: { Default: 'Organization membership' } }}
                 } @else {
                   {{ 'XP.Membership.TenantScope' | translate: { Default: 'Tenant membership' } }}
                 }
               </div>
-              <div class="mt-1 text-sm text-text-tertiary">
-                @if (status.scope === 'organization') {
-                  {{
-                    'XP.Membership.OrganizationScopeHint'
-                      | translate
-                        : {
-                            Default:
-                              'Organization plans control organization local Copilot models. Tenant models are used only when this scope has no plan.'
-                          }
-                  }}
-                } @else {
-                  {{
-                    'XP.Membership.TenantScopeHint'
-                      | translate: { Default: 'Tenant plans control tenant Copilot models and tenant fallback access.' }
-                  }}
-                }
-              </div>
+              <z-badge
+                zType="outline"
+                zShape="pill"
+                [class]="
+                  status.initialized
+                    ? 'border-state-success-hover bg-state-success-hover/20 text-text-success'
+                    : status.needsRepair
+                      ? 'border-state-warning-hover bg-state-warning-hover/20 text-text-warning'
+                      : 'border-divider-regular text-text-tertiary'
+                "
+              >
+                {{ scopeStatusLabel(status) }}
+              </z-badge>
             </div>
-            <z-badge
-              zType="outline"
-              zShape="pill"
-              [class]="
-                status.initialized
-                  ? 'border-state-success-hover bg-state-success-hover/20 text-text-success'
-                  : status.needsRepair
-                    ? 'border-state-warning-hover bg-state-warning-hover/20 text-text-warning'
-                    : 'border-divider-regular text-text-tertiary'
-              "
-            >
-              {{ scopeStatusLabel(status) }}
-            </z-badge>
+            <div class="mt-0.5 truncate text-xs text-text-tertiary">
+              @if (status.scope === 'organization') {
+                {{
+                  'XP.Membership.OrganizationScopeHint'
+                    | translate
+                      : {
+                          Default:
+                            'Organization plans control organization local Copilot models. Tenant models are used only when this scope has no plan.'
+                        }
+                }}
+              } @else {
+                {{
+                  'XP.Membership.TenantScopeHint'
+                    | translate: { Default: 'Tenant plans control tenant Copilot models and tenant fallback access.' }
+                }}
+              }
+            </div>
           </div>
         </div>
 
-        <div class="grid shrink-0 grid-cols-2 gap-2 text-sm md:grid-cols-4">
-          <div class="rounded-lg bg-components-card-bg px-3 py-2">
-            <div class="text-xs text-text-tertiary">
+        <dl class="grid shrink-0 grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3 xl:flex xl:items-center xl:gap-8">
+          <div class="min-w-24">
+            <dt class="text-xs text-text-tertiary">
               {{ 'XP.Membership.DefaultPlanLabel' | translate: { Default: 'Default plan' } }}
-            </div>
-            <div class="mt-1 truncate font-semibold text-text-primary" [title]="scopeDefaultPlanLabel(status)">
+            </dt>
+            <dd
+              class="mt-0.5 max-w-44 truncate text-sm font-semibold text-text-primary"
+              [title]="scopeDefaultPlanLabel(status)"
+            >
               {{ scopeDefaultPlanLabel(status) }}
-            </div>
+            </dd>
           </div>
-          <div class="rounded-lg bg-components-card-bg px-3 py-2">
-            <div class="text-xs text-text-tertiary">
+          <div>
+            <dt class="text-xs text-text-tertiary">
               {{ 'XP.Membership.ActivePlans' | translate: { Default: 'Active plans' } }}
-            </div>
-            <div class="mt-1 font-semibold text-text-primary">{{ status.activePlanCount | number }}</div>
+            </dt>
+            <dd class="mt-0.5 text-sm font-semibold tabular-nums text-text-primary">
+              {{ activePlanCount() | number }} / {{ plans().length | number }}
+            </dd>
+          </div>
+          <div>
+            <dt class="text-xs text-text-tertiary">
+              {{ 'XP.Membership.ArchivedPlans' | translate: { Default: 'Archived plans' } }}
+            </dt>
+            <dd class="mt-0.5 text-sm font-semibold tabular-nums text-text-primary">
+              {{ archivedPlanCount() | number }}
+            </dd>
           </div>
           @if (status.scope === 'organization') {
-            <div class="rounded-lg bg-components-card-bg px-3 py-2">
-              <div class="text-xs text-text-tertiary">
+            <div>
+              <dt class="text-xs text-text-tertiary">
                 {{ 'XP.Membership.AssignedMembers' | translate: { Default: 'Assigned members' } }}
-              </div>
-              <div class="mt-1 font-semibold text-text-primary">
+              </dt>
+              <dd class="mt-0.5 text-sm font-semibold tabular-nums text-text-primary">
                 {{ status.assignedMemberCount ?? 0 | number }} / {{ status.activeMemberCount ?? 0 | number }}
-              </div>
-            </div>
-            <div class="rounded-lg bg-components-card-bg px-3 py-2">
-              <div class="text-xs text-text-tertiary">
-                {{ 'XP.Membership.LocalCopilots' | translate: { Default: 'Local Copilots' } }}
-              </div>
-              <div class="mt-1 font-semibold text-text-primary">{{ status.localCopilotCount ?? 0 | number }}</div>
+              </dd>
             </div>
           }
-        </div>
+        </dl>
 
         @if (showScopeAction()) {
           <button
@@ -123,137 +153,659 @@
             }
           </button>
         }
-      </z-card-content>
-    </z-card>
-  }
+      </section>
+    }
 
-  <div class="grid gap-3 md:grid-cols-3">
-    <z-card class="border border-divider-regular bg-components-panel-bg shadow-none">
-      <z-card-content class="flex items-center gap-3 p-4">
-        <span
-          class="flex size-12 shrink-0 items-center justify-center rounded-xl bg-components-card-bg text-text-secondary"
-        >
-          <z-icon zType="credit-card" class="size-6"></z-icon>
-        </span>
-        <div class="min-w-0">
-          <div class="text-xs font-medium text-text-tertiary">
-            {{ 'XP.Membership.TotalPlans' | translate: { Default: 'Total plans' } }}
+    <div class="grid shrink-0 grid-cols-1 items-start gap-4 xl:grid-cols-12">
+      <z-card
+        class="min-w-0 overflow-hidden border border-divider-subtle bg-components-panel-bg shadow-none xl:col-span-4"
+      >
+        <z-card-header class="items-center py-4">
+          <div class="flex w-full items-center justify-between gap-3">
+            <div class="min-w-0">
+              <z-card-title>{{ 'XP.Membership.PlanCatalog' | translate: { Default: 'Plan catalog' } }}</z-card-title>
+              <z-card-subtitle class="mt-1">
+                {{
+                  'XP.Membership.PlanCatalogHint' | translate: { Default: 'Select a plan to review or edit its rules.' }
+                }}
+              </z-card-subtitle>
+            </div>
+            @if (loading()) {
+              <z-badge zType="secondary" zShape="pill">
+                {{ 'XP.KEY_WORDS.Loading' | translate: { Default: 'Loading...' } }}
+              </z-badge>
+            }
           </div>
-          <div class="mt-1 text-xl font-semibold text-text-primary">{{ plans().length | number }}</div>
-        </div>
-      </z-card-content>
-    </z-card>
+        </z-card-header>
 
-    <z-card class="border border-divider-regular bg-components-panel-bg shadow-none">
-      <z-card-content class="flex items-center gap-3 p-4">
-        <span
-          class="flex size-12 shrink-0 items-center justify-center rounded-xl bg-components-card-bg text-text-secondary"
-        >
-          <z-icon zType="circle-check" class="size-6"></z-icon>
-        </span>
-        <div class="min-w-0">
-          <div class="text-xs font-medium text-text-tertiary">
-            {{ 'XP.Membership.ActivePlans' | translate: { Default: 'Active plans' } }}
-          </div>
-          <div class="mt-1 text-xl font-semibold text-text-primary">{{ activePlanCount() | number }}</div>
-        </div>
-      </z-card-content>
-    </z-card>
-
-    <z-card class="border border-divider-regular bg-components-panel-bg shadow-none">
-      <z-card-content class="flex items-center gap-3 p-4">
-        <span
-          class="flex size-12 shrink-0 items-center justify-center rounded-xl bg-components-card-bg text-text-secondary"
-        >
-          <z-icon zType="archive" class="size-6"></z-icon>
-        </span>
-        <div class="min-w-0">
-          <div class="text-xs font-medium text-text-tertiary">
-            {{ 'XP.Membership.ArchivedPlans' | translate: { Default: 'Archived plans' } }}
-          </div>
-          <div class="mt-1 text-xl font-semibold text-text-primary">{{ archivedPlanCount() | number }}</div>
-        </div>
-      </z-card-content>
-    </z-card>
-  </div>
-
-  <div class="grid shrink-0 grid-cols-1 items-start gap-4 xl:grid-cols-12">
-    <z-card
-      class="min-w-0 overflow-hidden border border-divider-regular bg-components-card-bg shadow-none xl:col-span-4"
-    >
-      <z-card-header class="items-center border-b border-divider-regular py-5">
-        <div class="flex w-full items-center justify-between gap-3">
-          <div class="min-w-0">
-            <z-card-title>{{ 'XP.Membership.PlanCatalog' | translate: { Default: 'Plan catalog' } }}</z-card-title>
-            <z-card-subtitle class="mt-1">
-              {{
-                'XP.Membership.PlanCatalogHint' | translate: { Default: 'Select a plan to review or edit its rules.' }
-              }}
-            </z-card-subtitle>
-          </div>
-          @if (loading()) {
-            <z-badge zType="secondary" zShape="pill">
-              {{ 'XP.KEY_WORDS.Loading' | translate: { Default: 'Loading...' } }}
-            </z-badge>
-          }
-        </div>
-      </z-card-header>
-
-      <z-card-content class="p-2">
-        <div class="flex flex-col gap-2">
-          @for (plan of plans(); track plan.id) {
-            <div
-              role="button"
-              tabindex="0"
-              class="group rounded-lg border px-3 py-3 transition-colors hover:bg-hover-bg"
-              [ngClass]="
-                selectedPlan()?.id === plan.id
-                  ? 'border-primary/40 bg-components-panel-bg'
-                  : 'border-divider-subtle bg-components-card-bg'
-              "
-              (click)="selectPlan(plan)"
-              (keydown.enter)="selectPlan(plan)"
-              (keydown.space)="selectPlan(plan)"
-            >
-              <div class="flex min-w-0 items-start justify-between gap-3">
-                <div class="min-w-0">
-                  <div class="truncate text-base font-semibold text-text-primary" [title]="plan.name">
-                    {{ plan.name }}
+        <z-card-content class="p-2">
+          <div class="flex flex-col gap-2">
+            @for (plan of plans(); track plan.id) {
+              <div
+                role="button"
+                tabindex="0"
+                class="group rounded-lg border px-3 py-3 transition-colors hover:bg-hover-bg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                [ngClass]="
+                  selectedPlan()?.id === plan.id
+                    ? 'border-primary/40 bg-components-card-bg shadow-sm'
+                    : 'border-divider-subtle bg-components-card-bg hover:border-divider-regular'
+                "
+                (click)="selectPlan(plan)"
+                (keydown.enter)="selectPlan(plan)"
+                (keydown.space)="selectPlan(plan)"
+              >
+                <div class="flex min-w-0 items-start justify-between gap-3">
+                  <div class="min-w-0">
+                    <div class="truncate text-base font-semibold text-text-primary" [title]="plan.name">
+                      {{ plan.name }}
+                    </div>
+                    <div class="mt-1 truncate font-mono text-xs text-text-tertiary" [title]="plan.code">
+                      {{ plan.code }}
+                    </div>
                   </div>
-                  <div class="mt-1 truncate font-mono text-xs text-text-tertiary" [title]="plan.code">
-                    {{ plan.code }}
+
+                  <div class="flex shrink-0 flex-wrap justify-end gap-1">
+                    @if (plan.isDefault) {
+                      <z-badge zType="secondary" zShape="pill">
+                        {{ 'XP.Membership.DefaultPlan' | translate: { Default: 'Default' } }}
+                      </z-badge>
+                    }
+                    <z-badge zType="outline" zShape="pill">
+                      {{ 'XP.Membership.Level' | translate: { Default: 'Level' } }} {{ plan.level }}
+                    </z-badge>
+                    <z-badge
+                      zType="outline"
+                      zShape="pill"
+                      [class]="
+                        plan.status === MembershipPlanStatusEnum.Active
+                          ? 'border-state-success-hover bg-state-success-hover/20 text-text-success'
+                          : 'border-divider-regular text-text-tertiary'
+                      "
+                    >
+                      {{ 'XP.Membership.Statuses.' + plan.status | translate: { Default: plan.status } }}
+                    </z-badge>
                   </div>
                 </div>
 
-                <div class="flex shrink-0 flex-wrap justify-end gap-1">
-                  @if (plan.isDefault) {
-                    <z-badge zType="secondary" zShape="pill">
-                      {{ 'XP.Membership.DefaultPlan' | translate: { Default: 'Default' } }}
-                    </z-badge>
-                  }
-                  <z-badge zType="outline" zShape="pill">
-                    {{ 'XP.Membership.Level' | translate: { Default: 'Level' } }} {{ plan.level }}
-                  </z-badge>
-                  <z-badge
-                    zType="outline"
-                    zShape="pill"
-                    [class]="
-                      plan.status === MembershipPlanStatusEnum.Active
-                        ? 'border-state-success-hover bg-state-success-hover/20 text-text-success'
-                        : 'border-divider-regular text-text-tertiary'
-                    "
-                  >
-                    {{ 'XP.Membership.Statuses.' + plan.status | translate: { Default: plan.status } }}
-                  </z-badge>
+                <div class="mt-3 flex items-end justify-between gap-3 text-sm">
+                  <div>
+                    <div class="text-xs text-text-tertiary">
+                      {{ 'XP.Membership.Points' | translate: { Default: 'Points' } }}
+                    </div>
+                    <div class="mt-0.5 font-semibold tabular-nums text-text-primary">
+                      @if (plan.includedPoints === null) {
+                        {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
+                      } @else {
+                        {{ plan.includedPoints | number }}
+                      }
+                    </div>
+                  </div>
+                  <div class="min-w-0 truncate text-sm text-text-tertiary">
+                    @if (plan.priceAmount !== null && plan.priceAmount !== undefined) {
+                      {{ plan.priceAmount | currency: plan.priceCurrency || 'CNY' : 'symbol-narrow' }}
+                    } @else {
+                      {{ 'XP.KEY_WORDS.None' | translate: { Default: 'None' } }}
+                    }
+                  </div>
+
+                  <div class="flex shrink-0 items-center gap-1">
+                    <button
+                      z-button
+                      zType="secondary"
+                      zSize="sm"
+                      type="button"
+                      (click)="$event.stopPropagation(); edit(plan)"
+                    >
+                      <z-icon zType="edit"></z-icon>
+                      {{ 'XP.ACTIONS.Edit' | translate: { Default: 'Edit' } }}
+                    </button>
+                    @if (plan.status === MembershipPlanStatusEnum.Archived) {
+                      <button
+                        z-button
+                        zType="destructive"
+                        zSize="sm"
+                        type="button"
+                        (click)="$event.stopPropagation(); deletePlan(plan)"
+                      >
+                        <z-icon zType="delete"></z-icon>
+                        {{ 'XP.ACTIONS.Delete' | translate: { Default: 'Delete' } }}
+                      </button>
+                    } @else {
+                      <button
+                        z-button
+                        zType="outline"
+                        zSize="sm"
+                        type="button"
+                        [disabled]="plan.isDefault"
+                        (click)="$event.stopPropagation(); archive(plan)"
+                      >
+                        <z-icon zType="archive"></z-icon>
+                        {{ 'XP.Membership.ArchivePlan' | translate: { Default: 'Archive' } }}
+                      </button>
+                    }
+                  </div>
                 </div>
               </div>
+            } @empty {
+              <div
+                class="flex min-h-52 flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-divider-regular bg-components-panel-bg px-4 py-10 text-center"
+              >
+                <span
+                  class="flex size-12 items-center justify-center rounded-xl bg-components-card-bg text-text-tertiary"
+                >
+                  <z-icon zType="credit-card"></z-icon>
+                </span>
+                <div class="text-sm font-semibold text-text-primary">
+                  {{ 'XP.Membership.NoPlans' | translate: { Default: 'No membership plans yet.' } }}
+                </div>
+                <button z-button zType="default" type="button" (click)="create()">
+                  <z-icon zType="add"></z-icon>
+                  {{ 'XP.Membership.NewPlan' | translate: { Default: 'New plan' } }}
+                </button>
+              </div>
+            }
+          </div>
+        </z-card-content>
+      </z-card>
 
-              <div class="mt-4 grid grid-cols-1 gap-2 text-sm">
-                <div class="rounded-lg bg-components-panel-bg px-3 py-2">
-                  <div class="text-xs text-text-tertiary">
-                    {{ 'XP.Membership.Points' | translate: { Default: 'Points' } }}
+      <div class="min-w-0 xl:col-span-8">
+        @if (editing()) {
+          <form [formGroup]="planForm" (ngSubmit)="save()">
+            <z-card class="overflow-hidden border border-divider-subtle bg-components-card-bg shadow-none">
+              <z-card-header class="items-center py-4">
+                <div class="flex w-full flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                  <div class="min-w-0">
+                    <z-card-title>
+                      {{
+                        (draft.id ? 'XP.Membership.EditPlan' : 'XP.Membership.CreatePlan')
+                          | translate: { Default: draft.id ? 'Edit plan' : 'Create plan' }
+                      }}
+                    </z-card-title>
+                    <z-card-subtitle class="mt-1">
+                      {{
+                        'XP.Membership.PlanFormHint'
+                          | translate: { Default: 'Define the allowance, exchange rate, and optional model rules.' }
+                      }}
+                    </z-card-subtitle>
                   </div>
-                  <div class="mt-1 font-semibold text-text-primary">
+
+                  <div class="flex shrink-0 items-center gap-2">
+                    <button z-button zType="secondary" type="button" [disabled]="loading()" (click)="cancel()">
+                      {{ 'XP.ACTIONS.Cancel' | translate: { Default: 'Cancel' } }}
+                    </button>
+                    <button z-button zType="default" type="submit" [disabled]="loading() || planForm.invalid">
+                      <z-icon zType="save"></z-icon>
+                      {{ 'XP.ACTIONS.Save' | translate: { Default: 'Save' } }}
+                    </button>
+                  </div>
+                </div>
+              </z-card-header>
+
+              <z-card-content class="space-y-5 p-4">
+                <section class="rounded-lg bg-components-panel-bg p-4">
+                  <div class="mb-3 text-sm font-semibold text-text-primary">
+                    {{ 'XP.Membership.PlanIdentity' | translate: { Default: 'Plan identity' } }}
+                  </div>
+
+                  <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <z-form-field class="w-full">
+                      <z-form-label>{{ 'XP.Membership.Code' | translate: { Default: 'Code' } }}</z-form-label>
+                      <input z-input formControlName="code" />
+                    </z-form-field>
+
+                    <z-form-field class="w-full">
+                      <z-form-label>{{ 'XP.Membership.Name' | translate: { Default: 'Name' } }}</z-form-label>
+                      <input z-input formControlName="name" />
+                    </z-form-field>
+
+                    <z-form-field class="w-full">
+                      <z-form-label>{{ 'XP.Membership.Level' | translate: { Default: 'Level' } }}</z-form-label>
+                      <input
+                        z-input
+                        type="number"
+                        min="0"
+                        step="1"
+                        formControlName="level"
+                        [zStatus]="
+                          planForm.controls.level.invalid && planForm.controls.level.touched ? 'error' : undefined
+                        "
+                      />
+                      @if (planForm.controls.level.invalid && planForm.controls.level.touched) {
+                        <z-form-message zType="error">
+                          {{
+                            'XP.Membership.LevelValidation'
+                              | translate: { Default: 'Level must be a whole number of zero or greater.' }
+                          }}
+                        </z-form-message>
+                      }
+                    </z-form-field>
+
+                    <z-form-field class="w-full">
+                      <z-form-label>{{ 'XP.Membership.Status' | translate: { Default: 'Status' } }}</z-form-label>
+                      <z-select class="w-full" formControlName="status" (zSelectionChange)="setDraftStatus($event)">
+                        <z-select-item [zValue]="MembershipPlanStatusEnum.Active">
+                          {{ 'XP.Membership.Statuses.active' | translate: { Default: 'Active' } }}
+                        </z-select-item>
+                        <z-select-item [zValue]="MembershipPlanStatusEnum.Archived">
+                          {{ 'XP.Membership.Statuses.archived' | translate: { Default: 'Archived' } }}
+                        </z-select-item>
+                      </z-select>
+                    </z-form-field>
+
+                    <div class="flex items-end">
+                      <z-checkbox
+                        class="min-h-9 items-center"
+                        displayDensity="cosy"
+                        formControlName="isDefault"
+                        [zDisabled]="planForm.controls.status.value === MembershipPlanStatusEnum.Archived"
+                        (checkChange)="setDraftDefault($event)"
+                      >
+                        {{ 'XP.Membership.SetDefaultPlan' | translate: { Default: 'Set as default plan' } }}
+                      </z-checkbox>
+                    </div>
+                  </div>
+                </section>
+
+                <section class="rounded-lg bg-components-panel-bg p-4">
+                  <div class="mb-3 text-sm font-semibold text-text-primary">
+                    {{ 'XP.Membership.PointRules' | translate: { Default: 'Point rules' } }}
+                  </div>
+
+                  <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <z-form-field class="w-full">
+                      <z-form-label>
+                        {{ 'XP.Membership.PointsPerPeriod' | translate: { Default: 'Points per period' } }}
+                      </z-form-label>
+                      <input
+                        z-input
+                        type="number"
+                        min="0"
+                        formControlName="includedPoints"
+                        [disabled]="planForm.controls.unlimited.value"
+                      />
+                      <z-checkbox
+                        class="mt-1 min-h-8 items-center"
+                        displayDensity="cosy"
+                        formControlName="unlimited"
+                        (checkChange)="setDraftUnlimited($event)"
+                      >
+                        {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
+                      </z-checkbox>
+                    </z-form-field>
+
+                    <z-form-field class="w-full">
+                      <z-form-label>
+                        {{ 'XP.Membership.PriceAmount' | translate: { Default: 'Display price' } }}
+                      </z-form-label>
+                      <input z-input type="number" min="0" formControlName="priceAmount" />
+                    </z-form-field>
+
+                    <z-form-field class="w-full">
+                      <z-form-label [zRequired]="true">
+                        {{ 'XP.Membership.PriceCurrency' | translate: { Default: 'Currency' } }}
+                      </z-form-label>
+                      <input
+                        z-input
+                        maxlength="12"
+                        formControlName="priceCurrency"
+                        [zStatus]="
+                          planForm.controls.priceCurrency.invalid && planForm.controls.priceCurrency.touched
+                            ? 'error'
+                            : undefined
+                        "
+                      />
+                      @if (planForm.controls.priceCurrency.invalid && planForm.controls.priceCurrency.touched) {
+                        <z-form-message zType="error">
+                          {{
+                            'XP.Membership.PriceCurrencyValidation'
+                              | translate: { Default: 'Enter a currency code of up to 12 characters.' }
+                          }}
+                        </z-form-message>
+                      }
+                    </z-form-field>
+                  </div>
+                </section>
+
+                <section class="rounded-lg bg-components-panel-bg p-4">
+                  <div class="mb-3 text-sm font-semibold text-text-primary">
+                    {{ 'XP.Membership.Description' | translate: { Default: 'Description' } }}
+                  </div>
+                  <z-form-field class="w-full">
+                    <textarea z-input class="min-h-24 resize-y" formControlName="description"></textarea>
+                  </z-form-field>
+                </section>
+
+                <section class="rounded-lg bg-components-panel-bg p-4">
+                  <div class="mb-1 text-sm font-semibold text-text-primary">
+                    {{ 'XP.Membership.ModelUsageRules' | translate: { Default: 'Model access and usage rules' } }}
+                  </div>
+                  <div class="mb-4 text-xs text-text-tertiary">
+                    {{
+                      'XP.Membership.ModelUsageRulesHint'
+                        | translate
+                          : {
+                              Default:
+                                'Choose available models and optionally customize point multipliers and usage limits.'
+                            }
+                    }}
+                  </div>
+
+                  <div class="space-y-5">
+                    <div class="rounded-lg border border-divider-subtle bg-components-card-bg p-4">
+                      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <div class="text-sm font-medium text-text-primary">
+                            {{ 'XP.Membership.AllowedModels' | translate: { Default: 'Allowed models' } }}
+                          </div>
+                          <div class="mt-1 text-xs text-text-tertiary">
+                            {{
+                              'XP.Membership.AllowedModelsHint'
+                                | translate: { Default: 'Choose which models members of this plan can use.' }
+                            }}
+                          </div>
+                        </div>
+                        <z-checkbox
+                          class="min-h-8 shrink-0 items-center"
+                          displayDensity="cosy"
+                          formControlName="allowAllModels"
+                          (checkChange)="setAllowAllModels($event)"
+                        >
+                          {{ 'XP.Membership.AllowAllModels' | translate: { Default: 'Allow all models' } }}
+                        </z-checkbox>
+                      </div>
+
+                      @if (!planForm.controls.allowAllModels.value) {
+                        <div class="mt-4">
+                          <z-select
+                            class="w-full"
+                            [zMultiple]="true"
+                            [zMaxLabelCount]="3"
+                            [zValue]="allowedModelValues()"
+                            [zPlaceholder]="
+                              'XP.Membership.SelectModels' | translate: { Default: 'Select allowed models' }
+                            "
+                            (zSelectionChange)="setAllowedModelValues($event)"
+                          >
+                            @for (option of modelOptions(); track option.value) {
+                              <z-select-item [zValue]="option.value">{{ modelTargetLabel(option) }}</z-select-item>
+                            }
+                          </z-select>
+                          @if (!modelOptions().length) {
+                            <div class="mt-2 text-xs text-text-tertiary">
+                              {{
+                                'XP.Membership.NoModelsAvailable'
+                                  | translate: { Default: 'No configured Copilot models are available in this scope.' }
+                              }}
+                            </div>
+                          }
+                        </div>
+                      }
+                    </div>
+
+                    <div class="rounded-lg border border-divider-subtle bg-components-card-bg p-4">
+                      <div class="flex items-start justify-between gap-3">
+                        <div>
+                          <div class="text-sm font-medium text-text-primary">
+                            {{ 'XP.Membership.ModelMultipliers' | translate: { Default: 'Model multipliers' } }}
+                          </div>
+                          <div class="mt-1 text-xs text-text-tertiary">
+                            {{
+                              'XP.Membership.ModelMultipliersHint'
+                                | translate
+                                  : {
+                                      Default:
+                                        'Adjust how many points selected models consume. The default multiplier is 1.'
+                                    }
+                            }}
+                          </div>
+                        </div>
+                        <button z-button zType="outline" zSize="sm" type="button" (click)="addModelMultiplier()">
+                          <z-icon zType="add"></z-icon>
+                          {{ 'XP.ACTIONS.ADD' | translate: { Default: 'Add' } }}
+                        </button>
+                      </div>
+
+                      @if (modelMultipliers.length) {
+                        <div class="mt-4 space-y-3">
+                          @for (rule of modelMultipliers; track $index) {
+                            <div
+                              class="grid grid-cols-1 items-end gap-3 rounded-lg bg-components-panel-bg p-3 md:grid-cols-[minmax(0,1fr)_10rem_auto]"
+                            >
+                              <label class="flex min-w-0 flex-col gap-1">
+                                <span class="text-xs text-text-tertiary">
+                                  {{ 'XP.Membership.ModelScope' | translate: { Default: 'Model scope' } }}
+                                </span>
+                                <z-select
+                                  class="w-full"
+                                  [zValue]="modelMultiplierTargetValue(rule)"
+                                  (zSelectionChange)="setModelMultiplierTarget($index, $event)"
+                                >
+                                  <z-select-item [zValue]="globalModelTargetValue">
+                                    {{ 'XP.Membership.AllModels' | translate: { Default: 'All models' } }}
+                                  </z-select-item>
+                                  @for (option of modelOptions(); track option.value) {
+                                    <z-select-item [zValue]="option.value">{{
+                                      modelTargetLabel(option)
+                                    }}</z-select-item>
+                                  }
+                                </z-select>
+                              </label>
+
+                              <label class="flex flex-col gap-1">
+                                <span class="text-xs text-text-tertiary">
+                                  {{ 'XP.Membership.Multiplier' | translate: { Default: 'Multiplier' } }}
+                                </span>
+                                <input
+                                  z-input
+                                  type="number"
+                                  min="0"
+                                  step="0.1"
+                                  [attr.value]="rule.multiplier"
+                                  (input)="setModelMultiplierValue($index, $event)"
+                                />
+                              </label>
+
+                              <button
+                                z-button
+                                zType="ghost"
+                                zSize="icon"
+                                zShape="circle"
+                                type="button"
+                                class="text-text-tertiary hover:text-text-destructive"
+                                [attr.aria-label]="'XP.ACTIONS.DELETE' | translate: { Default: 'Delete' }"
+                                (click)="removeModelMultiplier($index)"
+                              >
+                                <z-icon zType="delete"></z-icon>
+                              </button>
+                            </div>
+                          }
+                        </div>
+                      } @else {
+                        <div
+                          class="mt-4 rounded-lg border border-dashed border-divider-regular px-4 py-5 text-center text-sm text-text-tertiary"
+                        >
+                          {{
+                            'XP.Membership.NoModelMultipliers'
+                              | translate: { Default: 'No custom multipliers. All models use a multiplier of 1.' }
+                          }}
+                        </div>
+                      }
+                    </div>
+
+                    <div class="rounded-lg border border-divider-subtle bg-components-card-bg p-4">
+                      <div class="flex items-start justify-between gap-3">
+                        <div>
+                          <div class="text-sm font-medium text-text-primary">
+                            {{ 'XP.Membership.RateLimits' | translate: { Default: 'Usage limits' } }}
+                          </div>
+                          <div class="mt-1 text-xs text-text-tertiary">
+                            {{
+                              'XP.Membership.RateLimitsHint'
+                                | translate
+                                  : { Default: 'Limit the number of points members can consume within a period.' }
+                            }}
+                          </div>
+                        </div>
+                        <button z-button zType="outline" zSize="sm" type="button" (click)="addRateLimit()">
+                          <z-icon zType="add"></z-icon>
+                          {{ 'XP.ACTIONS.ADD' | translate: { Default: 'Add' } }}
+                        </button>
+                      </div>
+
+                      @if (rateLimits.length) {
+                        <div class="mt-4 space-y-3">
+                          @for (rule of rateLimits; track $index) {
+                            <div
+                              class="grid grid-cols-1 items-end gap-3 rounded-lg bg-components-panel-bg p-3 md:grid-cols-[minmax(0,1fr)_9rem_10rem_auto]"
+                            >
+                              <label class="flex min-w-0 flex-col gap-1">
+                                <span class="text-xs text-text-tertiary">
+                                  {{ 'XP.Membership.ModelScope' | translate: { Default: 'Model scope' } }}
+                                </span>
+                                <z-select
+                                  class="w-full"
+                                  [zValue]="rateLimitTargetValue(rule)"
+                                  (zSelectionChange)="setRateLimitTarget($index, $event)"
+                                >
+                                  <z-select-item [zValue]="globalModelTargetValue">
+                                    {{ 'XP.Membership.AllModels' | translate: { Default: 'All models' } }}
+                                  </z-select-item>
+                                  @for (option of modelOptions(); track option.value) {
+                                    <z-select-item [zValue]="option.value">{{
+                                      modelTargetLabel(option)
+                                    }}</z-select-item>
+                                  }
+                                </z-select>
+                              </label>
+
+                              <label class="flex flex-col gap-1">
+                                <span class="text-xs text-text-tertiary">
+                                  {{ 'XP.Membership.Period' | translate: { Default: 'Period' } }}
+                                </span>
+                                <z-select
+                                  class="w-full"
+                                  [zValue]="rule.period"
+                                  (zSelectionChange)="setRateLimitPeriod($index, $event)"
+                                >
+                                  @for (period of rateLimitPeriods; track period) {
+                                    <z-select-item [zValue]="period">
+                                      {{ 'XP.Membership.RateLimitPeriods.' + period | translate: { Default: period } }}
+                                    </z-select-item>
+                                  }
+                                </z-select>
+                              </label>
+
+                              <label class="flex flex-col gap-1">
+                                <span class="text-xs text-text-tertiary">
+                                  {{ 'XP.Membership.PointLimit' | translate: { Default: 'Point limit' } }}
+                                </span>
+                                <input
+                                  z-input
+                                  type="number"
+                                  min="1"
+                                  step="1"
+                                  [attr.value]="rule.pointLimit"
+                                  (input)="setRateLimitValue($index, $event)"
+                                />
+                              </label>
+
+                              <button
+                                z-button
+                                zType="ghost"
+                                zSize="icon"
+                                zShape="circle"
+                                type="button"
+                                class="text-text-tertiary hover:text-text-destructive"
+                                [attr.aria-label]="'XP.ACTIONS.DELETE' | translate: { Default: 'Delete' }"
+                                (click)="removeRateLimit($index)"
+                              >
+                                <z-icon zType="delete"></z-icon>
+                              </button>
+                            </div>
+                          }
+                        </div>
+                      } @else {
+                        <div
+                          class="mt-4 rounded-lg border border-dashed border-divider-regular px-4 py-5 text-center text-sm text-text-tertiary"
+                        >
+                          {{ 'XP.Membership.NoRateLimits' | translate: { Default: 'No additional usage limits.' } }}
+                        </div>
+                      }
+                    </div>
+                  </div>
+                </section>
+              </z-card-content>
+            </z-card>
+          </form>
+        } @else if (selectedPlan(); as plan) {
+          <z-card class="overflow-hidden border border-divider-subtle bg-components-card-bg shadow-none">
+            <z-card-header class="items-center py-4">
+              <div class="flex w-full flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                <div class="min-w-0">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <z-card-title class="truncate text-2xl">{{ plan.name }}</z-card-title>
+                    @if (plan.isDefault) {
+                      <z-badge zType="secondary" zShape="pill">
+                        {{ 'XP.Membership.DefaultPlan' | translate: { Default: 'Default' } }}
+                      </z-badge>
+                    }
+                  </div>
+                  <z-card-subtitle class="mt-2 font-mono">{{ plan.code }}</z-card-subtitle>
+                </div>
+
+                <div class="flex shrink-0 items-center gap-2">
+                  <button z-button zType="secondary" type="button" (click)="edit(plan)">
+                    <z-icon zType="edit"></z-icon>
+                    {{ 'XP.ACTIONS.Edit' | translate: { Default: 'Edit' } }}
+                  </button>
+                  @if (plan.status === MembershipPlanStatusEnum.Archived) {
+                    <button z-button zType="destructive" type="button" (click)="deletePlan(plan)">
+                      <z-icon zType="delete"></z-icon>
+                      {{ 'XP.ACTIONS.Delete' | translate: { Default: 'Delete' } }}
+                    </button>
+                  } @else {
+                    <button z-button zType="outline" type="button" [disabled]="plan.isDefault" (click)="archive(plan)">
+                      <z-icon zType="archive"></z-icon>
+                      {{ 'XP.Membership.ArchivePlan' | translate: { Default: 'Archive' } }}
+                    </button>
+                  }
+                </div>
+              </div>
+            </z-card-header>
+
+            <z-card-content class="space-y-5 p-4">
+              <div class="grid grid-cols-1 gap-3 md:grid-cols-4">
+                <div class="rounded-lg border border-divider-subtle bg-components-panel-bg px-4 py-3">
+                  <div class="text-xs font-medium text-text-tertiary">
+                    {{ 'XP.Membership.Level' | translate: { Default: 'Level' } }}
+                  </div>
+                  <div class="mt-1 text-xl font-semibold text-text-primary">{{ plan.level }}</div>
+                </div>
+
+                <div class="rounded-lg border border-divider-subtle bg-components-panel-bg px-4 py-3">
+                  <div class="text-xs font-medium text-text-tertiary">
+                    {{ 'XP.Membership.Status' | translate: { Default: 'Status' } }}
+                  </div>
+                  <div class="mt-2">
+                    <z-badge
+                      zType="outline"
+                      zShape="pill"
+                      [class]="
+                        plan.status === MembershipPlanStatusEnum.Active
+                          ? 'border-state-success-hover bg-state-success-hover/20 text-text-success'
+                          : 'border-divider-regular text-text-tertiary'
+                      "
+                    >
+                      {{ 'XP.Membership.Statuses.' + plan.status | translate: { Default: plan.status } }}
+                    </z-badge>
+                  </div>
+                </div>
+
+                <div class="rounded-lg border border-divider-subtle bg-components-panel-bg px-4 py-3">
+                  <div class="text-xs font-medium text-text-tertiary">
+                    {{ 'XP.Membership.PointsPerPeriod' | translate: { Default: 'Points per period' } }}
+                  </div>
+                  <div class="mt-1 text-xl font-semibold text-text-primary">
                     @if (plan.includedPoints === null) {
                       {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
                     } @else {
@@ -261,1037 +813,489 @@
                     }
                   </div>
                 </div>
+
+                <div class="rounded-lg border border-divider-subtle bg-components-panel-bg px-4 py-3">
+                  <div class="text-xs font-medium text-text-tertiary">
+                    {{ 'XP.Membership.Price' | translate: { Default: 'Price' } }}
+                  </div>
+                  <div class="mt-1 text-xl font-semibold text-text-primary">
+                    @if (plan.priceAmount !== null && plan.priceAmount !== undefined) {
+                      {{ plan.priceAmount | currency: plan.priceCurrency || 'CNY' : 'symbol-narrow' }}
+                    } @else {
+                      <span class="text-base font-medium text-text-tertiary">
+                        {{ 'XP.KEY_WORDS.None' | translate: { Default: 'None' } }}
+                      </span>
+                    }
+                  </div>
+                </div>
               </div>
 
-              <div class="mt-3 flex items-center justify-between gap-2 border-t border-divider-subtle pt-3">
-                <div class="min-w-0 truncate text-sm text-text-tertiary">
-                  @if (plan.priceAmount !== null && plan.priceAmount !== undefined) {
-                    {{ plan.priceAmount | currency: plan.priceCurrency || 'CNY' : 'symbol-narrow' }}
-                  } @else {
-                    {{ 'XP.KEY_WORDS.None' | translate: { Default: 'None' } }}
+              @if (plan.description) {
+                <section class="rounded-lg border border-divider-subtle bg-components-panel-bg px-4 py-3">
+                  <div class="text-xs font-medium text-text-tertiary">
+                    {{ 'XP.Membership.Description' | translate: { Default: 'Description' } }}
+                  </div>
+                  <div class="mt-2 whitespace-pre-wrap text-sm leading-6 text-text-primary">{{ plan.description }}</div>
+                </section>
+              }
+
+              <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
+                <section class="rounded-lg border border-divider-subtle bg-components-panel-bg px-4 py-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="min-w-0">
+                      <div class="text-sm font-semibold text-text-primary">
+                        {{ 'XP.Membership.AllowedModels' | translate: { Default: 'Allowed models' } }}
+                      </div>
+                      <div class="mt-1 text-sm text-text-tertiary">
+                        @if (allowedModelCount(plan)) {
+                          {{ allowedModelCount(plan) | number }}
+                          {{ 'XP.KEY_WORDS.Items' | translate: { Default: 'items' } }}
+                        } @else {
+                          {{ 'XP.Membership.AllModels' | translate: { Default: 'All models' } }}
+                        }
+                      </div>
+                    </div>
+                    <z-icon zType="deployed_code" class="size-6 text-text-tertiary"></z-icon>
+                  </div>
+                </section>
+
+                <section class="rounded-lg border border-divider-subtle bg-components-panel-bg px-4 py-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="min-w-0">
+                      <div class="text-sm font-semibold text-text-primary">
+                        {{ 'XP.Membership.ModelMultipliers' | translate: { Default: 'Model multipliers' } }}
+                      </div>
+                      <div class="mt-1 text-sm text-text-tertiary">
+                        {{ modelMultiplierCount(plan) | number }}
+                        {{ 'XP.KEY_WORDS.Items' | translate: { Default: 'items' } }}
+                      </div>
+                    </div>
+                    <z-icon zType="tune" class="size-6 text-text-tertiary"></z-icon>
+                  </div>
+                </section>
+
+                <section class="rounded-lg border border-divider-subtle bg-components-panel-bg px-4 py-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="min-w-0">
+                      <div class="text-sm font-semibold text-text-primary">
+                        {{ 'XP.Membership.RateLimits' | translate: { Default: 'Rate limits' } }}
+                      </div>
+                      <div class="mt-1 text-sm text-text-tertiary">
+                        {{ rateLimitCount(plan) | number }}
+                        {{ 'XP.KEY_WORDS.Items' | translate: { Default: 'items' } }}
+                      </div>
+                    </div>
+                    <z-icon zType="activity" class="size-6 text-text-tertiary"></z-icon>
+                  </div>
+                </section>
+              </div>
+
+              <section class="overflow-hidden rounded-lg border border-divider-subtle">
+                <div
+                  class="flex flex-col gap-3 border-b border-divider-subtle px-4 py-3 md:flex-row md:items-center md:justify-between"
+                >
+                  <div>
+                    <div class="text-sm font-semibold text-text-primary">
+                      {{ 'XP.Membership.AssignedUsers' | translate: { Default: 'Assigned users' } }}
+                    </div>
+                    <div class="mt-1 text-xs text-text-tertiary">
+                      {{
+                        'XP.Membership.AssignedUsersHint'
+                          | translate: { Default: 'Active and paused users currently assigned to this plan.' }
+                      }}
+                    </div>
+                  </div>
+
+                  @if (planMembers().length && migrationTargets().length) {
+                    <div class="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center">
+                      <z-select
+                        class="w-full min-w-56"
+                        [zValue]="migrationTargetPlanId"
+                        (zSelectionChange)="setMigrationTarget($event)"
+                      >
+                        @for (target of migrationTargets(); track target.id) {
+                          <z-select-item [zValue]="target.id">{{ target.name }}</z-select-item>
+                        }
+                      </z-select>
+                      <button
+                        z-button
+                        zType="outline"
+                        type="button"
+                        [disabled]="loading() || !migrationTargetPlanId"
+                        (click)="reassignMembers(plan)"
+                      >
+                        {{ 'XP.Membership.ReassignUsers' | translate: { Default: 'Reassign users' } }}
+                      </button>
+                    </div>
                   }
                 </div>
 
-                <div class="flex shrink-0 items-center gap-1">
-                  <button
-                    z-button
-                    zType="secondary"
-                    zSize="sm"
-                    type="button"
-                    (click)="$event.stopPropagation(); edit(plan)"
-                  >
-                    <z-icon zType="edit"></z-icon>
-                    {{ 'XP.ACTIONS.Edit' | translate: { Default: 'Edit' } }}
-                  </button>
-                  @if (plan.status === MembershipPlanStatusEnum.Archived) {
-                    <button
-                      z-button
-                      zType="destructive"
-                      zSize="sm"
-                      type="button"
-                      (click)="$event.stopPropagation(); deletePlan(plan)"
-                    >
-                      <z-icon zType="delete"></z-icon>
-                      {{ 'XP.ACTIONS.Delete' | translate: { Default: 'Delete' } }}
-                    </button>
-                  } @else {
-                    <button
-                      z-button
-                      zType="outline"
-                      zSize="sm"
-                      type="button"
-                      [disabled]="plan.isDefault"
-                      (click)="$event.stopPropagation(); archive(plan)"
-                    >
-                      <z-icon zType="archive"></z-icon>
-                      {{ 'XP.Membership.ArchivePlan' | translate: { Default: 'Archive' } }}
-                    </button>
+                <div class="divide-y divide-divider-subtle">
+                  @for (member of planMembers(); track member.id) {
+                    <div class="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div class="min-w-0">
+                        <div class="truncate text-sm font-medium text-text-primary" [title]="memberLabel(member)">
+                          {{ memberLabel(member) }}
+                        </div>
+                        @if (member.user?.email) {
+                          <div class="truncate text-xs text-text-tertiary">{{ member.user.email }}</div>
+                        }
+                      </div>
+                      <div class="flex shrink-0 items-center gap-2 text-xs text-text-tertiary">
+                        <z-badge zType="outline" zShape="pill">
+                          {{ 'XP.Membership.MemberStatuses.' + member.status | translate: { Default: member.status } }}
+                        </z-badge>
+                        <span>{{ member.currentPeriodEnd | date: 'mediumDate' }}</span>
+                      </div>
+                    </div>
+                  } @empty {
+                    <div class="px-4 py-8 text-center text-sm text-text-tertiary">
+                      @if (planMembersLoading()) {
+                        {{ 'XP.KEY_WORDS.Loading' | translate: { Default: 'Loading...' } }}
+                      } @else {
+                        {{
+                          'XP.Membership.NoAssignedUsers'
+                            | translate: { Default: 'No users are assigned to this plan.' }
+                        }}
+                      }
+                    </div>
                   }
                 </div>
-              </div>
-            </div>
-          } @empty {
-            <div
-              class="flex min-h-52 flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-divider-regular bg-components-panel-bg px-4 py-10 text-center"
-            >
+                @if (planMemberCount() > planMemberPageSize()) {
+                  <z-paginator
+                    class="border-t border-divider-subtle px-2 py-1"
+                    displayDensity="compact"
+                    [disabled]="planMembersLoading()"
+                    [hidePageSizeLabel]="true"
+                    [length]="planMemberCount()"
+                    [pageIndex]="planMemberPageIndex()"
+                    [pageSize]="planMemberPageSize()"
+                    [pageSizeOptions]="[10, 20, 50, 100]"
+                    [showFirstLastButtons]="true"
+                    (page)="onPlanMemberPage($event)"
+                  />
+                }
+              </section>
+            </z-card-content>
+          </z-card>
+        } @else {
+          <z-card
+            class="overflow-hidden border border-dashed border-divider-regular bg-components-panel-bg shadow-none"
+          >
+            <z-card-content class="flex min-h-96 flex-col items-center justify-center gap-3 px-6 py-16 text-center">
               <span
                 class="flex size-12 items-center justify-center rounded-xl bg-components-card-bg text-text-tertiary"
               >
                 <z-icon zType="credit-card"></z-icon>
               </span>
-              <div class="text-sm font-semibold text-text-primary">
-                {{ 'XP.Membership.NoPlans' | translate: { Default: 'No membership plans yet.' } }}
+              <div class="text-lg font-semibold text-text-primary">
+                {{ 'XP.Membership.NoPlanSelected' | translate: { Default: 'No plan selected' } }}
+              </div>
+              <div class="max-w-md text-sm text-text-tertiary">
+                {{
+                  'XP.Membership.SelectPlanHint'
+                    | translate: { Default: 'Create a plan or select one from the catalog to manage it.' }
+                }}
               </div>
               <button z-button zType="default" type="button" (click)="create()">
                 <z-icon zType="add"></z-icon>
                 {{ 'XP.Membership.NewPlan' | translate: { Default: 'New plan' } }}
               </button>
-            </div>
-          }
-        </div>
-      </z-card-content>
-    </z-card>
-
-    <div class="min-w-0 xl:col-span-8">
-      @if (editing()) {
-        <form [formGroup]="planForm" (ngSubmit)="save()">
-          <z-card class="overflow-hidden border border-divider-regular bg-components-card-bg shadow-none">
-            <z-card-header class="items-center border-b border-divider-regular py-5">
-              <div class="flex w-full flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                <div class="min-w-0">
-                  <z-card-title>
-                    {{
-                      (draft.id ? 'XP.Membership.EditPlan' : 'XP.Membership.CreatePlan')
-                        | translate: { Default: draft.id ? 'Edit plan' : 'Create plan' }
-                    }}
-                  </z-card-title>
-                  <z-card-subtitle class="mt-1">
-                    {{
-                      'XP.Membership.PlanFormHint'
-                        | translate: { Default: 'Define the allowance, exchange rate, and optional model rules.' }
-                    }}
-                  </z-card-subtitle>
-                </div>
-
-                <div class="flex shrink-0 items-center gap-2">
-                  <button z-button zType="secondary" type="button" [disabled]="loading()" (click)="cancel()">
-                    {{ 'XP.ACTIONS.Cancel' | translate: { Default: 'Cancel' } }}
-                  </button>
-                  <button z-button zType="default" type="submit" [disabled]="loading() || planForm.invalid">
-                    <z-icon zType="save"></z-icon>
-                    {{ 'XP.ACTIONS.Save' | translate: { Default: 'Save' } }}
-                  </button>
-                </div>
-              </div>
-            </z-card-header>
-
-            <z-card-content class="space-y-5 p-4">
-              <section class="rounded-lg bg-components-panel-bg p-4">
-                <div class="mb-3 text-sm font-semibold text-text-primary">
-                  {{ 'XP.Membership.PlanIdentity' | translate: { Default: 'Plan identity' } }}
-                </div>
-
-                <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-                  <z-form-field class="w-full">
-                    <z-form-label>{{ 'XP.Membership.Code' | translate: { Default: 'Code' } }}</z-form-label>
-                    <input z-input formControlName="code" />
-                  </z-form-field>
-
-                  <z-form-field class="w-full">
-                    <z-form-label>{{ 'XP.Membership.Name' | translate: { Default: 'Name' } }}</z-form-label>
-                    <input z-input formControlName="name" />
-                  </z-form-field>
-
-                  <z-form-field class="w-full">
-                    <z-form-label>{{ 'XP.Membership.Level' | translate: { Default: 'Level' } }}</z-form-label>
-                    <input
-                      z-input
-                      type="number"
-                      min="0"
-                      step="1"
-                      formControlName="level"
-                      [zStatus]="
-                        planForm.controls.level.invalid && planForm.controls.level.touched ? 'error' : undefined
-                      "
-                    />
-                    @if (planForm.controls.level.invalid && planForm.controls.level.touched) {
-                      <z-form-message zType="error">
-                        {{
-                          'XP.Membership.LevelValidation'
-                            | translate: { Default: 'Level must be a whole number of zero or greater.' }
-                        }}
-                      </z-form-message>
-                    }
-                  </z-form-field>
-
-                  <z-form-field class="w-full">
-                    <z-form-label>{{ 'XP.Membership.Status' | translate: { Default: 'Status' } }}</z-form-label>
-                    <z-select class="w-full" formControlName="status" (zSelectionChange)="setDraftStatus($event)">
-                      <z-select-item [zValue]="MembershipPlanStatusEnum.Active">
-                        {{ 'XP.Membership.Statuses.active' | translate: { Default: 'Active' } }}
-                      </z-select-item>
-                      <z-select-item [zValue]="MembershipPlanStatusEnum.Archived">
-                        {{ 'XP.Membership.Statuses.archived' | translate: { Default: 'Archived' } }}
-                      </z-select-item>
-                    </z-select>
-                  </z-form-field>
-
-                  <div class="flex items-end">
-                    <z-checkbox
-                      class="min-h-9 items-center"
-                      displayDensity="cosy"
-                      formControlName="isDefault"
-                      [zDisabled]="planForm.controls.status.value === MembershipPlanStatusEnum.Archived"
-                      (checkChange)="setDraftDefault($event)"
-                    >
-                      {{ 'XP.Membership.SetDefaultPlan' | translate: { Default: 'Set as default plan' } }}
-                    </z-checkbox>
-                  </div>
-                </div>
-              </section>
-
-              <section class="rounded-lg bg-components-panel-bg p-4">
-                <div class="mb-3 text-sm font-semibold text-text-primary">
-                  {{ 'XP.Membership.PointRules' | translate: { Default: 'Point rules' } }}
-                </div>
-
-                <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-                  <z-form-field class="w-full">
-                    <z-form-label>
-                      {{ 'XP.Membership.PointsPerPeriod' | translate: { Default: 'Points per period' } }}
-                    </z-form-label>
-                    <input
-                      z-input
-                      type="number"
-                      min="0"
-                      formControlName="includedPoints"
-                      [disabled]="planForm.controls.unlimited.value"
-                    />
-                    <z-checkbox
-                      class="mt-1 min-h-8 items-center"
-                      displayDensity="cosy"
-                      formControlName="unlimited"
-                      (checkChange)="setDraftUnlimited($event)"
-                    >
-                      {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
-                    </z-checkbox>
-                  </z-form-field>
-
-                  <z-form-field class="w-full">
-                    <z-form-label>
-                      {{ 'XP.Membership.PriceAmount' | translate: { Default: 'Display price' } }}
-                    </z-form-label>
-                    <input z-input type="number" min="0" formControlName="priceAmount" />
-                  </z-form-field>
-
-                  <z-form-field class="w-full">
-                    <z-form-label [zRequired]="true">
-                      {{ 'XP.Membership.PriceCurrency' | translate: { Default: 'Currency' } }}
-                    </z-form-label>
-                    <input
-                      z-input
-                      maxlength="12"
-                      formControlName="priceCurrency"
-                      [zStatus]="
-                        planForm.controls.priceCurrency.invalid && planForm.controls.priceCurrency.touched
-                          ? 'error'
-                          : undefined
-                      "
-                    />
-                    @if (planForm.controls.priceCurrency.invalid && planForm.controls.priceCurrency.touched) {
-                      <z-form-message zType="error">
-                        {{
-                          'XP.Membership.PriceCurrencyValidation'
-                            | translate: { Default: 'Enter a currency code of up to 12 characters.' }
-                        }}
-                      </z-form-message>
-                    }
-                  </z-form-field>
-                </div>
-              </section>
-
-              <section class="rounded-lg bg-components-panel-bg p-4">
-                <div class="mb-3 text-sm font-semibold text-text-primary">
-                  {{ 'XP.Membership.Description' | translate: { Default: 'Description' } }}
-                </div>
-                <z-form-field class="w-full">
-                  <textarea z-input class="min-h-24 resize-y" formControlName="description"></textarea>
-                </z-form-field>
-              </section>
-
-              <section class="rounded-lg bg-components-panel-bg p-4">
-                <div class="mb-1 text-sm font-semibold text-text-primary">
-                  {{ 'XP.Membership.ModelUsageRules' | translate: { Default: 'Model access and usage rules' } }}
-                </div>
-                <div class="mb-4 text-xs text-text-tertiary">
-                  {{
-                    'XP.Membership.ModelUsageRulesHint'
-                      | translate
-                        : {
-                            Default:
-                              'Choose available models and optionally customize point multipliers and usage limits.'
-                          }
-                  }}
-                </div>
-
-                <div class="space-y-5">
-                  <div class="rounded-lg border border-divider-subtle bg-components-card-bg p-4">
-                    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                      <div>
-                        <div class="text-sm font-medium text-text-primary">
-                          {{ 'XP.Membership.AllowedModels' | translate: { Default: 'Allowed models' } }}
-                        </div>
-                        <div class="mt-1 text-xs text-text-tertiary">
-                          {{
-                            'XP.Membership.AllowedModelsHint'
-                              | translate: { Default: 'Choose which models members of this plan can use.' }
-                          }}
-                        </div>
-                      </div>
-                      <z-checkbox
-                        class="min-h-8 shrink-0 items-center"
-                        displayDensity="cosy"
-                        formControlName="allowAllModels"
-                        (checkChange)="setAllowAllModels($event)"
-                      >
-                        {{ 'XP.Membership.AllowAllModels' | translate: { Default: 'Allow all models' } }}
-                      </z-checkbox>
-                    </div>
-
-                    @if (!planForm.controls.allowAllModels.value) {
-                      <div class="mt-4">
-                        <z-select
-                          class="w-full"
-                          [zMultiple]="true"
-                          [zMaxLabelCount]="3"
-                          [zValue]="allowedModelValues()"
-                          [zPlaceholder]="
-                            'XP.Membership.SelectModels' | translate: { Default: 'Select allowed models' }
-                          "
-                          (zSelectionChange)="setAllowedModelValues($event)"
-                        >
-                          @for (option of modelOptions(); track option.value) {
-                            <z-select-item [zValue]="option.value">{{ modelTargetLabel(option) }}</z-select-item>
-                          }
-                        </z-select>
-                        @if (!modelOptions().length) {
-                          <div class="mt-2 text-xs text-text-tertiary">
-                            {{
-                              'XP.Membership.NoModelsAvailable'
-                                | translate: { Default: 'No configured Copilot models are available in this scope.' }
-                            }}
-                          </div>
-                        }
-                      </div>
-                    }
-                  </div>
-
-                  <div class="rounded-lg border border-divider-subtle bg-components-card-bg p-4">
-                    <div class="flex items-start justify-between gap-3">
-                      <div>
-                        <div class="text-sm font-medium text-text-primary">
-                          {{ 'XP.Membership.ModelMultipliers' | translate: { Default: 'Model multipliers' } }}
-                        </div>
-                        <div class="mt-1 text-xs text-text-tertiary">
-                          {{
-                            'XP.Membership.ModelMultipliersHint'
-                              | translate
-                                : {
-                                    Default:
-                                      'Adjust how many points selected models consume. The default multiplier is 1.'
-                                  }
-                          }}
-                        </div>
-                      </div>
-                      <button z-button zType="outline" zSize="sm" type="button" (click)="addModelMultiplier()">
-                        <z-icon zType="add"></z-icon>
-                        {{ 'XP.ACTIONS.ADD' | translate: { Default: 'Add' } }}
-                      </button>
-                    </div>
-
-                    @if (modelMultipliers.length) {
-                      <div class="mt-4 space-y-3">
-                        @for (rule of modelMultipliers; track $index) {
-                          <div
-                            class="grid grid-cols-1 items-end gap-3 rounded-lg bg-components-panel-bg p-3 md:grid-cols-[minmax(0,1fr)_10rem_auto]"
-                          >
-                            <label class="flex min-w-0 flex-col gap-1">
-                              <span class="text-xs text-text-tertiary">
-                                {{ 'XP.Membership.ModelScope' | translate: { Default: 'Model scope' } }}
-                              </span>
-                              <z-select
-                                class="w-full"
-                                [zValue]="modelMultiplierTargetValue(rule)"
-                                (zSelectionChange)="setModelMultiplierTarget($index, $event)"
-                              >
-                                <z-select-item [zValue]="globalModelTargetValue">
-                                  {{ 'XP.Membership.AllModels' | translate: { Default: 'All models' } }}
-                                </z-select-item>
-                                @for (option of modelOptions(); track option.value) {
-                                  <z-select-item [zValue]="option.value">{{ modelTargetLabel(option) }}</z-select-item>
-                                }
-                              </z-select>
-                            </label>
-
-                            <label class="flex flex-col gap-1">
-                              <span class="text-xs text-text-tertiary">
-                                {{ 'XP.Membership.Multiplier' | translate: { Default: 'Multiplier' } }}
-                              </span>
-                              <input
-                                z-input
-                                type="number"
-                                min="0"
-                                step="0.1"
-                                [attr.value]="rule.multiplier"
-                                (input)="setModelMultiplierValue($index, $event)"
-                              />
-                            </label>
-
-                            <button
-                              z-button
-                              zType="ghost"
-                              zSize="icon"
-                              zShape="circle"
-                              type="button"
-                              class="text-text-tertiary hover:text-text-destructive"
-                              [attr.aria-label]="'XP.ACTIONS.DELETE' | translate: { Default: 'Delete' }"
-                              (click)="removeModelMultiplier($index)"
-                            >
-                              <z-icon zType="delete"></z-icon>
-                            </button>
-                          </div>
-                        }
-                      </div>
-                    } @else {
-                      <div
-                        class="mt-4 rounded-lg border border-dashed border-divider-regular px-4 py-5 text-center text-sm text-text-tertiary"
-                      >
-                        {{
-                          'XP.Membership.NoModelMultipliers'
-                            | translate: { Default: 'No custom multipliers. All models use a multiplier of 1.' }
-                        }}
-                      </div>
-                    }
-                  </div>
-
-                  <div class="rounded-lg border border-divider-subtle bg-components-card-bg p-4">
-                    <div class="flex items-start justify-between gap-3">
-                      <div>
-                        <div class="text-sm font-medium text-text-primary">
-                          {{ 'XP.Membership.RateLimits' | translate: { Default: 'Usage limits' } }}
-                        </div>
-                        <div class="mt-1 text-xs text-text-tertiary">
-                          {{
-                            'XP.Membership.RateLimitsHint'
-                              | translate
-                                : { Default: 'Limit the number of points members can consume within a period.' }
-                          }}
-                        </div>
-                      </div>
-                      <button z-button zType="outline" zSize="sm" type="button" (click)="addRateLimit()">
-                        <z-icon zType="add"></z-icon>
-                        {{ 'XP.ACTIONS.ADD' | translate: { Default: 'Add' } }}
-                      </button>
-                    </div>
-
-                    @if (rateLimits.length) {
-                      <div class="mt-4 space-y-3">
-                        @for (rule of rateLimits; track $index) {
-                          <div
-                            class="grid grid-cols-1 items-end gap-3 rounded-lg bg-components-panel-bg p-3 md:grid-cols-[minmax(0,1fr)_9rem_10rem_auto]"
-                          >
-                            <label class="flex min-w-0 flex-col gap-1">
-                              <span class="text-xs text-text-tertiary">
-                                {{ 'XP.Membership.ModelScope' | translate: { Default: 'Model scope' } }}
-                              </span>
-                              <z-select
-                                class="w-full"
-                                [zValue]="rateLimitTargetValue(rule)"
-                                (zSelectionChange)="setRateLimitTarget($index, $event)"
-                              >
-                                <z-select-item [zValue]="globalModelTargetValue">
-                                  {{ 'XP.Membership.AllModels' | translate: { Default: 'All models' } }}
-                                </z-select-item>
-                                @for (option of modelOptions(); track option.value) {
-                                  <z-select-item [zValue]="option.value">{{ modelTargetLabel(option) }}</z-select-item>
-                                }
-                              </z-select>
-                            </label>
-
-                            <label class="flex flex-col gap-1">
-                              <span class="text-xs text-text-tertiary">
-                                {{ 'XP.Membership.Period' | translate: { Default: 'Period' } }}
-                              </span>
-                              <z-select
-                                class="w-full"
-                                [zValue]="rule.period"
-                                (zSelectionChange)="setRateLimitPeriod($index, $event)"
-                              >
-                                @for (period of rateLimitPeriods; track period) {
-                                  <z-select-item [zValue]="period">
-                                    {{ 'XP.Membership.RateLimitPeriods.' + period | translate: { Default: period } }}
-                                  </z-select-item>
-                                }
-                              </z-select>
-                            </label>
-
-                            <label class="flex flex-col gap-1">
-                              <span class="text-xs text-text-tertiary">
-                                {{ 'XP.Membership.PointLimit' | translate: { Default: 'Point limit' } }}
-                              </span>
-                              <input
-                                z-input
-                                type="number"
-                                min="1"
-                                step="1"
-                                [attr.value]="rule.pointLimit"
-                                (input)="setRateLimitValue($index, $event)"
-                              />
-                            </label>
-
-                            <button
-                              z-button
-                              zType="ghost"
-                              zSize="icon"
-                              zShape="circle"
-                              type="button"
-                              class="text-text-tertiary hover:text-text-destructive"
-                              [attr.aria-label]="'XP.ACTIONS.DELETE' | translate: { Default: 'Delete' }"
-                              (click)="removeRateLimit($index)"
-                            >
-                              <z-icon zType="delete"></z-icon>
-                            </button>
-                          </div>
-                        }
-                      </div>
-                    } @else {
-                      <div
-                        class="mt-4 rounded-lg border border-dashed border-divider-regular px-4 py-5 text-center text-sm text-text-tertiary"
-                      >
-                        {{ 'XP.Membership.NoRateLimits' | translate: { Default: 'No additional usage limits.' } }}
-                      </div>
-                    }
-                  </div>
-                </div>
-              </section>
             </z-card-content>
           </z-card>
-        </form>
-      } @else if (selectedPlan(); as plan) {
-        <z-card class="overflow-hidden border border-divider-regular bg-components-card-bg shadow-none">
-          <z-card-header class="items-center border-b border-divider-regular py-5">
-            <div class="flex w-full flex-col gap-3 md:flex-row md:items-start md:justify-between">
-              <div class="min-w-0">
-                <div class="flex flex-wrap items-center gap-2">
-                  <z-card-title class="truncate text-2xl">{{ plan.name }}</z-card-title>
-                  @if (plan.isDefault) {
-                    <z-badge zType="secondary" zShape="pill">
-                      {{ 'XP.Membership.DefaultPlan' | translate: { Default: 'Default' } }}
-                    </z-badge>
-                  }
-                </div>
-                <z-card-subtitle class="mt-2 font-mono">{{ plan.code }}</z-card-subtitle>
-              </div>
-
-              <div class="flex shrink-0 items-center gap-2">
-                <button z-button zType="secondary" type="button" (click)="edit(plan)">
-                  <z-icon zType="edit"></z-icon>
-                  {{ 'XP.ACTIONS.Edit' | translate: { Default: 'Edit' } }}
-                </button>
-                @if (plan.status === MembershipPlanStatusEnum.Archived) {
-                  <button z-button zType="destructive" type="button" (click)="deletePlan(plan)">
-                    <z-icon zType="delete"></z-icon>
-                    {{ 'XP.ACTIONS.Delete' | translate: { Default: 'Delete' } }}
-                  </button>
-                } @else {
-                  <button z-button zType="outline" type="button" [disabled]="plan.isDefault" (click)="archive(plan)">
-                    <z-icon zType="archive"></z-icon>
-                    {{ 'XP.Membership.ArchivePlan' | translate: { Default: 'Archive' } }}
-                  </button>
-                }
-              </div>
-            </div>
-          </z-card-header>
-
-          <z-card-content class="space-y-5 p-4">
-            <div class="grid grid-cols-1 gap-3 md:grid-cols-4">
-              <div class="rounded-lg bg-components-panel-bg px-4 py-3">
-                <div class="text-xs font-medium text-text-tertiary">
-                  {{ 'XP.Membership.Level' | translate: { Default: 'Level' } }}
-                </div>
-                <div class="mt-1 text-xl font-semibold text-text-primary">{{ plan.level }}</div>
-              </div>
-
-              <div class="rounded-lg bg-components-panel-bg px-4 py-3">
-                <div class="text-xs font-medium text-text-tertiary">
-                  {{ 'XP.Membership.Status' | translate: { Default: 'Status' } }}
-                </div>
-                <div class="mt-2">
-                  <z-badge
-                    zType="outline"
-                    zShape="pill"
-                    [class]="
-                      plan.status === MembershipPlanStatusEnum.Active
-                        ? 'border-state-success-hover bg-state-success-hover/20 text-text-success'
-                        : 'border-divider-regular text-text-tertiary'
-                    "
-                  >
-                    {{ 'XP.Membership.Statuses.' + plan.status | translate: { Default: plan.status } }}
-                  </z-badge>
-                </div>
-              </div>
-
-              <div class="rounded-lg bg-components-panel-bg px-4 py-3">
-                <div class="text-xs font-medium text-text-tertiary">
-                  {{ 'XP.Membership.PointsPerPeriod' | translate: { Default: 'Points per period' } }}
-                </div>
-                <div class="mt-1 text-xl font-semibold text-text-primary">
-                  @if (plan.includedPoints === null) {
-                    {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
-                  } @else {
-                    {{ plan.includedPoints | number }}
-                  }
-                </div>
-              </div>
-
-              <div class="rounded-lg bg-components-panel-bg px-4 py-3">
-                <div class="text-xs font-medium text-text-tertiary">
-                  {{ 'XP.Membership.Price' | translate: { Default: 'Price' } }}
-                </div>
-                <div class="mt-1 text-xl font-semibold text-text-primary">
-                  @if (plan.priceAmount !== null && plan.priceAmount !== undefined) {
-                    {{ plan.priceAmount | currency: plan.priceCurrency || 'CNY' : 'symbol-narrow' }}
-                  } @else {
-                    <span class="text-base font-medium text-text-tertiary">
-                      {{ 'XP.KEY_WORDS.None' | translate: { Default: 'None' } }}
-                    </span>
-                  }
-                </div>
-              </div>
-            </div>
-
-            @if (plan.description) {
-              <section class="rounded-lg border border-divider-subtle px-4 py-3">
-                <div class="text-xs font-medium text-text-tertiary">
-                  {{ 'XP.Membership.Description' | translate: { Default: 'Description' } }}
-                </div>
-                <div class="mt-2 whitespace-pre-wrap text-sm leading-6 text-text-primary">{{ plan.description }}</div>
-              </section>
-            }
-
-            <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
-              <section class="rounded-lg border border-divider-subtle px-4 py-3">
-                <div class="flex items-center justify-between gap-3">
-                  <div class="min-w-0">
-                    <div class="text-sm font-semibold text-text-primary">
-                      {{ 'XP.Membership.AllowedModels' | translate: { Default: 'Allowed models' } }}
-                    </div>
-                    <div class="mt-1 text-sm text-text-tertiary">
-                      @if (allowedModelCount(plan)) {
-                        {{ allowedModelCount(plan) | number }}
-                        {{ 'XP.KEY_WORDS.Items' | translate: { Default: 'items' } }}
-                      } @else {
-                        {{ 'XP.Membership.AllModels' | translate: { Default: 'All models' } }}
-                      }
-                    </div>
-                  </div>
-                  <z-icon zType="deployed_code" class="size-6 text-text-tertiary"></z-icon>
-                </div>
-              </section>
-
-              <section class="rounded-lg border border-divider-subtle px-4 py-3">
-                <div class="flex items-center justify-between gap-3">
-                  <div class="min-w-0">
-                    <div class="text-sm font-semibold text-text-primary">
-                      {{ 'XP.Membership.ModelMultipliers' | translate: { Default: 'Model multipliers' } }}
-                    </div>
-                    <div class="mt-1 text-sm text-text-tertiary">
-                      {{ modelMultiplierCount(plan) | number }}
-                      {{ 'XP.KEY_WORDS.Items' | translate: { Default: 'items' } }}
-                    </div>
-                  </div>
-                  <z-icon zType="tune" class="size-6 text-text-tertiary"></z-icon>
-                </div>
-              </section>
-
-              <section class="rounded-lg border border-divider-subtle px-4 py-3">
-                <div class="flex items-center justify-between gap-3">
-                  <div class="min-w-0">
-                    <div class="text-sm font-semibold text-text-primary">
-                      {{ 'XP.Membership.RateLimits' | translate: { Default: 'Rate limits' } }}
-                    </div>
-                    <div class="mt-1 text-sm text-text-tertiary">
-                      {{ rateLimitCount(plan) | number }}
-                      {{ 'XP.KEY_WORDS.Items' | translate: { Default: 'items' } }}
-                    </div>
-                  </div>
-                  <z-icon zType="activity" class="size-6 text-text-tertiary"></z-icon>
-                </div>
-              </section>
-            </div>
-
-            <section class="overflow-hidden rounded-lg border border-divider-subtle">
-              <div
-                class="flex flex-col gap-3 border-b border-divider-subtle px-4 py-3 md:flex-row md:items-center md:justify-between"
-              >
-                <div>
-                  <div class="text-sm font-semibold text-text-primary">
-                    {{ 'XP.Membership.AssignedUsers' | translate: { Default: 'Assigned users' } }}
-                  </div>
-                  <div class="mt-1 text-xs text-text-tertiary">
-                    {{
-                      'XP.Membership.AssignedUsersHint'
-                        | translate: { Default: 'Active and paused users currently assigned to this plan.' }
-                    }}
-                  </div>
-                </div>
-
-                @if (planMembers().length && migrationTargets().length) {
-                  <div class="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center">
-                    <z-select
-                      class="w-full min-w-56"
-                      [zValue]="migrationTargetPlanId"
-                      (zSelectionChange)="setMigrationTarget($event)"
-                    >
-                      @for (target of migrationTargets(); track target.id) {
-                        <z-select-item [zValue]="target.id">{{ target.name }}</z-select-item>
-                      }
-                    </z-select>
-                    <button
-                      z-button
-                      zType="outline"
-                      type="button"
-                      [disabled]="loading() || !migrationTargetPlanId"
-                      (click)="reassignMembers(plan)"
-                    >
-                      {{ 'XP.Membership.ReassignUsers' | translate: { Default: 'Reassign users' } }}
-                    </button>
-                  </div>
-                }
-              </div>
-
-              <div class="divide-y divide-divider-subtle">
-                @for (member of planMembers(); track member.id) {
-                  <div class="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div class="min-w-0">
-                      <div class="truncate text-sm font-medium text-text-primary" [title]="memberLabel(member)">
-                        {{ memberLabel(member) }}
-                      </div>
-                      @if (member.user?.email) {
-                        <div class="truncate text-xs text-text-tertiary">{{ member.user.email }}</div>
-                      }
-                    </div>
-                    <div class="flex shrink-0 items-center gap-2 text-xs text-text-tertiary">
-                      <z-badge zType="outline" zShape="pill">
-                        {{ 'XP.Membership.MemberStatuses.' + member.status | translate: { Default: member.status } }}
-                      </z-badge>
-                      <span>{{ member.currentPeriodEnd | date: 'mediumDate' }}</span>
-                    </div>
-                  </div>
-                } @empty {
-                  <div class="px-4 py-8 text-center text-sm text-text-tertiary">
-                    @if (planMembersLoading()) {
-                      {{ 'XP.KEY_WORDS.Loading' | translate: { Default: 'Loading...' } }}
-                    } @else {
-                      {{
-                        'XP.Membership.NoAssignedUsers' | translate: { Default: 'No users are assigned to this plan.' }
-                      }}
-                    }
-                  </div>
-                }
-              </div>
-              @if (planMemberCount() > planMemberPageSize()) {
-                <z-paginator
-                  class="border-t border-divider-subtle px-2 py-1"
-                  displayDensity="compact"
-                  [disabled]="planMembersLoading()"
-                  [hidePageSizeLabel]="true"
-                  [length]="planMemberCount()"
-                  [pageIndex]="planMemberPageIndex()"
-                  [pageSize]="planMemberPageSize()"
-                  [pageSizeOptions]="[10, 20, 50, 100]"
-                  [showFirstLastButtons]="true"
-                  (page)="onPlanMemberPage($event)"
-                />
-              }
-            </section>
-          </z-card-content>
-        </z-card>
-      } @else {
-        <z-card class="overflow-hidden border border-dashed border-divider-regular bg-components-panel-bg shadow-none">
-          <z-card-content class="flex min-h-96 flex-col items-center justify-center gap-3 px-6 py-16 text-center">
-            <span class="flex size-12 items-center justify-center rounded-xl bg-components-card-bg text-text-tertiary">
-              <z-icon zType="credit-card"></z-icon>
-            </span>
-            <div class="text-lg font-semibold text-text-primary">
-              {{ 'XP.Membership.NoPlanSelected' | translate: { Default: 'No plan selected' } }}
-            </div>
-            <div class="max-w-md text-sm text-text-tertiary">
-              {{
-                'XP.Membership.SelectPlanHint'
-                  | translate: { Default: 'Create a plan or select one from the catalog to manage it.' }
-              }}
-            </div>
-            <button z-button zType="default" type="button" (click)="create()">
-              <z-icon zType="add"></z-icon>
-              {{ 'XP.Membership.NewPlan' | translate: { Default: 'New plan' } }}
-            </button>
-          </z-card-content>
-        </z-card>
-      }
-    </div>
-  </div>
-
-  <z-card class="shrink-0 overflow-hidden border border-divider-regular bg-components-card-bg shadow-none">
-    <z-card-header class="border-b border-divider-regular py-4">
-      <div>
-        <z-card-title>{{ 'XP.Membership.UserManagement' | translate: { Default: 'User memberships' } }}</z-card-title>
-        <div class="mt-1 text-sm text-text-tertiary">
-          {{
-            'XP.Membership.UserManagementHint'
-              | translate
-                : {
-                    Default:
-                      'View every user in the current scope, including users without a membership, and apply common actions in batches.'
-                  }
-          }}
-        </div>
+        }
       </div>
-    </z-card-header>
-
-    <z-card-content class="flex flex-col gap-4 p-4">
-      <form
-        [formGroup]="memberFilterForm"
-        class="grid gap-3 rounded-lg bg-components-panel-bg p-4 md:grid-cols-2 xl:grid-cols-[minmax(14rem,1fr)_minmax(9rem,1fr)_minmax(10rem,1fr)_minmax(12rem,1fr)]"
-        (ngSubmit)="applyMemberFilters()"
-      >
-        <z-form-field class="w-full">
-          <z-form-label>{{ 'XP.Membership.SearchUsers' | translate: { Default: 'Search users' } }}</z-form-label>
-          <input
-            z-input
-            formControlName="search"
-            [placeholder]="'XP.Membership.SearchUsersPlaceholder' | translate: { Default: 'Name, username, or email' }"
-          />
-        </z-form-field>
-        <z-form-field class="w-full">
-          <z-form-label>{{ 'XP.Membership.Status' | translate: { Default: 'Status' } }}</z-form-label>
-          <z-select class="w-full" formControlName="status" (zSelectionChange)="setMemberStatusFilter($event)">
-            <z-select-item zValue="">
-              {{ 'XP.KEY_WORDS.All' | translate: { Default: 'All' } }}
-            </z-select-item>
-            @for (
-              status of [
-                MembershipAdminUserStatusEnum.Active,
-                MembershipAdminUserStatusEnum.Paused,
-                MembershipAdminUserStatusEnum.Expired,
-                MembershipAdminUserStatusEnum.Unassigned
-              ];
-              track status
-            ) {
-              <z-select-item [zValue]="status">
-                {{ 'XP.Membership.MemberStatuses.' + status | translate: { Default: status } }}
-              </z-select-item>
-            }
-          </z-select>
-        </z-form-field>
-        <z-form-field class="w-full">
-          <z-form-label>{{ 'XP.Membership.Plan' | translate: { Default: 'Plan' } }}</z-form-label>
-          <z-select class="w-full" formControlName="planId">
-            <z-select-item zValue="">
-              {{ 'XP.KEY_WORDS.All' | translate: { Default: 'All' } }}
-            </z-select-item>
-            @for (plan of plans(); track plan.id) {
-              <z-select-item [zValue]="plan.id">{{ plan.name }}</z-select-item>
-            }
-          </z-select>
-        </z-form-field>
-        <z-form-field class="w-full min-w-0">
-          <z-form-label>
-            {{ 'XP.Membership.ExpiringBefore' | translate: { Default: 'Expiring before' } }}
-          </z-form-label>
-          <z-date-picker
-            class="w-full min-w-0 [&>button]:min-w-0"
-            zFormat="yyyy-MM-dd"
-            formControlName="expiringBefore"
-          />
-        </z-form-field>
-        <div class="col-span-full flex justify-end gap-2">
-          <button z-button zType="default" type="submit" [disabled]="adminMembersLoading()">
-            {{ 'XP.ACTIONS.Search' | translate: { Default: 'Search' } }}
-          </button>
-          <button
-            z-button
-            zType="outline"
-            type="button"
-            [disabled]="adminMembersLoading()"
-            (click)="resetMemberFilters()"
-          >
-            {{ 'XP.ACTIONS.Reset' | translate: { Default: 'Reset' } }}
-          </button>
-        </div>
-      </form>
-
-      <form
-        [formGroup]="bulkActionForm"
-        class="flex flex-col gap-3 rounded-lg border border-divider-regular p-3 xl:flex-row xl:items-end"
-      >
-        <div class="flex min-w-36 items-center gap-2 self-start pb-2 xl:self-end">
-          <z-checkbox
-            displayDensity="cosy"
-            [ngModel]="allVisibleUsersSelected()"
-            [ngModelOptions]="{ standalone: true }"
-            [indeterminate]="selectedUserCount() > 0 && !allVisibleUsersSelected()"
-            (checkChange)="toggleVisibleUsers($event)"
-          >
+    </div>
+  } @else {
+    <section class="shrink-0 overflow-hidden bg-components-card-bg">
+      <header class="px-1 pb-2 pt-1">
+        <div>
+          <h2 class="text-base font-semibold text-text-primary">
+            {{ 'XP.Membership.UserManagement' | translate: { Default: 'User memberships' } }}
+          </h2>
+          <div class="mt-1 text-sm text-text-tertiary">
             {{
-              'XP.Membership.SelectedUsers'
-                | translate: { count: selectedUserCount(), Default: selectedUserCount() + ' selected' }
+              'XP.Membership.UserManagementHint'
+                | translate
+                  : {
+                      Default:
+                        'View every user in the current scope, including users without a membership, and apply common actions in batches.'
+                    }
             }}
-          </z-checkbox>
+          </div>
         </div>
-        <z-form-field class="w-full xl:w-44">
-          <z-form-label>{{ 'XP.Membership.BulkAction' | translate: { Default: 'Batch action' } }}</z-form-label>
-          <z-select class="w-full" formControlName="action" (zSelectionChange)="setBulkAction($event)">
-            @for (
-              action of [
-                MembershipBulkActionEnum.Assign,
-                MembershipBulkActionEnum.Renew,
-                MembershipBulkActionEnum.Pause,
-                MembershipBulkActionEnum.Resume,
-                MembershipBulkActionEnum.Revoke
-              ];
-              track action
-            ) {
-              <z-select-item [zValue]="action">
-                {{ 'XP.Membership.BulkActions.' + action | translate: { Default: action } }}
+      </header>
+
+      <div class="flex flex-col gap-3 py-2">
+        <form
+          [formGroup]="memberFilterForm"
+          class="grid items-end gap-3 rounded-lg bg-components-panel-bg p-3 md:grid-cols-2 xl:grid-cols-[minmax(14rem,1fr)_minmax(9rem,0.75fr)_minmax(10rem,0.85fr)_minmax(12rem,0.9fr)_auto]"
+          (ngSubmit)="applyMemberFilters()"
+        >
+          <z-form-field class="w-full">
+            <z-form-label>{{ 'XP.Membership.SearchUsers' | translate: { Default: 'Search users' } }}</z-form-label>
+            <input
+              z-input
+              formControlName="search"
+              [placeholder]="
+                'XP.Membership.SearchUsersPlaceholder' | translate: { Default: 'Name, username, or email' }
+              "
+            />
+          </z-form-field>
+          <z-form-field class="w-full">
+            <z-form-label>{{ 'XP.Membership.Status' | translate: { Default: 'Status' } }}</z-form-label>
+            <z-select class="w-full" formControlName="status" (zSelectionChange)="setMemberStatusFilter($event)">
+              <z-select-item zValue="">
+                {{ 'XP.KEY_WORDS.All' | translate: { Default: 'All' } }}
               </z-select-item>
-            }
-          </z-select>
-        </z-form-field>
-        @if (bulkActionRequiresPlan()) {
-          <z-form-field class="w-full xl:w-56">
+              @for (
+                status of [
+                  MembershipAdminUserStatusEnum.Active,
+                  MembershipAdminUserStatusEnum.Paused,
+                  MembershipAdminUserStatusEnum.Expired,
+                  MembershipAdminUserStatusEnum.Unassigned
+                ];
+                track status
+              ) {
+                <z-select-item [zValue]="status">
+                  {{ 'XP.Membership.MemberStatuses.' + status | translate: { Default: status } }}
+                </z-select-item>
+              }
+            </z-select>
+          </z-form-field>
+          <z-form-field class="w-full">
             <z-form-label>{{ 'XP.Membership.Plan' | translate: { Default: 'Plan' } }}</z-form-label>
             <z-select class="w-full" formControlName="planId">
+              <z-select-item zValue="">
+                {{ 'XP.KEY_WORDS.All' | translate: { Default: 'All' } }}
+              </z-select-item>
               @for (plan of plans(); track plan.id) {
-                @if (plan.status === MembershipPlanStatusEnum.Active) {
-                  <z-select-item [zValue]="plan.id">{{ plan.name }}</z-select-item>
-                }
+                <z-select-item [zValue]="plan.id">{{ plan.name }}</z-select-item>
               }
             </z-select>
           </z-form-field>
-          <z-form-field class="w-full xl:w-44">
+          <z-form-field class="w-full min-w-0">
             <z-form-label>
-              {{ 'XP.Membership.RenewalMode' | translate: { Default: 'Renewal mode' } }}
+              {{ 'XP.Membership.ExpiringBefore' | translate: { Default: 'Expiring before' } }}
             </z-form-label>
-            <z-select class="w-full" formControlName="renewalMode">
-              <z-select-item [zValue]="MembershipRenewalModeEnum.Auto">
-                {{ 'XP.Membership.RenewalModes.auto' | translate: { Default: 'Auto renew' } }}
-              </z-select-item>
-              <z-select-item [zValue]="MembershipRenewalModeEnum.Manual">
-                {{ 'XP.Membership.RenewalModes.manual' | translate: { Default: 'Manual renew' } }}
-              </z-select-item>
-            </z-select>
+            <z-date-picker
+              class="w-full min-w-0 [&>button]:min-w-0"
+              zFormat="yyyy-MM-dd"
+              formControlName="expiringBefore"
+            />
           </z-form-field>
-          <z-form-field class="min-w-0 flex-1">
-            <z-form-label>{{ 'XP.Membership.AssignNote' | translate: { Default: 'Assignment note' } }}</z-form-label>
-            <input z-input formControlName="note" />
-          </z-form-field>
-        }
-        <button
-          z-button
-          zType="secondary"
-          type="button"
-          class="shrink-0 xl:mb-3"
-          [disabled]="
-            adminMembersLoading() ||
-            !selectedUserCount() ||
-            (bulkActionRequiresPlan() && !bulkActionForm.controls.planId.value)
-          "
-          (click)="applyBulkAction()"
-        >
-          {{ 'XP.Membership.ApplyBulkAction' | translate: { Default: 'Apply action' } }}
-        </button>
-      </form>
-
-      <div class="overflow-hidden rounded-lg border border-divider-regular">
-        <div
-          class="hidden grid-cols-[2rem_minmax(12rem,1.5fr)_minmax(8rem,1fr)_8rem_9rem_8rem_3rem] gap-3 border-b border-divider-regular bg-components-panel-bg px-4 py-3 text-xs font-medium text-text-tertiary lg:grid"
-        >
-          <span></span>
-          <span>{{ 'XP.Membership.User' | translate: { Default: 'User' } }}</span>
-          <span>{{ 'XP.Membership.Plan' | translate: { Default: 'Plan' } }}</span>
-          <span>{{ 'XP.Membership.Status' | translate: { Default: 'Status' } }}</span>
-          <span>{{ 'XP.Membership.RemainingPoints' | translate: { Default: 'Remaining points' } }}</span>
-          <span>{{ 'XP.Membership.PeriodEnd' | translate: { Default: 'Period end' } }}</span>
-          <span></span>
-        </div>
-
-        <div class="divide-y divide-divider-subtle">
-          @for (member of adminMembers(); track member.user.id) {
-            <div
-              class="grid gap-3 px-4 py-3 lg:grid-cols-[2rem_minmax(12rem,1.5fr)_minmax(8rem,1fr)_8rem_9rem_8rem_3rem] lg:items-center"
+          <div class="flex gap-1 md:col-span-2 xl:col-span-1">
+            <button z-button zType="default" type="submit" [disabled]="adminMembersLoading()">
+              <z-icon zType="search"></z-icon>
+              <span class="sr-only">{{ 'XP.ACTIONS.Search' | translate: { Default: 'Search' } }}</span>
+            </button>
+            <button
+              z-button
+              zType="outline"
+              type="button"
+              [disabled]="adminMembersLoading()"
+              [attr.aria-label]="'XP.ACTIONS.Reset' | translate: { Default: 'Reset' }"
+              [title]="'XP.ACTIONS.Reset' | translate: { Default: 'Reset' }"
+              (click)="resetMemberFilters()"
             >
-              <z-checkbox
-                displayDensity="cosy"
-                [ngModel]="selectedUserIds().has(member.user.id)"
-                [ngModelOptions]="{ standalone: true }"
-                (checkChange)="toggleUserSelection(member.user.id, $event)"
-              ></z-checkbox>
-              <div class="min-w-0">
-                <div class="truncate text-sm font-medium text-text-primary" [title]="adminMemberLabel(member)">
-                  {{ adminMemberLabel(member) }}
-                </div>
-                <div class="truncate text-xs text-text-tertiary">{{ member.user.email || member.user.username }}</div>
-              </div>
-              <div class="min-w-0 text-sm text-text-secondary">
-                <div class="truncate">{{ member.membership?.plan?.name || '-' }}</div>
-                @if (member.scheduledPeriodCount) {
-                  <div class="mt-1 text-xs text-text-tertiary">
-                    {{
-                      'XP.Membership.UpcomingPeriodCount'
-                        | translate
-                          : {
-                              count: member.scheduledPeriodCount,
-                              Default: member.scheduledPeriodCount + ' upcoming'
-                            }
-                    }}
-                  </div>
-                }
-              </div>
-              <div>
-                <z-badge zType="outline" zShape="pill">
-                  {{
-                    'XP.Membership.MemberStatuses.' + adminMemberStatus(member)
-                      | translate: { Default: adminMemberStatus(member) }
-                  }}
-                </z-badge>
-              </div>
-              <div class="text-sm text-text-secondary">
-                @if (!member.membership) {
-                  -
-                } @else if (member.membership.pointsGranted === null) {
-                  {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
-                } @else {
-                  {{ adminMemberRemainingPoints(member) | number: '1.0-10' }}
-                }
-              </div>
-              <div class="text-sm text-text-secondary">
-                {{
-                  member.membership?.currentPeriodEnd ? (member.membership?.currentPeriodEnd | date: 'mediumDate') : '-'
-                }}
-              </div>
-              <a
-                z-button
-                zType="ghost"
-                zSize="sm"
-                [routerLink]="['/settings/users', member.user.id]"
-                [queryParams]="{ tab: 'membership' }"
-                [attr.aria-label]="'XP.Membership.ManageUserMembership' | translate: { Default: 'Manage membership' }"
-                [title]="'XP.Membership.ManageUserMembership' | translate: { Default: 'Manage membership' }"
-              >
-                <z-icon zType="chevron-right"></z-icon>
-              </a>
-            </div>
-          } @empty {
-            <div class="px-4 py-10 text-center text-sm text-text-tertiary">
-              @if (adminMembersLoading()) {
-                {{ 'XP.KEY_WORDS.Loading' | translate: { Default: 'Loading...' } }}
-              } @else {
-                {{ 'XP.Membership.NoUsersFound' | translate: { Default: 'No users match these filters.' } }}
-              }
-            </div>
-          }
-        </div>
-      </div>
+              <z-icon zType="refresh"></z-icon>
+            </button>
+          </div>
+        </form>
 
-      <z-paginator
-        [length]="adminMemberCount()"
-        [pageIndex]="adminMemberPageIndex()"
-        [pageSize]="adminMemberPageSize()"
-        [pageSizeOptions]="[10, 20, 50, 100]"
-        [showFirstLastButtons]="true"
-        (page)="onAdminMemberPage($event)"
-      />
-    </z-card-content>
-  </z-card>
-</div>
+        @if (selectedUserCount()) {
+          <form
+            [formGroup]="bulkActionForm"
+            class="flex flex-col gap-3 rounded-lg bg-components-panel-bg p-3 xl:flex-row xl:items-end"
+          >
+            <div class="flex min-h-10 min-w-36 items-center gap-2 self-start xl:self-end">
+              <span
+                class="flex size-6 items-center justify-center rounded-full bg-components-card-bg text-xs font-semibold tabular-nums text-text-primary"
+              >
+                {{ selectedUserCount() }}
+              </span>
+              <span class="text-sm font-medium text-text-primary">
+                {{
+                  'XP.Membership.SelectedUsers'
+                    | translate: { count: selectedUserCount(), Default: selectedUserCount() + ' selected' }
+                }}
+              </span>
+            </div>
+            <z-form-field class="w-full xl:w-44">
+              <z-form-label>{{ 'XP.Membership.BulkAction' | translate: { Default: 'Batch action' } }}</z-form-label>
+              <z-select class="w-full" formControlName="action" (zSelectionChange)="setBulkAction($event)">
+                @for (
+                  action of [
+                    MembershipBulkActionEnum.Assign,
+                    MembershipBulkActionEnum.Renew,
+                    MembershipBulkActionEnum.Pause,
+                    MembershipBulkActionEnum.Resume,
+                    MembershipBulkActionEnum.Revoke
+                  ];
+                  track action
+                ) {
+                  <z-select-item [zValue]="action">
+                    {{ 'XP.Membership.BulkActions.' + action | translate: { Default: action } }}
+                  </z-select-item>
+                }
+              </z-select>
+            </z-form-field>
+            @if (bulkActionRequiresPlan()) {
+              <z-form-field class="w-full xl:w-56">
+                <z-form-label>{{ 'XP.Membership.Plan' | translate: { Default: 'Plan' } }}</z-form-label>
+                <z-select class="w-full" formControlName="planId">
+                  @for (plan of plans(); track plan.id) {
+                    @if (plan.status === MembershipPlanStatusEnum.Active) {
+                      <z-select-item [zValue]="plan.id">{{ plan.name }}</z-select-item>
+                    }
+                  }
+                </z-select>
+              </z-form-field>
+              <z-form-field class="w-full xl:w-44">
+                <z-form-label>
+                  {{ 'XP.Membership.RenewalMode' | translate: { Default: 'Renewal mode' } }}
+                </z-form-label>
+                <z-select class="w-full" formControlName="renewalMode">
+                  <z-select-item [zValue]="MembershipRenewalModeEnum.Auto">
+                    {{ 'XP.Membership.RenewalModes.auto' | translate: { Default: 'Auto renew' } }}
+                  </z-select-item>
+                  <z-select-item [zValue]="MembershipRenewalModeEnum.Manual">
+                    {{ 'XP.Membership.RenewalModes.manual' | translate: { Default: 'Manual renew' } }}
+                  </z-select-item>
+                </z-select>
+              </z-form-field>
+              <z-form-field class="min-w-0 flex-1">
+                <z-form-label>{{
+                  'XP.Membership.AssignNote' | translate: { Default: 'Assignment note' }
+                }}</z-form-label>
+                <input z-input formControlName="note" />
+              </z-form-field>
+            }
+            <button
+              z-button
+              zType="secondary"
+              type="button"
+              class="shrink-0 xl:mb-3"
+              [disabled]="
+                adminMembersLoading() ||
+                !selectedUserCount() ||
+                (bulkActionRequiresPlan() && !bulkActionForm.controls.planId.value)
+              "
+              (click)="applyBulkAction()"
+            >
+              {{ 'XP.Membership.ApplyBulkAction' | translate: { Default: 'Apply action' } }}
+            </button>
+          </form>
+        }
+
+        <div class="overflow-hidden rounded-lg bg-components-panel-bg">
+          <div
+            class="hidden grid-cols-[2rem_minmax(12rem,1.5fr)_minmax(8rem,1fr)_8rem_9rem_8rem_3rem] gap-3 bg-components-panel-bg px-4 py-3 text-xs font-medium text-text-tertiary lg:grid"
+          >
+            <z-checkbox
+              displayDensity="cosy"
+              [ngModel]="allVisibleUsersSelected()"
+              [indeterminate]="selectedUserCount() > 0 && !allVisibleUsersSelected()"
+              [attr.aria-label]="'XP.Membership.SelectVisibleUsers' | translate: { Default: 'Select visible users' }"
+              (checkChange)="toggleVisibleUsers($event)"
+            ></z-checkbox>
+            <span>{{ 'XP.Membership.User' | translate: { Default: 'User' } }}</span>
+            <span>{{ 'XP.Membership.Plan' | translate: { Default: 'Plan' } }}</span>
+            <span>{{ 'XP.Membership.Status' | translate: { Default: 'Status' } }}</span>
+            <span>{{ 'XP.Membership.RemainingPoints' | translate: { Default: 'Remaining points' } }}</span>
+            <span>{{ 'XP.Membership.PeriodEnd' | translate: { Default: 'Period end' } }}</span>
+            <span></span>
+          </div>
+
+          <div class="divide-y divide-divider-subtle">
+            @for (member of adminMembers(); track member.user.id) {
+              <div
+                class="grid gap-3 px-4 py-3 lg:grid-cols-[2rem_minmax(12rem,1.5fr)_minmax(8rem,1fr)_8rem_9rem_8rem_3rem] lg:items-center"
+              >
+                <z-checkbox
+                  displayDensity="cosy"
+                  [ngModel]="selectedUserIds().has(member.user.id)"
+                  [ngModelOptions]="{ standalone: true }"
+                  (checkChange)="toggleUserSelection(member.user.id, $event)"
+                ></z-checkbox>
+                <div class="min-w-0">
+                  <div class="truncate text-sm font-medium text-text-primary" [title]="adminMemberLabel(member)">
+                    {{ adminMemberLabel(member) }}
+                  </div>
+                  <div class="truncate text-xs text-text-tertiary">{{ member.user.email || member.user.username }}</div>
+                </div>
+                <div class="min-w-0 text-sm text-text-secondary">
+                  <div class="truncate">{{ member.membership?.plan?.name || '-' }}</div>
+                  @if (member.scheduledPeriodCount) {
+                    <div class="mt-1 text-xs text-text-tertiary">
+                      {{
+                        'XP.Membership.UpcomingPeriodCount'
+                          | translate
+                            : {
+                                count: member.scheduledPeriodCount,
+                                Default: member.scheduledPeriodCount + ' upcoming'
+                              }
+                      }}
+                    </div>
+                  }
+                </div>
+                <div>
+                  <z-badge zType="outline" zShape="pill">
+                    {{
+                      'XP.Membership.MemberStatuses.' + adminMemberStatus(member)
+                        | translate: { Default: adminMemberStatus(member) }
+                    }}
+                  </z-badge>
+                </div>
+                <div class="text-sm text-text-secondary">
+                  @if (!member.membership) {
+                    -
+                  } @else if (member.membership.pointsGranted === null) {
+                    {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
+                  } @else {
+                    {{ adminMemberRemainingPoints(member) | number: '1.0-10' }}
+                  }
+                </div>
+                <div class="text-sm text-text-secondary">
+                  {{
+                    member.membership?.currentPeriodEnd
+                      ? (member.membership?.currentPeriodEnd | date: 'mediumDate')
+                      : '-'
+                  }}
+                </div>
+                <a
+                  z-button
+                  zType="ghost"
+                  zSize="sm"
+                  [routerLink]="['/settings/users', member.user.id]"
+                  [queryParams]="{ tab: 'membership' }"
+                  [attr.aria-label]="'XP.Membership.ManageUserMembership' | translate: { Default: 'Manage membership' }"
+                  [title]="'XP.Membership.ManageUserMembership' | translate: { Default: 'Manage membership' }"
+                >
+                  <z-icon zType="chevron-right"></z-icon>
+                </a>
+              </div>
+            } @empty {
+              <div class="px-4 py-10 text-center text-sm text-text-tertiary">
+                @if (adminMembersLoading()) {
+                  {{ 'XP.KEY_WORDS.Loading' | translate: { Default: 'Loading...' } }}
+                } @else {
+                  {{ 'XP.Membership.NoUsersFound' | translate: { Default: 'No users match these filters.' } }}
+                }
+              </div>
+            }
+          </div>
+        </div>
+
+        <z-paginator
+          [length]="adminMemberCount()"
+          [pageIndex]="adminMemberPageIndex()"
+          [pageSize]="adminMemberPageSize()"
+          [pageSizeOptions]="[10, 20, 50, 100]"
+          [showFirstLastButtons]="true"
+          (page)="onAdminMemberPage($event)"
+        />
+      </div>
+    </section>
+  }
+</z-tab-nav-panel>

--- a/apps/cloud/src/app/features/setting/membership/membership.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.spec.ts
@@ -95,6 +95,32 @@ describe('MembershipAdminComponent', () => {
     expect(membershipService.archivePlan).not.toHaveBeenCalled()
   })
 
+  it('opens plan configuration by default and switches to user memberships', () => {
+    expect(component.activeTab()).toBe('plans')
+
+    component.setActiveTab('users')
+
+    expect(component.activeTab()).toBe('users')
+  })
+
+  it('keeps plan and user management in separate task tabs', () => {
+    const template = readFileSync(join(__dirname, 'membership.component.html'), 'utf8')
+
+    expect(template).toContain('z-tab-nav-bar')
+    expect(template).toContain("activeTab() === 'plans'")
+    expect(template).toContain("setActiveTab('users')")
+  })
+
+  it('uses subtle borders for plan choices and the plan detail surfaces', () => {
+    const template = readFileSync(join(__dirname, 'membership.component.html'), 'utf8')
+
+    expect(template).toContain("'border-divider-subtle bg-components-card-bg hover:border-divider-regular'")
+    expect(
+      template.match(/overflow-hidden border border-divider-subtle bg-components-card-bg shadow-none/g)
+    ).toHaveLength(2)
+    expect(template.match(/rounded-lg border border-divider-subtle bg-components-panel-bg px-4 py-3/g)).toHaveLength(8)
+  })
+
   it('round-trips the explicit plan level in the edit form', () => {
     component.edit(targetPlan)
 

--- a/apps/cloud/src/app/features/setting/membership/membership.component.ts
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.ts
@@ -33,7 +33,8 @@ import {
   ZardInputDirective,
   type ZardPageEvent,
   ZardPaginatorComponent,
-  ZardSelectImports
+  ZardSelectImports,
+  ZardTabsImports
 } from '@xpert-ai/headless-ui'
 import { userLabel } from '../../../@shared/pipes'
 import { format } from 'date-fns'
@@ -43,6 +44,8 @@ type MembershipModelOption = {
   provider: string
   model: string
 }
+
+type MembershipAdminTab = 'plans' | 'users'
 
 const MEMBERSHIP_RATE_LIMIT_PERIODS: TMembershipRateLimitPeriod[] = ['hour', 'day', 'week', 'cycle']
 
@@ -64,7 +67,8 @@ const MEMBERSHIP_RATE_LIMIT_PERIODS: TMembershipRateLimitPeriod[] = ['hour', 'da
     ZardPaginatorComponent,
     ...ZardFormImports,
     ...ZardCardImports,
-    ...ZardSelectImports
+    ...ZardSelectImports,
+    ...ZardTabsImports
   ],
   templateUrl: './membership.component.html',
   styleUrls: ['./membership.component.scss']
@@ -80,6 +84,7 @@ export class MembershipAdminComponent implements OnInit {
   readonly plans = signal<IMembershipPlan[]>([])
   readonly scopeStatus = signal<IMembershipScopeStatus | null>(null)
   readonly loading = signal(false)
+  readonly activeTab = signal<MembershipAdminTab>('plans')
   readonly editing = signal(false)
   readonly selectedPlanId = signal<string | null>(null)
   readonly planMembers = signal<IUserMembership[]>([])
@@ -170,6 +175,10 @@ export class MembershipAdminComponent implements OnInit {
 
   ngOnInit() {
     this.load()
+  }
+
+  setActiveTab(tab: MembershipAdminTab) {
+    this.activeTab.set(tab)
   }
 
   load() {

--- a/apps/cloud/src/app/features/setting/referrals/referrals.component.html
+++ b/apps/cloud/src/app/features/setting/referrals/referrals.component.html
@@ -1,10 +1,12 @@
-<div class="flex w-full min-w-0 flex-col p-6">
-  <div class="flex flex-wrap items-end justify-between gap-4">
-    <div>
-      <h1 class="text-2xl font-semibold text-text-primary">
+<div class="flex h-full w-full min-w-0 flex-col overflow-hidden">
+  <div
+    class="xp-page-header gap-4 border-b border-divider-regular bg-components-card-bg pb-4 md:flex-row md:items-end md:justify-between"
+  >
+    <div class="min-w-0">
+      <h1 class="xp-page-title text-text-primary">
         {{ 'XP.Referral.Relationships' | translate: { Default: 'Invitation relationships' } }}
       </h1>
-      <p class="mt-1 text-sm text-text-secondary">
+      <p class="mt-1 max-w-3xl text-sm text-text-tertiary">
         {{
           'XP.Referral.RelationshipsDescription'
             | translate: { Default: 'Read-only direct account invitation relationships in this tenant.' }
@@ -12,52 +14,91 @@
       </p>
     </div>
 
-    <form [formGroup]="filterForm" class="flex items-center gap-2" (ngSubmit)="search()">
+    <form [formGroup]="filterForm" class="flex w-full min-w-0 items-center gap-2 md:w-auto" (ngSubmit)="search()">
+      <label for="referral-search" class="sr-only">
+        {{ 'XP.Referral.SearchPlaceholder' | translate: { Default: 'Search user or code' } }}
+      </label>
       <input
+        id="referral-search"
         z-input
+        type="search"
         formControlName="search"
-        class="w-72"
+        class="min-w-0 flex-1 md:w-80"
+        autocomplete="off"
         [placeholder]="'XP.Referral.SearchPlaceholder' | translate: { Default: 'Search user or code' }"
       />
-      <button z-button zType="secondary" type="submit">
+      <button z-button zType="secondary" type="submit" [zDisabled]="loading()">
         {{ 'XP.ACTIONS.Search' | translate: { Default: 'Search' } }}
       </button>
     </form>
   </div>
 
-  <div class="mt-6 overflow-x-auto rounded-xl border border-divider-regular bg-components-card-bg">
-    <table z-table zSize="compact" class="min-w-[52rem]">
-      <thead z-table-header>
-        <tr z-table-row>
-          <th z-table-head>{{ 'XP.Referral.Referrer' | translate: { Default: 'Inviter' } }}</th>
-          <th z-table-head>{{ 'XP.Referral.Referred' | translate: { Default: 'Invitee' } }}</th>
-          <th z-table-head>{{ 'XP.Referral.UsedCode' | translate: { Default: 'Used code' } }}</th>
-          <th z-table-head>{{ 'XP.Referral.BoundAt' | translate: { Default: 'Bound at' } }}</th>
-        </tr>
-      </thead>
-      <tbody z-table-body>
-        @for (relation of relations(); track relation.id) {
-          <tr z-table-row>
-            <td z-table-cell>
-              <div class="font-medium text-text-primary">{{ accountLabel(relation.referrer) }}</div>
-              @if (!relation.referrer.deleted && relation.referrer.email) {
-                <div class="text-xs text-text-secondary">{{ relation.referrer.email }}</div>
+  <div class="xp-page-body flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-auto p-4">
+    <div
+      class="flex min-h-[28rem] min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-divider-regular bg-components-card-bg"
+    >
+      @if (relations().length) {
+        <div class="min-h-0 flex-1 overflow-x-auto">
+          <table z-table zSize="compact" class="min-w-[52rem] table-fixed">
+            <thead z-table-header>
+              <tr z-table-row>
+                <th z-table-head class="w-[29%] px-4">
+                  {{ 'XP.Referral.Referrer' | translate: { Default: 'Inviter' } }}
+                </th>
+                <th z-table-head class="w-[29%] px-4">
+                  {{ 'XP.Referral.Referred' | translate: { Default: 'Invitee' } }}
+                </th>
+                <th z-table-head class="w-[18%] px-4">
+                  {{ 'XP.Referral.UsedCode' | translate: { Default: 'Used code' } }}
+                </th>
+                <th z-table-head class="w-[24%] px-4">
+                  {{ 'XP.Referral.BoundAt' | translate: { Default: 'Bound at' } }}
+                </th>
+              </tr>
+            </thead>
+            <tbody z-table-body>
+              @for (relation of relations(); track relation.id) {
+                <tr z-table-row>
+                  <td z-table-cell class="px-4">
+                    <div class="truncate font-medium text-text-primary" [title]="accountLabel(relation.referrer)">
+                      {{ accountLabel(relation.referrer) }}
+                    </div>
+                    @if (!relation.referrer.deleted && relation.referrer.email) {
+                      <div class="truncate text-xs text-text-tertiary" [title]="relation.referrer.email">
+                        {{ relation.referrer.email }}
+                      </div>
+                    }
+                  </td>
+                  <td z-table-cell class="px-4">
+                    <div class="truncate font-medium text-text-primary" [title]="accountLabel(relation.referred)">
+                      {{ accountLabel(relation.referred) }}
+                    </div>
+                    @if (!relation.referred.deleted && relation.referred.email) {
+                      <div class="truncate text-xs text-text-tertiary" [title]="relation.referred.email">
+                        {{ relation.referred.email }}
+                      </div>
+                    }
+                  </td>
+                  <td z-table-cell class="px-4">
+                    <code class="text-text-primary">{{ relation.usedCode }}</code>
+                  </td>
+                  <td z-table-cell class="whitespace-nowrap px-4 text-text-secondary">
+                    {{ relation.boundAt | date: 'medium' }}
+                  </td>
+                </tr>
               }
-            </td>
-            <td z-table-cell>
-              <div class="font-medium text-text-primary">{{ accountLabel(relation.referred) }}</div>
-              @if (!relation.referred.deleted && relation.referred.email) {
-                <div class="text-xs text-text-secondary">{{ relation.referred.email }}</div>
-              }
-            </td>
-            <td z-table-cell>
-              <code>{{ relation.usedCode }}</code>
-            </td>
-            <td z-table-cell class="whitespace-nowrap">{{ relation.boundAt | date: 'medium' }}</td>
-          </tr>
-        } @empty {
-          <tr z-table-row>
-            <td z-table-cell colspan="4" class="py-10 text-center text-text-secondary">
+            </tbody>
+          </table>
+        </div>
+      } @else {
+        <div class="flex min-h-0 flex-1 items-center justify-center px-6 py-12">
+          <div class="flex max-w-md flex-col items-center text-center">
+            <div
+              class="flex size-14 items-center justify-center rounded-2xl bg-components-panel-bg text-text-secondary"
+            >
+              <z-icon zType="link" zSize="xl" />
+            </div>
+            <div class="mt-4 text-base font-semibold text-text-primary">
               @if (loading()) {
                 {{ 'XP.KEY_WORDS.Loading' | translate: { Default: 'Loading...' } }}
               } @else if (loadFailed()) {
@@ -65,43 +106,62 @@
               } @else {
                 {{ 'XP.Referral.Empty' | translate: { Default: 'No invitation relationships found.' } }}
               }
-            </td>
-          </tr>
-        }
-      </tbody>
-    </table>
-  </div>
-
-  <div class="mt-4 flex items-center justify-end gap-3 text-sm text-text-secondary">
-    <span>
-      {{
-        'XP.Referral.PageSummary'
-          | translate
-            : {
-                page: pageIndex() + 1,
-                pages: pageCount(),
-                total: total(),
-                Default: 'Page ' + (pageIndex() + 1) + ' of ' + pageCount() + ' · ' + total() + ' total'
+            </div>
+            @if (!loading() && !loadFailed()) {
+              <p class="mt-1 text-sm leading-6 text-text-tertiary">
+                {{
+                  'XP.Referral.RelationshipsDescription'
+                    | translate: { Default: 'Read-only direct account invitation relationships in this tenant.' }
+                }}
+              </p>
+              @if (filterForm.controls.search.value) {
+                <button z-button zType="ghost" zSize="sm" type="button" class="mt-4" (click)="clearSearch()">
+                  {{ 'XP.KEY_WORDS.Reset' | translate: { Default: 'Clear search' } }}
+                </button>
               }
-      }}
-    </span>
-    <button
-      z-button
-      zType="secondary"
-      type="button"
-      [zDisabled]="loading() || pageIndex() === 0"
-      (click)="previousPage()"
-    >
-      {{ 'XP.Referral.Previous' | translate: { Default: 'Previous' } }}
-    </button>
-    <button
-      z-button
-      zType="secondary"
-      type="button"
-      [zDisabled]="loading() || pageIndex() + 1 >= pageCount()"
-      (click)="nextPage()"
-    >
-      {{ 'XP.Referral.Next' | translate: { Default: 'Next' } }}
-    </button>
+            }
+          </div>
+        </div>
+      }
+
+      <div
+        class="flex min-h-12 flex-wrap items-center justify-between gap-3 border-t border-divider-regular px-4 py-2 text-sm text-text-tertiary"
+      >
+        <span>
+          {{
+            'XP.Referral.PageSummary'
+              | translate
+                : {
+                    page: pageIndex() + 1,
+                    pages: pageCount(),
+                    total: total(),
+                    Default: 'Page ' + (pageIndex() + 1) + ' of ' + pageCount() + ' · ' + total() + ' total'
+                  }
+          }}
+        </span>
+        <div class="flex items-center gap-2">
+          <button
+            z-button
+            zType="secondary"
+            zSize="sm"
+            type="button"
+            [zDisabled]="loading() || pageIndex() === 0"
+            (click)="previousPage()"
+          >
+            {{ 'XP.Referral.Previous' | translate: { Default: 'Previous' } }}
+          </button>
+          <button
+            z-button
+            zType="secondary"
+            zSize="sm"
+            type="button"
+            [zDisabled]="loading() || pageIndex() + 1 >= pageCount()"
+            (click)="nextPage()"
+          >
+            {{ 'XP.Referral.Next' | translate: { Default: 'Next' } }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/apps/cloud/src/app/features/setting/referrals/referrals.component.ts
+++ b/apps/cloud/src/app/features/setting/referrals/referrals.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, OnInit, computed, inject, signal } 
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms'
 import { ReferralService } from '@cloud/app/@core/state'
 import { IReferralRelationView } from '@xpert-ai/contracts'
-import { ZardButtonComponent, ZardInputDirective, ZardTableImports } from '@xpert-ai/headless-ui'
+import { ZardButtonComponent, ZardIconComponent, ZardInputDirective, ZardTableImports } from '@xpert-ai/headless-ui'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { getErrorMessage } from '../../../@core/types'
 import { injectToastr } from '../../../@core/services/toastr.service'
@@ -12,11 +12,15 @@ import { injectToastr } from '../../../@core/services/toastr.service'
   standalone: true,
   selector: 'xp-referral-relations',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'flex min-w-0 w-full max-w-full flex-1'
+  },
   imports: [
     CommonModule,
     ReactiveFormsModule,
     TranslateModule,
     ZardButtonComponent,
+    ZardIconComponent,
     ZardInputDirective,
     ...ZardTableImports
   ],
@@ -66,6 +70,11 @@ export class ReferralRelationsComponent implements OnInit {
   }
 
   search() {
+    void this.load(0)
+  }
+
+  clearSearch() {
+    this.filterForm.controls.search.reset()
     void this.load(0)
   }
 

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -1212,7 +1212,7 @@
       "PriceTotalUsed": "Price Total Used"
     },
     "Membership": {
-      "AdminTitle": "Membership Plans",
+      "AdminTitle": "Membership management",
       "Level": "Level",
       "LevelValidation": "Level must be a non-negative integer.",
       "PriceCurrency": "Currency",
@@ -1233,6 +1233,7 @@
       "DefaultPlanLabel": "Default plan",
       "NoDefaultPlan": "No default plan",
       "NewPlan": "New plan",
+      "PlanManagement": "Plan configuration",
       "TotalPlans": "Total plans",
       "ActivePlans": "Active plans",
       "ArchivedPlans": "Archived plans",
@@ -1376,6 +1377,7 @@
       "SearchUsersPlaceholder": "Name, username, or email",
       "ExpiringBefore": "Expiring before",
       "SelectedUsers": "{{count}} selected",
+      "SelectVisibleUsers": "Select visible users",
       "BulkAction": "Batch action",
       "ApplyBulkAction": "Apply action",
       "BulkActionConfirmTitle": "Apply membership action?",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -1578,7 +1578,7 @@
       "PriceTotalUsed": "Price Total Used"
     },
     "Membership": {
-      "AdminTitle": "Membership Plans",
+      "AdminTitle": "Membership management",
       "Level": "Level",
       "LevelValidation": "Level must be a non-negative integer.",
       "PriceCurrency": "Currency",
@@ -1599,6 +1599,7 @@
       "DefaultPlanLabel": "Default plan",
       "NoDefaultPlan": "No default plan",
       "NewPlan": "New plan",
+      "PlanManagement": "Plan configuration",
       "TotalPlans": "Total plans",
       "ActivePlans": "Active plans",
       "ArchivedPlans": "Archived plans",
@@ -1742,6 +1743,7 @@
       "SearchUsersPlaceholder": "Name, username, or email",
       "ExpiringBefore": "Expiring before",
       "SelectedUsers": "{{count}} selected",
+      "SelectVisibleUsers": "Select visible users",
       "BulkAction": "Batch action",
       "ApplyBulkAction": "Apply action",
       "BulkActionConfirmTitle": "Apply membership action?",

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -2163,7 +2163,7 @@
       }
     },
     "Membership": {
-      "AdminTitle": "会员套餐",
+      "AdminTitle": "会员管理",
       "Level": "等级",
       "LevelValidation": "等级必须为非负整数。",
       "PriceCurrency": "币种",
@@ -2184,6 +2184,7 @@
       "DefaultPlanLabel": "默认套餐",
       "NoDefaultPlan": "无默认套餐",
       "NewPlan": "新建套餐",
+      "PlanManagement": "套餐配置",
       "TotalPlans": "套餐总数",
       "ActivePlans": "启用套餐",
       "ArchivedPlans": "归档套餐",
@@ -2327,6 +2328,7 @@
       "SearchUsersPlaceholder": "姓名、用户名或邮箱",
       "ExpiringBefore": "到期时间不晚于",
       "SelectedUsers": "已选择 {{count}} 人",
+      "SelectVisibleUsers": "选择当前页用户",
       "BulkAction": "批量操作",
       "ApplyBulkAction": "执行操作",
       "BulkActionConfirmTitle": "确认执行会员操作？",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -3490,7 +3490,7 @@
       }
     },
     "Membership": {
-      "AdminTitle": "会员套餐",
+      "AdminTitle": "会员管理",
       "Level": "等级",
       "LevelValidation": "等级必须为非负整数。",
       "PriceCurrency": "币种",
@@ -3511,6 +3511,7 @@
       "DefaultPlanLabel": "默认套餐",
       "NoDefaultPlan": "无默认套餐",
       "NewPlan": "新建套餐",
+      "PlanManagement": "套餐配置",
       "TotalPlans": "套餐总数",
       "ActivePlans": "启用套餐",
       "ArchivedPlans": "归档套餐",
@@ -3654,6 +3655,7 @@
       "SearchUsersPlaceholder": "姓名、用户名或邮箱",
       "ExpiringBefore": "到期时间不晚于",
       "SelectedUsers": "已选择 {{count}} 人",
+      "SelectVisibleUsers": "选择当前页用户",
       "BulkAction": "批量操作",
       "ApplyBulkAction": "执行操作",
       "BulkActionConfirmTitle": "确认执行会员操作？",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -2585,7 +2585,7 @@
       }
     },
     "Membership": {
-      "AdminTitle": "會員套餐",
+      "AdminTitle": "會員管理",
       "Level": "等級",
       "LevelValidation": "等級必須為非負整數。",
       "PriceCurrency": "幣種",
@@ -2606,6 +2606,7 @@
       "DefaultPlanLabel": "預設套餐",
       "NoDefaultPlan": "無預設套餐",
       "NewPlan": "新建套餐",
+      "PlanManagement": "套餐設定",
       "TotalPlans": "套餐總數",
       "ActivePlans": "啟用套餐",
       "ArchivedPlans": "歸檔套餐",
@@ -2749,6 +2750,7 @@
       "SearchUsersPlaceholder": "姓名、使用者名稱或信箱",
       "ExpiringBefore": "到期時間不晚於",
       "SelectedUsers": "已選擇 {{count}} 人",
+      "SelectVisibleUsers": "選擇目前頁面使用者",
       "BulkAction": "批次操作",
       "ApplyBulkAction": "執行操作",
       "BulkActionConfirmTitle": "確認執行會員操作？",

--- a/packages/ui/src/i18n/en.json
+++ b/packages/ui/src/i18n/en.json
@@ -24,6 +24,16 @@
     "moreItemsSelected_one": "{{count}} more item selected",
     "moreItemsSelected_other": "{{count}} more items selected"
   },
+  "paginator": {
+    "itemsPerPage": "Items per page:",
+    "itemsPerPagePlaceholder": "Items per page",
+    "firstPage": "First page",
+    "previousPage": "Previous page",
+    "nextPage": "Next page",
+    "lastPage": "Last page",
+    "range": "{{start}} – {{end}} of {{length}}",
+    "emptyRange": "0 of {{length}}"
+  },
   "chipGrid": {
     "emptyPlaceholder": "Select or add items"
   }

--- a/packages/ui/src/i18n/zh-Hans.json
+++ b/packages/ui/src/i18n/zh-Hans.json
@@ -23,6 +23,16 @@
   "select": {
     "moreItemsSelected_other": "还有 {{count}} 项已选择"
   },
+  "paginator": {
+    "itemsPerPage": "每页条数：",
+    "itemsPerPagePlaceholder": "每页条数",
+    "firstPage": "第一页",
+    "previousPage": "上一页",
+    "nextPage": "下一页",
+    "lastPage": "最后一页",
+    "range": "第 {{start}}–{{end}} 条，共 {{length}} 条",
+    "emptyRange": "共 {{length}} 条"
+  },
   "chipGrid": {
     "emptyPlaceholder": "选择或添加项目"
   }

--- a/packages/ui/src/i18n/zh-Hant.json
+++ b/packages/ui/src/i18n/zh-Hant.json
@@ -23,6 +23,16 @@
   "select": {
     "moreItemsSelected_other": "還有 {{count}} 項已選擇"
   },
+  "paginator": {
+    "itemsPerPage": "每頁筆數：",
+    "itemsPerPagePlaceholder": "每頁筆數",
+    "firstPage": "第一頁",
+    "previousPage": "上一頁",
+    "nextPage": "下一頁",
+    "lastPage": "最後一頁",
+    "range": "第 {{start}}–{{end}} 筆，共 {{length}} 筆",
+    "emptyRange": "共 {{length}} 筆"
+  },
   "chipGrid": {
     "emptyPlaceholder": "選擇或添加項目"
   }

--- a/packages/ui/src/lib/components/pagination/paginator.component.spec.ts
+++ b/packages/ui/src/lib/components/pagination/paginator.component.spec.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
+import { Component, signal } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { By } from '@angular/platform-browser'
 
-import { ZardPaginatorComponent, type ZardPageEvent } from './paginator.component';
+import { provideUiI18nAdapter, type UiI18nOptions } from '../../core/i18n/ui-i18n.service'
+import { ZardPaginatorComponent, type ZardPageEvent } from './paginator.component'
 
 @Component({
   imports: [ZardPaginatorComponent],
@@ -15,49 +16,72 @@ import { ZardPaginatorComponent, type ZardPageEvent } from './paginator.componen
       [showFirstLastButtons]="showFirstLastButtons"
       (page)="events.push($event)"
     />
-  `,
+  `
 })
 class HostComponent {
-  length = 0;
-  pageIndex = 0;
-  pageSize = 0;
-  pageSizeOptions = [20, 50, 100];
-  showFirstLastButtons = true;
-  events: ZardPageEvent[] = [];
+  length = 0
+  pageIndex = 0
+  pageSize = 0
+  pageSizeOptions = [20, 50, 100]
+  showFirstLastButtons = true
+  events: ZardPageEvent[] = []
 }
 
 describe('ZardPaginatorComponent', () => {
-  async function createHost() {
+  async function createHost(initialLanguage = 'en') {
+    const language = signal(initialLanguage)
+    const translations: Record<string, Record<string, string>> = {
+      'zh-Hans': {
+        'paginator.itemsPerPage': '每页条数：',
+        'paginator.itemsPerPagePlaceholder': '每页条数',
+        'paginator.firstPage': '第一页',
+        'paginator.previousPage': '上一页',
+        'paginator.nextPage': '下一页',
+        'paginator.lastPage': '最后一页',
+        'paginator.range': '第 {{start}}–{{end}} 条，共 {{length}} 条',
+        'paginator.emptyRange': '共 {{length}} 条'
+      }
+    }
     const fixture = await TestBed.configureTestingModule({
       imports: [HostComponent],
-    }).createComponent(HostComponent);
+      providers: [
+        provideUiI18nAdapter({
+          language,
+          translate: (key: string, options?: UiI18nOptions) => {
+            const locale = options?.lng ?? language() ?? 'en'
+            const template = translations[locale]?.[key] ?? options?.Default ?? key
+            return template.replace(/{{(\w+)}}/g, (_, name: string) => String(options?.[name] ?? ''))
+          }
+        })
+      ]
+    }).createComponent(HostComponent)
 
-    fixture.detectChanges();
+    fixture.detectChanges()
 
     const paginator = fixture.debugElement.query(By.directive(ZardPaginatorComponent))
-      .componentInstance as ZardPaginatorComponent;
+      .componentInstance as ZardPaginatorComponent
 
-    return { fixture, paginator };
+    return { fixture, language, paginator }
   }
 
   it('initializes page size like Material when pageSize is unset', async () => {
-    const { paginator } = await createHost();
+    const { paginator } = await createHost()
 
-    expect(paginator.pageSize).toBe(20);
-    expect(paginator.pageSizeOptions).toEqual([20, 50, 100]);
-  });
+    expect(paginator.pageSize).toBe(20)
+    expect(paginator.pageSizeOptions).toEqual([20, 50, 100])
+  })
 
   it('emits zero-based page events for navigation and page-size changes', async () => {
-    const { fixture, paginator } = await createHost();
+    const { fixture, paginator } = await createHost()
 
-    paginator.length = 240;
-    paginator.nextPage();
-    paginator.lastPage();
-    paginator.previousPage();
-    paginator.firstPage();
-    paginator.nextPage();
-    paginator.changePageSize(50);
-    fixture.detectChanges();
+    paginator.length = 240
+    paginator.nextPage()
+    paginator.lastPage()
+    paginator.previousPage()
+    paginator.firstPage()
+    paginator.nextPage()
+    paginator.changePageSize(50)
+    fixture.detectChanges()
 
     expect(fixture.componentInstance.events).toEqual([
       { previousPageIndex: 0, pageIndex: 1, pageSize: 20, length: 240 },
@@ -65,66 +89,88 @@ describe('ZardPaginatorComponent', () => {
       { previousPageIndex: 11, pageIndex: 10, pageSize: 20, length: 240 },
       { previousPageIndex: 10, pageIndex: 0, pageSize: 20, length: 240 },
       { previousPageIndex: 0, pageIndex: 1, pageSize: 20, length: 240 },
-      { previousPageIndex: 1, pageIndex: 0, pageSize: 50, length: 240 },
-    ]);
-  });
+      { previousPageIndex: 1, pageIndex: 0, pageSize: 50, length: 240 }
+    ])
+  })
 
   it('updates the range label when length, pageIndex, and pageSize change externally', async () => {
-    const { fixture, paginator } = await createHost();
+    const { fixture, paginator } = await createHost()
 
-    paginator.length = 100;
-    paginator.pageSize = 10;
-    paginator.pageIndex = 0;
-    fixture.detectChanges();
+    paginator.length = 100
+    paginator.pageSize = 10
+    paginator.pageIndex = 0
+    fixture.detectChanges()
 
+    expect(fixture.nativeElement.querySelector('[data-slot="paginator-range-label"]')?.textContent?.trim()).toBe(
+      '1 – 10 of 100'
+    )
+
+    paginator.pageIndex = 4
+    fixture.detectChanges()
+
+    expect(fixture.nativeElement.querySelector('[data-slot="paginator-range-label"]')?.textContent?.trim()).toBe(
+      '41 – 50 of 100'
+    )
+
+    paginator.length = 45
+    fixture.detectChanges()
+
+    expect(fixture.nativeElement.querySelector('[data-slot="paginator-range-label"]')?.textContent?.trim()).toBe(
+      '41 – 45 of 45'
+    )
+  })
+
+  it('localizes visible labels, ranges, and navigation labels with the active language', async () => {
+    const { fixture, paginator } = await createHost('zh-Hans')
+
+    paginator.length = 45
+    paginator.pageSize = 20
+    paginator.pageIndex = 0
+    fixture.detectChanges()
+
+    expect(fixture.nativeElement.querySelector('[data-slot="paginator-page-size-label"]')?.textContent?.trim()).toBe(
+      '每页条数：'
+    )
+    expect(fixture.nativeElement.querySelector('[data-slot="paginator-range-label"]')?.textContent?.trim()).toBe(
+      '第 1–20 条，共 45 条'
+    )
     expect(
-      fixture.nativeElement.querySelector('[data-slot="paginator-range-label"]')?.textContent?.trim(),
-    ).toBe('1 – 10 of 100');
-
-    paginator.pageIndex = 4;
-    fixture.detectChanges();
-
-    expect(
-      fixture.nativeElement.querySelector('[data-slot="paginator-range-label"]')?.textContent?.trim(),
-    ).toBe('41 – 50 of 100');
-
-    paginator.length = 45;
-    fixture.detectChanges();
-
-    expect(
-      fixture.nativeElement.querySelector('[data-slot="paginator-range-label"]')?.textContent?.trim(),
-    ).toBe('41 – 45 of 45');
-  });
+      fixture.nativeElement.querySelector('[data-slot="paginator-first-button"]')?.getAttribute('aria-label')
+    ).toBe('第一页')
+    expect(fixture.nativeElement.querySelector('[data-slot="paginator-next-button"]')?.getAttribute('aria-label')).toBe(
+      '下一页'
+    )
+  })
 
   it('disables first and previous at the first page, then next and last at the last page', async () => {
-    const { fixture, paginator } = await createHost();
+    const { fixture, paginator } = await createHost()
 
-    paginator.length = 100;
-    paginator.pageSize = 10;
-    paginator.pageIndex = 0;
-    fixture.detectChanges();
+    paginator.length = 100
+    paginator.pageSize = 10
+    paginator.pageIndex = 0
+    fixture.detectChanges()
 
+    expect(fixture.nativeElement.querySelector('[data-slot="paginator-first-button"]')?.getAttribute('disabled')).toBe(
+      ''
+    )
     expect(
-      fixture.nativeElement.querySelector('[data-slot="paginator-first-button"]')?.getAttribute('disabled'),
-    ).toBe('');
-    expect(
-      fixture.nativeElement.querySelector('[data-slot="paginator-previous-button"]')?.getAttribute('disabled'),
-    ).toBe('');
-    expect(
-      fixture.nativeElement.querySelector('[data-slot="paginator-next-button"]')?.hasAttribute('disabled'),
-    ).toBe(false);
-    expect(
-      fixture.nativeElement.querySelector('[data-slot="paginator-last-button"]')?.hasAttribute('disabled'),
-    ).toBe(false);
+      fixture.nativeElement.querySelector('[data-slot="paginator-previous-button"]')?.getAttribute('disabled')
+    ).toBe('')
+    expect(fixture.nativeElement.querySelector('[data-slot="paginator-next-button"]')?.hasAttribute('disabled')).toBe(
+      false
+    )
+    expect(fixture.nativeElement.querySelector('[data-slot="paginator-last-button"]')?.hasAttribute('disabled')).toBe(
+      false
+    )
 
-    paginator.pageIndex = 9;
-    fixture.detectChanges();
+    paginator.pageIndex = 9
+    fixture.detectChanges()
 
-    expect(
-      fixture.nativeElement.querySelector('[data-slot="paginator-next-button"]')?.getAttribute('disabled'),
-    ).toBe('');
-    expect(
-      fixture.nativeElement.querySelector('[data-slot="paginator-last-button"]')?.getAttribute('disabled'),
-    ).toBe('');
-  });
-});
+    expect(fixture.nativeElement.querySelector('[data-slot="paginator-next-button"]')?.getAttribute('disabled')).toBe(
+      ''
+    )
+    expect(fixture.nativeElement.querySelector('[data-slot="paginator-last-button"]')?.getAttribute('disabled')).toBe(
+      ''
+    )
+  })
+})

--- a/packages/ui/src/lib/components/pagination/paginator.component.ts
+++ b/packages/ui/src/lib/components/pagination/paginator.component.ts
@@ -24,6 +24,7 @@ import { ZardButtonComponent } from '../button'
 import { ZardIconComponent } from '../icon'
 import { ZardPaginationContentComponent, ZardPaginationItemComponent } from './pagination.component'
 import { ZardSelectComponent, ZardSelectItemComponent } from '../select'
+import { injectUiI18nService } from '../../core/i18n/ui-i18n.service'
 import { mergeClasses } from '../../utils/merge-classes'
 
 const DEFAULT_PAGE_SIZE = 50
@@ -68,7 +69,7 @@ export interface ZardPaginatorLike {
         <div data-slot="paginator-page-size" [class]="pageSizeClasses()">
           @if (!hidePageSizeLabel) {
             <span data-slot="paginator-page-size-label" class="whitespace-nowrap text-current/80">
-              Items per page:
+              {{ itemsPerPageLabel() }}
             </span>
           }
 
@@ -78,7 +79,7 @@ export interface ZardPaginatorLike {
               [class]="selectClasses()"
               [ngModel]="pageSize"
               [zDisabled]="disabled"
-              [zPlaceholder]="'Items per page'"
+              [zPlaceholder]="itemsPerPagePlaceholder()"
               (ngModelChange)="changePageSize($event)"
             >
               @for (option of displayedPageSizeOptions(); track option) {
@@ -116,8 +117,8 @@ export interface ZardPaginatorLike {
                 zType="ghost"
                 [zSize]="buttonSize()"
                 [zDisabled]="previousButtonsDisabled()"
-                [attr.aria-label]="'First page'"
-                [attr.title]="'First page'"
+                [attr.aria-label]="firstPageLabel()"
+                [attr.title]="firstPageLabel()"
                 (click)="firstPage()"
               >
                 <z-icon class="z-icon-rtl-mirror" zType="chevrons-left" aria-hidden="true" />
@@ -133,8 +134,8 @@ export interface ZardPaginatorLike {
               zType="ghost"
               [zSize]="buttonSize()"
               [zDisabled]="previousButtonsDisabled()"
-              [attr.aria-label]="'Previous page'"
-              [attr.title]="'Previous page'"
+              [attr.aria-label]="previousPageLabel()"
+              [attr.title]="previousPageLabel()"
               (click)="previousPage()"
             >
               <z-icon class="z-icon-rtl-mirror" zType="chevron-left" aria-hidden="true" />
@@ -149,8 +150,8 @@ export interface ZardPaginatorLike {
               zType="ghost"
               [zSize]="buttonSize()"
               [zDisabled]="nextButtonsDisabled()"
-              [attr.aria-label]="'Next page'"
-              [attr.title]="'Next page'"
+              [attr.aria-label]="nextPageLabel()"
+              [attr.title]="nextPageLabel()"
               (click)="nextPage()"
             >
               <z-icon class="z-icon-rtl-mirror" zType="chevron-right" aria-hidden="true" />
@@ -166,8 +167,8 @@ export interface ZardPaginatorLike {
                 zType="ghost"
                 [zSize]="buttonSize()"
                 [zDisabled]="nextButtonsDisabled()"
-                [attr.aria-label]="'Last page'"
-                [attr.title]="'Last page'"
+                [attr.aria-label]="lastPageLabel()"
+                [attr.title]="lastPageLabel()"
                 (click)="lastPage()"
               >
                 <z-icon class="z-icon-rtl-mirror" zType="chevrons-right" aria-hidden="true" />
@@ -189,6 +190,7 @@ export interface ZardPaginatorLike {
 })
 export class ZardPaginatorComponent implements OnInit, OnDestroy, ZardPaginatorLike {
   private readonly changeDetectorRef = inject(ChangeDetectorRef)
+  private readonly i18n = injectUiI18nService()
 
   readonly class = input<ClassValue>('')
 
@@ -327,19 +329,40 @@ export class ZardPaginatorComponent implements OnInit, OnDestroy, ZardPaginatorL
 
   protected readonly displayedPageSizeOptions = computed(() => this.displayedPageSizeOptionsState())
 
+  protected readonly itemsPerPageLabel = computed(() =>
+    this.i18n.t('paginator.itemsPerPage', { Default: 'Items per page:' })
+  )
+  protected readonly itemsPerPagePlaceholder = computed(() =>
+    this.i18n.t('paginator.itemsPerPagePlaceholder', { Default: 'Items per page' })
+  )
+  protected readonly firstPageLabel = computed(() => this.i18n.t('paginator.firstPage', { Default: 'First page' }))
+  protected readonly previousPageLabel = computed(() =>
+    this.i18n.t('paginator.previousPage', { Default: 'Previous page' })
+  )
+  protected readonly nextPageLabel = computed(() => this.i18n.t('paginator.nextPage', { Default: 'Next page' }))
+  protected readonly lastPageLabel = computed(() => this.i18n.t('paginator.lastPage', { Default: 'Last page' }))
+
   protected readonly rangeLabel = computed(() => {
     const length = this.lengthState()
     const pageSize = this.pageSizeState()
     const pageIndex = this.pageIndexState()
 
     if (length === 0 || pageSize === 0) {
-      return `0 of ${length}`
+      return this.i18n.t('paginator.emptyRange', {
+        length,
+        Default: `0 of ${length}`
+      })
     }
 
     const startIndex = pageIndex * pageSize
     const endIndex = startIndex < length ? Math.min(startIndex + pageSize, length) : startIndex + pageSize
 
-    return `${startIndex + 1} \u2013 ${endIndex} of ${length}`
+    return this.i18n.t('paginator.range', {
+      start: startIndex + 1,
+      end: endIndex,
+      length,
+      Default: `${startIndex + 1} \u2013 ${endIndex} of ${length}`
+    })
   })
 
   ngOnInit(): void {


### PR DESCRIPTION
## Summary

- align the registration form width with the redesigned authentication shell already merged in #819
- make invitation relationships use the full settings workspace with a clearer table, empty state, search, and pagination controls
- split membership plan configuration and user membership management into task-focused tabs
- add consistent bordered information surfaces, responsive layouts, and localized paginator labels in English, Simplified Chinese, and Traditional Chinese

## Context

The login-page redesign requested with this work is already present on `develop` through #819. This PR builds on that baseline and contains the remaining registration, invitation-relationship, and membership-management changes.

## Test plan

- `pnpm nx test cloud --runInBand --testPathPatterns='apps/cloud/src/app/auth/(login|register)/.*\\.spec\\.ts'`
- `pnpm nx test cloud --runInBand --testPathPatterns='apps/cloud/src/app/features/setting/referrals/.*\\.spec\\.ts'`
- `pnpm nx test cloud --runInBand --testPathPatterns=apps/cloud/src/app/features/setting/membership/membership.component.spec.ts`
- `pnpm nx test ui --runInBand --testPathPatterns=packages/ui/src/lib/components/pagination/paginator.component.spec.ts`
- `pnpm nx run cloud:build:development --skip-nx-cache`