### PR TITLE
feat: add MCP OAuth consent page

### DIFF
--- a/apps/cloud/src/app/auth/auth-routing.module.ts
+++ b/apps/cloud/src/app/auth/auth-routing.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core'
 import { RouterModule, Routes } from '@angular/router'
+import { environment } from '../../environments/environment'
 import { XpAuthComponent } from './auth.component'
+import { OidcConsentComponent } from './consent/consent.component'
 import { ForgotPasswordComponent } from './forgot-password/forgot-password.component'
 import { NoAuthGuard } from './guards/no-auth.guard'
 import { UserLoginComponent } from './login/login.component'
@@ -23,6 +25,15 @@ const routes: Routes = [
         component: UserLoginComponent,
         data: { title: '登录', titleI18n: 'app.login.login' }
       },
+      ...(environment.mcpOAuthEnabled
+        ? [
+            {
+              path: 'consent',
+              component: OidcConsentComponent,
+              data: { title: 'Authorization request', titleI18n: 'Auth.McpConsent.Eyebrow' }
+            }
+          ]
+        : []),
       {
         path: 'register',
         component: UserRegisterComponent,

--- a/apps/cloud/src/app/auth/auth.module.ts
+++ b/apps/cloud/src/app/auth/auth.module.ts
@@ -12,6 +12,7 @@ import {
   ZardTabGroupComponent
 } from '@xpert-ai/headless-ui'
 import { XpAuthRoutingModule } from './auth-routing.module'
+import { OidcConsentComponent } from './consent/consent.component'
 import {
   defaultAuthOptions,
   XpAuthOptions,
@@ -67,7 +68,8 @@ export function nbOptionsFactory(options) {
     ResetPasswordComponent,
     VarifyEmailComponent,
     SsoBindComponent,
-    CurrentUserSsoConfirmComponent
+    CurrentUserSsoConfirmComponent,
+    OidcConsentComponent
   ],
   imports: [
     CommonModule,

--- a/apps/cloud/src/app/auth/consent/consent.component.html
+++ b/apps/cloud/src/app/auth/consent/consent.component.html
@@ -1,0 +1,114 @@
+<section class="w-full" aria-labelledby="oidc-consent-title">
+  <header>
+    <p class="mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-text-accent">
+      {{ 'Auth.McpConsent.Eyebrow' | translate: { Default: 'Authorization request' } }}
+    </p>
+    <h1 id="oidc-consent-title" class="m-0 text-3xl font-semibold tracking-[-0.04em] text-text-primary">
+      @if (!loading && !loadFailed) {
+        {{ clientName || ('Auth.McpConsent.UnknownClient' | translate: { Default: 'An application' }) }}
+        {{ 'Auth.McpConsent.RequestsAccess' | translate: { Default: 'requests access' } }}
+      } @else {
+        {{ 'Auth.McpConsent.ReviewRequest' | translate: { Default: 'Review access request' } }}
+      }
+    </h1>
+    <p class="mb-0 mt-2 text-sm leading-6 text-text-secondary">
+      {{
+        'Auth.McpConsent.Description'
+          | translate
+            : {
+                Default: 'Review the MCP services and identity permissions requested by this client before continuing.'
+              }
+      }}
+    </p>
+  </header>
+
+  @if (loading) {
+    <div class="mt-6 rounded-xl border border-divider-regular bg-components-panel-bg p-4">
+      <div class="h-4 w-28 animate-pulse rounded bg-divider-regular"></div>
+      <div class="mt-3 h-5 w-48 animate-pulse rounded bg-divider-regular"></div>
+      <p class="mb-0 mt-4 text-sm text-text-secondary">
+        {{ 'Auth.McpConsent.Loading' | translate: { Default: 'Loading authorization request…' } }}
+      </p>
+    </div>
+  } @else if (loadFailed) {
+    <div class="mt-6 rounded-xl border border-divider-regular bg-components-panel-bg p-4">
+      <p class="m-0 text-sm font-medium text-text-destructive">
+        {{
+          'Auth.McpConsent.InvalidRequest' | translate: { Default: 'This authorization request is missing or expired.' }
+        }}
+      </p>
+    </div>
+  } @else {
+    <div class="mt-6 rounded-xl border border-divider-regular bg-components-panel-bg p-4">
+      <p class="m-0 text-xs font-medium uppercase tracking-[0.12em] text-text-tertiary">
+        {{ 'Auth.McpConsent.Client' | translate: { Default: 'Client' } }}
+      </p>
+      <p class="mb-0 mt-2 text-base font-semibold text-text-primary">{{ clientName }}</p>
+      @if (clientId && clientId !== clientName) {
+        <p class="mb-0 mt-1 break-all font-mono text-xs text-text-tertiary">{{ clientId }}</p>
+      }
+    </div>
+
+    <div class="mt-5">
+      <h2 class="m-0 text-sm font-semibold text-text-primary">
+        {{ 'Auth.McpConsent.McpServices' | translate: { Default: 'MCP services' } }}
+      </h2>
+      @if (resources.length) {
+        <ul class="mb-0 mt-3 flex list-none flex-col gap-2 p-0">
+          @for (resource of resources; track resource) {
+            <li class="rounded-lg border border-divider-regular px-3 py-2.5 font-mono text-xs text-text-secondary">
+              {{ resource }}
+            </li>
+          }
+        </ul>
+      } @else {
+        <p class="mb-0 mt-2 text-sm text-text-tertiary">
+          {{ 'Auth.McpConsent.NoMcpService' | translate: { Default: 'No MCP service was specified.' } }}
+        </p>
+      }
+    </div>
+
+    <div class="mt-5">
+      <h2 class="m-0 text-sm font-semibold text-text-primary">
+        {{ 'Auth.McpConsent.Permissions' | translate: { Default: 'Requested permissions' } }}
+      </h2>
+      @if (scopes.length) {
+        <div class="mt-3 flex flex-wrap gap-2">
+          @for (scope of scopes; track scope) {
+            <span
+              class="rounded-full border border-divider-regular bg-components-panel-bg px-3 py-1.5 font-mono text-xs text-text-secondary"
+            >
+              {{ scope }}
+            </span>
+          }
+        </div>
+      } @else {
+        <p class="mb-0 mt-2 text-sm text-text-tertiary">
+          {{
+            'Auth.McpConsent.NoPermissions' | translate: { Default: 'No additional permission scopes were requested.' }
+          }}
+        </p>
+      }
+    </div>
+
+    <p class="mb-0 mt-6 rounded-lg border border-divider-regular p-3 text-xs leading-5 text-text-secondary">
+      {{
+        'Auth.McpConsent.SecurityHint'
+          | translate
+            : {
+                Default:
+                  'Only allow access if you recognize this client. The client will receive access only to the services and permissions shown above.'
+              }
+      }}
+    </p>
+
+    <div class="mt-6 flex items-center justify-end gap-3">
+      <button z-button zType="outline" type="button" [disabled]="submitting" (click)="deny()">
+        {{ 'Auth.McpConsent.Deny' | translate: { Default: 'Deny' } }}
+      </button>
+      <button z-button type="button" [zLoading]="submitting" [disabled]="submitting" (click)="allow()">
+        {{ 'Auth.McpConsent.Allow' | translate: { Default: 'Allow access' } }}
+      </button>
+    </div>
+  }
+</section>

--- a/apps/cloud/src/app/auth/consent/consent.component.spec.ts
+++ b/apps/cloud/src/app/auth/consent/consent.component.spec.ts
@@ -1,0 +1,105 @@
+import { HttpClient } from '@angular/common/http'
+import { TestBed } from '@angular/core/testing'
+import { ActivatedRoute, convertToParamMap } from '@angular/router'
+import { of } from 'rxjs'
+import { XP_API_BASE_URL } from '../auth.options'
+import { OidcConsentComponent } from './consent.component'
+
+describe('OidcConsentComponent', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule()
+    jest.restoreAllMocks()
+  })
+
+  async function createFixture(
+    queryParams: Record<string, string>,
+    details = {
+      clientId: 'chatkit',
+      clientName: 'ChatKit',
+      scopes: ['openid', 'profile', 'email'],
+      resources: ['http://localhost:3000/api/mcp/p/cut']
+    }
+  ) {
+    const get = jest.fn(() => of(details))
+    await TestBed.configureTestingModule({
+      declarations: [OidcConsentComponent],
+      providers: [
+        { provide: XP_API_BASE_URL, useValue: 'http://localhost:3000/' },
+        {
+          provide: HttpClient,
+          useValue: { get }
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap: convertToParamMap(queryParams)
+            }
+          }
+        }
+      ]
+    })
+      .overrideComponent(OidcConsentComponent, {
+        set: {
+          template: ''
+        }
+      })
+      .compileComponents()
+
+    const fixture = TestBed.createComponent(OidcConsentComponent)
+    fixture.detectChanges()
+    await fixture.whenStable()
+    fixture.detectChanges()
+    return { component: fixture.componentInstance, get }
+  }
+
+  it('shows the requesting client, scopes, and MCP resources from the interaction URL', async () => {
+    const { component, get } = await createFixture(
+      {
+        interaction: 'interaction-1'
+      },
+      {
+        clientId: 'chatkit',
+        clientName: 'ChatKit',
+        scopes: ['openid', 'profile', 'email'],
+        resources: ['http://localhost:3000/api/mcp/p/cut', 'http://localhost:3000/api/mcp/p/media']
+      }
+    )
+
+    expect(get).toHaveBeenCalledWith('http://localhost:3000/oidc/interaction/interaction-1/consent', {
+      withCredentials: true
+    })
+    expect(component.clientName).toBe('ChatKit')
+    expect(component.clientId).toBe('chatkit')
+    expect(component.scopes).toEqual(['openid', 'profile', 'email'])
+    expect(component.resources).toEqual([
+      'http://localhost:3000/api/mcp/p/cut',
+      'http://localhost:3000/api/mcp/p/media'
+    ])
+  })
+
+  it('submits an explicit allow decision to the provider interaction endpoint', async () => {
+    const { component } = await createFixture({
+      interaction: 'interaction/1'
+    })
+    const submit = jest.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation()
+
+    component.allow()
+
+    expect(submit).toHaveBeenCalledTimes(1)
+    const form = submit.mock.instances[0] as HTMLFormElement
+    expect(form.method).toBe('post')
+    expect(form.action).toBe('http://localhost:3000/oidc/interaction/interaction%2F1/consent')
+    expect(form.querySelector<HTMLInputElement>('input[name="decision"]')?.value).toBe('allow')
+  })
+
+  it('does not submit when the interaction identifier is missing', async () => {
+    const { component, get } = await createFixture({})
+    const submit = jest.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation()
+
+    component.deny()
+
+    expect(get).not.toHaveBeenCalled()
+    expect(submit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/cloud/src/app/auth/consent/consent.component.ts
+++ b/apps/cloud/src/app/auth/consent/consent.component.ts
@@ -1,0 +1,91 @@
+import { HttpClient } from '@angular/common/http'
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core'
+import { ActivatedRoute } from '@angular/router'
+import { firstValueFrom } from 'rxjs'
+import { XP_API_BASE_URL } from '../auth.options'
+
+interface OidcConsentDetails {
+  clientId: string
+  clientName: string
+  scopes: string[]
+  resources: string[]
+}
+
+@Component({
+  standalone: false,
+  selector: 'xp-oidc-consent',
+  templateUrl: './consent.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class OidcConsentComponent implements OnInit {
+  readonly #apiBaseUrl = inject(XP_API_BASE_URL).replace(/\/$/, '')
+  readonly #http = inject(HttpClient)
+  readonly #cdr = inject(ChangeDetectorRef)
+  readonly #route = inject(ActivatedRoute)
+  readonly #queryParams = this.#route.snapshot.queryParamMap
+
+  readonly interaction = this.#queryParams.get('interaction')?.trim() || ''
+  clientId = ''
+  clientName = ''
+  scopes: string[] = []
+  resources: string[] = []
+
+  loading = true
+  loadFailed = false
+  submitting = false
+
+  async ngOnInit(): Promise<void> {
+    if (!this.interaction) {
+      this.loading = false
+      this.loadFailed = true
+      return
+    }
+
+    try {
+      const details = await firstValueFrom(
+        this.#http.get<OidcConsentDetails>(
+          `${this.#apiBaseUrl}/oidc/interaction/${encodeURIComponent(this.interaction)}/consent`,
+          { withCredentials: true }
+        )
+      )
+      this.clientId = details.clientId
+      this.clientName = details.clientName || details.clientId
+      this.scopes = details.scopes
+      this.resources = details.resources
+    } catch {
+      this.loadFailed = true
+    } finally {
+      this.loading = false
+      this.#cdr.markForCheck()
+    }
+  }
+
+  allow(): void {
+    this.submitDecision('allow')
+  }
+
+  deny(): void {
+    this.submitDecision('deny')
+  }
+
+  private submitDecision(decision: 'allow' | 'deny'): void {
+    if (!this.interaction || this.loading || this.loadFailed || this.submitting) {
+      return
+    }
+
+    this.submitting = true
+    const form = document.createElement('form')
+    form.method = 'post'
+    form.action = `${this.#apiBaseUrl}/oidc/interaction/${encodeURIComponent(this.interaction)}/consent`
+    form.style.display = 'none'
+
+    const decisionInput = document.createElement('input')
+    decisionInput.type = 'hidden'
+    decisionInput.name = 'decision'
+    decisionInput.value = decision
+    form.appendChild(decisionInput)
+
+    document.body.appendChild(form)
+    form.submit()
+  }
+}

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -1,4 +1,23 @@
 {
+  "Auth": {
+    "McpConsent": {
+      "Eyebrow": "Authorization request",
+      "UnknownClient": "An application",
+      "RequestsAccess": "requests access",
+      "ReviewRequest": "Review access request",
+      "Loading": "Loading authorization request…",
+      "Description": "Review the MCP services and identity permissions requested by this client before continuing.",
+      "Client": "Client",
+      "McpServices": "MCP services",
+      "NoMcpService": "No MCP service was specified.",
+      "Permissions": "Requested permissions",
+      "NoPermissions": "No additional permission scopes were requested.",
+      "SecurityHint": "Only allow access if you recognize this client. The client will receive access only to the services and permissions shown above.",
+      "InvalidRequest": "This authorization request is missing or expired.",
+      "Deny": "Deny",
+      "Allow": "Allow access"
+    }
+  },
   "MENU": {
     "TENANT": "Tenant",
     "ORGANIZATION": "Organization",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -1,4 +1,23 @@
 {
+  "Auth": {
+    "McpConsent": {
+      "Eyebrow": "Authorization request",
+      "UnknownClient": "An application",
+      "RequestsAccess": "requests access",
+      "ReviewRequest": "Review access request",
+      "Loading": "Loading authorization request…",
+      "Description": "Review the MCP services and identity permissions requested by this client before continuing.",
+      "Client": "Client",
+      "McpServices": "MCP services",
+      "NoMcpService": "No MCP service was specified.",
+      "Permissions": "Requested permissions",
+      "NoPermissions": "No additional permission scopes were requested.",
+      "SecurityHint": "Only allow access if you recognize this client. The client will receive access only to the services and permissions shown above.",
+      "InvalidRequest": "This authorization request is missing or expired.",
+      "Deny": "Deny",
+      "Allow": "Allow access"
+    }
+  },
   "MENU": {
     "TENANT": "Tenant",
     "ORGANIZATION": "Organization",

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -1,4 +1,23 @@
 {
+  "Auth": {
+    "McpConsent": {
+      "Eyebrow": "授权请求",
+      "UnknownClient": "某个应用",
+      "RequestsAccess": "请求访问",
+      "ReviewRequest": "确认访问请求",
+      "Loading": "正在加载授权请求…",
+      "Description": "继续前，请确认该客户端请求访问的 MCP 服务和身份权限。",
+      "Client": "客户端",
+      "McpServices": "MCP 服务",
+      "NoMcpService": "未指定 MCP 服务。",
+      "Permissions": "请求的权限",
+      "NoPermissions": "未请求额外的权限范围。",
+      "SecurityHint": "仅在你信任该客户端时允许访问。客户端只能获得上方显示的服务和权限。",
+      "InvalidRequest": "此授权请求缺失或已过期。",
+      "Deny": "拒绝",
+      "Allow": "允许访问"
+    }
+  },
   "MENU": {
     "TENANT": "集团",
     "ORGANIZATION": "公司",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -1,4 +1,23 @@
 {
+  "Auth": {
+    "McpConsent": {
+      "Eyebrow": "授权请求",
+      "UnknownClient": "某个应用",
+      "RequestsAccess": "请求访问",
+      "ReviewRequest": "确认访问请求",
+      "Loading": "正在加载授权请求…",
+      "Description": "继续前，请确认该客户端请求访问的 MCP 服务和身份权限。",
+      "Client": "客户端",
+      "McpServices": "MCP 服务",
+      "NoMcpService": "未指定 MCP 服务。",
+      "Permissions": "请求的权限",
+      "NoPermissions": "未请求额外的权限范围。",
+      "SecurityHint": "仅在你信任该客户端时允许访问。客户端只能获得上方显示的服务和权限。",
+      "InvalidRequest": "此授权请求缺失或已过期。",
+      "Deny": "拒绝",
+      "Allow": "允许访问"
+    }
+  },
   "Pro": {
     "ContactUs": "联系我们",
     "UpgradePro": "升级成专业版",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -1,4 +1,23 @@
 {
+  "Auth": {
+    "McpConsent": {
+      "Eyebrow": "授權請求",
+      "UnknownClient": "某個應用程式",
+      "RequestsAccess": "請求存取",
+      "ReviewRequest": "確認存取請求",
+      "Loading": "正在載入授權請求…",
+      "Description": "繼續前，請確認該客戶端請求存取的 MCP 服務和身分權限。",
+      "Client": "客戶端",
+      "McpServices": "MCP 服務",
+      "NoMcpService": "未指定 MCP 服務。",
+      "Permissions": "請求的權限",
+      "NoPermissions": "未請求額外的權限範圍。",
+      "SecurityHint": "僅在你信任該客戶端時允許存取。客戶端只能取得上方顯示的服務和權限。",
+      "InvalidRequest": "此授權請求缺失或已過期。",
+      "Deny": "拒絕",
+      "Allow": "允許存取"
+    }
+  },
   "Pro": {
     "ContactUs": "聯系我們",
     "UpgradePro": "升級成專業版",


### PR DESCRIPTION
## Summary
- add a shared MCP OAuth/OIDC consent page to the open-source web app
- register the consent route only when `mcpOAuthEnabled` is enabled
- add localized consent copy for English, Simplified Chinese, and Traditional Chinese

The open-source configuration remains disabled by default. Xpert Pro can enable the route and keep ownership of its OIDC provider endpoints without duplicating the common frontend page.

## Validation
- `NX_DAEMON=false corepack pnpm exec nx test cloud --runInBand --testPathPatterns=apps/cloud/src/app/auth/consent/consent.component.spec.ts`
- `NX_DAEMON=false corepack pnpm exec nx build cloud --configuration=development`
- `corepack pnpm exec prettier --check <changed files>`
- `git diff --check origin/develop...HEAD`