### PR TITLE
fix: match membership models by copilot id

### DIFF
--- a/apps/cloud/src/app/features/setting/membership/membership.component.html
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.html
@@ -487,11 +487,11 @@
                             "
                             (zSelectionChange)="setAllowedModelValues($event)"
                           >
-                            @for (option of modelOptions(); track option.value) {
+                            @for (option of allowedModelOptions(); track option.value) {
                               <z-select-item [zValue]="option.value">{{ modelTargetLabel(option) }}</z-select-item>
                             }
                           </z-select>
-                          @if (!modelOptions().length) {
+                          @if (!allowedModelOptions().length) {
                             <div class="mt-2 text-xs text-text-tertiary">
                               {{
                                 'XP.Membership.NoModelsAvailable'

--- a/apps/cloud/src/app/features/setting/membership/membership.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.spec.ts
@@ -171,14 +171,79 @@ describe('MembershipAdminComponent', () => {
     component.load()
     component.edit(plan)
 
-    expect(component.modelOptions()).toEqual(
+    expect(component.allowedModelOptions()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ provider: 'moonshot', model: 'kimi-k3', available: true }),
         expect.objectContaining({ provider: 'moonshot', model: 'kimi-k2-thinking', available: false })
       ])
     )
-    const unavailable = component.modelOptions().find((option) => option.model === 'kimi-k2-thinking')
+    const unavailable = component.allowedModelOptions().find((option) => option.model === 'kimi-k2-thinking')
     expect(unavailable && component.modelTargetLabel(unavailable)).toContain('XP.Membership.HistoricalModelUnavailable')
+  })
+
+  it('keeps same-named models separate by Copilot id', () => {
+    membershipService.getModelOptions.mockReturnValue(
+      of([
+        {
+          id: 'copilot-1',
+          name: 'Primary provider',
+          providerWithModels: {
+            provider: 'tongyi',
+            models: [{ model: 'qwen3.7-plus', model_type: AiModelTypeEnum.LLM }]
+          }
+        },
+        {
+          id: 'copilot-2',
+          name: 'Backup provider',
+          providerWithModels: {
+            provider: 'tongyi',
+            models: [{ model: 'qwen3.7-plus', model_type: AiModelTypeEnum.LLM }]
+          }
+        }
+      ])
+    )
+
+    component.load()
+
+    const options = component
+      .allowedModelOptions()
+      .filter((option) => option.provider === 'tongyi' && option.model === 'qwen3.7-plus')
+    expect(options).toHaveLength(2)
+    expect(options[0].value).not.toBe(options[1].value)
+
+    component.setAllowedModelValues(options[0].value)
+    expect(component.allowedModels).toEqual([
+      { provider: 'tongyi', model: 'qwen3.7-plus', copilotId: options[0].copilotId }
+    ])
+  })
+
+  it('round-trips legacy allowed model rules without assigning a Copilot id', () => {
+    const plan = {
+      ...targetPlan,
+      allowedModels: [{ provider: 'tongyi', model: 'qwen3.7-plus' }]
+    }
+    membershipService.getModelOptions.mockReturnValue(
+      of([
+        {
+          id: 'copilot-1',
+          providerWithModels: {
+            provider: 'tongyi',
+            models: [{ model: 'qwen3.7-plus', model_type: AiModelTypeEnum.LLM }]
+          }
+        }
+      ])
+    )
+    membershipService.getPlans.mockReturnValue(of([plan]))
+
+    component.load()
+    component.edit(plan)
+
+    const values = component.allowedModelValues()
+    expect(component.allowedModelOptions()).toEqual(
+      expect.arrayContaining([expect.objectContaining({ value: values[0], copilotId: undefined })])
+    )
+    component.setAllowedModelValues(values)
+    expect(component.allowedModels).toEqual(plan.allowedModels)
   })
 
   it('archives a plan only after confirmation', async () => {

--- a/apps/cloud/src/app/features/setting/membership/membership.component.ts
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.ts
@@ -44,6 +44,8 @@ type MembershipModelOption = {
   provider: string
   model: string
   available: boolean
+  copilotId?: string
+  copilotLabel?: string
 }
 
 type MembershipAdminTab = 'plans' | 'users'
@@ -124,6 +126,7 @@ export class MembershipAdminComponent implements OnInit {
   )
   readonly rateLimitPeriods = MEMBERSHIP_RATE_LIMIT_PERIODS
   readonly modelOptions = signal<MembershipModelOption[]>([])
+  readonly allowedModelOptions = signal<MembershipModelOption[]>([])
   readonly globalModelTargetValue = modelOptionValue('', '*')
 
   MembershipPlanStatusEnum = MembershipPlanStatusEnum
@@ -188,6 +191,7 @@ export class MembershipAdminComponent implements OnInit {
         this.scopeStatus.set(status)
         this.plans.set(editablePlans)
         this.modelOptions.set(this.toModelOptions(models))
+        this.allowedModelOptions.set(this.toAllowedModelOptions(models))
         const selectedPlanId = this.selectedPlanId()
         if (!selectedPlanId || !editablePlans.some((plan) => plan.id === selectedPlanId)) {
           this.selectedPlanId.set(editablePlans.find((plan) => plan.isDefault)?.id ?? editablePlans[0]?.id ?? null)
@@ -718,12 +722,12 @@ export class MembershipAdminComponent implements OnInit {
   }
 
   allowedModelValues() {
-    return this.allowedModels.map((item) => modelOptionValue(item.provider, item.model))
+    return this.allowedModels.map((item) => allowedModelOptionValue(item.provider, item.model, item.copilotId))
   }
 
   setAllowedModelValues(value: string | number | Array<string | number>) {
     this.allowedModels = selectionValues(value)
-      .map(decodeModelOptionValue)
+      .map(decodeAllowedModelOptionValue)
       .filter((item): item is IMembershipAllowedModel => !!item?.provider && !!item.model)
   }
 
@@ -804,6 +808,9 @@ export class MembershipAdminComponent implements OnInit {
       })}`
     } else {
       label = `${option.provider} · ${option.model}`
+    }
+    if (option.copilotId) {
+      label = `${label} · ${option.copilotLabel || option.copilotId}`
     }
     return option.available
       ? label
@@ -901,6 +908,26 @@ export class MembershipAdminComponent implements OnInit {
     return sortModelOptions(Array.from(options.values()))
   }
 
+  private toAllowedModelOptions(copilots: ICopilotWithProvider[]): MembershipModelOption[] {
+    const options = new Map<string, MembershipModelOption>()
+    for (const copilot of copilots) {
+      const provider = copilot.providerWithModels?.provider?.trim()
+      const copilotId = copilot.id
+      if (!provider || !copilotId) {
+        continue
+      }
+      const copilotLabel = copilot.name?.trim() || copilotId
+      addAllowedModelOption(options, provider, '*', copilotId, copilotLabel, true)
+      for (const model of copilot.providerWithModels.models ?? []) {
+        const modelName = model.model?.trim()
+        if (modelName) {
+          addAllowedModelOption(options, provider, modelName, copilotId, copilotLabel, true)
+        }
+      }
+    }
+    return sortModelOptions(Array.from(options.values()))
+  }
+
   private includeStoredModelOptions() {
     const options = new Map(this.modelOptions().map((option) => [option.value, option]))
     const rules = [...this.allowedModels, ...this.modelMultipliers, ...this.rateLimits]
@@ -912,6 +939,23 @@ export class MembershipAdminComponent implements OnInit {
       }
     }
     this.modelOptions.set(sortModelOptions(Array.from(options.values())))
+
+    const allowedOptions = new Map(this.allowedModelOptions().map((option) => [option.value, option]))
+    for (const rule of this.allowedModels) {
+      const provider = rule.provider.trim()
+      const model = rule.model.trim()
+      const copilotId = rule.copilotId?.trim()
+      const value = allowedModelOptionValue(provider, model, copilotId)
+      if (!allowedOptions.has(value)) {
+        const available =
+          !copilotId &&
+          Array.from(allowedOptions.values()).some(
+            (option) => option.provider === provider && option.model === model && option.available
+          )
+        addAllowedModelOption(allowedOptions, provider, model, copilotId, copilotId, available)
+      }
+    }
+    this.allowedModelOptions.set(sortModelOptions(Array.from(allowedOptions.values())))
   }
 }
 
@@ -937,6 +981,29 @@ function decodeModelOptionValue(value?: string): IMembershipAllowedModel | null 
   }
 }
 
+function allowedModelOptionValue(provider: string, model: string, copilotId?: string) {
+  return [copilotId ?? '', provider, model].map(encodeURIComponent).join('|')
+}
+
+function decodeAllowedModelOptionValue(value?: string): IMembershipAllowedModel | null {
+  if (!value) {
+    return null
+  }
+  const parts = value.split('|')
+  if (parts.length !== 3) {
+    return null
+  }
+  try {
+    const [copilotId, provider, model] = parts.map(decodeURIComponent)
+    if (!provider || !model) {
+      return null
+    }
+    return copilotId ? { provider, model, copilotId } : { provider, model }
+  } catch {
+    return null
+  }
+}
+
 function selectionValues(value: string | number | Array<string | number>) {
   return (Array.isArray(value) ? value : [value]).map(String)
 }
@@ -950,6 +1017,20 @@ function addModelOption(
   const value = modelOptionValue(provider, model)
   if (!options.has(value)) {
     options.set(value, { value, provider, model, available })
+  }
+}
+
+function addAllowedModelOption(
+  options: Map<string, MembershipModelOption>,
+  provider: string,
+  model: string,
+  copilotId: string | undefined,
+  copilotLabel: string | undefined,
+  available: boolean
+) {
+  const value = allowedModelOptionValue(provider, model, copilotId)
+  if (!options.has(value)) {
+    options.set(value, { value, provider, model, copilotId, copilotLabel, available })
   }
 }
 

--- a/packages/contracts/src/ai/membership.model.ts
+++ b/packages/contracts/src/ai/membership.model.ts
@@ -93,6 +93,7 @@ export interface IMembershipModelMultiplier {
 export interface IMembershipAllowedModel {
   provider: string
   model: string
+  copilotId?: string
 }
 
 export interface IMembershipRateLimit {

--- a/packages/server-ai/src/membership/dto/membership.dto.ts
+++ b/packages/server-ai/src/membership/dto/membership.dto.ts
@@ -41,6 +41,10 @@ class MembershipAllowedModelDto implements IMembershipAllowedModel {
     @IsNotEmpty()
     @MaxLength(255)
     model: string
+
+    @IsOptional()
+    @IsUUID()
+    copilotId?: string
 }
 
 class MembershipModelMultiplierDto implements IMembershipModelMultiplier {

--- a/packages/server-ai/src/membership/membership.service.spec.ts
+++ b/packages/server-ai/src/membership/membership.service.spec.ts
@@ -527,6 +527,21 @@ describe('MembershipService', () => {
                 'qwen-max'
             )
         ).toBe(false)
+        const exactPlan = createPlan({
+            allowedModels: [{ provider: 'tongyi', model: 'qwen3.6-plus', copilotId: 'copilot-1' }]
+        })
+        expect(service.isModelAllowed(exactPlan, 'tongyi', 'qwen3.6-plus', 'copilot-1')).toBe(true)
+        expect(service.isModelAllowed(exactPlan, 'tongyi', 'qwen3.6-plus', 'copilot-2')).toBe(false)
+    })
+
+    it('keeps legacy allowed model rules compatible with runtime Copilot ids', () => {
+        const service = createMembershipService({} as never, {} as never, {} as never, {} as never, {} as never)
+        const legacyPlan = createPlan({
+            allowedModels: [{ provider: 'tongyi', model: 'qwen3.6-plus' }]
+        })
+
+        expect(service.isModelAllowed(legacyPlan, 'tongyi', 'qwen3.6-plus', 'copilot-1')).toBe(true)
+        expect(service.isModelAllowed(legacyPlan, 'tongyi', 'qwen3.6-plus', 'copilot-2')).toBe(true)
     })
 
     function createScopeInitializationHarness(
@@ -1229,10 +1244,22 @@ describe('MembershipService', () => {
         await service.createPlan({
             code: 'restricted-models',
             name: 'Restricted models',
-            allowedModels: [{ provider: ' tongyi ', model: ' qwen3.6-plus ' }]
+            allowedModels: [
+                {
+                    provider: ' tongyi ',
+                    model: ' qwen3.6-plus ',
+                    copilotId: ' 112f87f9-409f-40f0-8cf4-52bb9f033258 '
+                }
+            ]
         })
 
-        expect(plans[0].allowedModels).toEqual([{ provider: 'tongyi', model: 'qwen3.6-plus' }])
+        expect(plans[0].allowedModels).toEqual([
+            {
+                provider: 'tongyi',
+                model: 'qwen3.6-plus',
+                copilotId: '112f87f9-409f-40f0-8cf4-52bb9f033258'
+            }
+        ])
         await expect(
             service.createPlan({
                 code: 'invalid-models',

--- a/packages/server-ai/src/membership/membership.service.ts
+++ b/packages/server-ai/src/membership/membership.service.ts
@@ -2584,7 +2584,14 @@ export class MembershipService {
     async assertCanUse(
         input: Pick<
             RecordUsageInput,
-            'tenantId' | 'organizationId' | 'copilotOrganizationId' | 'userId' | 'xpertId' | 'provider' | 'model'
+            | 'tenantId'
+            | 'organizationId'
+            | 'copilotOrganizationId'
+            | 'userId'
+            | 'xpertId'
+            | 'copilotId'
+            | 'provider'
+            | 'model'
         >,
         modelAccess?: IModelAccessResolution
     ): Promise<void> {
@@ -2616,7 +2623,12 @@ export class MembershipService {
         }
         if (modelAccess?.accessSource !== ModelAccessSourceEnum.Grant) {
             this.assertCopilotScopeMatches(access, input.copilotOrganizationId)
-            this.assertModelAllowed(access.membership.plan, input.provider, input.model)
+            this.assertModelAllowed(
+                access.membership.plan,
+                input.provider,
+                input.model,
+                modelAccess?.copilotId ?? input.copilotId
+            )
         }
 
         const pointsRemaining = this.pointsRemaining(access.membership)
@@ -2692,7 +2704,7 @@ export class MembershipService {
             }
             if (input.modelAccess?.accessSource !== ModelAccessSourceEnum.Grant) {
                 this.assertCopilotScopeMatches(access, input.copilotOrganizationId)
-                this.assertModelAllowed(access.membership.plan, input.provider, input.model)
+                this.assertModelAllowed(access.membership.plan, input.provider, input.model, input.copilotId)
             }
 
             const { membership, organizationId } = access
@@ -3062,7 +3074,12 @@ export class MembershipService {
         return (await this.getPersonalPointsBalance(access.tenantId, access.membership.userId)) > 0
     }
 
-    isModelAllowed(plan: Pick<IMembershipPlan, 'allowedModels'>, provider?: string, model?: string): boolean {
+    isModelAllowed(
+        plan: Pick<IMembershipPlan, 'allowedModels'>,
+        provider?: string,
+        model?: string,
+        copilotId?: string
+    ): boolean {
         const allowedModels = plan.allowedModels ?? []
         if (!allowedModels.length) {
             return true
@@ -3077,7 +3094,8 @@ export class MembershipService {
         return allowedModels.some(
             (rule) =>
                 (rule.provider === '*' || rule.provider === providerName) &&
-                (rule.model === '*' || rule.model === modelName)
+                (rule.model === '*' || rule.model === modelName) &&
+                (!rule.copilotId?.trim() || rule.copilotId.trim() === copilotId?.trim())
         )
     }
 
@@ -5050,8 +5068,8 @@ export class MembershipService {
         }
     }
 
-    private assertModelAllowed(plan: IMembershipPlan, provider?: string, model?: string) {
-        if (!this.isModelAllowed(plan, provider, model)) {
+    private assertModelAllowed(plan: IMembershipPlan, provider?: string, model?: string, copilotId?: string) {
+        if (!this.isModelAllowed(plan, provider, model, copilotId)) {
             throw new ExceedingLimitException(
                 this.translateMembershipError(
                     'server-ai:Error.CopilotModelUnavailableForMembershipPlan',
@@ -5162,6 +5180,10 @@ export class MembershipService {
                 typeof item === 'object' && item !== null && 'model' in item && typeof item.model === 'string'
                     ? item.model.trim()
                     : ''
+            const copilotId =
+                typeof item === 'object' && item !== null && 'copilotId' in item && typeof item.copilotId === 'string'
+                    ? item.copilotId.trim()
+                    : undefined
             if (!provider || !model) {
                 throw new BadRequestException(
                     this.translateMembershipError(
@@ -5170,7 +5192,7 @@ export class MembershipService {
                     )
                 )
             }
-            return { provider, model }
+            return copilotId ? { provider, model, copilotId } : { provider, model }
         })
     }
 

--- a/packages/server-ai/src/model-access/model-access.service.spec.ts
+++ b/packages/server-ai/src/model-access/model-access.service.spec.ts
@@ -728,7 +728,7 @@ describe('ModelAccessService model resolution', () => {
             organizationId: null,
             scope: ModelAccessOwnershipScopeEnum.Tenant
         })
-        expect(membershipService.isModelAllowed).toHaveBeenCalledWith(plan, 'openai', 'gpt-4.1')
+        expect(membershipService.isModelAllowed).toHaveBeenCalledWith(plan, 'openai', 'gpt-4.1', 'copilot-1')
     })
 
     it('restores the same personal grant after the plan stops including the model', async () => {
@@ -842,6 +842,7 @@ describe('ModelAccessService model resolution', () => {
                 tenantId: 'tenant-1',
                 organizationId: 'runtime-org',
                 copilotOrganizationId: null,
+                copilotId: 'copilot-1',
                 userId: 'creator-user',
                 provider: 'openai',
                 model: 'gpt-4.1'
@@ -894,6 +895,7 @@ describe('ModelAccessService model resolution', () => {
                 tenantId: 'tenant-1',
                 organizationId: 'runtime-org',
                 copilotOrganizationId: null,
+                copilotId: 'copilot-1',
                 userId: 'creator-user',
                 provider: 'openai',
                 model: 'gpt-4.1'

--- a/packages/server-ai/src/model-access/model-access.service.ts
+++ b/packages/server-ai/src/model-access/model-access.service.ts
@@ -341,7 +341,12 @@ export class ModelAccessService {
             const planIncluded =
                 !!target &&
                 !!membershipAccess &&
-                this.membershipService.isModelAllowed(membershipAccess.membership.plan, target.provider, target.model)
+                this.membershipService.isModelAllowed(
+                    membershipAccess.membership.plan,
+                    target.provider,
+                    target.model,
+                    target.copilotId
+                )
             const multiplier = planIncluded
                 ? this.membershipService.resolveModelMultiplierForPlan(
                       membershipAccess.membership.plan,
@@ -616,7 +621,12 @@ export class ModelAccessService {
         const quotaReason = await this.resolveQuotaReason(membershipAccess)
         const planIncluded =
             !!membershipAccess &&
-            this.membershipService.isModelAllowed(membershipAccess.membership.plan, target.provider, target.model)
+            this.membershipService.isModelAllowed(
+                membershipAccess.membership.plan,
+                target.provider,
+                target.model,
+                target.copilotId
+            )
         const multiplier = planIncluded
             ? this.membershipService.resolveModelMultiplierForPlan(
                   membershipAccess.membership.plan,
@@ -1497,6 +1507,7 @@ export class ModelAccessService {
                 tenantId: input.tenantId,
                 organizationId: input.organizationId,
                 copilotOrganizationId: resolution.organizationId,
+                copilotId: resolution.copilotId,
                 userId: resolution.billableUserId,
                 provider: resolution.provider ?? undefined,
                 model: resolution.model ?? undefined
@@ -2274,7 +2285,13 @@ export class ModelAccessService {
             access.organizationId === target.organizationId ||
             (target.organizationId === null && !!access.organizationId && !!access.membership.plan.catalogSourcePlanId)
         return (
-            scopeMatches && this.membershipService.isModelAllowed(access.membership.plan, target.provider, target.model)
+            scopeMatches &&
+            this.membershipService.isModelAllowed(
+                access.membership.plan,
+                target.provider,
+                target.model,
+                target.copilotId
+            )
         )
     }
 


### PR DESCRIPTION
## Summary

- preserve the selected Copilot id in membership allowed-model rules
- enforce plan access against the exact Copilot configuration while keeping legacy rules compatible
- keep same-named model options distinct and retain unavailable historical selections

## Validation

- MembershipService: 132 tests passed
- ModelAccessService: 50 tests passed
- MembershipAdminComponent: 18 tests passed
- server TypeScript check passed
- cloud development build passed
- ESLint passed with existing warnings only
- git diff --check passed

Browser verification was not run.