### PR TITLE
fix: make plugin runtime convergence lossless

### DIFF
--- a/apps/cloud/src/app/features/setting/plugins/plugin-runtime-restart.service.spec.ts
+++ b/apps/cloud/src/app/features/setting/plugins/plugin-runtime-restart.service.spec.ts
@@ -290,6 +290,56 @@ describe('PluginRuntimeRestartService', () => {
     expect(dialog.open).not.toHaveBeenCalled()
   })
 
+  it('tracks staged changes by their queued generation instead of an unrelated active restart', async () => {
+    alertDialog.confirm.mockReturnValue(of(true))
+    runtimeControlAPI.restart.mockReturnValue(
+      of({
+        accepted: true,
+        restartId: 'restart-active',
+        pluginGeneration: 12,
+        mode: 'rolling-self-signal',
+        instanceId: 'api-1',
+        requestedAt: new Date().toISOString(),
+        signalAfterMs: 750,
+        drainTimeoutMs: 30_000
+      })
+    )
+    const status = new Subject<Record<string, unknown>>()
+    runtimeControlAPI.pluginConvergenceStatus.mockReturnValue(status)
+    const service = TestBed.inject(PluginRuntimeRestartService)
+    service.restartCapability.set({ allowed: true, mode: 'rolling-self-signal', reason: 'allowed' })
+    service.markRequired('@xpert-ai/plugin-system-demo', [
+      {
+        scopeKey: 'system:global',
+        pluginName: '@xpert-ai/plugin-system-demo',
+        version: '1.0.0',
+        runtimeRevision: 'runtime:system-demo-next',
+        state: 'loaded'
+      }
+    ])
+
+    await service.confirmAndRestart()
+    await flushAsync()
+
+    expect(service.pending()).toMatchObject({ generation: 12 })
+    expect(service.isApplyingInBackground()).toBe(true)
+    expect(service.requiresManualRestart()).toBe(false)
+    expect(runtimeControlAPI.pluginConvergenceStatus).toHaveBeenCalledWith(12)
+    expect(runtimeControlAPI.restartStatus).not.toHaveBeenCalled()
+
+    status.next({
+      generation: 12,
+      status: 'completed',
+      restartId: 'restart-follow-up',
+      targetReplicaCount: 3,
+      completedReplicaCount: 3,
+      failedReplicaCount: 0
+    })
+    await flushAsync()
+
+    expect(service.pending()).toBeNull()
+  })
+
   it('continues tracking the active restart returned by a conflict', async () => {
     alertDialog.confirm.mockReturnValue(of(true))
     runtimeControlAPI.restart.mockReturnValue(
@@ -320,6 +370,40 @@ describe('PluginRuntimeRestartService', () => {
     expect(service.requiresManualRestart()).toBe(false)
     expect(service.lastError()).toBeNull()
     expect(runtimeControlAPI.restartStatus).toHaveBeenCalledWith('restart-active')
+  })
+
+  it('keeps staged requirements pending when an older backend returns a restart conflict', async () => {
+    alertDialog.confirm.mockReturnValue(of(true))
+    runtimeControlAPI.restart.mockReturnValue(
+      throwError(
+        () =>
+          new HttpErrorResponse({
+            status: 409,
+            error: {
+              statusCode: 409,
+              errorCode: 'RUNTIME_RESTART_IN_PROGRESS',
+              message: 'An API runtime restart is already in progress',
+              restartId: 'restart-unrelated'
+            }
+          })
+      )
+    )
+    const service = TestBed.inject(PluginRuntimeRestartService)
+    service.restartCapability.set({ allowed: true, mode: 'rolling-self-signal', reason: 'allowed' })
+    service.markRequired('@xpert-ai/plugin-system-demo', [
+      {
+        scopeKey: 'system:global',
+        pluginName: '@xpert-ai/plugin-system-demo',
+        state: 'loaded'
+      }
+    ])
+
+    await service.confirmAndRestart()
+    await flushAsync()
+
+    expect(service.pending()).not.toHaveProperty('restartId')
+    expect(service.requiresManualRestart()).toBe(true)
+    expect(runtimeControlAPI.restartStatus).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/cloud/src/app/features/setting/plugins/plugin-runtime-restart.service.ts
+++ b/apps/cloud/src/app/features/setting/plugins/plugin-runtime-restart.service.ts
@@ -20,8 +20,14 @@ export interface PendingPluginRuntimeRestart {
   pluginNames: string[]
   requestedAt: string
   restartId?: string
+  generation?: number
   runtimeRequirements?: IRuntimePluginRequirement[]
   error?: string
+}
+
+interface RuntimeRestartInProgressPayload {
+  errorCode: 'RUNTIME_RESTART_IN_PROGRESS'
+  restartId: string
 }
 
 interface PendingPluginRuntimeConvergence {
@@ -43,14 +49,18 @@ export class PluginRuntimeRestartService {
   readonly convergence = signal<PendingPluginRuntimeConvergence | null>(this.readConvergence())
   readonly restartCapability = signal<IRuntimeRestartCapability | null>(null)
   readonly canRestart = computed(() => this.restartCapability()?.allowed === true)
-  readonly requiresManualRestart = computed(() => !!this.pending() && !this.pending()?.restartId)
-  readonly isApplyingInBackground = computed(() => !!this.convergence() || !!this.pending()?.restartId)
+  readonly requiresManualRestart = computed(
+    () => !!this.pending() && !this.pending()?.restartId && !this.pending()?.generation
+  )
+  readonly isApplyingInBackground = computed(
+    () => !!this.convergence() || !!this.pending()?.restartId || !!this.pending()?.generation
+  )
   readonly lastError = computed(() => this.pending()?.error ?? null)
   readonly backgroundPluginNames = computed(() =>
     Array.from(
       new Set([
         ...(this.convergence()?.pluginNames ?? []),
-        ...(this.pending()?.restartId ? (this.pending()?.pluginNames ?? []) : [])
+        ...(this.pending()?.restartId || this.pending()?.generation ? (this.pending()?.pluginNames ?? []) : [])
       ])
     )
   )
@@ -122,7 +132,7 @@ export class PluginRuntimeRestartService {
   }
 
   async prompt() {
-    if (!this.canRestart() || this.#prompting || this.pending()?.restartId) {
+    if (!this.canRestart() || this.#prompting || this.pending()?.restartId || this.pending()?.generation) {
       return
     }
 
@@ -147,7 +157,7 @@ export class PluginRuntimeRestartService {
   }
 
   async confirmAndRestart() {
-    if (!this.canRestart() || this.pending()?.restartId) {
+    if (!this.canRestart() || this.pending()?.restartId || this.pending()?.generation) {
       return
     }
 
@@ -173,7 +183,7 @@ export class PluginRuntimeRestartService {
       await this.startRestartInBackground()
     } catch (error) {
       const activeRestartId = this.restartInProgressId(error)
-      if (activeRestartId) {
+      if (activeRestartId && !this.pending()?.runtimeRequirements?.length) {
         this.trackRestart(activeRestartId, 0)
         return
       }
@@ -190,8 +200,22 @@ export class PluginRuntimeRestartService {
       })
     )
 
-    this.trackRestart(restart.restartId, Math.max(RESTART_POLL_MS, restart.signalAfterMs + 500))
+    if (restart.pluginGeneration) {
+      this.trackPendingGeneration(restart.pluginGeneration)
+    } else {
+      this.trackRestart(restart.restartId, Math.max(RESTART_POLL_MS, restart.signalAfterMs + 500))
+    }
     return restart
+  }
+
+  private trackPendingGeneration(generation: number) {
+    const pending = this.pending()
+    if (pending) {
+      const current = { ...pending }
+      delete current.error
+      this.setPending({ ...current, generation })
+    }
+    void this.monitorPendingGeneration(generation)
   }
 
   private trackRestart(restartId: string, initialDelay: number) {
@@ -216,6 +240,8 @@ export class PluginRuntimeRestartService {
     }
     if (pending.restartId) {
       void this.monitorRestart(pending.restartId, 0)
+    } else if (pending.generation) {
+      void this.monitorPendingGeneration(pending.generation)
     }
   }
 
@@ -245,6 +271,22 @@ export class PluginRuntimeRestartService {
           runtimeRequirements: current.runtimeRequirements,
           error: getErrorMessage(error)
         })
+      }
+    }
+  }
+
+  private async monitorPendingGeneration(generation: number) {
+    try {
+      await this.pollPluginConvergence(generation)
+      if (this.pending()?.generation === generation) {
+        this.clearPending()
+      }
+    } catch (error) {
+      const current = this.pending()
+      if (current?.generation === generation) {
+        const retryable = { ...current, error: getErrorMessage(error) }
+        delete retryable.generation
+        this.setPending(retryable)
       }
     }
   }
@@ -327,18 +369,22 @@ export class PluginRuntimeRestartService {
   }
 
   private restartInProgressId(error: unknown): string | null {
-    if (
-      !(error instanceof HttpErrorResponse) ||
-      error.status !== 409 ||
-      !error.error ||
-      typeof error.error !== 'object'
-    ) {
+    if (!(error instanceof HttpErrorResponse) || error.status !== 409) {
       return null
     }
-    const response = error.error as Record<string, unknown>
-    return response.errorCode === 'RUNTIME_RESTART_IN_PROGRESS' && typeof response.restartId === 'string'
-      ? response.restartId
-      : null
+    return this.isRuntimeRestartInProgressPayload(error.error) ? error.error.restartId : null
+  }
+
+  private isRuntimeRestartInProgressPayload(value: unknown): value is RuntimeRestartInProgressPayload {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'errorCode' in value &&
+      value.errorCode === 'RUNTIME_RESTART_IN_PROGRESS' &&
+      'restartId' in value &&
+      typeof value.restartId === 'string' &&
+      value.restartId.length > 0
+    )
   }
 
   private restartDescription() {
@@ -397,6 +443,7 @@ export class PluginRuntimeRestartService {
         pluginNames: parsed.pluginNames.filter((name): name is string => typeof name === 'string'),
         requestedAt: parsed.requestedAt,
         ...(typeof parsed.restartId === 'string' ? { restartId: parsed.restartId } : {}),
+        ...(typeof parsed.generation === 'number' ? { generation: parsed.generation } : {}),
         ...(typeof parsed.error === 'string' ? { error: parsed.error } : {}),
         ...(Array.isArray(parsed.runtimeRequirements)
           ? { runtimeRequirements: parsed.runtimeRequirements as IRuntimePluginRequirement[] }

--- a/packages/contracts/src/runtime-control.ts
+++ b/packages/contracts/src/runtime-control.ts
@@ -8,6 +8,8 @@ export interface IRuntimePluginRequirement {
   scopeKey: string
   pluginName: string
   version?: string
+  /** Immutable staged artifact or source revision required on every API replica. */
+  runtimeRevision?: string
   state: 'loaded' | 'absent'
 }
 
@@ -39,6 +41,8 @@ export interface IRuntimeRestartRequest {
 export interface IRuntimeRestartResponse {
   accepted: true
   restartId: string
+  /** Durable convergence generation when staged requirements were queued behind another rollout. */
+  pluginGeneration?: number
   mode: RuntimeRestartMode
   instanceId: string
   requestedAt: string

--- a/packages/server/src/managed-connection/instance-registry.service.ts
+++ b/packages/server/src/managed-connection/instance-registry.service.ts
@@ -17,6 +17,7 @@ export interface RuntimePluginStateItem {
 	pluginName: string
 	packageName?: string
 	version?: string
+	runtimeRevision?: string
 }
 
 export interface RuntimePluginFailureItem {

--- a/packages/server/src/plugin/organization-plugin.store.ts
+++ b/packages/server/src/plugin/organization-plugin.store.ts
@@ -287,6 +287,11 @@ function readWorkspaceStageState(statePath: string): WorkspaceStageState | null 
 	return isWorkspaceStageState(value) ? value : null
 }
 
+export function readWorkspacePluginRuntimeRevision(pluginDir: string): string | undefined {
+	const state = readWorkspaceStageState(path.join(pluginDir, WORKSPACE_STAGE_STATE_FILE))
+	return state ? `workspace:${state.sourceFingerprint}` : undefined
+}
+
 function writeWorkspaceStageState(statePath: string, state: WorkspaceStageState) {
 	const temporaryPath = `${statePath}.${process.pid}.${Date.now()}.tmp`
 	try {

--- a/packages/server/src/plugin/plugin-management.service.spec.ts
+++ b/packages/server/src/plugin/plugin-management.service.spec.ts
@@ -109,6 +109,7 @@ jest.mock('./organization-plugin.store', () => ({
 		return `/tmp/plugins/${organizationId}/${sanitizedName}`
 	}),
 	getOrganizationPluginRoot: jest.fn(() => '/tmp/plugins'),
+	readWorkspacePluginRuntimeRevision: jest.fn(() => 'workspace:test-source'),
 	stagePackageDirectoryPlugin: jest.fn()
 }))
 
@@ -651,7 +652,7 @@ describe('PluginManagementService', () => {
 		}
 	})
 
-	it('uses isolated runtime directories for code plugins from local workspaces', async () => {
+	it('rotates the runtime revision when a same-version local workspace plugin is refreshed', async () => {
 		;(loadPlugin as jest.Mock).mockResolvedValue({
 			meta: {
 				name: '@xpert-ai/plugin-code-demo',
@@ -660,15 +661,16 @@ describe('PluginManagementService', () => {
 			}
 		})
 
-		await expect(
-			service.installPlugin({
-				pluginName: '@xpert-ai/plugin-code-demo',
-				source: 'code',
-				sourceConfig: {
-					workspacePath: '/tmp/workspaces/plugin-code-demo'
-				}
-			})
-		).resolves.toEqual(
+		const previousRuntimeName = '@xpert-ai/plugin-code-demo@runtime__previous'
+		const result = await service.installPlugin({
+			pluginName: '@xpert-ai/plugin-code-demo',
+			source: 'code',
+			sourceConfig: {
+				workspacePath: '/tmp/workspaces/plugin-code-demo',
+				runtimeName: previousRuntimeName
+			}
+		})
+		expect(result).toEqual(
 			expect.objectContaining({
 				success: true,
 				name: '@xpert-ai/plugin-code-demo'
@@ -676,6 +678,20 @@ describe('PluginManagementService', () => {
 		)
 
 		const runtimeName = (registerPluginsAsync as jest.Mock).mock.calls[0][0].plugins[0].runtimeName
+		expect(runtimeName).not.toBe(previousRuntimeName)
+		expect(result).toEqual(
+			expect.objectContaining({
+				runtimeRequirements: [
+					{
+						scopeKey: 'org-1',
+						pluginName: '@xpert-ai/plugin-code-demo',
+						version: '1.0.0',
+						runtimeRevision: `runtime:${runtimeName}`,
+						state: 'loaded'
+					}
+				]
+			})
+		)
 
 		expect(runtimeName).toMatch(/^@xpert-ai\/plugin-code-demo@runtime__/)
 		expect(registerPluginsAsync).toHaveBeenCalledWith(
@@ -686,7 +702,8 @@ describe('PluginManagementService', () => {
 						runtimeName,
 						source: 'code',
 						sourceConfig: {
-							workspacePath: '/tmp/workspaces/plugin-code-demo'
+							workspacePath: '/tmp/workspaces/plugin-code-demo',
+							runtimeName
 						}
 					})
 				]
@@ -712,17 +729,25 @@ describe('PluginManagementService', () => {
 			version: undefined,
 			source: 'code',
 			sourceConfig: {
-				workspacePath: '/tmp/workspaces/plugin-code-demo'
+				workspacePath: '/tmp/workspaces/plugin-code-demo',
+				runtimeName: previousRuntimeName
 			}
 		})
 		expect((pluginInstanceService as any).upsert).toHaveBeenCalledWith(
 			expect.objectContaining({
 				source: 'code',
 				sourceConfig: {
-					workspacePath: '/tmp/workspaces/plugin-code-demo'
+					workspacePath: '/tmp/workspaces/plugin-code-demo',
+					runtimeName
 				}
 			})
 		)
+		expect(runtimeControl.recordPluginRuntimeChange).toHaveBeenCalledWith({
+			pluginName: '@xpert-ai/plugin-code-demo',
+			version: '1.0.0',
+			runtimeRevision: `runtime:${runtimeName}`,
+			scopeKey: 'org-1'
+		})
 	})
 
 	it('installs uploaded plugin archives as staged code plugins without a workspace path', async () => {

--- a/packages/server/src/plugin/plugin-management.service.ts
+++ b/packages/server/src/plugin/plugin-management.service.ts
@@ -78,7 +78,7 @@ import {
 	resolveLoadedPluginBundleRoot
 } from './plugin-bundle-manifest'
 import { RuntimeControlService } from '../runtime-control/runtime-control.service'
-import { PluginRuntimeStateService } from './plugin-runtime-state.service'
+import { PluginRuntimeStateService, resolvePluginRuntimeRevision } from './plugin-runtime-state.service'
 
 @Injectable()
 export class PluginManagementService {
@@ -365,16 +365,8 @@ export class PluginManagementService {
 
 			const packageNameWithVersion = body.version ? `${packageName}@${body.version}` : packageName
 			const runtimePluginName =
-				source === 'code'
-					? isRestartRequiredPluginLevel(level)
-						? this.createCodeRuntimePluginName(packageName)
-						: (getCodeRuntimeName(sourceConfig) ?? this.createCodeRuntimePluginName(packageName))
-					: packageNameWithVersion
-			if (
-				source === 'code' &&
-				(packageDir || isRestartRequiredPluginLevel(level)) &&
-				getCodeRuntimeName(sourceConfig) !== runtimePluginName
-			) {
+				source === 'code' ? this.createCodeRuntimePluginName(packageName) : packageNameWithVersion
+			if (source === 'code' && getCodeRuntimeName(sourceConfig) !== runtimePluginName) {
 				sourceConfig = {
 					...sourceConfig,
 					runtimeName: runtimePluginName
@@ -488,6 +480,7 @@ export class PluginManagementService {
 							...((stagedCompatibility.version ?? body.version)
 								? { version: stagedCompatibility.version ?? body.version }
 								: {}),
+							...(source === 'code' ? { runtimeRevision: `runtime:${runtimePluginName}` } : {}),
 							state: 'loaded'
 						}
 					]
@@ -722,17 +715,24 @@ export class PluginManagementService {
 			})
 			clearPluginLoadFailure(scope.scopeKey, pluginName, packageName)
 			await this.runtimeState.report()
-			const convergence = await this.runtimeControl.recordPluginRuntimeChange({
-				pluginName,
-				version: plugin.meta?.version,
-				scopeKey: scope.scopeKey
+			const runtimeRevision = resolvePluginRuntimeRevision({
+				source,
+				sourceConfig,
+				baseDir: pluginBaseDir
 			})
 			const runtimeRequirement = {
 				scopeKey: scope.scopeKey,
 				pluginName,
 				...(plugin.meta?.version ? { version: plugin.meta.version } : {}),
+				...(runtimeRevision ? { runtimeRevision } : {}),
 				state: 'loaded' as const
 			}
+			const convergence = await this.runtimeControl.recordPluginRuntimeChange({
+				pluginName,
+				version: plugin.meta?.version,
+				runtimeRevision,
+				scopeKey: scope.scopeKey
+			})
 
 			return {
 				success: true,

--- a/packages/server/src/plugin/plugin-runtime-state.service.spec.ts
+++ b/packages/server/src/plugin/plugin-runtime-state.service.spec.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { InstanceRegistryService } from '../managed-connection'
+import { PluginRuntimeStateService } from './plugin-runtime-state.service'
+import type { LoadedPluginRecord } from './types'
+
+describe('PluginRuntimeStateService', () => {
+	it('reports the staged source fingerprint for same-version workspace plugins', async () => {
+		const baseDir = mkdtempSync(join(tmpdir(), 'xpert-plugin-runtime-state-'))
+		try {
+			writeFileSync(
+				join(baseDir, '.xpert-workspace-stage.json'),
+				JSON.stringify({
+					schemaVersion: 1,
+					packageName: '@xpert-ai/plugin-demo',
+					workspacePath: '/workspace/plugin-demo',
+					sourceFingerprint: 'source-fingerprint',
+					runtimeDependenciesFingerprint: 'dependencies-fingerprint',
+					relativeDistPath: null
+				})
+			)
+			const reportPluginState = jest.fn()
+			const registry = { reportPluginState } as unknown as InstanceRegistryService
+			const loadedPlugins: LoadedPluginRecord[] = [
+				{
+					organizationId: 'org-1',
+					scopeKey: 'org-1',
+					name: '@xpert-ai/plugin-demo',
+					packageName: '@xpert-ai/plugin-demo',
+					source: 'code',
+					sourceConfig: { workspacePath: '/workspace/plugin-demo' },
+					baseDir,
+					instance: { meta: { version: '1.0.0' } },
+					ctx: {}
+				}
+			]
+
+			await new PluginRuntimeStateService(loadedPlugins, registry).report()
+
+			expect(reportPluginState).toHaveBeenCalledWith({
+				plugins: [
+					{
+						scopeKey: 'org-1',
+						pluginName: '@xpert-ai/plugin-demo',
+						packageName: '@xpert-ai/plugin-demo',
+						version: '1.0.0',
+						runtimeRevision: 'workspace:source-fingerprint'
+					}
+				],
+				failures: []
+			})
+		} finally {
+			rmSync(baseDir, { recursive: true, force: true })
+		}
+	})
+})

--- a/packages/server/src/plugin/plugin-runtime-state.service.ts
+++ b/packages/server/src/plugin/plugin-runtime-state.service.ts
@@ -1,7 +1,22 @@
 import { Inject, Injectable } from '@nestjs/common'
 import { InstanceRegistryService } from '../managed-connection'
+import { readWorkspacePluginRuntimeRevision } from './organization-plugin.store'
 import { loadFailures } from './plugin.helper'
+import { getCodeRuntimeName } from './source-config'
 import { LOADED_PLUGINS, LoadedPluginRecord } from './types'
+
+export function resolvePluginRuntimeRevision(
+	plugin: Pick<LoadedPluginRecord, 'source' | 'sourceConfig' | 'baseDir'>
+): string | undefined {
+	if (plugin.source !== 'code') return undefined
+
+	const runtimeName = getCodeRuntimeName(plugin.sourceConfig)
+	if (runtimeName) return `runtime:${runtimeName}`
+
+	const workspaceRevision = plugin.baseDir ? readWorkspacePluginRuntimeRevision(plugin.baseDir) : undefined
+	if (workspaceRevision) return workspaceRevision
+	return undefined
+}
 
 @Injectable()
 export class PluginRuntimeStateService {
@@ -13,16 +28,7 @@ export class PluginRuntimeStateService {
 
 	async report(): Promise<void> {
 		await this.instanceRegistry.reportPluginState({
-			plugins: this.loadedPlugins.map((plugin) => {
-				const meta = plugin.instance?.meta
-				const version = meta && typeof meta.version === 'string' ? meta.version : undefined
-				return {
-					scopeKey: plugin.scopeKey ?? plugin.organizationId,
-					pluginName: plugin.name,
-					...(plugin.packageName ? { packageName: plugin.packageName } : {}),
-					...(version ? { version } : {})
-				}
-			}),
+			plugins: this.loadedPlugins.map((plugin) => this.runtimeState(plugin)),
 			failures: loadFailures.map((failure) => ({
 				scopeKey: failure.scopeKey ?? failure.organizationId,
 				pluginName: failure.pluginName,
@@ -30,5 +36,18 @@ export class PluginRuntimeStateService {
 				error: failure.error
 			}))
 		})
+	}
+
+	private runtimeState(plugin: LoadedPluginRecord) {
+		const meta = plugin.instance?.meta
+		const version = meta && typeof meta.version === 'string' ? meta.version : undefined
+		const runtimeRevision = resolvePluginRuntimeRevision(plugin)
+		return {
+			scopeKey: plugin.scopeKey ?? plugin.organizationId,
+			pluginName: plugin.name,
+			...(plugin.packageName ? { packageName: plugin.packageName } : {}),
+			...(version ? { version } : {}),
+			...(runtimeRevision ? { runtimeRevision } : {})
+		}
 	}
 }

--- a/packages/server/src/runtime-control/runtime-control.dto.ts
+++ b/packages/server/src/runtime-control/runtime-control.dto.ts
@@ -16,6 +16,11 @@ class RuntimePluginRequirementDto implements IRuntimePluginRequirement {
 	@MaxLength(100)
 	version?: string
 
+	@IsOptional()
+	@IsString()
+	@MaxLength(500)
+	runtimeRevision?: string
+
 	@IsIn(['loaded', 'absent'])
 	state: 'loaded' | 'absent'
 }

--- a/packages/server/src/runtime-control/runtime-restart-coordinator.service.spec.ts
+++ b/packages/server/src/runtime-control/runtime-restart-coordinator.service.spec.ts
@@ -12,6 +12,7 @@ class FakeRedis {
 	readonly expiresAt = new Map<string, number>()
 	readonly listeners = new Map<string, Set<Listener>>()
 	onActiveReleased?: () => Promise<void>
+	onGenerationPublished?: (generation: number) => Promise<void>
 
 	async set(key: string, value: string, options?: { NX?: boolean; PX?: number; EX?: number }) {
 		this.expireKeyIfNeeded(key)
@@ -30,13 +31,6 @@ class FakeRedis {
 	async get(key: string) {
 		this.expireKeyIfNeeded(key)
 		return this.values.get(key) ?? null
-	}
-
-	async incr(key: string) {
-		this.expireKeyIfNeeded(key)
-		const next = Number.parseInt(this.values.get(key) ?? '0', 10) + 1
-		this.values.set(key, `${next}`)
-		return next
 	}
 
 	async hSet(key: string, field: string, value: string) {
@@ -61,6 +55,24 @@ class FakeRedis {
 	}
 
 	async eval(script: string, options: { keys: string[]; arguments: string[] }) {
+		if (script.includes('xpert-publish-plugin-generation')) {
+			const generationKey = options.keys[0]
+			const generation = Number.parseInt(this.values.get(generationKey) ?? '0', 10) + 1
+			this.values.set(generationKey, `${generation}`)
+			const change = JSON.parse(options.arguments[0])
+			change.generation = generation
+			const prefix = options.arguments[1]
+			const ttlMs = Number.parseInt(options.arguments[2], 10) * 1_000
+			const changeKey = `${prefix}${generation}:change`
+			const statusKey = `${prefix}${generation}:status`
+			this.values.set(changeKey, JSON.stringify(change))
+			this.values.set(statusKey, JSON.stringify({ generation, status: 'in_progress' }))
+			this.expiresAt.set(changeKey, Date.now() + ttlMs)
+			this.expiresAt.set(statusKey, Date.now() + ttlMs)
+			await this.onGenerationPublished?.(generation)
+			return generation
+		}
+
 		const [key] = options.keys
 		const [expected] = options.arguments
 		this.expireKeyIfNeeded(key)
@@ -271,6 +283,35 @@ describe('RuntimeRestartCoordinatorService', () => {
 		await expect(redis.get('xpert:system:runtime:restart:active')).resolves.toBeNull()
 	})
 
+	it('restarts replicas whose code revision is stale even when the package version matches', async () => {
+		const currentRevision = 'workspace:current-source'
+		nodes.push(await createNode(redis, 'api-1', 'api-1-boot-1', loadedPluginState(currentRevision)))
+		nodes.push(await createNode(redis, 'api-2', 'api-2-boot-1', loadedPluginState('workspace:old-source')))
+
+		const change = await nodes[0].coordinator.recordPluginChange({
+			pluginName: requirement.pluginName,
+			version: requirement.version,
+			runtimeRevision: currentRevision,
+			scopeKey: requirement.scopeKey
+		})
+		await advance(2_750)
+
+		expect(nodes.find((node) => node.replicaId === 'api-1')?.signaler.signal).not.toHaveBeenCalled()
+		const staleNode = nodes.find((node) => node.replicaId === 'api-2')
+		expect(staleNode?.signaler.signal).toHaveBeenCalledWith('SIGTERM')
+		if (!staleNode) throw new Error('Expected the stale API replica')
+		await staleNode.coordinator.onModuleDestroy()
+		nodes = nodes.filter((node) => node !== staleNode)
+		nodes.push(await createNode(redis, 'api-2', 'api-2-boot-2', loadedPluginState(currentRevision)))
+		await advance(2_000)
+
+		await expect(nodes[0].coordinator.getPluginConvergenceStatus(change.generation)).resolves.toMatchObject({
+			status: 'completed',
+			targetReplicaCount: 2,
+			completedReplicaCount: 2
+		})
+	})
+
 	it('keeps the hot-loaded API online while stale replicas restart in bounded batches', async () => {
 		nodes.push(await createNode(redis, 'api-1', 'api-1-boot-1', loadedPluginState()))
 		nodes.push(await createNode(redis, 'api-2', 'api-2-boot-1', emptyPluginState()))
@@ -399,6 +440,68 @@ describe('RuntimeRestartCoordinatorService', () => {
 			status: 'completed'
 		})
 	})
+
+	it('publishes concurrent generations atomically before selecting their rollout', async () => {
+		const node = await createNode(redis, 'api-1', 'api-1-boot-1', loadedPluginState())
+		nodes.push(node)
+		let releaseFirstPublication: (() => void) | undefined
+		const releaseFirst = new Promise<void>((resolve) => {
+			releaseFirstPublication = resolve
+		})
+		redis.onGenerationPublished = async (generation) => {
+			if (generation !== 1) return
+			await releaseFirst
+		}
+
+		const firstPromise = node.coordinator.recordPluginChange({
+			pluginName: requirement.pluginName,
+			version: requirement.version,
+			scopeKey: requirement.scopeKey
+		})
+		await Promise.resolve()
+		await Promise.resolve()
+		const secondPromise = node.coordinator.recordPluginChange({
+			pluginName: requirement.pluginName,
+			version: requirement.version,
+			scopeKey: requirement.scopeKey
+		})
+		releaseFirstPublication?.()
+		const [first, second] = await Promise.all([firstPromise, secondPromise])
+		expect(first.generation).toBe(1)
+		expect(second.generation).toBe(2)
+		await advance(8_000)
+
+		await expect(node.coordinator.getPluginConvergenceStatus(first.generation)).resolves.toMatchObject({
+			status: 'completed'
+		})
+		await expect(node.coordinator.getPluginConvergenceStatus(second.generation)).resolves.toMatchObject({
+			status: 'completed'
+		})
+	})
+
+	it('queues staged runtime requirements behind an active restart and completes their generation', async () => {
+		const node = await createNode(redis, 'api-1', 'api-1-boot-1', emptyPluginState())
+		nodes.push(node)
+		const active = await node.coordinator.requestRestart({ source: 'interactive' })
+		const queued = await node.coordinator.requestRestart({
+			source: 'interactive',
+			runtimeRequirements: [requirement]
+		})
+
+		expect(queued.restartId).toBe(active.restartId)
+		expect(queued.pluginGeneration).toBe(1)
+		await advance(2_750)
+		expect(node.signaler.signal).toHaveBeenCalledWith('SIGTERM')
+
+		await node.coordinator.onModuleDestroy()
+		nodes = []
+		nodes.push(await createNode(redis, 'api-1', 'api-1-boot-2', loadedPluginState()))
+		await advance(5_000)
+
+		await expect(nodes[0].coordinator.getPluginConvergenceStatus(1)).resolves.toMatchObject({
+			status: 'completed'
+		})
+	})
 })
 
 async function createNode(
@@ -429,14 +532,15 @@ function emptyPluginState(): RuntimePluginState {
 	return { reportedAt: new Date().toISOString(), plugins: [], failures: [] }
 }
 
-function loadedPluginState(): RuntimePluginState {
+function loadedPluginState(runtimeRevision?: string): RuntimePluginState {
 	return {
 		reportedAt: new Date().toISOString(),
 		plugins: [
 			{
 				scopeKey: requirement.scopeKey,
 				pluginName: requirement.pluginName,
-				version: requirement.version
+				version: requirement.version,
+				...(runtimeRevision ? { runtimeRevision } : {})
 			}
 		],
 		failures: []

--- a/packages/server/src/runtime-control/runtime-restart-coordinator.service.ts
+++ b/packages/server/src/runtime-control/runtime-restart-coordinator.service.ts
@@ -29,6 +29,7 @@ import { RuntimeLifecycleService } from './runtime-lifecycle.service'
 
 const ACTIVE_RESTART_KEY = 'xpert:system:runtime:restart:active'
 const PLUGIN_GENERATION_KEY = 'xpert:system:plugin-runtime:generation'
+const PLUGIN_GENERATION_PREFIX = 'xpert:system:plugin-runtime:generation:'
 const RESTART_CHANNEL = 'xpert:system:runtime:restart:events'
 const DEFAULT_SIGNAL_DELAY_MS = 750
 const DEFAULT_DRAIN_TIMEOUT_MS = 30_000
@@ -68,11 +69,20 @@ end
 redis.call('psetex', KEYS[1], tonumber(ARGV[4]), ARGV[3])
 return 1
 `
+const PUBLISH_PLUGIN_GENERATION_SCRIPT = `
+-- xpert-publish-plugin-generation
+local generation = redis.call('incr', KEYS[1])
+local change = cjson.decode(ARGV[1])
+change['generation'] = generation
+local state = { generation = generation, status = 'in_progress' }
+redis.call('set', ARGV[2] .. generation .. ':change', cjson.encode(change), 'EX', tonumber(ARGV[3]))
+redis.call('set', ARGV[2] .. generation .. ':status', cjson.encode(state), 'EX', tonumber(ARGV[3]))
+return generation
+`
 
 type RuntimeRestartRedisClient = {
 	set: (key: string, value: string, options?: { NX?: boolean; PX?: number; EX?: number }) => Promise<string | null>
 	get: (key: string) => Promise<string | null>
-	incr: (key: string) => Promise<number>
 	hSet: (key: string, field: string, value: string) => Promise<number>
 	hGetAll: (key: string) => Promise<Record<string, string>>
 	expire: (key: string, seconds: number) => Promise<boolean | number>
@@ -120,7 +130,12 @@ type RestartTargetState = {
 
 type PluginGenerationChange = {
 	generation: number
-	requirement: IRuntimePluginRequirement
+	requirements: IRuntimePluginRequirement[]
+	source: 'interactive' | 'plugin-change'
+	reason?: string
+	actorUserId?: string
+	tenantId?: string
+	sourceIp?: string
 }
 
 type PluginGenerationState = {
@@ -144,6 +159,7 @@ type RestartOperationInput = {
 export interface PluginRuntimeChangeInput {
 	pluginName: string
 	version?: string | null
+	runtimeRevision?: string | null
 	scopeKey: string
 }
 
@@ -195,10 +211,43 @@ export class RuntimeRestartCoordinatorService implements OnModuleInit, OnModuleD
 		sourceIp?: string
 		runtimeRequirements?: IRuntimePluginRequirement[]
 	}): Promise<IRuntimeRestartResponse> {
+		const runtimeRequirements = this.mergeRuntimeRequirements(input.runtimeRequirements ?? [])
+		if (runtimeRequirements.length) {
+			const generation = await this.publishPluginGeneration({
+				generation: 0,
+				requirements: runtimeRequirements,
+				source: 'interactive',
+				reason: input.reason,
+				actorUserId: input.actorUserId,
+				tenantId: input.tenantId,
+				sourceIp: input.sourceIp
+			})
+			this.writeAuditLog('runtime.restart.queued', {
+				generation,
+				reason: input.reason,
+				actorUserId: input.actorUserId,
+				tenantId: input.tenantId,
+				sourceIp: input.sourceIp,
+				runtimeRequirements
+			})
+			await this.publish('plugin-generation-changed')
+			const restart = await this.ensurePendingPluginOperation()
+			if (!restart) {
+				throw new ServiceUnavailableException({
+					statusCode: 503,
+					errorCode: 'RUNTIME_RESTART_COORDINATION_UNAVAILABLE',
+					message: 'Runtime restart coordination is unavailable'
+				})
+			}
+			return { ...restart, pluginGeneration: generation }
+		}
+
 		const activeRestartId = await this.redis.get(ACTIVE_RESTART_KEY)
 		if (activeRestartId) {
 			throw this.restartInProgress(activeRestartId)
 		}
+		const pendingPluginChanges = await this.readPendingPluginChanges()
+		const pluginGeneration = pendingPluginChanges.at(-1)?.generation ?? (await this.currentPluginGeneration())
 
 		return await this.startOperation({
 			reason: input.reason,
@@ -206,61 +255,42 @@ export class RuntimeRestartCoordinatorService implements OnModuleInit, OnModuleD
 			actorUserId: input.actorUserId,
 			tenantId: input.tenantId,
 			sourceIp: input.sourceIp,
-			pluginGeneration: await this.currentPluginGeneration(),
-			pluginChanges: [],
-			runtimeRequirements: input.runtimeRequirements ?? []
+			pluginGeneration,
+			pluginChanges: pendingPluginChanges,
+			runtimeRequirements: []
 		})
 	}
 
 	async recordPluginChange(input: PluginRuntimeChangeInput): Promise<PluginRuntimeChangeResult> {
-		let generation = 0
+		let generation: number
 		try {
-			generation = await this.redis.incr(PLUGIN_GENERATION_KEY)
-			const change: PluginGenerationChange = {
-				generation,
-				requirement: {
-					scopeKey: input.scopeKey,
-					pluginName: input.pluginName,
-					...(input.version ? { version: input.version } : {}),
-					state: 'loaded'
-				}
-			}
-			await this.writePluginChange(change)
-			await this.writePluginGenerationState({ generation, status: 'in_progress' })
-
-			let restartId = await this.redis.get(ACTIVE_RESTART_KEY)
-			if (!restartId) {
-				try {
-					const restart = await this.startOperation({
-						reason: `Activate ${input.pluginName}@${input.version ?? 'latest'} in ${input.scopeKey}`,
-						source: 'plugin-change',
-						pluginGeneration: generation,
-						pluginChanges: [change],
-						runtimeRequirements: []
-					})
-					restartId = restart.restartId
-				} catch (error) {
-					if (!(error instanceof ConflictException)) {
-						throw error
+			generation = await this.publishPluginGeneration({
+				generation: 0,
+				requirements: [
+					{
+						scopeKey: input.scopeKey,
+						pluginName: input.pluginName,
+						...(input.version ? { version: input.version } : {}),
+						...(input.runtimeRevision ? { runtimeRevision: input.runtimeRevision } : {}),
+						state: 'loaded'
 					}
-					restartId = await this.redis.get(ACTIVE_RESTART_KEY)
-				}
-			}
-			if (restartId) {
-				await this.writePluginGenerationState({ generation, status: 'in_progress', restartId })
-			}
-			await this.publish(restartId ?? 'plugin-generation-changed')
-			return { scheduled: Boolean(restartId), generation }
+				],
+				source: 'plugin-change',
+				reason: `Activate ${input.pluginName}@${input.version ?? 'latest'} in ${input.scopeKey}`
+			})
 		} catch (error) {
 			const message = this.describeError(error)
-			this.logger.error(`Failed to schedule plugin runtime convergence: ${message}`)
-			if (generation > 0) {
-				await this.writePluginGenerationState({ generation, status: 'failed', error: message }).catch(
-					() => undefined
-				)
-			}
-			return { scheduled: false, generation }
+			this.logger.error(`Failed to publish plugin runtime convergence: ${message}`)
+			return { scheduled: false, generation: 0 }
 		}
+
+		await this.publish('plugin-generation-changed')
+		await this.ensurePendingPluginOperation().catch((error) => {
+			this.logger.warn(
+				`Plugin runtime generation ${generation} is durable but its rollout has not started yet: ${this.describeError(error)}`
+			)
+		})
+		return { scheduled: true, generation }
 	}
 
 	async getStatus(restartId: string): Promise<IRuntimeRestartStatus | null> {
@@ -318,13 +348,13 @@ export class RuntimeRestartCoordinatorService implements OnModuleInit, OnModuleD
 	private async startOperation(input: RestartOperationInput): Promise<IRuntimeRestartResponse> {
 		const metadata = this.buildOperationMetadata(input)
 		const { restartId } = metadata
+		await this.writeMetadata(metadata)
 		const claimed = await this.redis.set(ACTIVE_RESTART_KEY, restartId, { NX: true, PX: INITIAL_OPERATION_TTL_MS })
 		if (claimed !== 'OK') {
 			throw this.restartInProgress((await this.redis.get(ACTIVE_RESTART_KEY)) ?? undefined)
 		}
 
 		try {
-			await this.writeMetadata(metadata)
 			await this.activateOperation(metadata)
 
 			return this.operationResponse(metadata)
@@ -356,7 +386,7 @@ export class RuntimeRestartCoordinatorService implements OnModuleInit, OnModuleD
 			pluginGenerations: input.pluginChanges.map((change) => change.generation),
 			runtimeRequirements: this.mergeRuntimeRequirements([
 				...input.runtimeRequirements,
-				...input.pluginChanges.map((change) => change.requirement)
+				...input.pluginChanges.flatMap((change) => change.requirements)
 			]),
 			registrationDeadlineAt: new Date(Date.now() + REGISTRATION_WINDOW_MS).toISOString(),
 			phase: 'collecting',
@@ -404,7 +434,10 @@ export class RuntimeRestartCoordinatorService implements OnModuleInit, OnModuleD
 		this.processing = true
 		try {
 			const restartId = await this.redis.get(ACTIVE_RESTART_KEY)
-			if (!restartId) return
+			if (!restartId) {
+				await this.ensurePendingPluginOperation()
+				return
+			}
 			let metadata = await this.readMetadata(restartId)
 			if (!metadata) {
 				await this.releaseLock(ACTIVE_RESTART_KEY, restartId)
@@ -785,6 +818,12 @@ export class RuntimeRestartCoordinatorService implements OnModuleInit, OnModuleD
 					error: `Plugin ${requirement.pluginName} loaded ${plugin.version ?? 'unknown'} instead of ${requirement.version}`
 				}
 			}
+			if (requirement.runtimeRevision && plugin.runtimeRevision !== requirement.runtimeRevision) {
+				return {
+					status: 'failed',
+					error: `Plugin ${requirement.pluginName} loaded runtime revision ${plugin.runtimeRevision ?? 'unknown'} instead of ${requirement.runtimeRevision}`
+				}
+			}
 		}
 		return { status: 'satisfied' }
 	}
@@ -835,16 +874,82 @@ export class RuntimeRestartCoordinatorService implements OnModuleInit, OnModuleD
 		})
 	}
 
+	private async publishPluginGeneration(change: PluginGenerationChange): Promise<number> {
+		if (!this.redis.eval) {
+			throw new Error('Redis scripting is required for atomic plugin generation publication')
+		}
+		const generation = Number(
+			await this.redis.eval(PUBLISH_PLUGIN_GENERATION_SCRIPT, {
+				keys: [PLUGIN_GENERATION_KEY],
+				arguments: [JSON.stringify(change), PLUGIN_GENERATION_PREFIX, `${PLUGIN_GENERATION_TTL_SECONDS}`]
+			})
+		)
+		if (!Number.isInteger(generation) || generation <= 0) {
+			throw new Error('Redis returned an invalid plugin runtime generation')
+		}
+		return generation
+	}
+
+	private async ensurePendingPluginOperation(): Promise<IRuntimeRestartResponse | null> {
+		const activeRestartId = await this.redis.get(ACTIVE_RESTART_KEY)
+		if (activeRestartId) {
+			return await this.readOperationResponse(activeRestartId)
+		}
+
+		const changes = await this.readPendingPluginChanges()
+		if (!changes.length) return null
+
+		const latest = changes[changes.length - 1]
+		try {
+			return await this.startOperation({
+				reason: latest.reason ?? `Converge plugin runtime generation ${latest.generation}`,
+				source: latest.source,
+				actorUserId: latest.actorUserId,
+				tenantId: latest.tenantId,
+				sourceIp: latest.sourceIp,
+				pluginGeneration: latest.generation,
+				pluginChanges: changes,
+				runtimeRequirements: []
+			})
+		} catch (error) {
+			if (!(error instanceof ConflictException)) throw error
+			const restartId = await this.redis.get(ACTIVE_RESTART_KEY)
+			return restartId ? await this.readOperationResponse(restartId) : null
+		}
+	}
+
+	private async readPendingPluginChanges(): Promise<PluginGenerationChange[]> {
+		const currentGeneration = await this.currentPluginGeneration()
+		let firstGeneration = currentGeneration + 1
+		for (let generation = currentGeneration; generation > 0; generation -= 1) {
+			const state = await this.readPluginGenerationState(generation)
+			if (state?.status !== 'in_progress') break
+			firstGeneration = generation
+		}
+		return firstGeneration <= currentGeneration
+			? await this.readPluginChanges(firstGeneration, currentGeneration)
+			: []
+	}
+
+	private async readOperationResponse(restartId: string): Promise<IRuntimeRestartResponse> {
+		const metadata = await this.readMetadata(restartId)
+		if (metadata) return this.operationResponse(metadata)
+
+		return {
+			accepted: true,
+			restartId,
+			mode: 'rolling-self-signal',
+			instanceId: this.lifecycle.instanceId,
+			requestedAt: new Date().toISOString(),
+			signalAfterMs: this.signalDelayMs,
+			drainTimeoutMs: this.drainTimeoutMs
+		}
+	}
+
 	private async currentPluginGeneration(): Promise<number> {
 		const value = await this.redis.get(PLUGIN_GENERATION_KEY)
 		const parsed = Number.parseInt(value ?? '0', 10)
 		return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
-	}
-
-	private async writePluginChange(change: PluginGenerationChange): Promise<void> {
-		await this.redis.set(this.pluginChangeKey(change.generation), JSON.stringify(change), {
-			EX: PLUGIN_GENERATION_TTL_SECONDS
-		})
 	}
 
 	private async readPluginChanges(from: number, to: number): Promise<PluginGenerationChange[]> {
@@ -852,13 +957,60 @@ export class RuntimeRestartCoordinatorService implements OnModuleInit, OnModuleD
 		for (let generation = from; generation <= to; generation += 1) {
 			const value = await this.redis.get(this.pluginChangeKey(generation))
 			if (!value) throw new Error(`Plugin runtime generation ${generation} is missing`)
-			const parsed = JSON.parse(value) as PluginGenerationChange
-			if (parsed.generation !== generation || !parsed.requirement) {
+			const parsed = this.parsePluginGenerationChange(JSON.parse(value) as unknown)
+			if (!parsed || parsed.generation !== generation) {
 				throw new Error(`Plugin runtime generation ${generation} is invalid`)
 			}
 			changes.push(parsed)
 		}
 		return changes
+	}
+
+	private parsePluginGenerationChange(value: unknown): PluginGenerationChange | null {
+		if (typeof value !== 'object' || value === null || !('generation' in value)) return null
+		if (typeof value.generation !== 'number') return null
+
+		const requirements =
+			'requirements' in value && Array.isArray(value.requirements)
+				? value.requirements
+				: 'requirement' in value
+					? [value.requirement]
+					: []
+		if (
+			!requirements.length ||
+			!requirements.every((requirement) => this.isRuntimePluginRequirement(requirement))
+		) {
+			return null
+		}
+
+		return {
+			generation: value.generation,
+			requirements,
+			source: 'source' in value && value.source === 'interactive' ? 'interactive' : 'plugin-change',
+			...('reason' in value && typeof value.reason === 'string' ? { reason: value.reason } : {}),
+			...('actorUserId' in value && typeof value.actorUserId === 'string'
+				? { actorUserId: value.actorUserId }
+				: {}),
+			...('tenantId' in value && typeof value.tenantId === 'string' ? { tenantId: value.tenantId } : {}),
+			...('sourceIp' in value && typeof value.sourceIp === 'string' ? { sourceIp: value.sourceIp } : {})
+		}
+	}
+
+	private isRuntimePluginRequirement(value: unknown): value is IRuntimePluginRequirement {
+		return (
+			typeof value === 'object' &&
+			value !== null &&
+			'scopeKey' in value &&
+			typeof value.scopeKey === 'string' &&
+			'pluginName' in value &&
+			typeof value.pluginName === 'string' &&
+			'state' in value &&
+			(value.state === 'loaded' || value.state === 'absent') &&
+			(!('version' in value) || value.version === undefined || typeof value.version === 'string') &&
+			(!('runtimeRevision' in value) ||
+				value.runtimeRevision === undefined ||
+				typeof value.runtimeRevision === 'string')
+		)
 	}
 
 	private async writePluginGenerationState(state: PluginGenerationState): Promise<void> {
@@ -1008,10 +1160,10 @@ export class RuntimeRestartCoordinatorService implements OnModuleInit, OnModuleD
 		return `xpert:system:runtime:restart:${restartId}:registration`
 	}
 	private pluginChangeKey(generation: number) {
-		return `xpert:system:plugin-runtime:generation:${generation}:change`
+		return `${PLUGIN_GENERATION_PREFIX}${generation}:change`
 	}
 	private pluginGenerationStateKey(generation: number) {
-		return `xpert:system:plugin-runtime:generation:${generation}:status`
+		return `${PLUGIN_GENERATION_PREFIX}${generation}:status`
 	}
 
 	private restartInProgress(restartId?: string): ConflictException {


### PR DESCRIPTION
## Summary
- assign an immutable runtime revision to each code-plugin refresh so same-version source changes still converge across replicas
- publish plugin generations, change payloads, and initial status atomically in Redis, then recover or chain every queued generation
- queue system/tenant runtime requirements behind an active rollout and let the UI monitor the exact generation in the background
- validate restart-conflict payloads with a structural type guard instead of a broad record cast

## Validation
- `corepack pnpm nx test server --runInBand --testPathPatterns="(plugin-management|plugin-runtime-state|runtime-restart-coordinator).service.spec.ts"` (41 tests)
- `corepack pnpm nx test cloud --runInBand --testPathPatterns=plugin-runtime-restart.service.spec.ts` (11 tests)
- `corepack pnpm exec tsc -p packages/server/tsconfig.lib.json --noEmit`
- `corepack pnpm exec tsc -p apps/cloud/tsconfig.app.json --noEmit`
- focused ESLint: no new errors
- Prettier and `git diff --check`

No changeset is included, per request.