### PR TITLE
[codex] restore enterprise H5 client contract

### DIFF
--- a/apps/cloud/src/app/@core/services/xpert.service.ts
+++ b/apps/cloud/src/app/@core/services/xpert.service.ts
@@ -35,6 +35,8 @@ import {
   OrderTypeEnum,
   TChatApi,
   TChatApp,
+  TEnterpriseH5IdentityGrant,
+  TEnterpriseH5Platform,
   TChatConversationLog,
   TChatOptions,
   TChatRequest,
@@ -81,6 +83,31 @@ export type TPublicChatkitSession = {
   xpertId: string
   assistantId: string
   organizationId?: string | null
+}
+
+/** Indicates that the verified enterprise identity must be linked to an Xpert account. */
+export type TEnterpriseH5AccountBindingRequired = {
+  status: 'account_binding_required'
+  accountBindingProvider: string
+}
+
+/** Result of exchanging an enterprise H5 identity for a ChatKit session. */
+export type TEnterpriseH5ChatkitSession = TPublicChatkitSession | TEnterpriseH5AccountBindingRequired
+
+/** SSO provider metadata displayed when enterprise account binding is required. */
+export type TSSOProviderDescriptor = {
+  provider: string
+  displayName: string
+  icon: string
+  order: number
+  startUrl: string
+}
+
+/** Public bootstrap data used to initialize an enterprise H5 ChatKit client. */
+export type TEnterpriseH5ChatAppBootstrap = {
+  xpert: IXpert
+  platform: TEnterpriseH5Platform
+  clientConfig: Record<string, unknown>
 }
 
 type TXpertGetMyAllRequestOptions = {
@@ -452,6 +479,25 @@ export class XpertAPIService extends XpertWorkspaceBaseCrudService<IXpert> {
       this.apiBaseUrl + `/${encodeURIComponent(identifier)}/chatkit-session`,
       { currentClientSecret },
       { withCredentials: true }
+    )
+  }
+
+  getEnterpriseH5Bootstrap(identifier: string, platform: TEnterpriseH5Platform) {
+    return this.httpClient.get<TEnterpriseH5ChatAppBootstrap>(
+      this.apiBaseUrl + `/${encodeURIComponent(identifier)}/enterprise-h5/${encodeURIComponent(platform)}/bootstrap`
+    )
+  }
+
+  createEnterpriseH5Session(identifier: string, platform: TEnterpriseH5Platform, grant: TEnterpriseH5IdentityGrant) {
+    return this.httpClient.post<TEnterpriseH5ChatkitSession>(
+      this.apiBaseUrl + `/${encodeURIComponent(identifier)}/enterprise-h5/${encodeURIComponent(platform)}/session`,
+      { grant }
+    )
+  }
+
+  getSsoProviders() {
+    return this.httpClient.get<{ fallbackApplied: boolean; providers: TSSOProviderDescriptor[] }>(
+      '/api/auth/sso/providers'
     )
   }
 


### PR DESCRIPTION
## Issue

The `Publish xpert-webapp` job started failing during Angular compilation after PR #899 was merged into `develop`. The public ChatKit component still consumes the enterprise H5 bootstrap, session exchange, and SSO-provider APIs, but their client-side contract was no longer present in `XpertAPIService`.

This caused the webapp build to report missing exported types, missing service methods, and cascading `unknown` type errors in `public-chatkit.component.ts`.

## Root cause

PR #899 updated `apps/cloud/src/app/@core/services/xpert.service.ts` for workspace file APIs and unintentionally removed the enterprise H5 types and methods previously introduced for the ChatKit flow. The component, tests, and backend routes remained in place, leaving the frontend service contract incomplete.

## Fix

- Restore the enterprise H5 identity and platform imports.
- Restore the typed bootstrap, ChatKit session, account-binding, and SSO provider contracts.
- Restore `getEnterpriseH5Bootstrap`, `createEnterpriseH5Session`, and `getSsoProviders` on `XpertAPIService`.
- Preserve the workspace file API changes from PR #899.

## Validation

- `corepack pnpm exec jest --config apps/cloud/jest.config.ts --runTestsByPath apps/cloud/src/app/xpert/chatkit/public-chatkit.component.spec.ts --runInBand` — 13/13 tests passed.
- `NODE_EXTRA_CA_CERTS=/etc/ssl/cert.pem NX_TUI=false corepack pnpm nx build cloud --configuration=production --skip-nx-cache` — passed.
- `git diff --check` — passed.

Manual browser validation was not performed.
