### PR TITLE
fix: align model parameter defaults across UI and runtime

### DIFF
--- a/.changeset/fair-model-defaults.md
+++ b/.changeset/fair-model-defaults.md
@@ -1,0 +1,6 @@
+---
+'@xpert-ai/contracts': patch
+'@xpert-ai/plugin-sdk': patch
+---
+
+Resolve model parameter defaults consistently across configuration UIs and runtime model creation, and expose provider parameter rules through the plugin SDK.

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
@@ -282,7 +282,45 @@ describe('CopilotModelSelectComponent', () => {
     expect(component['cva'].value$()?.options).toEqual({
       [ModelPropertyKey.CONTEXT_SIZE]: 200000,
       temperature: 0.3,
-      max_tokens: 256
+      max_tokens: 256,
+      top_p: 0.9
+    })
+  }))
+
+  it('fills a missing thinking default when other options already exist', fakeAsync(() => {
+    tick(600)
+    fixture.detectChanges()
+
+    component.writeValue({
+      copilotId: copilot.id,
+      model: glmModel.model,
+      modelType: AiModelTypeEnum.LLM,
+      options: {
+        [ModelPropertyKey.CONTEXT_SIZE]: 200000,
+        temperature: 0.3
+      }
+    })
+    fixture.detectChanges()
+
+    glmRules$.next([
+      {
+        name: 'temperature',
+        type: ParameterType.FLOAT,
+        default: 0.7
+      },
+      {
+        name: 'enable_thinking',
+        type: ParameterType.BOOLEAN,
+        default: true
+      }
+    ])
+    tick()
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()?.options).toEqual({
+      [ModelPropertyKey.CONTEXT_SIZE]: 200000,
+      temperature: 0.3,
+      enable_thinking: true
     })
   }))
 

--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.ts
@@ -21,7 +21,13 @@ import { TranslateModule } from '@ngx-translate/core'
 import { NgxControlValueAccessor } from 'ngxtension/control-value-accessor'
 import { derivedAsync } from 'ngxtension/derived-async'
 import { distinctUntilChanged, map, of } from 'rxjs'
