### PR TITLE
fix(sandbox): gate local host command execution

### DIFF
--- a/docker/env.example
+++ b/docker/env.example
@@ -1,4 +1,6 @@
 NODE_ENV=production
+# Local Sandbox executes commands directly on the API host. Enable only in trusted environments.
+XPERT_LOCAL_SANDBOX_ENABLED=false
 # LOG_LEVEL=debug # 'error', 'warn', 'log', 'debug', 'verbose'
 # DEBUG=@langchain/mcp-adapters:*,ocap:*
 LOG_DIR=/var/lib/xpert/data/logs

--- a/env.local
+++ b/env.local
@@ -5,6 +5,9 @@ LOG_DIR=./dist/apps/api/logs
 LOG_FILE_MAX_SIZE=10m
 LOG_FILE_MAX_FILES=5
 
+# Local Sandbox executes commands directly on the development host. Enable only when needed.
+XPERT_LOCAL_SANDBOX_ENABLED=false
+
 # set true if running as a Demo
 DEMO=false
 #Installation 1.standalone 2.with-doris 3.with-starrocks

--- a/packages/server-ai/src/sandbox/local-shell-sandbox.provider.spec.ts
+++ b/packages/server-ai/src/sandbox/local-shell-sandbox.provider.spec.ts
@@ -674,6 +674,7 @@ describe('LocalShellSandboxProvider Sandbox Jobs', () => {
 
     it('rejects host-executed jobs in production', async () => {
         process.env.NODE_ENV = 'production'
+        process.env.XPERT_LOCAL_SANDBOX_ENABLED = 'true'
         delete process.env.NSJAIL_RUNNER_URL
         delete process.env.NSJAIL_RUNNER_TOKEN
         const provider = new LocalShellSandboxProvider()
@@ -694,42 +695,38 @@ describe('LocalShellSandboxProvider Sandbox Jobs', () => {
 })
 
 describe('LocalShellSandboxProvider', () => {
-    const originalNodeEnv = process.env.NODE_ENV
-    const originalRunnerUrl = process.env.NSJAIL_RUNNER_URL
-    const originalRunnerToken = process.env.NSJAIL_RUNNER_TOKEN
+    const originalEnvironment = { ...process.env }
 
     beforeEach(() => {
-        process.env.NODE_ENV = 'development'
+        process.env = { ...originalEnvironment }
+        delete process.env.XPERT_LOCAL_SANDBOX_ENABLED
         delete process.env.NSJAIL_RUNNER_URL
         delete process.env.NSJAIL_RUNNER_TOKEN
     })
 
     afterAll(() => {
-        if (originalNodeEnv === undefined) {
-            delete process.env.NODE_ENV
-        } else {
-            process.env.NODE_ENV = originalNodeEnv
-        }
-        if (originalRunnerUrl === undefined) {
-            delete process.env.NSJAIL_RUNNER_URL
-        } else {
-            process.env.NSJAIL_RUNNER_URL = originalRunnerUrl
-        }
-        if (originalRunnerToken === undefined) {
-            delete process.env.NSJAIL_RUNNER_TOKEN
-        } else {
-            process.env.NSJAIL_RUNNER_TOKEN = originalRunnerToken
-        }
+        process.env = { ...originalEnvironment }
     })
 
-    it('remains available when the NsJail Runner is not configured', () => {
-        expect(new LocalShellSandboxProvider().isAvailable()).toBe(true)
+    it.each([undefined, '', 'false', '1', 'yes'])('is unavailable unless explicitly enabled with true', (value) => {
+        if (value === undefined) {
+            delete process.env.XPERT_LOCAL_SANDBOX_ENABLED
+        } else {
+            process.env.XPERT_LOCAL_SANDBOX_ENABLED = value
+        }
+
+        expect(new LocalShellSandboxProvider().isAvailable()).toBe(false)
     })
 
-    it.each(['NSJAIL_RUNNER_URL', 'NSJAIL_RUNNER_TOKEN'] as const)(
-        'remains available in development when %s is configured',
-        async (name) => {
-            process.env[name] = 'configured'
+    it.each(['development', 'test', 'production', undefined])(
+        'is available when explicitly enabled independently of NODE_ENV=%s',
+        async (nodeEnv) => {
+            if (nodeEnv === undefined) {
+                delete process.env.NODE_ENV
+            } else {
+                process.env.NODE_ENV = nodeEnv
+            }
+            process.env.XPERT_LOCAL_SANDBOX_ENABLED = ' TRUE '
             const provider = new LocalShellSandboxProvider()
 
             expect(provider.isAvailable()).toBe(true)
@@ -737,15 +734,18 @@ describe('LocalShellSandboxProvider', () => {
         }
     )
 
-    it.each(['NSJAIL_RUNNER_URL', 'NSJAIL_RUNNER_TOKEN'] as const)(
-        'fails closed in production when %s is configured',
-        async (name) => {
-            process.env.NODE_ENV = 'production'
-            process.env[name] = 'configured'
-            const provider = new LocalShellSandboxProvider()
+    it('remains available when the NsJail Runner is configured', () => {
+        process.env.XPERT_LOCAL_SANDBOX_ENABLED = 'true'
+        process.env.NSJAIL_RUNNER_URL = 'http://runner:8090'
+        process.env.NSJAIL_RUNNER_TOKEN = 'secret'
 
-            expect(provider.isAvailable()).toBe(false)
-            await expect(provider.create()).rejects.toThrow('Sandbox provider is unavailable: local-shell-sandbox')
-        }
-    )
+        expect(new LocalShellSandboxProvider().isAvailable()).toBe(true)
+    })
+
+    it('rejects creation when host command execution is not enabled', async () => {
+        const provider = new LocalShellSandboxProvider()
+
+        expect(provider.isAvailable()).toBe(false)
+        await expect(provider.create()).rejects.toThrow('Sandbox provider is unavailable: local-shell-sandbox')
+    })
 })

--- a/packages/server-ai/src/sandbox/local-shell-sandbox.provider.ts
+++ b/packages/server-ai/src/sandbox/local-shell-sandbox.provider.ts
@@ -1264,10 +1264,7 @@ export class LocalShellSandboxProvider implements ISandboxProvider<LocalShellSan
     }
 
     isAvailable(): boolean {
-        if (process.env.NODE_ENV !== 'production') {
-            return true
-        }
-        return !process.env.NSJAIL_RUNNER_URL?.trim() && !process.env.NSJAIL_RUNNER_TOKEN?.trim()
+        return process.env.XPERT_LOCAL_SANDBOX_ENABLED?.trim().toLowerCase() === 'true'
     }
 
     async create(options?: SandboxProviderCreateOptions): Promise<LocalShellSandbox> {

--- a/tools/scripts/.env.example
+++ b/tools/scripts/.env.example
@@ -2,6 +2,8 @@
 IS_DOCKER=false
 
 NODE_ENV=production
+# Local Sandbox executes commands directly on the API host. Enable only in trusted environments.
+XPERT_LOCAL_SANDBOX_ENABLED=false
 # LOG_LEVEL=debug
 
 # XPERT_AI_HOME=xpertai


### PR DESCRIPTION
## Summary

- remove `LocalShellSandboxProvider.isAvailable()` dependency on `NODE_ENV`
- require `XPERT_LOCAL_SANDBOX_ENABLED=true` before Local Sandbox can execute commands on the API host
- document the new switch as disabled by default in local and deployment environment templates
- cover fail-closed values, `NODE_ENV` independence, and NsJail coexistence

## Testing

- `corepack pnpm nx test server-ai --testFile=packages/server-ai/src/sandbox/local-shell-sandbox.provider.spec.ts --runInBand`
- `corepack pnpm eslint packages/server-ai/src/sandbox/local-shell-sandbox.provider.ts packages/server-ai/src/sandbox/local-shell-sandbox.provider.spec.ts`
- `corepack pnpm prettier --check packages/server-ai/src/sandbox/local-shell-sandbox.provider.ts packages/server-ai/src/sandbox/local-shell-sandbox.provider.spec.ts`
- `git diff --check`

Sandbox directory test run: 24 of 25 suites passed (164 tests). The remaining three failures in `local-browser-runtime.provider.spec.ts` require the unavailable Node 20.20.2/Playwright runtime assets and are unrelated to this change.
