### PR TITLE
fix: provide runtime context for video generation

### DIFF
--- a/packages/server-ai/src/chat/video-generation.service.spec.ts
+++ b/packages/server-ai/src/chat/video-generation.service.spec.ts
@@ -98,6 +98,9 @@ describe('VideoGenerationService', () => {
         const harness = createHarness()
         jest.spyOn(RequestContext, 'currentUser').mockReturnValue({ id: 'user-1' } as never)
         jest.spyOn(RequestContext, 'currentApiPrincipal').mockReturnValue(null)
+        jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
+        jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('organization-1')
+        jest.spyOn(RequestContext, 'currentUserId').mockReturnValue('user-1')
         const invoke = jest
             .fn()
             .mockResolvedValueOnce({
@@ -116,6 +119,7 @@ describe('VideoGenerationService', () => {
 
         await harness.service.submit({
             xpertId: 'xpert-1',
+            projectId: 'project-1',
             toolsetId: 'seedance-linked',
             prompt: 'Generate a clip',
             model: 'seedance-model',
@@ -140,6 +144,25 @@ describe('VideoGenerationService', () => {
             name: 'query_video',
             args: { download_video: 'true' }
         })
+        expect(harness.modelRuntime.createScopedApi).toHaveBeenCalledWith({
+            tenantId: 'tenant-1',
+            organizationId: 'organization-1',
+            userId: 'user-1',
+            workspaceId: 'workspace-1',
+            projectId: 'project-1',
+            xpertId: 'xpert-1'
+        })
+        expect(createBuiltinToolset).toHaveBeenCalledWith(
+            'seedance_type',
+            expect.objectContaining({ id: 'seedance-linked' }),
+            expect.objectContaining({
+                managedQueue: harness.managedQueue,
+                modelRuntime: {
+                    createModelClient: harness.scopedModelRuntime.createModelClient,
+                    getModelProvider: harness.scopedModelRuntime.getModelProvider
+                }
+            })
+        )
     })
 
     it('routes multiple reference images through a protocol v2 reference tool', async () => {
@@ -346,14 +369,24 @@ function createHarness() {
             return { meta: {} }
         })
     }
+    const scopedModelRuntime = {
+        createModelClient: jest.fn(),
+        getModelProvider: jest.fn()
+    }
+    const modelRuntime = {
+        createScopedApi: jest.fn(() => scopedModelRuntime)
+    }
+    const managedQueue = { enqueue: jest.fn() }
     const service = new VideoGenerationService(
         xpertAccess as never,
         toolsets as never,
         registry as never,
         {} as never,
-        {} as never
+        {} as never,
+        modelRuntime as never,
+        managedQueue as never
     )
-    return { service, xpertAccess, toolsets, registry }
+    return { service, xpertAccess, toolsets, registry, scopedModelRuntime, modelRuntime, managedQueue }
 }
 
 function capability(family: 'seedance' | 'veo'): VideoGenerationToolsetCapability {
@@ -424,6 +457,7 @@ function toolset(
         id,
         name: id,
         type,
+        workspaceId: 'workspace-1',
         category: XpertToolsetCategoryEnum.BUILTIN,
         tools: enabledTools.map((name) => ({ name, enabled: true }))
     }

--- a/packages/server-ai/src/chat/video-generation.service.ts
+++ b/packages/server-ai/src/chat/video-generation.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import {
     RequestContext,
@@ -13,11 +13,14 @@ import {
     type VideoGenerationReferenceInput,
     type VideoGenerationToolsetCapability,
     type VideoGeneratorSummary,
-    type WorkspacePortableFileReference
+    type WorkspacePortableFileReference,
+    MANAGED_QUEUE_SERVICE_TOKEN,
+    type ManagedQueueService
 } from '@xpert-ai/plugin-sdk'
 import { SecretTokenBindingType, XpertToolsetCategoryEnum, type IXpertToolset } from '@xpert-ai/contracts'
 import { createBuiltinToolset, XpertToolsetService } from '../xpert-toolset'
 import { PublishedXpertAccessService } from '../xpert'
+import { AgentMiddlewareRuntimeService } from '../shared/agent/middleware-runtime.service'
 
 const COMPLETED_STATUSES = new Set(['completed', 'done', 'succeeded', 'success'])
 const FAILED_STATUSES = new Set(['failed', 'error', 'cancelled', 'canceled', 'expired'])
@@ -31,7 +34,10 @@ export class VideoGenerationService implements VideoGenerationPermissionService 
         private readonly toolsets: XpertToolsetService,
         private readonly registry: ToolsetRegistry,
         private readonly commandBus: CommandBus,
-        private readonly queryBus: QueryBus
+        private readonly queryBus: QueryBus,
+        private readonly modelRuntime: AgentMiddlewareRuntimeService,
+        @Inject(MANAGED_QUEUE_SERVICE_TOKEN)
+        private readonly managedQueue: ManagedQueueService
     ) {}
 
     async listGenerators(input: { xpertId: string }) {
@@ -216,15 +222,31 @@ export class VideoGenerationService implements VideoGenerationPermissionService 
         toolName: string,
         input: Record<string, unknown>
     ): Promise<unknown> {
+        const tenantId = RequestContext.currentTenantId()
+        const organizationId = RequestContext.getOrganizationId()
+        const userId = RequestContext.currentUserId()
+        const scopedModelRuntime = this.modelRuntime.createScopedApi({
+            tenantId,
+            organizationId,
+            userId,
+            workspaceId: toolset.workspaceId,
+            projectId,
+            xpertId
+        })
         const controller = await createBuiltinToolset(toolset.type, toolset, {
-            tenantId: RequestContext.currentTenantId(),
-            organizationId: RequestContext.getOrganizationId(),
-            userId: RequestContext.currentUserId(),
+            tenantId,
+            organizationId,
+            userId,
             xpertId,
             ...(projectId ? { projectId } : {}),
             env: {},
             commandBus: this.commandBus,
-            queryBus: this.queryBus
+            queryBus: this.queryBus,
+            managedQueue: this.managedQueue,
+            modelRuntime: {
+                createModelClient: scopedModelRuntime.createModelClient,
+                getModelProvider: scopedModelRuntime.getModelProvider
+            }
         })
         try {
             await controller.initTools()
@@ -239,9 +261,9 @@ export class VideoGenerationService implements VideoGenerationPermissionService 
                 },
                 {
                     configurable: {
-                        tenantId: RequestContext.currentTenantId(),
-                        organizationId: RequestContext.getOrganizationId(),
-                        userId: RequestContext.currentUserId()
+                        tenantId,
+                        organizationId,
+                        userId
                     }
                 }
             )


### PR DESCRIPTION
## Summary

- create a request-scoped model runtime for video generation tool invocations
- provide managed queue and model runtime dependencies to built-in video toolsets
- verify tenant, organization, user, workspace, project, and Xpert context propagation

## Why

Video generation invokes built-in plugin tools outside the normal agent execution path. The controller was created without the managed queue and scoped model runtime required by providers that submit asynchronous sandbox jobs, so requests could fail before the provider accepted them.

## Verification

- pnpm nx test server-ai --testPathPatterns=video-generation.service.spec.ts --runInBand (10 tests passed)
- pnpm nx build server-ai
- pnpm exec eslint packages/server-ai/src/chat/video-generation.service.ts packages/server-ai/src/chat/video-generation.service.spec.ts (0 errors, 3 existing warnings)