### PR TITLE
[codex] fix clipboard copy over HTTP

### DIFF
--- a/apps/cloud/src/app/features/setting/account/account.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/account/account.component.spec.ts
@@ -1,4 +1,5 @@
 import { DOCUMENT } from '@angular/common'
+import { Clipboard } from '@angular/cdk/clipboard'
 import { TestBed } from '@angular/core/testing'
 import { ReferralService } from '@cloud/app/@core/state'
 import { TranslateService } from '@ngx-translate/core'
@@ -53,10 +54,14 @@ describe('XpAccountComponent template', () => {
   })
 
   it('copies the loaded invitation code', async () => {
-    const writeText = jest.fn().mockResolvedValue(undefined)
+    const copy = jest.fn().mockReturnValue(true)
     const setTimeout = jest.fn()
     TestBed.configureTestingModule({
       providers: [
+        {
+          provide: Clipboard,
+          useValue: { copy }
+        },
         {
           provide: Store,
           useValue: {
@@ -97,11 +102,7 @@ describe('XpAccountComponent template', () => {
           provide: DOCUMENT,
           useValue: {
             defaultView: {
-              navigator: {
-                clipboard: {
-                  writeText
-                }
-              },
+              navigator: {},
               setTimeout
             }
           }
@@ -113,7 +114,7 @@ describe('XpAccountComponent template', () => {
 
     await component.copyReferralCode()
 
-    expect(writeText).toHaveBeenCalledWith('ABC234DEFG')
+    expect(copy).toHaveBeenCalledWith('ABC234DEFG')
     expect(component.referralCodeCopied()).toBe(true)
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1500)
   })

--- a/apps/cloud/src/app/features/setting/account/account.component.ts
+++ b/apps/cloud/src/app/features/setting/account/account.component.ts
@@ -1,4 +1,5 @@
 import { DOCUMENT } from '@angular/common'
+import { Clipboard } from '@angular/cdk/clipboard'
 import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
 import { ReferralService } from '@cloud/app/@core/state'
@@ -37,6 +38,7 @@ export class XpAccountComponent {
   private readonly store = inject(Store)
   private readonly referralService = inject(ReferralService)
   private readonly document = inject(DOCUMENT)
+  private readonly clipboard = inject(Clipboard)
   private readonly alertDialog = inject(ZardAlertDialogService)
   private readonly translate = inject(TranslateService)
   private readonly toastr = inject(ToastrService)
@@ -78,15 +80,17 @@ export class XpAccountComponent {
     })
   }
 
-  async copyReferralCode() {
+  copyReferralCode() {
     const code = this.referralCode()
-    const clipboard = this.document.defaultView?.navigator.clipboard
-    if (!code || !clipboard) {
+    if (!code) {
       return
     }
 
     try {
-      await clipboard.writeText(code)
+      if (!this.clipboard.copy(code)) {
+        this.referralCodeCopied.set(false)
+        return
+      }
       this.referralCodeCopied.set(true)
       this.document.defaultView?.setTimeout(() => this.referralCodeCopied.set(false), 1500)
     } catch {

--- a/apps/cloud/src/app/features/setting/account/model-gateway.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/account/model-gateway.component.spec.ts
@@ -1,4 +1,5 @@
 import { DOCUMENT } from '@angular/common'
+import { Clipboard } from '@angular/cdk/clipboard'
 import { TestBed } from '@angular/core/testing'
 import { TranslateService } from '@ngx-translate/core'
 import { Store } from '@cloud/app/@core/state'
@@ -130,5 +131,42 @@ describe('XpAccountModelGatewayComponent', () => {
 
     component.modelSearchControl.setValue('beta')
     expect(component.filteredCatalogItems()).toEqual([unavailable])
+  })
+
+  it('uses the CDK clipboard fallback and reports the copy result without the native Clipboard API', () => {
+    const copy = jest.fn().mockReturnValueOnce(true).mockReturnValueOnce(false)
+    const toastr = { error: jest.fn(), success: jest.fn() }
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Clipboard, useValue: { copy } },
+        { provide: ModelGatewayService, useValue: {} },
+        { provide: ZardDialogService, useValue: {} },
+        { provide: TranslateService, useValue: { instant: jest.fn((value: string) => value) } },
+        { provide: ToastrService, useValue: toastr },
+        { provide: Store, useValue: {} },
+        {
+          provide: DOCUMENT,
+          useValue: {
+            defaultView: {
+              location: { origin: 'http://10.151.251.15' },
+              navigator: {}
+            }
+          }
+        }
+      ]
+    })
+    const component = TestBed.runInInjectionContext(() => new XpAccountModelGatewayComponent())
+
+    component.copy('first value')
+
+    expect(copy).toHaveBeenCalledWith('first value')
+    expect(toastr.success).toHaveBeenCalledWith('XP.ACTIONS.Copied')
+    expect(toastr.error).not.toHaveBeenCalled()
+
+    component.copy('second value')
+
+    expect(copy).toHaveBeenCalledWith('second value')
+    expect(toastr.error).toHaveBeenCalledWith('XP.ModelGateway.CopyFailed')
   })
 })

--- a/apps/cloud/src/app/features/setting/account/model-gateway.component.ts
+++ b/apps/cloud/src/app/features/setting/account/model-gateway.component.ts
@@ -1,4 +1,5 @@
 import { CommonModule, DOCUMENT } from '@angular/common'
+import { Clipboard } from '@angular/cdk/clipboard'
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core'
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop'
 import { FormControl, ReactiveFormsModule } from '@angular/forms'
@@ -76,6 +77,7 @@ export class XpAccountModelGatewayComponent implements OnInit {
   readonly #toastr = injectToastr()
   readonly #translate = inject(TranslateService)
   readonly #document = inject(DOCUMENT)
+  readonly #clipboard = inject(Clipboard)
   readonly #store = inject(Store)
   readonly #destroyRef = inject(DestroyRef)
   #loadSequence = 0
@@ -278,9 +280,14 @@ export class XpAccountModelGatewayComponent implements OnInit {
     await this.load()
   }
 
-  async copy(value: string) {
+  copy(value: string) {
     try {
-      await this.#document.defaultView?.navigator.clipboard.writeText(value)
+      if (!this.#clipboard.copy(value)) {
+        this.#toastr.error(
+          this.#translate.instant('XP.ModelGateway.CopyFailed', { Default: 'Failed to copy to clipboard' })
+        )
+        return
+      }
       this.#toastr.success(this.#translate.instant('XP.ACTIONS.Copied', { Default: 'Copied' }))
     } catch (error) {
       this.#toastr.error(getErrorMessage(error))


### PR DESCRIPTION
## Summary

- route invitation-code and external-API copy actions through Angular CDK Clipboard
- preserve invitation-code copied-state feedback and report external-API copy failures
- cover HTTP origins where the native Clipboard API is unavailable

## Problem

When Xpert is opened from a non-secure HTTP IP address, browsers do not expose `navigator.clipboard`. The external API page therefore threw while reading `writeText`, while the invitation-code action returned without copying or showing feedback.

## Root cause and fix

Both account copy paths called the native Clipboard API directly even though the application already uses Angular CDK Clipboard elsewhere. The components now inject CDK Clipboard and use its boolean result to drive their existing success or failure behavior. No routes, API contracts, persistence behavior, or visual structure changed.

## Validation

- `pnpm exec jest apps/cloud/src/app/features/setting/account/account.component.spec.ts apps/cloud/src/app/features/setting/account/model-gateway.component.spec.ts --config apps/cloud/jest.config.ts --runInBand --no-cache` (7 tests passed)
- targeted ESLint for the four changed files
- `pnpm exec tsc -p apps/cloud/tsconfig.app.json --noEmit`
- `git diff --check`

Browser validation was intentionally not run; the HTTP deployment flow remains for manual acceptance.
