### PR TITLE
fix: restore API production build

### DIFF
--- a/packages/server-ai/src/ai/conversation.controller.ts
+++ b/packages/server-ai/src/ai/conversation.controller.ts
@@ -69,6 +69,8 @@ type FeedbackSearchRequest = {
     offset?: number
 }
 
+type FeedbackMutationRequest = Partial<Pick<IChatMessageFeedback, 'rating' | 'content'>>
+
 @ApiTags('AI/Conversations')
 @ApiBearerAuth()
 @Public()
@@ -405,7 +407,7 @@ export class ConversationsController {
     async createFeedback(
         @Param('conversation_id', UUIDValidationPipe) conversationId: string,
         @Param('message_id', UUIDValidationPipe) messageId: string,
-        @Body() body: Partial<IChatMessageFeedback>
+        @Body() body: FeedbackMutationRequest
     ) {
         await this.ensureMessage(conversationId, messageId)
         const publicScope = getPublicXpertSessionConversationScope()
@@ -437,7 +439,7 @@ export class ConversationsController {
         @Param('conversation_id', UUIDValidationPipe) conversationId: string,
         @Param('message_id', UUIDValidationPipe) messageId: string,
         @Param('feedback_id', UUIDValidationPipe) feedbackId: string,
-        @Body() body: Partial<IChatMessageFeedback>
+        @Body() body: FeedbackMutationRequest
     ) {
         await this.ensureMessage(conversationId, messageId)
         await this.feedbackService.findOneInOrganizationOrTenant(feedbackId, { where: { conversationId, messageId } })

--- a/packages/server-ai/src/chat-conversation/conversation.service.ts
+++ b/packages/server-ai/src/chat-conversation/conversation.service.ts
@@ -272,7 +272,7 @@ export class ChatConversationService extends TenantOrganizationAwareCrudService<
         })
     }
 
-    async findOneDetail(id: string, options: DeepPartial<PaginationParams<ChatConversation>>) {
+    async findOneDetail(id: string, options: Pick<PaginationParams<ChatConversation>, 'select' | 'relations'>) {
         // Split executions relation
         const { relations } = options ?? {}
         const entity = await this.findOne(id, {

--- a/packages/server-ai/src/xpert/xpert.controller.ts
+++ b/packages/server-ai/src/xpert/xpert.controller.ts
@@ -1048,7 +1048,9 @@ export class XpertController extends CrudController<Xpert> {
                 {
                     ...data,
                     where: {
-                        ...(transformWhere(where ?? {}) ?? {}),
+                        ...(transformWhere<
+                            Pick<ChatConversation, 'id' | 'threadId' | 'xpertId' | 'createdAt' | 'createdById'>
+                        >(where ?? {}) ?? {}),
                         xpertId: id,
                         createdAt: start ? Between(new Date(start), new Date(end)) : LessThanOrEqual(new Date(end))
                     }


### PR DESCRIPTION
## Summary

- Avoid TypeScript `TS2589` deep-type instantiation failures in the server AI API build.
- Narrow conversation query options and filter projections to the fields used at runtime.
- Constrain feedback mutation payloads to the supported mutable fields.

## Validation

- `corepack pnpm nx build api --skip-nx-cache`
- Targeted Jest suites: 3 passed, 41 tests passed.
- `git diff --check`
- The follow-up GitHub Actions run has passed the prior TypeScript failure point; the API image push is still in progress.

## Changes

This PR promotes commit `19f65ff1` from `develop` to `main` after the v3.17.2 release PR was merged.