### PR TITLE
[codex] Enforce organization membership model access

### DIFF
--- a/apps/cloud/src/app/features/setting/membership/membership.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.spec.ts
@@ -5,6 +5,7 @@ import { TranslateService } from '@ngx-translate/core'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import {
+  AiModelTypeEnum,
   IMembershipPlan,
   MembershipBulkActionEnum,
   MembershipPeriodEnum,
@@ -144,6 +145,40 @@ describe('MembershipAdminComponent', () => {
 
     expect(component.plans()).toEqual([targetPlan])
     expect(component.selectedPlanId()).toBe(targetPlan.id)
+  })
+
+  it('marks stored models that are no longer in the current provider catalog', () => {
+    const plan = {
+      ...targetPlan,
+      allowedModels: [
+        { provider: 'moonshot', model: 'kimi-k3' },
+        { provider: 'moonshot', model: 'kimi-k2-thinking' }
+      ]
+    }
+    membershipService.getModelOptions.mockReturnValue(
+      of([
+        {
+          id: 'copilot-1',
+          providerWithModels: {
+            provider: 'moonshot',
+            models: [{ model: 'kimi-k3', model_type: AiModelTypeEnum.LLM }]
+          }
+        }
+      ])
+    )
+    membershipService.getPlans.mockReturnValue(of([plan]))
+
+    component.load()
+    component.edit(plan)
+
+    expect(component.modelOptions()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ provider: 'moonshot', model: 'kimi-k3', available: true }),
+        expect.objectContaining({ provider: 'moonshot', model: 'kimi-k2-thinking', available: false })
+      ])
+    )
+    const unavailable = component.modelOptions().find((option) => option.model === 'kimi-k2-thinking')
+    expect(unavailable && component.modelTargetLabel(unavailable)).toContain('XP.Membership.HistoricalModelUnavailable')
   })
 
   it('archives a plan only after confirmation', async () => {

--- a/apps/cloud/src/app/features/setting/membership/membership.component.ts
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.ts
@@ -43,6 +43,7 @@ type MembershipModelOption = {
   value: string
   provider: string
   model: string
+  available: boolean
 }
 
 type MembershipAdminTab = 'plans' | 'users'
@@ -794,15 +795,21 @@ export class MembershipAdminComponent implements OnInit {
   }
 
   modelTargetLabel(option: MembershipModelOption) {
+    let label: string
     if (!option.provider) {
-      return this.#translate.instant('XP.Membership.AllModels', { Default: 'All models' })
-    }
-    if (option.model === '*') {
-      return `${option.provider} · ${this.#translate.instant('XP.Membership.AllProviderModels', {
+      label = this.#translate.instant('XP.Membership.AllModels', { Default: 'All models' })
+    } else if (option.model === '*') {
+      label = `${option.provider} · ${this.#translate.instant('XP.Membership.AllProviderModels', {
         Default: 'All provider models'
       })}`
+    } else {
+      label = `${option.provider} · ${option.model}`
     }
-    return `${option.provider} · ${option.model}`
+    return option.available
+      ? label
+      : `${label} · ${this.#translate.instant('XP.Membership.HistoricalModelUnavailable', {
+          Default: 'Removed / unavailable'
+        })}`
   }
 
   private buildPayload(): Partial<IMembershipPlan> | null {
@@ -883,11 +890,11 @@ export class MembershipAdminComponent implements OnInit {
       if (!provider) {
         continue
       }
-      addModelOption(options, provider, '*')
+      addModelOption(options, provider, '*', true)
       for (const model of copilot.providerWithModels.models ?? []) {
         const modelName = model.model?.trim()
         if (modelName) {
-          addModelOption(options, provider, modelName)
+          addModelOption(options, provider, modelName, true)
         }
       }
     }
@@ -901,7 +908,7 @@ export class MembershipAdminComponent implements OnInit {
       const provider = rule.provider?.trim() ?? ''
       const model = rule.model?.trim() || '*'
       if (provider || model !== '*') {
-        addModelOption(options, provider, model)
+        addModelOption(options, provider, model, false)
       }
     }
     this.modelOptions.set(sortModelOptions(Array.from(options.values())))
@@ -934,10 +941,15 @@ function selectionValues(value: string | number | Array<string | number>) {
   return (Array.isArray(value) ? value : [value]).map(String)
 }
 
-function addModelOption(options: Map<string, MembershipModelOption>, provider: string, model: string) {
+function addModelOption(
+  options: Map<string, MembershipModelOption>,
+  provider: string,
+  model: string,
+  available: boolean
+) {
   const value = modelOptionValue(provider, model)
   if (!options.has(value)) {
-    options.set(value, { value, provider, model })
+    options.set(value, { value, provider, model, available })
   }
 }
 

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -2255,6 +2255,7 @@
       "AccountAvailableModelsHint": "Models this account can use based on the current scope and membership plan.",
       "NoAccountAvailableModels": "No models are available to this account.",
       "AllowedModelsHint": "Choose which models members of this plan can use.",
+      "HistoricalModelUnavailable": "Removed / unavailable",
       "AllowAllModels": "Allow all models",
       "SelectModels": "Select allowed models",
       "NoModelsAvailable": "No configured Copilot models are available in this scope.",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -2296,6 +2296,7 @@
       "AccountAvailableModelsHint": "Models this account can use based on the current scope and membership plan.",
       "NoAccountAvailableModels": "No models are available to this account.",
       "AllowedModelsHint": "Choose which models members of this plan can use.",
+      "HistoricalModelUnavailable": "Removed / unavailable",
       "AllowAllModels": "Allow all models",
       "SelectModels": "Select allowed models",
       "NoModelsAvailable": "No configured Copilot models are available in this scope.",

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -2304,6 +2304,7 @@
       "AccountAvailableModelsHint": "根据当前范围和会员套餐，列出此账号可以使用的模型。",
       "NoAccountAvailableModels": "当前账号没有可用模型。",
       "AllowedModelsHint": "选择该套餐成员可以使用的模型。",
+      "HistoricalModelUnavailable": "已下架/不可用",
       "AllowAllModels": "允许使用全部模型",
       "SelectModels": "选择可用模型",
       "NoModelsAvailable": "当前范围尚未配置可选的 Copilot 模型。",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -4526,6 +4526,7 @@
       "AccountAvailableModelsHint": "根据当前范围和会员套餐，列出此账号可以使用的模型。",
       "NoAccountAvailableModels": "当前账号没有可用模型。",
       "AllowedModelsHint": "选择该套餐成员可以使用的模型。",
+      "HistoricalModelUnavailable": "已下架/不可用",
       "AllowAllModels": "允许使用全部模型",
       "SelectModels": "选择可用模型",
       "NoModelsAvailable": "当前范围尚未配置可选的 Copilot 模型。",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -3505,6 +3505,7 @@
       "AccountAvailableModelsHint": "根據目前範圍與會員套餐，列出此帳號可以使用的模型。",
       "NoAccountAvailableModels": "目前帳號沒有可用模型。",
       "AllowedModelsHint": "選擇該套餐成員可以使用的模型。",
+      "HistoricalModelUnavailable": "已下架/不可用",
       "AllowAllModels": "允許使用全部模型",
       "SelectModels": "選擇可用模型",
       "NoModelsAvailable": "目前範圍尚未配置可選的 Copilot 模型。",

--- a/packages/server-ai/src/membership/membership.service.spec.ts
+++ b/packages/server-ai/src/membership/membership.service.spec.ts
@@ -1707,6 +1707,30 @@ describe('MembershipService', () => {
         expect(requestedScopes).toEqual(['org-1', null])
     })
 
+    it('treats any active organization plan as configured, including catalog-derived plans', async () => {
+        const planRepository = {
+            count: jest.fn().mockResolvedValue(1)
+        }
+        const service = createMembershipService(
+            {} as never,
+            planRepository as never,
+            {} as never,
+            {} as never,
+            {} as never
+        )
+
+        await expect(service.hasActiveMembershipPlan({ tenantId: 'tenant-1', organizationId: 'org-1' })).resolves.toBe(
+            true
+        )
+        expect(planRepository.count).toHaveBeenCalledWith({
+            where: {
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                status: MembershipPlanStatusEnum.Active
+            }
+        })
+    })
+
     it('rejects membership admin reads when membership plan feature is disabled', async () => {
         const planRepository = {
             find: jest.fn()

--- a/packages/server-ai/src/membership/membership.service.ts
+++ b/packages/server-ai/src/membership/membership.service.ts
@@ -241,6 +241,23 @@ export class MembershipService {
         return this.isMembershipPlanEnabledForScope({ tenantId: scope.tenantId, organizationId: null }, manager)
     }
 
+    /** Includes catalog-derived plans because they also configure effective organization access. */
+    async hasActiveMembershipPlan(input?: ResolveScopeInput, manager?: EntityManager): Promise<boolean> {
+        const scope = this.resolveScope(input)
+        const repository = manager?.getRepository(MembershipPlan) ?? this.planRepository
+        if (!repository?.count) {
+            return false
+        }
+        return (
+            (await repository.count({
+                where: {
+                    ...this.scopeWhere(scope.tenantId, scope.organizationId),
+                    status: MembershipPlanStatusEnum.Active
+                }
+            })) > 0
+        )
+    }
+
     async findPlans(): Promise<MembershipPlan[]> {
         const scope = this.requireCurrentScope()
         await this.assertMembershipPlanFeatureEnabled(scope)

--- a/packages/server-ai/src/model-access/model-access.service.spec.ts
+++ b/packages/server-ai/src/model-access/model-access.service.spec.ts
@@ -53,6 +53,7 @@ function createFixture() {
         resolveBillableUserId: jest.fn().mockResolvedValue('creator-user'),
         isMembershipAccessEnabled: jest.fn().mockResolvedValue(true),
         isMembershipPlanEnabled: jest.fn().mockResolvedValue(true),
+        hasActiveMembershipPlan: jest.fn().mockResolvedValue(true),
         findModelAccess: jest.fn(),
         isModelAllowed: jest.fn(),
         resolveModelMultiplierForPlan: jest.fn().mockReturnValue(2),
@@ -255,43 +256,7 @@ describe('ModelAccessService model resolution', () => {
         })
     })
 
-    it('allows an organization model directly when the billable user cannot manage memberships', async () => {
-        const { copilotRepository, input, membershipService, service, userRepository } = createFixture()
-        copilotRepository.findOne.mockResolvedValue({
-            id: 'copilot-1',
-            tenantId: 'tenant-1',
-            organizationId: 'runtime-org',
-            name: 'Organization Provider',
-            enabled: true,
-            modelProvider: {
-                id: 'provider-1',
-                tenantId: 'tenant-1',
-                organizationId: 'runtime-org',
-                providerName: 'openai',
-                credentials: { api_key: 'configured' },
-                isValid: true
-            }
-        })
-        userRepository.findOne.mockResolvedValue({
-            id: 'creator-user',
-            type: UserType.USER,
-            role: { rolePermissions: [] }
-        })
-        membershipService.findModelAccess.mockResolvedValue({
-            organizationId: null,
-            membership: { planId: 'tenant-plan', plan: {} }
-        })
-
-        await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
-            allowed: true,
-            accessSource: ModelAccessSourceEnum.Direct,
-            organizationId: 'runtime-org',
-            scope: ModelAccessOwnershipScopeEnum.Organization
-        })
-        expect(membershipService.findModelAccess).not.toHaveBeenCalled()
-    })
-
-    it('keeps an organization credential model under membership for membership managers', async () => {
+    it('uses the organization plan for credential models when the user cannot manage providers', async () => {
         const { copilotRepository, input, membershipService, service, userRepository } = createFixture()
         copilotRepository.findOne.mockResolvedValue({
             id: 'copilot-1',
@@ -315,6 +280,48 @@ describe('ModelAccessService model resolution', () => {
                 rolePermissions: [{ permission: AIPermissionsEnum.MEMBERSHIP_EDIT, enabled: true }]
             }
         })
+        membershipService.findModelAccess.mockResolvedValue({
+            organizationId: 'runtime-org',
+            membership: { planId: 'organization-plan', plan: {} }
+        })
+        membershipService.isModelAllowed.mockReturnValue(false)
+
+        await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
+            allowed: false,
+            accessSource: null,
+            organizationId: 'runtime-org',
+            scope: ModelAccessOwnershipScopeEnum.Organization
+        })
+        expect(membershipService.findModelAccess).toHaveBeenCalled()
+    })
+
+    it('keeps organization credential models direct for provider managers even when they manage memberships', async () => {
+        const { copilotRepository, input, membershipService, service, userRepository } = createFixture()
+        copilotRepository.findOne.mockResolvedValue({
+            id: 'copilot-1',
+            tenantId: 'tenant-1',
+            organizationId: 'runtime-org',
+            name: 'Organization Provider',
+            enabled: true,
+            modelProvider: {
+                id: 'provider-1',
+                tenantId: 'tenant-1',
+                organizationId: 'runtime-org',
+                providerName: 'openai',
+                credentials: { api_key: 'configured' },
+                isValid: true
+            }
+        })
+        userRepository.findOne.mockResolvedValue({
+            id: 'creator-user',
+            type: UserType.USER,
+            role: {
+                rolePermissions: [
+                    { permission: AIPermissionsEnum.COPILOT_EDIT, enabled: true },
+                    { permission: AIPermissionsEnum.MEMBERSHIP_EDIT, enabled: true }
+                ]
+            }
+        })
         const plan = { id: 'organization-plan' }
         membershipService.findModelAccess.mockResolvedValue({
             organizationId: 'runtime-org',
@@ -324,10 +331,42 @@ describe('ModelAccessService model resolution', () => {
 
         await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
             allowed: true,
-            accessSource: ModelAccessSourceEnum.Plan,
-            planId: 'organization-plan',
+            accessSource: ModelAccessSourceEnum.Direct,
             organizationId: 'runtime-org'
         })
+        expect(membershipService.findModelAccess).not.toHaveBeenCalled()
+    })
+
+    it('keeps organization credential models direct when no organization plan is configured', async () => {
+        const { copilotRepository, input, membershipService, service, userRepository } = createFixture()
+        copilotRepository.findOne.mockResolvedValue({
+            id: 'copilot-1',
+            tenantId: 'tenant-1',
+            organizationId: 'runtime-org',
+            name: 'Organization Provider',
+            enabled: true,
+            modelProvider: {
+                id: 'provider-1',
+                tenantId: 'tenant-1',
+                organizationId: 'runtime-org',
+                providerName: 'openai',
+                credentials: { api_key: 'configured' },
+                isValid: true
+            }
+        })
+        userRepository.findOne.mockResolvedValue({
+            id: 'creator-user',
+            type: UserType.USER,
+            role: { rolePermissions: [] }
+        })
+        membershipService.hasActiveMembershipPlan.mockResolvedValue(false)
+
+        await expect(service.resolveModelAccess(input)).resolves.toMatchObject({
+            allowed: true,
+            accessSource: ModelAccessSourceEnum.Direct,
+            organizationId: 'runtime-org'
+        })
+        expect(membershipService.findModelAccess).not.toHaveBeenCalled()
     })
 
     it('does not use direct access without configured organization credentials', async () => {
@@ -621,6 +660,52 @@ describe('ModelAccessService model resolution', () => {
         expect(providerModelRepository.find).toHaveBeenCalledTimes(1)
         expect(providerModelRepository.findOne).not.toHaveBeenCalled()
         expect(grantRepository.createQueryBuilder).toHaveBeenCalledTimes(1)
+    })
+
+    it('filters organization credential models through the active plan for users without provider access', async () => {
+        const { copilotRepository, membershipService, service, userRepository } = createFixture()
+        copilotRepository.find.mockResolvedValue([
+            {
+                id: 'copilot-1',
+                tenantId: 'tenant-1',
+                organizationId: 'runtime-org',
+                name: 'Organization Provider',
+                enabled: true,
+                modelProvider: {
+                    id: 'provider-1',
+                    tenantId: 'tenant-1',
+                    organizationId: 'runtime-org',
+                    providerName: 'openai',
+                    credentials: { api_key: 'configured' },
+                    isValid: true
+                }
+            }
+        ])
+        userRepository.findOne.mockResolvedValue({
+            id: 'creator-user',
+            type: UserType.USER,
+            role: { rolePermissions: [] }
+        })
+        membershipService.findModelAccess.mockResolvedValue({
+            organizationId: 'runtime-org',
+            membership: { planId: 'organization-plan', plan: {} }
+        })
+        membershipService.isModelAllowed.mockReturnValue(false)
+
+        await expect(
+            service.canUseCatalogModels({
+                tenantId: 'tenant-1',
+                organizationId: 'runtime-org',
+                userId: 'runtime-user',
+                models: [
+                    {
+                        copilotId: 'copilot-1',
+                        copilotModelId: 'gpt-4.1',
+                        modelType: AiModelTypeEnum.LLM
+                    }
+                ]
+            })
+        ).resolves.toEqual([false])
     })
 
     it('uses an organization catalog membership for tenant catalog models', async () => {

--- a/packages/server-ai/src/model-access/model-access.service.ts
+++ b/packages/server-ai/src/model-access/model-access.service.ts
@@ -98,6 +98,7 @@ enum ModelTargetAccessMode {
 
 type MembershipFeatureState = {
     organizationEnabled: boolean
+    organizationPlanConfigured: boolean
     organizationModelsConfigured: boolean
     tenantEnabled: boolean
 }
@@ -123,7 +124,7 @@ type ModelAccessResolutionContext = {
     billableUserId: string
     runtimeOrganizationId: string | null
     membershipFeatureState: () => Promise<MembershipFeatureState>
-    canManageMembership: () => Promise<boolean>
+    canManageProviderModels: () => Promise<boolean>
     membershipAccess: () => Promise<MembershipModelAccess | null>
     technicalUser: () => Promise<boolean>
     modelAccessFeatureEnabled: (organizationId: string | null) => Promise<boolean>
@@ -192,6 +193,7 @@ export class ModelAccessService {
             organizationFeatureEnabled,
             tenantMembershipEnabled,
             organizationMembershipEnabled,
+            organizationPlanConfigured,
             organizationModelsConfigured
         ] = await Promise.all([
             this.loadVisibleCatalogTargets(organizationId),
@@ -206,6 +208,9 @@ export class ModelAccessService {
             this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
             organizationId
                 ? this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId })
+                : Promise.resolve(false),
+            organizationId
+                ? this.membershipService.hasActiveMembershipPlan({ tenantId, organizationId })
                 : Promise.resolve(false),
             organizationId ? this.hasConfiguredOrganizationModels(tenantId, organizationId) : Promise.resolve(false)
         ])
@@ -251,6 +256,7 @@ export class ModelAccessService {
                     organizationFeatureEnabled,
                     tenantMembershipEnabled,
                     organizationMembershipEnabled,
+                    organizationPlanConfigured,
                     organizationModelsConfigured,
                     runtimeOrganizationId: organizationId
                 })
@@ -1199,8 +1205,8 @@ export class ModelAccessService {
             billableUserId,
             runtimeOrganizationId,
             membershipFeatureState: () => this.resolveMembershipFeatureState(input.tenantId, runtimeOrganizationId),
-            canManageMembership: () =>
-                this.hasUserPermission(input.tenantId, billableUserId, AIPermissionsEnum.MEMBERSHIP_EDIT),
+            canManageProviderModels: () =>
+                this.hasUserPermission(input.tenantId, billableUserId, AIPermissionsEnum.COPILOT_EDIT),
             membershipAccess: () =>
                 this.membershipService.findModelAccess({
                     tenantId: input.tenantId,
@@ -1247,7 +1253,7 @@ export class ModelAccessService {
         let membershipFeatureStatePromise: Promise<MembershipFeatureState> | null = null
         let membershipAccessPromise: Promise<MembershipModelAccess | null> | null = null
         let quotaReasonPromise: Promise<ModelAccessUnavailableReasonEnum | null> | null = null
-        let userStatePromise: Promise<{ canManageMembership: boolean; technicalUser: boolean }> | null = null
+        let userStatePromise: Promise<{ canManageProviderModels: boolean; technicalUser: boolean }> | null = null
         const featureEnabledByScope = new Map<string | null, Promise<boolean>>()
         const userState = () =>
             (userStatePromise ??= this.userRepository
@@ -1256,8 +1262,8 @@ export class ModelAccessService {
                     relations: ['role', 'role.rolePermissions']
                 })
                 .then((user) => ({
-                    canManageMembership:
-                        !!user && this.userHasPermission(user, AIPermissionsEnum.MEMBERSHIP_EDIT) === true,
+                    canManageProviderModels:
+                        !!user && this.userHasPermission(user, AIPermissionsEnum.COPILOT_EDIT) === true,
                     technicalUser: user?.type === UserType.COMMUNICATION
                 })))
         const context: ModelAccessResolutionContext = {
@@ -1268,7 +1274,7 @@ export class ModelAccessService {
                     input.tenantId,
                     runtimeOrganizationId
                 )),
-            canManageMembership: async () => (await userState()).canManageMembership,
+            canManageProviderModels: async () => (await userState()).canManageProviderModels,
             membershipAccess: () =>
                 (membershipAccessPromise ??= this.membershipService.findModelAccess({
                     tenantId: input.tenantId,
@@ -1330,27 +1336,18 @@ export class ModelAccessService {
             }
         }
 
-        // const membershipFeatureState = await this.resolveMembershipFeatureState(input.tenantId, runtimeOrganizationId)
-        // const canManageMembership =
-        //     !target.usesOrganizationCredentials || !membershipFeatureState.organizationEnabled
-        //         ? true
-        //         : await this.hasUserPermission(input.tenantId, billableUserId, AIPermissionsEnum.MEMBERSHIP_EDIT)
-        // const accessMode = this.resolveTargetAccessMode(
-        //     target,
-        //     runtimeOrganizationId,
-        //     membershipFeatureState,
-        //     canManageMembership
-        // )
         const membershipFeatureState = await context.membershipFeatureState()
-        const canManageMembership =
-            !target.usesOrganizationCredentials || !membershipFeatureState.organizationEnabled
-                ? true
-                : await context.canManageMembership()
+        const canManageProviderModels =
+            target.usesOrganizationCredentials &&
+            membershipFeatureState.organizationEnabled &&
+            membershipFeatureState.organizationPlanConfigured
+                ? await context.canManageProviderModels()
+                : false
         const accessMode = this.resolveTargetAccessMode(
             target,
             context.runtimeOrganizationId,
             membershipFeatureState,
-            canManageMembership
+            canManageProviderModels
         )
         if (accessMode === ModelTargetAccessMode.Direct) {
             return {
@@ -1756,6 +1753,7 @@ export class ModelAccessService {
             organizationFeatureEnabled: boolean
             tenantMembershipEnabled: boolean
             organizationMembershipEnabled: boolean
+            organizationPlanConfigured: boolean
             organizationModelsConfigured: boolean
             runtimeOrganizationId: string | null
         }
@@ -1766,9 +1764,10 @@ export class ModelAccessService {
             {
                 tenantEnabled: features.tenantMembershipEnabled,
                 organizationEnabled: features.organizationMembershipEnabled,
+                organizationPlanConfigured: features.organizationPlanConfigured,
                 organizationModelsConfigured: features.organizationModelsConfigured
             },
-            this.userHasPermission(user, AIPermissionsEnum.MEMBERSHIP_EDIT) === true
+            this.userHasPermission(user, AIPermissionsEnum.COPILOT_EDIT) === true
         )
         const planIncluded =
             accessMode === ModelTargetAccessMode.Membership && this.isPlanIncluded(target, membershipAccess)
@@ -2325,21 +2324,29 @@ export class ModelAccessService {
         tenantId: string,
         runtimeOrganizationId: string | null
     ): Promise<MembershipFeatureState> {
-        const [tenantEnabled, organizationEnabled, organizationModelsConfigured] = await Promise.all([
-            this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
-            runtimeOrganizationId
-                ? this.membershipService.isMembershipPlanEnabled({
-                      tenantId,
-                      organizationId: runtimeOrganizationId
-                  })
-                : Promise.resolve(false),
-            runtimeOrganizationId
-                ? this.hasConfiguredOrganizationModels(tenantId, runtimeOrganizationId)
-                : Promise.resolve(false)
-        ])
+        const [tenantEnabled, organizationEnabled, organizationPlanConfigured, organizationModelsConfigured] =
+            await Promise.all([
+                this.membershipService.isMembershipPlanEnabled({ tenantId, organizationId: null }),
+                runtimeOrganizationId
+                    ? this.membershipService.isMembershipPlanEnabled({
+                          tenantId,
+                          organizationId: runtimeOrganizationId
+                      })
+                    : Promise.resolve(false),
+                runtimeOrganizationId
+                    ? this.membershipService.hasActiveMembershipPlan({
+                          tenantId,
+                          organizationId: runtimeOrganizationId
+                      })
+                    : Promise.resolve(false),
+                runtimeOrganizationId
+                    ? this.hasConfiguredOrganizationModels(tenantId, runtimeOrganizationId)
+                    : Promise.resolve(false)
+            ])
         return {
             tenantEnabled,
             organizationEnabled,
+            organizationPlanConfigured,
             organizationModelsConfigured
         }
     }
@@ -2348,15 +2355,19 @@ export class ModelAccessService {
         target: ModelTarget,
         runtimeOrganizationId: string | null,
         membershipFeatures: MembershipFeatureState,
-        canManageMembership: boolean
+        canManageProviderModels: boolean
     ): ModelTargetAccessMode {
         if (target.organizationId) {
             if (!membershipFeatures.organizationEnabled) {
                 return ModelTargetAccessMode.Direct
             }
-            return target.usesOrganizationCredentials && !canManageMembership
-                ? ModelTargetAccessMode.Direct
-                : ModelTargetAccessMode.Membership
+            if (
+                target.usesOrganizationCredentials &&
+                (!membershipFeatures.organizationPlanConfigured || canManageProviderModels)
+            ) {
+                return ModelTargetAccessMode.Direct
+            }
+            return ModelTargetAccessMode.Membership
         }
         if (!runtimeOrganizationId) {
             return membershipFeatures.tenantEnabled ? ModelTargetAccessMode.Membership : ModelTargetAccessMode.Direct


### PR DESCRIPTION
## Summary

Organization-scoped provider credentials were treated as direct model access for users who could not manage model providers. As a result, an active organization membership plan did not consistently restrict the models exposed to ordinary users.

This change routes organization credential models through membership access when organization membership is enabled, an active organization plan exists, and the effective user does not have `COPILOT_EDIT`. Provider administrators keep direct access, and organizations without an active membership plan keep the existing direct behavior.

The membership plan editor also preserves stored model rules that are absent from the current membership model catalog and labels them as removed or unavailable instead of silently dropping their display value.

## Behavior

- Organization membership disabled: organization credential models remain `Direct`.
- Organization membership enabled with an active plan and `COPILOT_EDIT`: organization credential models remain `Direct`.
- Organization membership enabled with an active plan and no `COPILOT_EDIT`: organization credential models use the existing `Plan` path, including model allowlists, points, multipliers, rate limits, and settlement.
- Tenant-scoped model access keeps its existing resolution behavior.
- Catalog-derived active organization plans count as configured plans.

## Implementation

- Add an organization-scope active-plan check to membership services.
- Use `COPILOT_EDIT` as the direct-access exception for organization provider credentials.
- Apply the same access decision to single model resolution, batch model catalogs, and account model catalog presentation.
- Mark stored membership model rules as unavailable when they are no longer returned by the membership management catalog.
- Add localized labels and focused regression coverage.

## Validation

- Server model access and membership tests: 181 passed.
- Cloud membership component tests: 16 passed.
- Server TypeScript typecheck passed.
- Cloud TypeScript typecheck passed.
- `git diff --check` passed.
- Commit hooks passed the hardcoded-color and TypeORM column checks.

## Manual verification

Browser verification was not run. Verify the membership plan editor, account available-model page, and Xpert model selector with both a provider administrator and an ordinary organization member.

The removed/unavailable marker is based on absence from `/copilot/membership-models`; models that the server still returns for compatibility remain classified as catalog entries.
