### PR TITLE
[codex] avoid duplicate image reference prompts

### DIFF
--- a/packages/server-ai/src/shared/agent/message.spec.ts
+++ b/packages/server-ai/src/shared/agent/message.spec.ts
@@ -22,6 +22,7 @@ import { GetFileAssetByStorageFileQuery } from '../../file-understanding/queries
 import { GetFileAssetQuery } from '../../file-understanding/queries/get-file-asset.query'
 import { GetFilePreviewQuery } from '../../file-understanding/queries/get-file-preview.query'
 import { LoadFileCommand } from '../commands'
+import { hydrateSendRequestHumanInput } from './human-input'
 import { createHumanMessage } from './message'
 import { ResolvePromptWorkflowInvocationQuery } from './queries/resolve-prompt-workflow-invocation.query'
 import { ListWorkspaceSkillsQuery } from '../../xpert-agent/queries/list-workspace-skills.query'
@@ -349,6 +350,80 @@ describe('createHumanMessage', () => {
         expect(textPart?.text).not.toContain(clientWorkspacePath)
         expect(queryBus.execute).toHaveBeenCalledWith(expect.objectContaining({ storageFileId: imageReference.fileId }))
     })
+
+    it.each([
+        ['compose input', 'Animate this image', 'diagram.png'],
+        ['reference-only input', '', 'diagram.png'],
+        ['replacement-token image name', 'Animate this image', 'price-$&.png']
+    ])(
+        'replaces a precomposed image reference prompt for %s when hydrating its workspace path',
+        async (_, input, imageName) => {
+            const workspacePath = '/workspace/sessions/conversation-1/files/asset-1/diagram.png'
+            const imageReference = {
+                type: 'image' as const,
+                fileId: 'storage-1',
+                url: 'https://example.com/diagram.png',
+                name: imageName,
+                mimeType: 'image/png',
+                text: 'Pasted image'
+            }
+            const hydratedRequest = hydrateSendRequestHumanInput({
+                action: 'send',
+                message: {
+                    input: {
+                        input,
+                        referenceComposition: 'compose' as const,
+                        references: [imageReference]
+                    }
+                }
+            })
+            const queryBus = {
+                execute: jest.fn().mockImplementation(async (query: unknown) => {
+                    if (query instanceof GetFileAssetByStorageFileQuery) {
+                        return {
+                            id: 'asset-1',
+                            storageFileId: 'storage-1',
+                            workspacePath
+                        }
+                    }
+                    if (query instanceof GetStorageFileQuery) {
+                        return [
+                            {
+                                id: 'storage-1',
+                                file: '',
+                                originalName: imageName,
+                                mimetype: 'image/png',
+                                size: 2048,
+                                storageProvider: 'local'
+                            }
+                        ]
+                    }
+                    return null
+                })
+            }
+
+            const message = await createHumanMessage(
+                {
+                    execute: jest.fn()
+                } as unknown as CommandBus,
+                queryBus as unknown as QueryBus,
+                {
+                    human: hydratedRequest.message.input
+                },
+                undefined
+            )
+
+            const textPart = (message.content as Array<{ type: string; text?: string }>).find(
+                (part) => part.type === 'text'
+            )
+            if (input) {
+                expect(textPart?.text).toContain(input)
+            }
+            expect(textPart?.text).toContain(`Workspace Path: ${workspacePath}`)
+            expect(textPart?.text?.match(/Referenced content:/g)).toHaveLength(1)
+            expect(textPart?.text?.split(`[Image] ${imageName}`)).toHaveLength(2)
+        }
+    )
 
     it('adds file understanding cards without inlining preview chunks', async () => {
         const queryBus = {

--- a/packages/server-ai/src/shared/agent/message.ts
+++ b/packages/server-ai/src/shared/agent/message.ts
@@ -204,7 +204,9 @@ export async function createHumanMessage(
     const { human } = state
     const agentHuman = await resolvePromptWorkflowHumanInput(queryBus, human, options?.xpert)
     const input = typeof agentHuman?.input === 'string' ? agentHuman.input : JSON.stringify(agentHuman?.input ?? '')
-    const references = await hydrateImageReferenceWorkspacePaths(queryBus, normalizeReferences(agentHuman?.references))
+    const normalizedReferences = normalizeReferences(agentHuman?.references)
+    const originalReferencePrompt = buildReferencedPrompt(normalizedReferences)
+    const references = await hydrateImageReferenceWorkspacePaths(queryBus, normalizedReferences)
     const referencePrompt = buildReferencedPrompt(references)
     const selectedSkillsPrompt = await buildSelectedRuntimeSkillsPrompt(
         queryBus,
@@ -213,14 +215,16 @@ export async function createHumanMessage(
         agentHuman,
         options?.xpert
     )
-    const finalTextWithoutSkills =
-        input.trim().length > 0 && referencePrompt.trim().length > 0
-            ? input.includes(referencePrompt)
-                ? input
-                : `${input.trimEnd()}\n\n${referencePrompt}`
-            : input.trim().length > 0
-              ? input
-              : referencePrompt
+    let finalTextWithoutSkills: string
+    if (!input.trim().length) {
+        finalTextWithoutSkills = referencePrompt
+    } else if (!referencePrompt.trim().length || input.includes(referencePrompt)) {
+        finalTextWithoutSkills = input
+    } else if (originalReferencePrompt.trim().length && input.endsWith(originalReferencePrompt)) {
+        finalTextWithoutSkills = `${input.slice(0, -originalReferencePrompt.length)}${referencePrompt}`
+    } else {
+        finalTextWithoutSkills = `${input.trimEnd()}\n\n${referencePrompt}`
+    }
     const finalText = appendPromptSection(finalTextWithoutSkills, selectedSkillsPrompt)
     const imageReferences = references.filter(
         (reference): reference is Extract<(typeof references)[number], { type: 'image' }> => reference.type === 'image'


### PR DESCRIPTION
## Summary

Prevent precomposed image reference prompts from being appended a second time after the server hydrates an authoritative workspace path.

## Problem

Reference-only requests and requests using `referenceComposition: 'compose'` precompose the original image reference prompt into the human input. Later, `createHumanMessage` resolves the image's authoritative `FileAsset.workspacePath` and rebuilds the prompt. Because the hydrated prompt differs from the precomposed prompt, the previous exact containment check treated it as absent and appended the whole reference block again. Models then received the same image description twice.

## Fix

- Build and retain the normalized prompt before workspace-path hydration.
- When that original prompt is the system-generated suffix of the input, replace only that suffix with the hydrated prompt.
- Use string slicing instead of `String.replace` so `$&` and other replacement tokens in user-controlled image metadata remain literal.
- Preserve the existing append behavior when the input was not precomposed.

## Validation

- `message.spec.ts`: 15 tests passed, including compose, reference-only, and a `price-$&.png` regression case.
- `chat.reference-only.spec.ts`: 5 tests passed.
- `corepack pnpm nx build server-ai`: passed.
- Prettier and `git diff --check`: passed.
- Manually verified that the final HumanMessage contains one image reference block with the authoritative workspace path.
