### PR TITLE
fix: allow reasoning providers to select LLM models

### DIFF
--- a/apps/cloud/src/app/@shared/copilot/copilot-config-form/form.component.spec.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-config-form/form.component.spec.ts
@@ -1,13 +1,15 @@
 jest.mock('echarts/core', () => ({ registerTheme: jest.fn() }))
 
 import { Dialog } from '@angular/cdk/dialog'
-import { TestBed } from '@angular/core/testing'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { AiModelTypeEnum, AiProviderRole } from '@xpert-ai/contracts'
 import { Subject } from 'rxjs'
 import { CopilotServerService, ToastrService } from '../../../@core'
 import { CopilotConfigFormComponent } from './form.component'
 
 describe('CopilotConfigFormComponent', () => {
   let component: CopilotConfigFormComponent
+  let fixture: ComponentFixture<CopilotConfigFormComponent>
   let dialogClosed: Subject<string | undefined>
 
   beforeEach(() => {
@@ -45,8 +47,15 @@ describe('CopilotConfigFormComponent', () => {
       }
     })
 
-    const fixture = TestBed.createComponent(CopilotConfigFormComponent)
+    fixture = TestBed.createComponent(CopilotConfigFormComponent)
     component = fixture.componentInstance
+  })
+
+  it('uses LLM models for the reasoning provider', () => {
+    fixture.componentRef.setInput('copilot', { role: AiProviderRole.Reasoning })
+    fixture.detectChanges()
+
+    expect(component.defaultModelType()).toBe(AiModelTypeEnum.LLM)
   })
 
   it('notifies its parent after deleting the model provider', () => {

--- a/apps/cloud/src/app/@shared/copilot/copilot-config-form/form.component.ts
+++ b/apps/cloud/src/app/@shared/copilot/copilot-config-form/form.component.ts
@@ -57,6 +57,7 @@ export class CopilotConfigFormComponent {
     switch (this.role()) {
       case AiProviderRole.Primary:
       case AiProviderRole.Secondary:
+      case AiProviderRole.Reasoning:
         return AiModelTypeEnum.LLM
       case AiProviderRole.Embedding:
         return AiModelTypeEnum.TEXT_EMBEDDING


### PR DESCRIPTION
## Summary

- map the Reasoning provider role to the LLM model type
- add focused regression coverage for the role mapping

## Validation

- `corepack pnpm exec jest --config apps/cloud/jest.config.ts apps/cloud/src/app/@shared/copilot/copilot-config-form/form.component.spec.ts --runInBand`
- `git diff --check origin/develop...HEAD`