### PR TITLE
fix: handle model limits and ChatKit artifacts

### DIFF
--- a/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-model-select/select.component.spec.ts
@@ -324,7 +324,7 @@ describe('CopilotModelSelectComponent', () => {
     })
   }))
 
-  it('clamps numeric parameter updates to the active rule range', fakeAsync(() => {
+  it('preserves output token updates beyond the active slider range', fakeAsync(() => {
     tick(600)
     fixture.detectChanges()
 
@@ -348,7 +348,7 @@ describe('CopilotModelSelectComponent', () => {
     component.updateParameter('max_tokens', 655361234)
     fixture.detectChanges()
 
-    expect(component['cva'].value$()?.options?.max_tokens).toBe(32768)
+    expect(component['cva'].value$()?.options?.max_tokens).toBe(655361234)
   }))
 
   it('does not clamp parameter updates with stale rules while new model rules are loading', fakeAsync(() => {
@@ -397,7 +397,7 @@ describe('CopilotModelSelectComponent', () => {
     expect(component['cva'].value$()?.options?.max_tokens).toBe(32000)
   }))
 
-  it('clamps persisted numeric options when model parameter rules resolve', fakeAsync(() => {
+  it('preserves persisted output token options beyond the configured slider range', fakeAsync(() => {
     tick(600)
     fixture.detectChanges()
 
@@ -426,7 +426,7 @@ describe('CopilotModelSelectComponent', () => {
 
     expect(component['cva'].value$()?.options).toEqual({
       [ModelPropertyKey.CONTEXT_SIZE]: 200000,
-      max_tokens: 32768
+      max_tokens: 655361234
     })
   }))
 

--- a/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.html
+++ b/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.html
@@ -27,7 +27,7 @@
       <z-slider
         class="w-[200px]"
         [min]="parameter.min"
-        [max]="parameter.max"
+        [max]="sliderMaximum()"
         [showValueLabel]="true"
         [value]="value$()"
         (changeEnd)="updateValue($event)"
@@ -36,7 +36,7 @@
       <input
         z-input
         class="shrink-0 block ml-4 pl-3 w-24 h-8 text-[13px] text-gra-900"
-        [max]="parameter.max"
+        [max]="sliderMaximum()"
         [min]="parameter.min"
         [step]="1"
         type="number"

--- a/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.spec.ts
@@ -50,4 +50,25 @@ describe('ModelParameterInputComponent', () => {
     expect(component['cva'].value$()).toBe(256)
     expect(typeof component['cva'].value$()).toBe('number')
   })
+
+  it('expands the output token slider maximum to a larger input value', () => {
+    fixture.componentRef.setInput('parameter', {
+      name: 'max_tokens',
+      label: { en_US: 'Max Tokens' },
+      type: ParameterType.INT,
+      min: 1,
+      max: 2048
+    })
+    component['cva'].value$.set(2048)
+    fixture.detectChanges()
+
+    const input = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement
+    input.value = '4096'
+    input.dispatchEvent(new Event('input'))
+    fixture.detectChanges()
+
+    expect(component['cva'].value$()).toBe(4096)
+    expect(component.sliderMaximum()).toBe(4096)
+    expect(input.max).toBe('4096')
+  })
 })

--- a/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/model-parameter-input/input.component.ts
@@ -2,7 +2,7 @@ import { Component, inject, input } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { ZardInputDirective, ZardSliderComponent, ZardSwitchComponent } from '@xpert-ai/headless-ui'
 import { NgxControlValueAccessor } from 'ngxtension/control-value-accessor'
-import { ParameterRule, ParameterType } from '@xpert-ai/contracts'
+import { isOutputTokenParameter, ParameterRule, ParameterType } from '@xpert-ai/contracts'
 
 /**
  * @todo Use JSON Schema to implement
@@ -32,6 +32,21 @@ export class ModelParameterInputComponent {
     this.updateValue(this.normalizeNumericValue(value, type))
   }
 
+  sliderMaximum(): number | undefined {
+    const parameter = this.parameter()
+    const configuredMax = this.finiteNumber(parameter?.max)
+    if (!isOutputTokenParameter(parameter) || configuredMax === undefined) {
+      return configuredMax
+    }
+
+    const currentValue = this.finiteNumber(this.value$())
+    if (currentValue === undefined) {
+      return configuredMax
+    }
+
+    return Math.max(configuredMax, currentValue)
+  }
+
   private normalizeNumericValue(value: unknown, type: ParameterType.FLOAT | ParameterType.INT): number | undefined {
     if (value === '' || value === null || value === undefined) {
       return undefined
@@ -47,5 +62,10 @@ export class ModelParameterInputComponent {
     }
 
     return undefined
+  }
+
+  private finiteNumber(value: unknown): number | undefined {
+    const numericValue = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN
+    return Number.isFinite(numericValue) ? numericValue : undefined
   }
 }

--- a/apps/cloud/src/app/@shared/user/forms/basic-info/basic-info-form.component.ts
+++ b/apps/cloud/src/app/@shared/user/forms/basic-info/basic-info-form.component.ts
@@ -62,6 +62,7 @@ export class BasicInfoFormComponent implements ControlValueAccessor, OnChanges {
   @Input() public createdById: string
   @Input() public selectedTags: ITag[]
   @Input() public readOnly = false
+  @Input() public emailDisabled = false
 
   readonly roleOptions$ = new ReplaySubject<Array<{ key: string; caption: string }>>(1)
   private roles: IRole[] = []
@@ -93,7 +94,7 @@ export class BasicInfoFormComponent implements ControlValueAccessor, OnChanges {
   setDisabledState?(isDisabled: boolean): void {}
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes['readOnly']) {
+    if (changes['readOnly'] || changes['emailDisabled']) {
       this.syncReadOnlyState()
     }
   }
@@ -197,6 +198,7 @@ export class BasicInfoFormComponent implements ControlValueAccessor, OnChanges {
               label: TRANSLATES?.Email ?? 'Email',
               placeholder: '',
               required: true,
+              disabled: this.emailDisabled,
               appearance: 'fill'
             },
             validators: {
@@ -298,11 +300,12 @@ export class BasicInfoFormComponent implements ControlValueAccessor, OnChanges {
   private syncReadOnlyState(fields = this.fields) {
     for (const field of fields) {
       const baseDisabled = !!field.props?.['baseDisabled']
+      const fieldDisabled = field.key === 'email' && this.emailDisabled
       if (field.props) {
-        field.props.disabled = this.readOnly || baseDisabled
+        field.props.disabled = this.readOnly || baseDisabled || fieldDisabled
       }
       if (field.formControl) {
-        if (this.readOnly || baseDisabled) {
+        if (this.readOnly || baseDisabled || fieldDisabled) {
           field.formControl.disable({ emitEvent: false })
         } else {
           field.formControl.enable({ emitEvent: false })

--- a/apps/cloud/src/app/@theme/header/organization-selector/organization-selector.component.html
+++ b/apps/cloud/src/app/@theme/header/organization-selector/organization-selector.component.html
@@ -26,7 +26,11 @@
         <div class="truncate text-[10px] uppercase tracking-[0.24em] text-text-tertiary">
           {{ scopeEyebrow() }}
         </div>
-        <div class="truncate text-sm font-medium text-text-primary">
+        <div
+          class="truncate text-sm font-medium text-text-primary"
+          [zTooltip]="scopeLabel()"
+          zTooltipClass="max-w-80 break-all whitespace-normal"
+        >
           {{ scopeLabel() }}
         </div>
       </div>

--- a/apps/cloud/src/app/@theme/header/user/user.component.html
+++ b/apps/cloud/src/app/@theme/header/user/user.component.html
@@ -1,6 +1,7 @@
 <button
   type="button"
-  class="inline-flex items-center rounded-lg p-1.5 text-sm text-text-primary cursor-pointer hover:rounded-lg hover:bg-hover-bg"
+  class="header-user-trigger inline-flex items-center rounded-lg p-1.5 text-sm text-text-primary cursor-pointer hover:rounded-lg hover:bg-hover-bg"
+  [class.is-sidebar]="sidebar() && !compact()"
   [class.m-1.5]="!fullWidth()"
   [class.w-full]="fullWidth()"
   [cdkMenuTriggerFor]="menu"
@@ -46,19 +47,29 @@
     }
   }
   @if (!compact()) {
-    {{ user() | user }}
-    <i class="ri-arrow-drop-down-line"></i>
+    @if (sidebar()) {
+      <span class="header-user-trigger__copy">
+        <span class="header-user-trigger__name">{{ user() | user }}</span>
+        @if (user().email) {
+          <span class="header-user-trigger__email">{{ user().email }}</span>
+        }
+      </span>
+      <i class="ri-expand-up-down-line header-user-trigger__chevron"></i>
+    } @else {
+      {{ user() | user }}
+      <i class="ri-arrow-drop-down-line"></i>
+    }
   }
 </button>
 
 <ng-template #menu>
-  <div class="z-50 text-text-primary" cdkMenu @overlayAnimation1>
-    <div class="p-2 border-b flex items-center border-divider-subtle rounded-t-lg">
+  <div class="header-user-menu z-50 text-text-primary" cdkMenu @overlayAnimation1>
+    <div class="header-user-menu__profile p-2 border-b flex items-center border-divider-subtle rounded-t-lg">
       <xp-user-profile-inline [user]="user()" />
     </div>
 
     @if (user()) {
-      <div class="w-[220px] flex flex-col justify-start items-stretch gap-1 p-1">
+      <div class="header-user-menu__items flex flex-col justify-start items-stretch gap-1 p-1">
         <div
           class="flex items-center justify-between h-9 px-3 rounded-lg cursor-pointer group hover:bg-hover-bg"
           cdkMenuItem

--- a/apps/cloud/src/app/@theme/header/user/user.component.scss
+++ b/apps/cloud/src/app/@theme/header/user/user.component.scss
@@ -1,0 +1,72 @@
+.header-user-trigger.is-sidebar {
+  min-width: 0;
+  min-height: 3rem;
+  gap: 0.625rem;
+  border-radius: 0.375rem;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.header-user-trigger.is-sidebar > :first-child {
+  width: 2rem !important;
+  height: 2rem !important;
+  flex: 0 0 2rem;
+  margin-right: 0 !important;
+}
+
+.header-user-trigger__copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+.header-user-trigger__name,
+.header-user-trigger__email {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.header-user-trigger__name {
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.15rem;
+}
+
+.header-user-trigger__email {
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.header-user-trigger__chevron {
+  flex: 0 0 auto;
+  color: var(--color-text-primary);
+  font-size: 1.15rem;
+}
+
+.header-user-menu {
+  width: max-content;
+  min-width: 220px;
+  max-width: min(360px, calc(100vw - 1rem));
+}
+
+.header-user-menu__profile {
+  width: max-content;
+  min-width: 100%;
+  max-width: 100%;
+}
+
+.header-user-menu__profile xp-user-profile-inline {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.header-user-menu__items {
+  width: 100%;
+  min-width: 220px;
+  max-width: 100%;
+}

--- a/apps/cloud/src/app/@theme/header/user/user.component.ts
+++ b/apps/cloud/src/app/@theme/header/user/user.component.ts
@@ -48,6 +48,7 @@ const THEMES = [
   imports: [FormsModule, CdkMenuModule, TranslateModule, UserPipe, UserProfileInlineComponent],
   selector: 'xp-header-user',
   templateUrl: './user.component.html',
+  styleUrl: './user.component.scss',
   animations: [OverlayAnimation1]
 })
 export class HeaderUserComponent {
@@ -69,6 +70,7 @@ export class HeaderUserComponent {
   readonly user = input<IUser>()
   readonly compact = input(false)
   readonly fullWidth = input(false)
+  readonly sidebar = input(false)
 
   readonly entryGuideClick = output<void>()
 

--- a/apps/cloud/src/app/features/setting/account/profile.component.ts
+++ b/apps/cloud/src/app/features/setting/account/profile.component.ts
@@ -14,7 +14,12 @@ import { UserFormsModule } from '../../../@shared/user'
   imports: [FormsModule, ReactiveFormsModule, UserFormsModule, TranslateModule],
   selector: 'xp-account-profile',
   template: `<div class="flex flex-col items-center justify-start p-4">
-    <xp-user-basic-info-form #form class="block max-w-full md:max-w-[600px] lg:max-w-[900px]" [(ngModel)]="user" />
+    <xp-user-basic-info-form
+      #form
+      class="block max-w-full md:max-w-[600px] lg:max-w-[900px]"
+      [emailDisabled]="true"
+      [(ngModel)]="user"
+    />
 
     <div class="w-full flex justify-center items-center gap-2">
       <button type="button" class="btn disabled:btn-disabled btn-large" (click)="reset()">

--- a/apps/cloud/src/app/features/setting/users/manage-user/manage-user.component.html
+++ b/apps/cloud/src/app/features/setting/users/manage-user/manage-user.component.html
@@ -198,13 +198,19 @@
 
               <td z-table-cell class="px-4 py-3">
                 @if (user.displayOrganizations.length) {
-                  <div class="flex max-w-60 flex-wrap gap-1">
+                  <div class="flex min-w-0 max-w-60 flex-wrap gap-1">
                     @for (
                       organization of user.displayOrganizations.slice(0, 2);
                       track organization.id || organization.name
                     ) {
-                      <z-badge zType="secondary" zShape="pill" class="max-w-36 truncate">
-                        {{ organization.name }}
+                      <z-badge
+                        zType="secondary"
+                        zShape="pill"
+                        class="min-w-0 max-w-full"
+                        [zTooltip]="organization.name"
+                        zTooltipClass="max-w-80 break-all whitespace-normal"
+                      >
+                        <span class="min-w-0 max-w-full truncate">{{ organization.name }}</span>
                       </z-badge>
                     }
 

--- a/apps/cloud/src/app/features/setting/users/manage-user/manage-user.component.ts
+++ b/apps/cloud/src/app/features/setting/users/manage-user/manage-user.component.ts
@@ -34,7 +34,8 @@ import {
   ZardIconComponent,
   ZardSearchInputComponent,
   ZardSelectImports,
-  ZardTableImports
+  ZardTableImports,
+  ZardTooltipImports
 } from '@xpert-ai/headless-ui'
 import { distinctUntilChanged } from 'rxjs/operators'
 
@@ -93,6 +94,7 @@ const USER_STATUS_OPTIONS: Array<{ value: UserStatusFilter; labelKey: string; de
     ZardSearchInputComponent,
     ...ZardSelectImports,
     ...ZardTableImports,
+    ...ZardTooltipImports,
     DateRelativePipe
   ]
 })

--- a/packages/contracts/src/ai/ai-model.model.spec.ts
+++ b/packages/contracts/src/ai/ai-model.model.spec.ts
@@ -49,7 +49,7 @@ describe('model parameter options', () => {
       normalizeModelParameterValue(
         '12.8',
         rule({
-          name: 'max_tokens',
+          name: 'top_k',
           type: ParameterType.INT,
           min: 1,
           max: 10
@@ -68,6 +68,23 @@ describe('model parameter options', () => {
       )
     ).toBe(0)
   })
+
+  it.each(['max_tokens', 'max_output_tokens', 'max_completion_tokens', 'max_tokens_to_sample'])(
+    'allows %s to expand beyond the configured slider maximum',
+    (name) => {
+      expect(
+        normalizeModelParameterValue(
+          65536,
+          rule({
+            name,
+            type: ParameterType.INT,
+            min: 1,
+            max: 32768
+          })
+        )
+      ).toBe(65536)
+    }
+  )
 
   it('preserves options that are not described by parameter rules', () => {
     const options = resolveModelParameterOptions({ context_size: 128000, provider_option: 'value' }, [

--- a/packages/contracts/src/ai/ai-model.model.ts
+++ b/packages/contracts/src/ai/ai-model.model.ts
@@ -194,6 +194,17 @@ export interface ParameterRule {
   options?: string[]
 }
 
+const OUTPUT_TOKEN_PARAMETER_NAMES = new Set([
+  'max_tokens',
+  'max_output_tokens',
+  'max_completion_tokens',
+  'max_tokens_to_sample'
+])
+
+export function isOutputTokenParameter(rule: Pick<ParameterRule, 'name'> | null | undefined): boolean {
+  return !!rule?.name && OUTPUT_TOKEN_PARAMETER_NAMES.has(rule.name)
+}
+
 export function normalizeModelParameterValue(value: unknown, rule: ParameterRule): unknown | undefined {
   switch (rule.type) {
     case ParameterType.FLOAT:
@@ -211,7 +222,7 @@ export function normalizeModelParameterValue(value: unknown, rule: ParameterRule
       if (typeof rule.min === 'number' && Number.isFinite(rule.min)) {
         normalizedValue = Math.max(normalizedValue, rule.min)
       }
-      if (typeof rule.max === 'number' && Number.isFinite(rule.max)) {
+      if (!isOutputTokenParameter(rule) && typeof rule.max === 'number' && Number.isFinite(rule.max)) {
         normalizedValue = Math.min(normalizedValue, rule.max)
       }
       return rule.type === ParameterType.INT ? Math.trunc(normalizedValue) : normalizedValue

--- a/packages/server-ai/src/chat-conversation/task-summary.service.spec.ts
+++ b/packages/server-ai/src/chat-conversation/task-summary.service.spec.ts
@@ -187,6 +187,64 @@ describe('ChatTaskSummaryService', () => {
         expect(page.total).toBe(60)
         expect(page.items[0]).toMatchObject({ id: 'output-1', title: 'Newest output' })
     })
+
+    it('re-extracts outputs from messages with an incomplete persisted summary', async () => {
+        const messageService = {
+            findAllInOrganizationOrTenant: jest
+                .fn()
+                .mockResolvedValueOnce({ items: [], total: 0 })
+                .mockResolvedValueOnce({
+                    items: [
+                        {
+                            id: 'message-1',
+                            taskSummary: { version: 1 },
+                            content: [
+                                {
+                                    type: 'component',
+                                    data: {
+                                        artifact: {
+                                            files: [
+                                                {
+                                                    fileName: 'generated-video.mp4',
+                                                    workspacePath: 'files/videos/generated-video.mp4',
+                                                    mimeType: 'video/mp4'
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
+                            createdAt: new Date('2026-07-13T05:00:00.000Z'),
+                            updatedAt: new Date('2026-07-13T05:00:00.000Z')
+                        }
+                    ],
+                    total: 1
+                }),
+            save: jest.fn()
+        }
+        const service = new ChatTaskSummaryService(
+            messageService as never,
+            { getByConversationId: jest.fn(() => Promise.resolve(null)) } as never,
+            { findAllInOrganizationOrTenant: jest.fn(() => Promise.resolve({ items: [], total: 0 })) } as never,
+            { find: jest.fn(() => Promise.resolve([])) } as never
+        )
+
+        const result = await service.getSnapshot(conversation())
+
+        expect(messageService.findAllInOrganizationOrTenant).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({ select: expect.arrayContaining(['content', 'taskSummary']) })
+        )
+        expect(result.outputs).toEqual({
+            items: [
+                expect.objectContaining({
+                    id: 'artifact:files/videos/generated-video.mp4',
+                    title: 'generated-video.mp4'
+                })
+            ],
+            total: 1
+        })
+    })
 })
 
 function conversation(): ChatConversation {

--- a/packages/server-ai/src/chat-conversation/task-summary.service.ts
+++ b/packages/server-ai/src/chat-conversation/task-summary.service.ts
@@ -94,6 +94,7 @@ export class ChatTaskSummaryService {
                 where: { conversationId: conversation.id },
                 select: [
                     'id',
+                    'content',
                     'taskSummary',
                     'executionId',
                     'followUpMode',
@@ -117,9 +118,24 @@ export class ChatTaskSummaryService {
         ])
 
         const messages = messageResult.items
-        const contributions = messages.flatMap((message) =>
-            message.taskSummary?.version === TASK_SUMMARY_VERSION ? [message.taskSummary] : []
-        )
+        const contributions = messages.flatMap((message) => {
+            const persisted = message.taskSummary?.version === TASK_SUMMARY_VERSION ? message.taskSummary : undefined
+            if (!persisted) {
+                const extracted = extractChatMessageTaskSummary(message)
+                return extracted.outputs?.length ? [extracted] : []
+            }
+            const extractedOutputs = extractChatMessageTaskSummary(message).outputs
+            const existingOutputIds = new Set(persisted.outputs?.map((output) => output.id) ?? [])
+            const additionalOutputs = extractedOutputs?.filter((output) => !existingOutputIds.has(output.id)) ?? []
+            return [
+                {
+                    ...persisted,
+                    ...(additionalOutputs.length
+                        ? { outputs: [...(persisted.outputs ?? []), ...additionalOutputs] }
+                        : {})
+                }
+            ]
+        })
         const plan = this.latestItem(contributions.flatMap((contribution) => contribution.plan ?? []))
         const todos = this.latestItem(contributions.flatMap((contribution) => contribution.todos ?? []))
         const outputs = this.mergeLatest(contributions.flatMap((contribution) => contribution.outputs ?? []))

--- a/packages/server-ai/src/chat-message/task-summary.spec.ts
+++ b/packages/server-ai/src/chat-message/task-summary.spec.ts
@@ -97,6 +97,119 @@ describe('extractChatMessageTaskSummary', () => {
         expect(JSON.stringify(summary)).not.toContain('Raw shell output')
     })
 
+    it('extracts generated files from artifact collections without exposing provider data', () => {
+        const summary = extractChatMessageTaskSummary(
+            message({
+                content: [
+                    {
+                        type: 'component',
+                        data: {
+                            tool: 'video_generation_query',
+                            artifact: {
+                                files: [
+                                    {
+                                        fileName: 'generated-video.mp4',
+                                        filePath: 'files/videos/generated-video.mp4',
+                                        workspacePath: 'files/videos/generated-video.mp4',
+                                        fileUrl: 'https://example.com/internal/generated-video.mp4?token=secret',
+                                        mimeType: 'video/mp4'
+                                    },
+                                    {
+                                        fileName: 'generated-video-cover.png',
+                                        workspacePath: 'files/covers/generated-video-cover.png',
+                                        url: 'https://provider.example.com/generated-video-cover.png?token=secret',
+                                        mimeType: 'image/png'
+                                    }
+                                ],
+                                data: {
+                                    providerVideoUrl: 'https://provider.example.com/video.mp4?token=secret'
+                                }
+                            }
+                        }
+                    }
+                ]
+            })
+        )
+
+        expect(summary.outputs).toEqual([
+            {
+                id: 'artifact:files/videos/generated-video.mp4',
+                kind: 'file',
+                title: 'generated-video.mp4',
+                resource: {
+                    type: 'workspace_file',
+                    workspacePath: 'files/videos/generated-video.mp4'
+                },
+                messageId: 'message-1',
+                updatedAt: '2026-07-13T01:00:00.000Z'
+            },
+            {
+                id: 'artifact:files/covers/generated-video-cover.png',
+                kind: 'image',
+                title: 'generated-video-cover.png',
+                resource: {
+                    type: 'workspace_file',
+                    workspacePath: 'files/covers/generated-video-cover.png'
+                },
+                messageId: 'message-1',
+                updatedAt: '2026-07-13T01:00:00.000Z'
+            }
+        ])
+        expect(JSON.stringify(summary)).not.toContain('provider.example.com')
+        expect(JSON.stringify(summary)).not.toContain('token=secret')
+    })
+
+    it('extracts structured artifacts returned by tools through output text', () => {
+        const summary = extractChatMessageTaskSummary(
+            message({
+                content: [
+                    {
+                        type: 'component',
+                        data: {
+                            tool: 'drawio_publish_artifact_link',
+                            output: JSON.stringify({
+                                drawingId: 'drawing-1',
+                                artifactId: 'artifact-drawio',
+                                publicUrl: 'https://example.com/artifacts/share/secret'
+                            })
+                        }
+                    },
+                    {
+                        type: 'component',
+                        data: {
+                            tool: 'export_report',
+                            output: JSON.stringify({
+                                files: [
+                                    {
+                                        fileName: 'report.pdf',
+                                        workspacePath: 'files/report.pdf',
+                                        mimeType: 'application/pdf'
+                                    }
+                                ]
+                            })
+                        }
+                    }
+                ]
+            })
+        )
+
+        expect(summary.outputs).toMatchObject([
+            {
+                id: 'artifact:artifact-drawio',
+                kind: 'site',
+                title: 'draw.io diagram',
+                resource: { type: 'artifact', artifactId: 'artifact-drawio' }
+            },
+            {
+                id: 'artifact:files/report.pdf',
+                kind: 'document',
+                title: 'report.pdf',
+                resource: { type: 'workspace_file', workspacePath: 'files/report.pdf' }
+            }
+        ])
+        expect(JSON.stringify(summary)).not.toContain('example.com/artifacts/share/secret')
+    })
+
     it('preserves element and file_element references and capability sources', () => {
         const summary = extractChatMessageTaskSummary(
             message({

--- a/packages/server-ai/src/chat-message/task-summary.ts
+++ b/packages/server-ai/src/chat-message/task-summary.ts
@@ -35,6 +35,7 @@ type ComponentData = {
     file?: unknown
     input?: unknown
     tool?: unknown
+    output?: unknown
     url?: unknown
 }
 
@@ -48,11 +49,16 @@ type ArtifactCandidate = {
     kind?: unknown
     title?: unknown
     description?: unknown
+    files?: unknown
     workspacePath?: unknown
+    filePath?: unknown
     fileAssetId?: unknown
     storageFileId?: unknown
     name?: unknown
     originalName?: unknown
+    fileName?: unknown
+    mimeType?: unknown
+    extension?: unknown
 }
 
 type TaskSummaryResourceCandidate = {
@@ -454,14 +460,20 @@ function artifactOutput(value: unknown, messageId?: string, updatedAt?: string):
     }
     const artifact = value as ArtifactCandidate
     const artifactId = readString(artifact.artifactId) ?? readString(artifact.id)
-    const workspacePath = readString(artifact.workspacePath)
+    const workspacePath = readString(artifact.workspacePath) ?? readString(artifact.filePath)
     const fileId = readString(artifact.fileAssetId) ?? readString(artifact.storageFileId)
     const id = artifactId ?? fileId ?? workspacePath
-    const title = readString(artifact.title) ?? readString(artifact.originalName) ?? readString(artifact.name) ?? id
+    const title =
+        readString(artifact.title) ??
+        readString(artifact.originalName) ??
+        readString(artifact.name) ??
+        readString(artifact.fileName) ??
+        fileNameFromPath(workspacePath) ??
+        id
     if (!id || !title) {
         return undefined
     }
-    const kind = mapArtifactKind(artifact.kind) ?? 'file'
+    const kind = artifactKind(artifact)
     if (!artifactId && !workspacePath) {
         return undefined
     }
@@ -483,6 +495,132 @@ function artifactOutput(value: unknown, messageId?: string, updatedAt?: string):
         ...(messageId ? { messageId } : {}),
         ...(updatedAt ? { updatedAt } : {})
     }
+}
+
+function artifactOutputs(value: unknown, messageId?: string, updatedAt?: string): ChatTaskSummaryOutput[] {
+    if (!isObjectValue(value)) {
+        return []
+    }
+    const artifact = value as ArtifactCandidate
+    const output = artifactOutput(value, messageId, updatedAt)
+    const files = Array.isArray(artifact.files)
+        ? artifact.files.flatMap((file) => artifactOutput(file, messageId, updatedAt) ?? [])
+        : []
+    return [...(output ? [output] : []), ...files]
+}
+
+function parseStructuredOutput(value: unknown): Record<string, unknown> | undefined {
+    if (isObjectValue(value)) {
+        return value as Record<string, unknown>
+    }
+    if (typeof value !== 'string' || !value.trim()) {
+        return undefined
+    }
+    try {
+        const parsed = JSON.parse(value)
+        return isObjectValue(parsed) ? (parsed as Record<string, unknown>) : undefined
+    } catch {
+        return undefined
+    }
+}
+
+function structuredToolOutputs(data: ComponentData, messageId?: string, updatedAt?: string) {
+    const payload = parseStructuredOutput(data.output)
+    if (!payload) {
+        return []
+    }
+
+    const tool = readString(data.tool)
+    const outputs: ChatTaskSummaryOutput[] = []
+    if (tool === 'drawio_publish_artifact_link' && readString(payload.artifactId)) {
+        const output = artifactOutput(
+            {
+                ...payload,
+                kind: 'html',
+                title: readString(payload.title) ?? 'draw.io diagram'
+            },
+            messageId,
+            updatedAt
+        )
+        if (output) {
+            outputs.push(output)
+        }
+    }
+
+    if (!outputs.length) {
+        outputs.push(...artifactOutputs(payload, messageId, updatedAt))
+        outputs.push(...artifactOutputs(payload.artifact, messageId, updatedAt))
+        outputs.push(...artifactOutputs(payload.file, messageId, updatedAt))
+    }
+    return outputs
+}
+
+function artifactKind(artifact: ArtifactCandidate): ChatTaskSummaryOutputKind {
+    const explicitKind = mapArtifactKind(artifact.kind)
+    if (explicitKind) {
+        return explicitKind
+    }
+    const mimeType = readString(artifact.mimeType)?.toLowerCase()
+    if (mimeType) {
+        if (mimeType === 'text/html') {
+            return 'site'
+        }
+        if (mimeType.startsWith('image/')) {
+            return 'image'
+        }
+        if (mimeType === 'text/csv' || mimeType.includes('spreadsheet') || mimeType.includes('excel')) {
+            return 'spreadsheet'
+        }
+        if (mimeType.includes('presentation') || mimeType.includes('powerpoint')) {
+            return 'presentation'
+        }
+        if (
+            mimeType === 'application/pdf' ||
+            mimeType === 'text/markdown' ||
+            mimeType === 'text/plain' ||
+            mimeType.includes('wordprocessingml') ||
+            mimeType.includes('msword') ||
+            mimeType.includes('opendocument.text')
+        ) {
+            return 'document'
+        }
+    }
+    const extension = artifactExtension(artifact)
+    if (['html', 'htm'].includes(extension)) {
+        return 'site'
+    }
+    if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif'].includes(extension)) {
+        return 'image'
+    }
+    if (['csv', 'xls', 'xlsx', 'ods'].includes(extension)) {
+        return 'spreadsheet'
+    }
+    if (['ppt', 'pptx', 'odp'].includes(extension)) {
+        return 'presentation'
+    }
+    if (['pdf', 'doc', 'docx', 'md', 'markdown', 'txt', 'rtf', 'odt'].includes(extension)) {
+        return 'document'
+    }
+    return 'file'
+}
+
+function artifactExtension(artifact: ArtifactCandidate) {
+    const explicit = readString(artifact.extension)?.replace(/^\./, '').toLowerCase()
+    if (explicit) {
+        return explicit
+    }
+    const fileName =
+        readString(artifact.fileName) ??
+        readString(artifact.originalName) ??
+        readString(artifact.name) ??
+        readString(artifact.workspacePath) ??
+        readString(artifact.filePath)
+    const match = fileName?.match(/\.([^./\\]+)$/)
+    return match?.[1]?.toLowerCase() ?? ''
+}
+
+function fileNameFromPath(value: string | undefined) {
+    return value?.split(/[/\\]/).filter(Boolean).at(-1)
 }
 
 function mapArtifactKind(value: unknown): ChatTaskSummaryOutputKind | undefined {
@@ -550,18 +688,10 @@ function partOutputs(part: MessageContentPart, messageId?: string, updatedAt?: s
             ...(updatedAt ? { updatedAt } : {})
         })
     }
-    const legacyArtifact = artifactOutput(data.artifact, messageId, updatedAt)
-    if (legacyArtifact) {
-        outputs.push(legacyArtifact)
-    }
-    const artifactLink = artifactOutput(data.artifactLink, messageId, updatedAt)
-    if (artifactLink) {
-        outputs.push(artifactLink)
-    }
-    const file = artifactOutput(data.file, messageId, updatedAt)
-    if (file) {
-        outputs.push(file)
-    }
+    outputs.push(...artifactOutputs(data.artifact, messageId, updatedAt))
+    outputs.push(...artifactOutputs(data.artifactLink, messageId, updatedAt))
+    outputs.push(...artifactOutputs(data.file, messageId, updatedAt))
+    outputs.push(...structuredToolOutputs(data, messageId, updatedAt))
     return outputs
 }
 


### PR DESCRIPTION
## Summary
- allow output-token parameters to exceed the configured slider maximum while keeping the slider synchronized with the entered value
- disable email editing in the account profile and improve long organization/email display behavior
- extract generated files and draw.io Artifact results from structured tool output into ChatKit task summaries
- re-extract outputs for persisted messages whose task summary is incomplete

## Verification
- `pnpm exec jest --config packages/server-ai/jest.config.ts --runInBand packages/server-ai/src/chat-message/task-summary.spec.ts packages/server-ai/src/chat-conversation/task-summary.service.spec.ts`
- `pnpm exec jest --config packages/contracts/jest.config.ts --runInBand packages/contracts/src/ai/ai-model.model.spec.ts`
- `pnpm exec tsc -p packages/server-ai/tsconfig.lib.json --noEmit --pretty false`
- `pnpm exec tsc -p packages/contracts/tsconfig.lib.json --noEmit --pretty false`
