### PR TITLE
fix: limit displayed point precision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ Thumbs.db
 .angular/
 .workflow/
 
+# Pi workspace files
+/.pi-glla/
+
 .angular
 .deploy/k8s/secret.prod.yaml
 /apps/api/public

--- a/apps/cloud/src/app/features/setting/account/billing.component.html
+++ b/apps/cloud/src/app/features/setting/account/billing.component.html
@@ -39,7 +39,7 @@
               @if (isUnlimited()) {
                 {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
               } @else {
-                {{ me()?.pointsRemaining | number: '1.0-10' }} / {{ me()?.pointsGranted | number: '1.0-10' }}
+                {{ me()?.pointsRemaining | number: '1.0-2' }} / {{ me()?.pointsGranted | number: '1.0-2' }}
               }
             </div>
             <div class="mt-1 text-xs text-text-tertiary">
@@ -56,7 +56,7 @@
             <div class="text-xs font-medium text-text-tertiary">
               {{ 'XP.Membership.UsedPoints' | translate: { Default: 'Used points' } }}
             </div>
-            <div class="mt-2 text-2xl font-semibold text-text-primary">{{ me()?.pointsUsed | number: '1.0-10' }}</div>
+            <div class="mt-2 text-2xl font-semibold text-text-primary">{{ me()?.pointsUsed | number: '1.0-2' }}</div>
             <div class="mt-1 text-xs text-text-tertiary">
               {{ usedPercent() | number }}% {{ 'XP.Membership.PointUsage' | translate: { Default: 'Point usage' } }}
             </div>
@@ -67,7 +67,7 @@
               {{ 'XP.Membership.PersonalPoints' | translate: { Default: 'Personal points' } }}
             </div>
             <div class="mt-2 text-2xl font-semibold text-text-primary">
-              {{ me()?.personalPointsBalance | number: '1.0-10' }}
+              {{ me()?.personalPointsBalance | number: '1.0-2' }}
             </div>
             <div class="mt-1 text-xs text-text-tertiary">
               {{
@@ -83,10 +83,10 @@
             <span>{{ 'XP.Membership.PointUsage' | translate: { Default: 'Point usage' } }}</span>
             <span>
               @if (isUnlimited()) {
-                {{ me()?.pointsUsed | number: '1.0-10' }} /
+                {{ me()?.pointsUsed | number: '1.0-2' }} /
                 {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
               } @else {
-                {{ me()?.pointsUsed | number: '1.0-10' }} / {{ me()?.pointsGranted | number: '1.0-10' }}
+                {{ me()?.pointsUsed | number: '1.0-2' }} / {{ me()?.pointsGranted | number: '1.0-2' }}
               }
             </span>
           </div>
@@ -121,7 +121,7 @@
             @if (me()?.plan?.includedPoints === null) {
               {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
             } @else {
-              {{ me()?.plan?.includedPoints | number }}
+              {{ me()?.plan?.includedPoints | number: '1.0-2' }}
             }
           </span>
         </div>
@@ -233,7 +233,7 @@
                     class="whitespace-nowrap px-4 py-3 text-right font-semibold"
                     [ngClass]="summary.pointsDelta > 0 ? 'text-text-success' : 'text-text-primary'"
                   >
-                    {{ summary.pointsDelta > 0 ? '+' : '' }}{{ summary.pointsDelta | number: '1.0-10' }}
+                    {{ summary.pointsDelta > 0 ? '+' : '' }}{{ summary.pointsDelta | number: '1.0-2' }}
                   </td>
                 </tr>
                 @if (isExpanded(summary)) {
@@ -283,7 +283,7 @@
                                   class="whitespace-nowrap px-4 py-2 text-right font-semibold"
                                   [ngClass]="ledger.pointsDelta > 0 ? 'text-text-success' : 'text-text-primary'"
                                 >
-                                  {{ ledger.pointsDelta > 0 ? '+' : '' }}{{ ledger.pointsDelta | number: '1.0-10' }}
+                                  {{ ledger.pointsDelta > 0 ? '+' : '' }}{{ ledger.pointsDelta | number: '1.0-2' }}
                                 </td>
                               </tr>
                             } @empty {

--- a/apps/cloud/src/app/features/setting/account/model-gateway.component.html
+++ b/apps/cloud/src/app/features/setting/account/model-gateway.component.html
@@ -389,7 +389,7 @@
                     <td z-table-cell>
                       {{ 'XP.ModelGateway.CallStatus.' + call.status | translate: { Default: call.status } }}
                     </td>
-                    <td z-table-cell>{{ call.chargedPoints }}</td>
+                    <td z-table-cell>{{ call.chargedPoints | number: '1.0-2' }}</td>
                     <td z-table-cell>{{ formatDate(call.startedAt) }}</td>
                   </tr>
                 }

--- a/apps/cloud/src/app/features/setting/account/usage.component.html
+++ b/apps/cloud/src/app/features/setting/account/usage.component.html
@@ -31,7 +31,7 @@
               @if (overview()?.pointsRemaining === null) {
                 {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
               } @else {
-                {{ overview()?.pointsRemaining | number: '1.0-10' }}
+                {{ overview()?.pointsRemaining | number: '1.0-2' }}
               }
             </div>
           </div>
@@ -40,7 +40,7 @@
               {{ 'XP.Membership.UsedPoints' | translate: { Default: 'Used points' } }}
             </div>
             <div class="mt-1 text-xl font-semibold text-text-primary">
-              {{ overview()?.pointsUsed | number: '1.0-10' }}
+              {{ overview()?.pointsUsed | number: '1.0-2' }}
             </div>
           </div>
           <div class="rounded-lg bg-components-panel-bg p-3">
@@ -48,7 +48,7 @@
               {{ 'XP.Membership.PersonalPoints' | translate: { Default: 'Personal points' } }}
             </div>
             <div class="mt-1 text-xl font-semibold text-text-primary">
-              {{ overview()?.personalPointsBalance | number: '1.0-10' }}
+              {{ overview()?.personalPointsBalance | number: '1.0-2' }}
             </div>
           </div>
         </div>
@@ -81,7 +81,7 @@
             <div class="text-xs font-medium text-text-tertiary">
               {{ 'XP.Membership.TotalPoints' | translate: { Default: 'Total points' } }}
             </div>
-            <div class="mt-1 text-2xl font-semibold text-text-primary">{{ totalPoints() | number: '1.0-10' }}</div>
+            <div class="mt-1 text-2xl font-semibold text-text-primary">{{ totalPoints() | number: '1.0-2' }}</div>
           </div>
         </z-card-content>
       </z-card>
@@ -113,7 +113,7 @@
             <div class="text-xs font-medium text-text-tertiary">
               {{ 'XP.Membership.PeakDailyPoints' | translate: { Default: 'Peak daily points' } }}
             </div>
-            <div class="mt-1 text-2xl font-semibold text-text-primary">{{ peakDailyPoints() | number: '1.0-10' }}</div>
+            <div class="mt-1 text-2xl font-semibold text-text-primary">{{ peakDailyPoints() | number: '1.0-2' }}</div>
           </div>
         </z-card-content>
       </z-card>
@@ -231,7 +231,7 @@
                 @if (period.pointsGranted === null) {
                   {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
                 } @else {
-                  {{ period.pointsGranted | number: '1.0-10' }}
+                  {{ period.pointsGranted | number: '1.0-2' }}
                   {{ 'XP.Membership.PointsShort' | translate: { Default: 'pts' } }}
                 }
               </div>
@@ -310,7 +310,7 @@
               </div>
             </div>
             <z-badge zType="secondary" zShape="pill">
-              {{ item.pointsUsed | number: '1.0-10' }}
+              {{ item.pointsUsed | number: '1.0-2' }}
               {{ 'XP.Membership.PointsShort' | translate: { Default: 'pts' } }}
             </z-badge>
           </div>
@@ -340,7 +340,7 @@
               </div>
             </div>
             <z-badge zType="secondary" zShape="pill">
-              {{ item.pointsUsed | number: '1.0-10' }}
+              {{ item.pointsUsed | number: '1.0-2' }}
               {{ 'XP.Membership.PointsShort' | translate: { Default: 'pts' } }}
             </z-badge>
           </div>
@@ -370,7 +370,7 @@
               </div>
             </div>
             <z-badge zType="secondary" zShape="pill">
-              {{ item.pointsUsed | number: '1.0-10' }}
+              {{ item.pointsUsed | number: '1.0-2' }}
               {{ 'XP.Membership.PointsShort' | translate: { Default: 'pts' } }}
             </z-badge>
           </div>

--- a/apps/cloud/src/app/features/setting/account/usage.component.ts
+++ b/apps/cloud/src/app/features/setting/account/usage.component.ts
@@ -109,7 +109,7 @@ export class XpAccountUsageComponent implements OnInit {
       month: 'long',
       day: 'numeric'
     }).format(bucket.dateValue)
-    const pointsUsed = new Intl.NumberFormat(locale, { maximumFractionDigits: 10 }).format(bucket.pointsUsed)
+    const pointsUsed = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 }).format(bucket.pointsUsed)
 
     return this.#translate.instant('XP.Membership.HeatmapDailyPointsTitle', {
       date,

--- a/apps/cloud/src/app/features/setting/copilot/basic/basic.component.html
+++ b/apps/cloud/src/app/features/setting/copilot/basic/basic.component.html
@@ -40,8 +40,8 @@
                 >∞</span
               >
             } @else {
-              {{ membership.pointsRemaining | number: '1.0-10' }} /
-              {{ membership.pointsGranted | number: '1.0-10' }}
+              {{ membership.pointsRemaining | number: '1.0-2' }} /
+              {{ membership.pointsGranted | number: '1.0-2' }}
             }
           </div>
           <div class="mt-1 text-xs text-text-tertiary">
@@ -60,7 +60,7 @@
             {{ 'XP.Membership.PersonalPoints' | translate: { Default: 'Personal points' } }}
           </div>
           <div class="mt-1 font-semibold text-text-primary">
-            {{ membership.personalPointsBalance | number: '1.0-10' }}
+            {{ membership.personalPointsBalance | number: '1.0-2' }}
           </div>
           <div class="mt-1 text-xs text-text-tertiary">
             {{ 'XP.Membership.Permanent' | translate: { Default: 'Permanent' } }}

--- a/apps/cloud/src/app/features/setting/membership/membership.component.html
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.html
@@ -236,7 +236,7 @@
                       @if (plan.includedPoints === null) {
                         {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
                       } @else {
-                        {{ plan.includedPoints | number }}
+                        {{ plan.includedPoints | number: '1.0-2' }}
                       }
                     </div>
                   </div>
@@ -774,7 +774,7 @@
                     @if (plan.includedPoints === null) {
                       {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
                     } @else {
-                      {{ plan.includedPoints | number }}
+                      {{ plan.includedPoints | number: '1.0-2' }}
                     }
                   </div>
                 </div>
@@ -1203,7 +1203,7 @@
                   } @else if (member.membership.pointsGranted === null) {
                     {{ 'XP.Membership.Unlimited' | translate: { Default: 'Unlimited' } }}
                   } @else {
-                    {{ adminMemberRemainingPoints(member) | number: '1.0-10' }}
+                    {{ adminMemberRemainingPoints(member) | number: '1.0-2' }}
                   }
                 </div>
                 <div class="text-sm text-text-secondary">

--- a/apps/cloud/src/app/features/setting/membership/membership.component.ts
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.ts
@@ -363,7 +363,9 @@ export class MembershipAdminComponent implements OnInit {
   pointsLabel(points?: number | null) {
     return points === null
       ? this.#translate.instant('XP.Membership.Unlimited', { Default: 'Unlimited' })
-      : String(points ?? 0)
+      : new Intl.NumberFormat(this.#translate.currentLang || this.#translate.getDefaultLang() || 'en', {
+          maximumFractionDigits: 2
+        }).format(points ?? 0)
   }
 
   scopeDefaultPlanLabel(status: IMembershipScopeStatus | null) {

--- a/apps/cloud/src/app/features/setting/model-gateway/model-gateway.component.html
+++ b/apps/cloud/src/app/features/setting/model-gateway/model-gateway.component.html
@@ -97,7 +97,7 @@
                     <td z-table-cell>
                       {{ 'XP.ModelGateway.CallStatus.' + call.status | translate: { Default: call.status } }}
                     </td>
-                    <td z-table-cell>{{ call.chargedPoints }}</td>
+                    <td z-table-cell>{{ call.chargedPoints | number: '1.0-2' }}</td>
                     <td z-table-cell>{{ formatDate(call.startedAt) }}</td>
                     <td z-table-cell class="text-right">
                       @if (call.bodyExpiresAt) {

--- a/apps/cloud/src/app/features/setting/users/user-membership/user-membership.component.html
+++ b/apps/cloud/src/app/features/setting/users/user-membership/user-membership.component.html
@@ -53,7 +53,7 @@
                   >∞</span
                 >
               } @else {
-                {{ remainingPoints() | number: '1.0-10' }}
+                {{ remainingPoints() | number: '1.0-2' }}
               }
             </div>
           </div>
@@ -62,7 +62,7 @@
               <div class="text-sm text-text-tertiary">
                 {{ 'XP.Membership.PersonalPoints' | translate: { Default: 'Personal points' } }}
               </div>
-              <div class="font-medium">{{ personalPointsBalance() | number: '1.0-10' }}</div>
+              <div class="font-medium">{{ personalPointsBalance() | number: '1.0-2' }}</div>
             </div>
           }
         </div>
@@ -74,10 +74,10 @@
             </div>
             <div class="font-medium">
               @if (isUnlimited()) {
-                {{ currentMembership.pointsUsed | number: '1.0-10' }} / ∞
+                {{ currentMembership.pointsUsed | number: '1.0-2' }} / ∞
               } @else {
-                {{ currentMembership.pointsUsed | number: '1.0-10' }} /
-                {{ currentMembership.pointsGranted | number: '1.0-10' }}
+                {{ currentMembership.pointsUsed | number: '1.0-2' }} /
+                {{ currentMembership.pointsGranted | number: '1.0-2' }}
               }
             </div>
           </div>
@@ -230,7 +230,7 @@
                               >∞</span
                             >
                           } @else {
-                            {{ period.pointsGranted | number: '1.0-10' }}
+                            {{ period.pointsGranted | number: '1.0-2' }}
                           }
                         </div>
                       </div>
@@ -331,7 +331,7 @@
                       >∞</span
                     >
                   } @else {
-                    {{ period.pointsGranted | number: '1.0-10' }}
+                    {{ period.pointsGranted | number: '1.0-2' }}
                   }
                 </div>
               </div>
@@ -550,7 +550,7 @@
                 <z-badge zType="outline" zShape="pill">{{ auditScopeLabel(entry) }}</z-badge>
                 @if (entry.pointsDelta) {
                   <z-badge [zType]="entry.pointsDelta > 0 ? 'secondary' : 'outline'" zShape="pill">
-                    {{ entry.pointsDelta > 0 ? '+' : '' }}{{ entry.pointsDelta | number: '1.0-10' }}
+                    {{ entry.pointsDelta > 0 ? '+' : '' }}{{ entry.pointsDelta | number: '1.0-2' }}
                   </z-badge>
                 }
               </div>


### PR DESCRIPTION
# PR

## Summary

- Limit displayed membership and model usage points to at most two decimal places across account, billing, membership, copilot, and model gateway views.
- Use locale-aware two-decimal formatting for point labels and usage heatmap details.
- Ignore the repository-local `.pi-glla/` Pi workspace directory.

## Validation

- Targeted ESLint passed for all nine changed Cloud frontend files.
- Commit hooks passed: Prettier, hardcoded color usage check, and TypeORM column type check.
- `corepack pnpm nx lint cloud` remains blocked by pre-existing lint errors in unrelated, unchanged files.

# Checklist

- [x] Have you followed the [contributing guidelines](https://github.com/xpert-ai/xpert/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?