-import { AiModelTypeEnum, ModelFeature, ModelPropertyKey, ParameterType } from '@xpert-ai/contracts'
+import {
+  AiModelTypeEnum,
+  ModelFeature,
+  ModelPropertyKey,
+  normalizeModelParameterValue,
+  resolveModelParameterOptions
+} from '@xpert-ai/contracts'
 import type {
   I18nObject,
   ICopilot,
@@ -431,7 +437,7 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
     const rule = this.hasResolvedCurrentModelParameterRules()
       ? this.modelParameterRules().find((item) => item.name === name)
       : null
-    const nextValue = rule ? this.normalizeParameterValue(value, rule) : value
+    const nextValue = rule ? normalizeModelParameterValue(value, rule) : value
 
     this.updateValue({
       ...this.cva.value$(),
@@ -616,35 +622,21 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
 
   private resolveOptions(options: Record<string, any> | undefined, rules: ParameterRule[]) {
     const contextSize = this.parseContextSize(options?.[ModelPropertyKey.CONTEXT_SIZE])
-    const nextOptions = {
+    const retainedOptions = {
       ...(typeof contextSize === 'number' ? { [ModelPropertyKey.CONTEXT_SIZE]: contextSize } : {})
     } as Record<string, any>
 
-    let hasRetainedRuleValue = false
     for (const rule of rules) {
       if (!rule.name) {
         continue
       }
 
-      const value = options?.[rule.name]
-      if (value !== undefined) {
-        const nextValue = this.normalizeParameterValue(value, rule)
-        if (nextValue !== undefined) {
-          nextOptions[rule.name] = nextValue
-          hasRetainedRuleValue = true
-        }
+      if (Object.prototype.hasOwnProperty.call(options ?? {}, rule.name)) {
+        retainedOptions[rule.name] = options?.[rule.name]
       }
     }
 
-    if (!hasRetainedRuleValue && this.shouldInitDefaultOptions(options)) {
-      for (const rule of rules) {
-        if (rule.name && rule.default !== undefined) {
-          nextOptions[rule.name] = rule.default
-        }
-      }
-    }
-
-    return Object.keys(nextOptions).length ? nextOptions : undefined
+    return resolveModelParameterOptions(retainedOptions, rules)
   }
 
   private cloneOptions(options?: Record<string, any>) {
@@ -660,65 +652,6 @@ export class CopilotModelSelectComponent implements ControlValueAccessor {
     }
 
     return currentKeys.every((key) => current?.[key] === next?.[key])
-  }
-
-  private shouldInitDefaultOptions(options?: Record<string, any>): boolean {
-    if (!options) {
-      return true
-    }
-    const keys = Object.keys(options).filter((key) => options[key] !== undefined)
-    return keys.length === 0 || (keys.length === 1 && keys[0] === ModelPropertyKey.CONTEXT_SIZE)
-  }
-
-  private normalizeParameterValue(value: unknown, rule: ParameterRule) {
-    if (rule.type !== ParameterType.FLOAT && rule.type !== ParameterType.INT) {
-      return value
-    }
-
-    const numericValue = this.parseNumericParameterValue(value, rule.type)
-    if (numericValue === undefined) {
-      return undefined
-    }
-
-    return this.clampNumericParameterValue(numericValue, rule)
-  }
-
-  private parseNumericParameterValue(
-    value: unknown,
-    type: ParameterType.FLOAT | ParameterType.INT
-  ): number | undefined {
-    if (value === '' || value === null || value === undefined) {
-      return undefined
-    }
-
-    let parsed: number
-    if (typeof value === 'number') {
-      parsed = value
-    } else if (typeof value === 'string') {
-      parsed = type === ParameterType.INT ? Number.parseInt(value, 10) : Number.parseFloat(value)
-    } else {
-      return undefined
-    }
-
-    if (!Number.isFinite(parsed)) {
-      return undefined
-    }
-
-    return type === ParameterType.INT ? Math.trunc(parsed) : parsed
-  }
-
-  private clampNumericParameterValue(value: number, rule: ParameterRule) {
-    let nextValue = value
-
-    if (typeof rule.min === 'number' && Number.isFinite(rule.min) && nextValue < rule.min) {
-      nextValue = rule.min
-    }
-
-    if (typeof rule.max === 'number' && Number.isFinite(rule.max) && nextValue > rule.max) {
-      nextValue = rule.max
-    }
-
-    return rule.type === ParameterType.INT ? Math.trunc(nextValue) : nextValue
   }
 
   private getMenuRailBounds(containerWidth: number | null | undefined) {

--- a/packages/contracts/src/ai/ai-model.model.spec.ts
+++ b/packages/contracts/src/ai/ai-model.model.spec.ts
@@ -1,0 +1,83 @@
+import {
+  normalizeModelParameterValue,
+  ParameterRule,
+  ParameterType,
+  resolveModelParameterOptions
+} from './ai-model.model'
+
+const label = { en_US: 'Parameter' }
+
+function rule(input: Partial<ParameterRule> & Pick<ParameterRule, 'name' | 'type'>): ParameterRule {
+  return { label, ...input }
+}
+
+describe('model parameter options', () => {
+  it('fills each missing default without replacing saved values', () => {
+    const options = resolveModelParameterOptions({ temperature: 0.3 }, [
+      rule({ name: 'temperature', type: ParameterType.FLOAT, default: 0.7 }),
+      rule({ name: 'enable_thinking', type: ParameterType.BOOLEAN, default: true })
+    ])
+
+    expect(options).toEqual({ temperature: 0.3, enable_thinking: true })
+  })
+
+  it('preserves explicit false and zero values', () => {
+    const options = resolveModelParameterOptions({ enable_thinking: false, temperature: 0 }, [
+      rule({ name: 'enable_thinking', type: ParameterType.BOOLEAN, default: true }),
+      rule({ name: 'temperature', type: ParameterType.FLOAT, default: 0.7 })
+    ])
+
+    expect(options).toEqual({ enable_thinking: false, temperature: 0 })
+  })
+
+  it('normalizes boolean strings and falls back from invalid enum values', () => {
+    const options = resolveModelParameterOptions({ enable_search: 'false', thinking: 'unsupported' }, [
+      rule({ name: 'enable_search', type: ParameterType.BOOLEAN, default: true }),
+      rule({
+        name: 'thinking',
+        type: ParameterType.STRING,
+        options: ['enabled', 'disabled'],
+        default: 'enabled'
+      })
+    ])
+
+    expect(options).toEqual({ enable_search: false, thinking: 'enabled' })
+  })
+
+  it('parses and clamps numeric values', () => {
+    expect(
+      normalizeModelParameterValue(
+        '12.8',
+        rule({
+          name: 'max_tokens',
+          type: ParameterType.INT,
+          min: 1,
+          max: 10
+        })
+      )
+    ).toBe(10)
+    expect(
+      normalizeModelParameterValue(
+        '-0.5',
+        rule({
+          name: 'temperature',
+          type: ParameterType.FLOAT,
+          min: 0,
+          max: 2
+        })
+      )
+    ).toBe(0)
+  })
+
+  it('preserves options that are not described by parameter rules', () => {
+    const options = resolveModelParameterOptions({ context_size: 128000, provider_option: 'value' }, [
+      rule({ name: 'enable_thinking', type: ParameterType.BOOLEAN, default: true })
+    ])
+
+    expect(options).toEqual({
+      context_size: 128000,
+      provider_option: 'value',
+      enable_thinking: true
+    })
+  })
+})

--- a/packages/contracts/src/ai/ai-model.model.ts
+++ b/packages/contracts/src/ai/ai-model.model.ts
@@ -194,6 +194,91 @@ export interface ParameterRule {
   options?: string[]
 }
 
+export function normalizeModelParameterValue(value: unknown, rule: ParameterRule): unknown | undefined {
+  switch (rule.type) {
+    case ParameterType.FLOAT:
+    case ParameterType.INT: {
+      if (value === '' || value === null || value === undefined) {
+        return undefined
+      }
+
+      const numericValue = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN
+      if (!Number.isFinite(numericValue)) {
+        return undefined
+      }
+
+      let normalizedValue = rule.type === ParameterType.INT ? Math.trunc(numericValue) : numericValue
+      if (typeof rule.min === 'number' && Number.isFinite(rule.min)) {
+        normalizedValue = Math.max(normalizedValue, rule.min)
+      }
+      if (typeof rule.max === 'number' && Number.isFinite(rule.max)) {
+        normalizedValue = Math.min(normalizedValue, rule.max)
+      }
+      return rule.type === ParameterType.INT ? Math.trunc(normalizedValue) : normalizedValue
+    }
+    case ParameterType.BOOLEAN:
+      if (typeof value === 'boolean') {
+        return value
+      }
+      if (typeof value === 'string') {
+        const normalizedValue = value.trim().toLowerCase()
+        if (normalizedValue === 'true') {
+          return true
+        }
+        if (normalizedValue === 'false') {
+          return false
+        }
+      }
+      if (value === 1) {
+        return true
+      }
+      if (value === 0) {
+        return false
+      }
+      return undefined
+    case ParameterType.STRING:
+    case ParameterType.TEXT:
+      if (typeof value !== 'string') {
+        return undefined
+      }
+      if (rule.options?.length && !rule.options.includes(value)) {
+        return undefined
+      }
+      return value
+    default:
+      return value === undefined ? undefined : value
+  }
+}
+
+export function resolveModelParameterOptions(
+  modelOptions: Record<string, unknown> | undefined,
+  rules: ParameterRule[],
+  config: { preserveUnknown?: boolean } = {}
+): Record<string, unknown> | undefined {
+  const preserveUnknown = config.preserveUnknown ?? true
+  const resolvedOptions: Record<string, unknown> = preserveUnknown ? { ...(modelOptions ?? {}) } : {}
+
+  for (const rule of rules) {
+    if (!rule.name) {
+      continue
+    }
+
+    const hasSavedValue = Object.prototype.hasOwnProperty.call(modelOptions ?? {}, rule.name)
+    let resolvedValue = hasSavedValue ? normalizeModelParameterValue(modelOptions?.[rule.name], rule) : undefined
+    if (resolvedValue === undefined && rule.default !== undefined) {
+      resolvedValue = normalizeModelParameterValue(rule.default, rule)
+    }
+
+    if (resolvedValue === undefined) {
+      delete resolvedOptions[rule.name]
+    } else {
+      resolvedOptions[rule.name] = resolvedValue
+    }
+  }
+
+  return Object.keys(resolvedOptions).length ? resolvedOptions : undefined
+}
+
 export interface PriceTierConfig {
   input: number
   output?: number

--- a/packages/plugin-sdk/src/lib/ai-model/types/model.ts
+++ b/packages/plugin-sdk/src/lib/ai-model/types/model.ts
@@ -4,8 +4,9 @@ import {
   ICopilot,
   ICopilotModel,
   ILLMUsage,
-  ModelUsagePricingSnapshot,
   ModelUsagePricingContext,
+  ModelUsagePricingSnapshot,
+  ParameterRule,
   ParameterType,
   PriceInfo,
   PriceType
@@ -36,6 +37,7 @@ export interface IAIModel {
   validateCredentials(model: string, credentials: Record<string, any>): Promise<void>
   getChatModel(copilotModel: ICopilotModel, options?: TChatModelOptions): BaseChatModel
   predefinedModels(): AIModelEntity[]
+  getParameterRules(model: string, credentials: Record<string, string>): ParameterRule[]
   getUsagePricingSnapshot(
     model: string,
     credentials: Record<string, any>,

--- a/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.spec.ts
+++ b/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.spec.ts
@@ -10,7 +10,9 @@ import {
     ModelAccessChannelEnum,
     ModelAccessOwnershipScopeEnum,
     ModelAccessSourceEnum,
-    ModelFeature
+    ModelFeature,
+    ParameterRule,
+    ParameterType
 } from '@xpert-ai/contracts'
 import { RequestContext } from '@xpert-ai/plugin-sdk'
 import { AIModelGetProviderQuery } from '../../../ai-model'
@@ -21,7 +23,12 @@ import { CopilotModelGetChatModelHandler } from './get-chat-model.handler'
 import { prepareMessagesForModel } from '../../model-capabilities'
 
 describe('CopilotModelGetChatModelHandler', () => {
-    function createFixture(features: ModelFeature[] = [], modelType = AiModelTypeEnum.LLM) {
+    function createFixture(
+        features: ModelFeature[] = [],
+        modelType = AiModelTypeEnum.LLM,
+        parameterRules: ParameterRule[] = [],
+        modelOptions?: Record<string, unknown>
+    ) {
         const modelAccess: IModelAccessResolution = {
             allowed: true,
             channel: ModelAccessChannelEnum.Xpert,
@@ -56,6 +63,8 @@ describe('CopilotModelGetChatModelHandler', () => {
                 label: { en_US: 'qwen3.6-plus', zh_Hans: 'qwen3.6-plus' }
             }
         ])
+        const getParameterRules = jest.fn().mockReturnValue(parameterRules)
+        const getModelManager = jest.fn().mockReturnValue({ getParameterRules })
         const queryBus = {
             execute: jest.fn(async (query) => {
                 if (query instanceof GetCopilotProviderModelQuery) {
@@ -65,7 +74,8 @@ describe('CopilotModelGetChatModelHandler', () => {
                     return {
                         name: 'tongyi',
                         getModelInstance,
-                        getProviderModels
+                        getProviderModels,
+                        getModelManager
                     }
                 }
                 throw new Error(`Unexpected query: ${query?.constructor?.name}`)
@@ -88,7 +98,8 @@ describe('CopilotModelGetChatModelHandler', () => {
             {
                 copilotId: 'copilot-1',
                 model: 'qwen3.6-plus',
-                modelType
+                modelType,
+                options: modelOptions
             } as never,
             {
                 usageCallback: jest.fn(),
@@ -98,7 +109,16 @@ describe('CopilotModelGetChatModelHandler', () => {
             }
         )
 
-        return { commandBus, getModelInstance, handler, model, modelAccess, modelAccessCallback, query }
+        return {
+            commandBus,
+            getModelInstance,
+            getParameterRules,
+            handler,
+            model,
+            modelAccess,
+            modelAccessCallback,
+            query
+        }
     }
 
     beforeEach(() => {
@@ -148,9 +168,9 @@ describe('CopilotModelGetChatModelHandler', () => {
             modelAccess,
             tokenUsed: 120
         })
-        expect(commandBus.execute.mock.calls.filter(([command]) => command instanceof CopilotCheckLimitCommand)).toHaveLength(
-            1
-        )
+        expect(
+            commandBus.execute.mock.calls.filter(([command]) => command instanceof CopilotCheckLimitCommand)
+        ).toHaveLength(1)
     })
 
     it('waits for the execution usage callback before recording provider usage', async () => {
@@ -171,16 +191,16 @@ describe('CopilotModelGetChatModelHandler', () => {
         })
         await Promise.resolve()
 
-        expect(
-            commandBus.execute.mock.calls.some(([command]) => command instanceof CopilotTokenRecordCommand)
-        ).toBe(false)
+        expect(commandBus.execute.mock.calls.some(([command]) => command instanceof CopilotTokenRecordCommand)).toBe(
+            false
+        )
 
         releaseUsage!()
         await reporting
 
-        expect(
-            commandBus.execute.mock.calls.some(([command]) => command instanceof CopilotTokenRecordCommand)
-        ).toBe(true)
+        expect(commandBus.execute.mock.calls.some(([command]) => command instanceof CopilotTokenRecordCommand)).toBe(
+            true
+        )
     })
 
     it('does not record estimated usage in the provider billing ledger', async () => {
@@ -193,9 +213,36 @@ describe('CopilotModelGetChatModelHandler', () => {
             usage: { totalTokens: 120, type: 'estimated' }
         })
 
-        expect(
-            commandBus.execute.mock.calls.some(([command]) => command instanceof CopilotTokenRecordCommand)
-        ).toBe(false)
+        expect(commandBus.execute.mock.calls.some(([command]) => command instanceof CopilotTokenRecordCommand)).toBe(
+            false
+        )
+    })
+
+    it('resolves missing parameter defaults before creating the model instance', async () => {
+        const rules: ParameterRule[] = [
+            {
+                name: 'temperature',
+                label: { en_US: 'Temperature' },
+                type: ParameterType.FLOAT,
+                default: 0.7
+            },
+            {
+                name: 'enable_thinking',
+                label: { en_US: 'Thinking mode' },
+                type: ParameterType.BOOLEAN,
+                default: true
+            }
+        ]
+        const { getModelInstance, handler, query } = createFixture([], AiModelTypeEnum.LLM, rules, {
+            temperature: 0.3
+        })
+
+        await handler.execute(query)
+
+        expect(getModelInstance.mock.calls[0][1].options).toEqual({
+            temperature: 0.3,
+            enable_thinking: true
+        })
     })
 
     it('marks predefined vision models', async () => {

--- a/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.ts
+++ b/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.ts
@@ -1,4 +1,4 @@
-import { IModelAccessResolution, mapTranslationLanguage } from '@xpert-ai/contracts'
+import { IModelAccessResolution, mapTranslationLanguage, resolveModelParameterOptions } from '@xpert-ai/contracts'
 import { omit } from '@xpert-ai/server-common'
 import { Logger } from '@nestjs/common'
 import { CommandBus, IQueryHandler, QueryBus, QueryHandler } from '@nestjs/cqrs'
@@ -79,10 +79,19 @@ export class CopilotModelGetChatModelHandler implements IQueryHandler<CopilotMod
 
         ensureCopilotModelContextSize(copilotModel, modelProvider, modelName, customModels)
 
+        const parameterRules =
+            modelProvider
+                .getModelManager(copilotModel.modelType)
+                ?.getParameterRules(modelName, customModels[0]?.modelProperties) ?? []
+        const resolvedCopilotModel = {
+            ...copilotModel,
+            options: resolveModelParameterOptions(copilotModel.options, parameterRules)
+        }
+
         const model = await modelProvider.getModelInstance(
             copilotModel.modelType,
             {
-                ...copilotModel,
+                ...resolvedCopilotModel,
                 copilot
             },
             {


### PR DESCRIPTION
# PR

## Summary

- Add shared normalization and default resolution for model parameters.
- Use the same resolution logic in the model selector UI and server-side model creation.
- Preserve explicit false and zero values while filling only missing defaults.
- Expose provider parameter rules through the plugin SDK contract.

## Motivation

Model parameter defaults could previously be applied differently by the frontend and backend. This caused controls such as thinking mode to display a disabled state while runtime requests used the enabled provider default. This change makes the persisted value, displayed state, and runtime request consistent.

## Validation

- `corepack pnpm nx test contracts --runInBand` (14 suites, 66 tests)
- `corepack pnpm nx test cloud --runInBand --testFile=apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts` (16 tests)
- `corepack pnpm nx test server-ai --runInBand --testFile=packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.spec.ts` (6 tests)
- `git diff --check`

# Checklist

- [x] Have you followed the contributing guidelines?
- [x] Have you explained what your changes do, and why they add value?