### PR TITLE
feat: initialize ClawXpert during user bootstrap

### DIFF
--- a/packages/server-ai/src/initialization/bootstrap.service.spec.ts
+++ b/packages/server-ai/src/initialization/bootstrap.service.spec.ts
@@ -82,8 +82,26 @@ jest.mock('../model-gateway', () => ({
     ModelGatewayService: class ModelGatewayService {}
 }))
 
+jest.mock('../assistant-binding', () => ({
+    AssistantBindingService: class AssistantBindingService {}
+}))
+
+jest.mock('../plugin-resource', () => ({
+    PluginTemplateInstallCommand: class PluginTemplateInstallCommand {
+        constructor(
+            public readonly templateId: string,
+            public readonly workspaceId: string,
+            public readonly language: string,
+            public readonly basic?: unknown,
+            public readonly publish = false
+        ) {}
+    }
+}))
+
 import { ServerAIBootstrapService } from './bootstrap.service'
 import { XpertImportCommand } from '../xpert'
+import { PluginTemplateInstallCommand } from '../plugin-resource'
+import type { AssistantBindingService } from '../assistant-binding'
 import type { MembershipService } from '../membership'
 import type { ModelAccessService } from '../model-access'
 import type { ModelGatewayService } from '../model-gateway'
@@ -92,6 +110,7 @@ import type {
     PluginManagementService,
     UserOrganizationCreatedEvent
 } from '@xpert-ai/server-core'
+import { AiModelTypeEnum, AssistantBindingScope, AssistantCode, LanguagesEnum } from '@xpert-ai/contracts'
 
 type PluginManagementServiceMock = jest.Mocked<Pick<PluginManagementService, 'findLoadedPlugin' | 'installPlugin'>>
 
@@ -209,7 +228,8 @@ describe('ServerAIBootstrapService', () => {
             repository: {
                 createQueryBuilder: jest.fn()
             },
-            validateName: jest.fn().mockResolvedValue(true)
+            validateName: jest.fn().mockResolvedValue(true),
+            publish: jest.fn()
         }
         const xpertTemplateService = {
             getTemplateDetail: jest.fn().mockResolvedValue({
@@ -257,6 +277,10 @@ describe('ServerAIBootstrapService', () => {
         const modelGatewayService = {
             revokeOrganizationKeysForRemovedUser: jest.fn().mockResolvedValue(undefined)
         }
+        const assistantBindingService = {
+            getBinding: jest.fn().mockResolvedValue(null),
+            upsertBinding: jest.fn()
+        }
         const pluginManagementService: PluginManagementServiceMock = {
             findLoadedPlugin: jest.fn().mockReturnValue(undefined),
             installPlugin: jest.fn().mockResolvedValue({
@@ -282,6 +306,7 @@ describe('ServerAIBootstrapService', () => {
             xpertTemplateService as any,
             templateSkillSyncService as any,
             toPluginManagementService(pluginManagementService),
+            assistantBindingService as unknown as AssistantBindingService,
             membershipService as unknown as MembershipService,
             modelAccessService as unknown as ModelAccessService,
             modelGatewayService as unknown as ModelGatewayService
@@ -292,6 +317,7 @@ describe('ServerAIBootstrapService', () => {
         )
 
         return {
+            assistantBindingService,
             commandBus,
             configService,
             environmentService,
@@ -312,6 +338,44 @@ describe('ServerAIBootstrapService', () => {
             xpertService,
             xpertTemplateService
         }
+    }
+
+    function configureAvailableClawXpertModel({
+        queryBus,
+        userService,
+        workspaceService,
+        xpertService
+    }: ReturnType<typeof createService>) {
+        userService.findOne.mockResolvedValue({
+            id: 'member-1',
+            preferredLanguage: LanguagesEnum.English,
+            role: {
+                name: 'ADMIN'
+            }
+        })
+        workspaceService.findUserDefaultWorkspace.mockResolvedValue(null)
+        workspaceService.create.mockResolvedValue({
+            id: 'workspace-2',
+            ownerId: 'member-1'
+        })
+        queryBus.execute.mockResolvedValue([
+            {
+                id: 'copilot-1',
+                providerWithModels: {
+                    models: [
+                        {
+                            model: 'gpt-4o',
+                            model_type: 'llm'
+                        }
+                    ]
+                }
+            }
+        ])
+        xpertService.repository.createQueryBuilder.mockReturnValue({
+            where: jest.fn().mockReturnThis(),
+            andWhere: jest.fn().mockReturnThis(),
+            getOne: jest.fn().mockResolvedValue(null)
+        })
     }
 
     it('keeps organization bootstrap focused on workspace and membership setup', async () => {
@@ -689,6 +753,197 @@ connections: []`
             workspaceId: 'workspace-2',
             createdNewUserDefaultWorkspace: true
         })
+    })
+
+    it('initializes and binds ClawXpert when an LLM is available after user organization bootstrap', async () => {
+        const setup = createService()
+        const {
+            assistantBindingService,
+            commandBus,
+            environmentService,
+            membershipService,
+            pluginManagementService,
+            queryBus,
+            service,
+            xpertService,
+            xpertTemplateService
+        } = setup
+        configureAvailableClawXpertModel(setup)
+        xpertTemplateService.getTemplateDetail.mockResolvedValue({
+            id: 'xpert-my-claw-xpert',
+            name: 'ClawXpert',
+            dependencies: {
+                plugins: ['@xpert-ai/plugin-file-memory']
+            },
+            export_data: 'team:\n  name: ClawXpert\n'
+        })
+        commandBus.execute.mockResolvedValue({
+            xpert: {
+                id: 'clawxpert-1'
+            }
+        })
+        xpertService.publish.mockResolvedValue({
+            id: 'clawxpert-1'
+        })
+        assistantBindingService.upsertBinding.mockResolvedValue({
+            assistantId: 'clawxpert-1'
+        })
+
+        await service.bootstrapUserInOrganization({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            userId: 'member-1'
+        } as UserOrganizationCreatedEvent)
+
+        expect(membershipService.ensureUserAssignedIfScopeInitialized.mock.invocationCallOrder[0]).toBeLessThan(
+            queryBus.execute.mock.invocationCallOrder[0]
+        )
+        expect(pluginManagementService.installPlugin).toHaveBeenCalledWith({
+            pluginName: '@xpert-ai/plugin-file-memory'
+        })
+        expect(pluginManagementService.installPlugin.mock.invocationCallOrder[0]).toBeLessThan(
+            commandBus.execute.mock.invocationCallOrder[0]
+        )
+        expect(commandBus.execute).toHaveBeenCalledWith(
+            expect.objectContaining({
+                templateId: 'xpert-my-claw-xpert',
+                workspaceId: 'workspace-2',
+                language: LanguagesEnum.English,
+                basic: {
+                    name: 'clawxpert-workspace-2',
+                    title: 'ClawXpert',
+                    copilotModel: {
+                        copilotId: 'copilot-1',
+                        model: 'gpt-4o',
+                        modelType: AiModelTypeEnum.LLM
+                    }
+                },
+                publish: false
+            } satisfies Partial<PluginTemplateInstallCommand>)
+        )
+        expect(xpertService.publish).toHaveBeenCalledWith(
+            'clawxpert-1',
+            false,
+            'environment-1',
+            'Initial ClawXpert bootstrap release.'
+        )
+        expect(assistantBindingService.upsertBinding).toHaveBeenCalledWith({
+            code: AssistantCode.CLAWXPERT,
+            scope: AssistantBindingScope.USER,
+            assistantId: 'clawxpert-1'
+        })
+        expect(environmentService.create).toHaveBeenCalled()
+    })
+
+    it('continues ClawXpert initialization when plugin preparation fails', async () => {
+        const setup = createService()
+        const {
+            assistantBindingService,
+            commandBus,
+            pluginManagementService,
+            service,
+            xpertService,
+            xpertTemplateService
+        } = setup
+        configureAvailableClawXpertModel(setup)
+        xpertTemplateService.getTemplateDetail.mockResolvedValue({
+            id: 'xpert-my-claw-xpert',
+            name: 'ClawXpert',
+            dependencies: {
+                plugins: ['@xpert-ai/plugin-file-memory']
+            },
+            export_data: 'team:\n  name: ClawXpert\n'
+        })
+        pluginManagementService.installPlugin.mockRejectedValue(new Error('install failed'))
+        commandBus.execute.mockResolvedValue({
+            xpert: {
+                id: 'clawxpert-1'
+            }
+        })
+        xpertService.publish.mockResolvedValue({
+            id: 'clawxpert-1'
+        })
+        assistantBindingService.upsertBinding.mockResolvedValue({
+            assistantId: 'clawxpert-1'
+        })
+
+        await expect(
+            service.bootstrapUserInOrganization({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                userId: 'member-1'
+            } as UserOrganizationCreatedEvent)
+        ).resolves.toEqual({
+            workspaceId: 'workspace-2',
+            createdNewUserDefaultWorkspace: true
+        })
+
+        expect(pluginManagementService.installPlugin).toHaveBeenCalledWith({
+            pluginName: '@xpert-ai/plugin-file-memory'
+        })
+        expect(commandBus.execute).toHaveBeenCalledWith(expect.any(PluginTemplateInstallCommand))
+        expect(assistantBindingService.upsertBinding).toHaveBeenCalledWith({
+            code: AssistantCode.CLAWXPERT,
+            scope: AssistantBindingScope.USER,
+            assistantId: 'clawxpert-1'
+        })
+    })
+
+    it('does not fail user organization bootstrap when ClawXpert creation fails', async () => {
+        const setup = createService()
+        const { commandBus, membershipService, service } = setup
+        configureAvailableClawXpertModel(setup)
+        commandBus.execute.mockRejectedValue(new Error('template install failed'))
+
+        await expect(
+            service.bootstrapUserInOrganization({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                userId: 'member-1'
+            } as UserOrganizationCreatedEvent)
+        ).resolves.toEqual({
+            workspaceId: 'workspace-2',
+            createdNewUserDefaultWorkspace: true
+        })
+
+        expect(membershipService.ensureUserAssignedIfScopeInitialized).toHaveBeenCalledWith({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            userId: 'member-1',
+            assignedById: 'member-1'
+        })
+    })
+
+    it('skips ClawXpert initialization when no LLM is available', async () => {
+        const { assistantBindingService, commandBus, queryBus, service, userService, workspaceService, xpertService } =
+            createService()
+        userService.findOne.mockResolvedValue({
+            id: 'member-1',
+            preferredLanguage: 'en_US',
+            role: {
+                name: 'ADMIN'
+            }
+        })
+        workspaceService.findUserDefaultWorkspace.mockResolvedValue({
+            id: 'workspace-existing',
+            ownerId: 'member-1'
+        })
+        queryBus.execute.mockResolvedValue([])
+
+        await expect(
+            service.bootstrapUserInOrganization({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                userId: 'member-1'
+            } as UserOrganizationCreatedEvent)
+        ).resolves.toEqual({
+            workspaceId: 'workspace-existing',
+            createdNewUserDefaultWorkspace: false
+        })
+
+        expect(commandBus.execute).not.toHaveBeenCalledWith(expect.any(PluginTemplateInstallCommand))
+        expect(xpertService.publish).not.toHaveBeenCalled()
+        expect(assistantBindingService.upsertBinding).not.toHaveBeenCalled()
     })
 
     it('assigns the tenant default membership to trial users while preserving organization assignment', async () => {

--- a/packages/server-ai/src/initialization/bootstrap.service.ts
+++ b/packages/server-ai/src/initialization/bootstrap.service.ts
@@ -1,6 +1,10 @@
 import {
     AiModelTypeEnum,
     AiProviderRole,
+    AssistantBindingScope,
+    AssistantCode,
+    ICopilotWithProvider,
+    IXpert,
     LanguagesEnum,
     RolesEnum,
     TCopilotModel,
@@ -34,6 +38,8 @@ import { XpertWorkspaceService } from '../xpert-workspace/workspace.service'
 import { MembershipService } from '../membership'
 import { ModelAccessService } from '../model-access'
 import { ModelGatewayService } from '../model-gateway'
+import { AssistantBindingService } from '../assistant-binding'
+import { PluginResourceInstallResult, PluginTemplateInstallCommand } from '../plugin-resource'
 import { captureRequestContext, runWithCapturedRequestContext } from '../shared/request-context'
 import { DEFAULT_ENVIRONMENT_NAME, getDefaultOrganizationWorkspaceName } from './constants'
 
@@ -62,6 +68,9 @@ type WorkspaceWithId = {
 
 const DEFAULT_ORGANIZATION_ASSISTANT_TEMPLATE_KEY = 'xpert-authoring-assistant'
 const CLAWXPERT_TEMPLATE_KEY = 'xpert-my-claw-xpert'
+const CLAWXPERT_NAME = 'clawxpert'
+const CLAWXPERT_TITLE = 'ClawXpert'
+const CLAWXPERT_AUTO_PUBLISH_RELEASE_NOTES = 'Initial ClawXpert bootstrap release.'
 
 type BootstrapModelScanContext = {
     nodeType?: string
@@ -93,6 +102,7 @@ export class ServerAIBootstrapService {
         private readonly xpertTemplateService: XpertTemplateService,
         private readonly templateSkillSyncService: TemplateSkillSyncService,
         private readonly pluginManagementService: PluginManagementService,
+        private readonly assistantBindingService: AssistantBindingService,
         private readonly membershipService: MembershipService,
         private readonly modelAccessService: ModelAccessService,
         private readonly modelGatewayService: ModelGatewayService
@@ -149,6 +159,7 @@ export class ServerAIBootstrapService {
     async bootstrapUserInOrganization(event: UserOrganizationCreatedEvent): Promise<UserOrganizationBootstrapResult> {
         const user = await this.userService.findOne(event.userId, { relations: ['role'] })
         let workspaceId: string | null = null
+        let environmentId: string | null = null
         let createdNewUserDefaultWorkspace = false
 
         await this.membershipService.ensureTenantDefaultMembership({
@@ -159,8 +170,9 @@ export class ServerAIBootstrapService {
         await this.runInOrganizationContext(user, event.organizationId, async () => {
             if (this.shouldBootstrapPersonalWorkspace(user)) {
                 const { workspace, created } = await this.ensureUserWorkspace(event.organizationId, user)
-                await this.ensureDefaultEnvironment(workspace.id)
+                const environment = await this.ensureDefaultEnvironment(workspace.id)
                 workspaceId = workspace.id
+                environmentId = environment.id
                 createdNewUserDefaultWorkspace = created
             }
 
@@ -178,6 +190,23 @@ export class ServerAIBootstrapService {
                 userId: event.userId,
                 assignedById: event.userId
             })
+
+            if (workspaceId && environmentId) {
+                try {
+                    await this.initializeClawXpertIfModelAvailable({
+                        organizationId: event.organizationId,
+                        workspaceId,
+                        environmentId,
+                        user
+                    })
+                } catch (error) {
+                    this.logger.warn(
+                        `Failed initializing ClawXpert for user '${event.userId}' in organization '${event.organizationId}': ${getErrorMessage(
+                            error
+                        )}`
+                    )
+                }
+            }
         })
 
         return {
@@ -425,11 +454,108 @@ export class ServerAIBootstrapService {
         })
     }
 
-    private async preinstallClawXpertTemplatePlugins(organizationId: string, owner: IUser) {
+    private async initializeClawXpertIfModelAvailable({
+        organizationId,
+        workspaceId,
+        environmentId,
+        user
+    }: {
+        organizationId: string
+        workspaceId: string
+        environmentId: string
+        user: IUser
+    }) {
+        const existingBinding = await this.assistantBindingService.getBinding(
+            AssistantCode.CLAWXPERT,
+            AssistantBindingScope.USER
+        )
+        if (existingBinding?.assistantId) {
+            return
+        }
+
+        const copilotModel = await this.resolveFirstAvailableLlmModel()
+        if (!copilotModel) {
+            return
+        }
+
+        await this.preinstallClawXpertTemplatePlugins(organizationId, user)
+
+        let clawXpert = await this.findUserClawXpert(workspaceId, user.id)
+        if (!clawXpert) {
+            const language = Object.values(LanguagesEnum).find((value) => value === user.preferredLanguage)
+            const installResult = await this.commandBus.execute<
+                PluginTemplateInstallCommand,
+                PluginResourceInstallResult
+            >(
+                new PluginTemplateInstallCommand(
+                    CLAWXPERT_TEMPLATE_KEY,
+                    workspaceId,
+                    language ?? LanguagesEnum.English,
+                    {
+                        name: `${CLAWXPERT_NAME}-${workspaceId}`,
+                        title: CLAWXPERT_TITLE,
+                        copilotModel
+                    }
+                )
+            )
+            if (!installResult.xpert?.id) {
+                throw new Error('ClawXpert template installation did not return an xpert id')
+            }
+            clawXpert = installResult.xpert
+        }
+
+        if (!clawXpert.publishAt) {
+            clawXpert = await this.xpertService.publish(
+                clawXpert.id,
+                false,
+                environmentId,
+                CLAWXPERT_AUTO_PUBLISH_RELEASE_NOTES
+            )
+        }
+
+        await this.assistantBindingService.upsertBinding({
+            code: AssistantCode.CLAWXPERT,
+            scope: AssistantBindingScope.USER,
+            assistantId: clawXpert.id
+        })
+    }
+
+    private async resolveFirstAvailableLlmModel(): Promise<TCopilotModel | null> {
+        const copilots = await this.queryBus.execute<FindCopilotModelsQuery, ICopilotWithProvider[]>(
+            new FindCopilotModelsQuery(AiModelTypeEnum.LLM)
+        )
+        for (const copilot of copilots ?? []) {
+            const model = copilot.providerWithModels?.models?.[0]
+            if (copilot.id && model?.model) {
+                return {
+                    copilotId: copilot.id,
+                    model: model.model,
+                    modelType: AiModelTypeEnum.LLM
+                }
+            }
+        }
+
+        return null
+    }
+
+    private findUserClawXpert(workspaceId: string, userId: string): Promise<IXpert | null> {
+        return this.xpertService.repository
+            .createQueryBuilder('xpert')
+            .where('xpert.workspaceId = :workspaceId', { workspaceId })
+            .andWhere('xpert.createdById = :userId', { userId })
+            .andWhere('xpert.latest = true')
+            .andWhere('xpert.deletedAt IS NULL')
+            .andWhere(`COALESCE((xpert.options)::jsonb -> 'templateSource' ->> 'templateKey', '') = :templateKey`, {
+                templateKey: CLAWXPERT_TEMPLATE_KEY
+            })
+            .getOne()
+    }
+
+    private async preinstallClawXpertTemplatePlugins(organizationId: string, user: IUser) {
         try {
             const template = await this.xpertTemplateService.getTemplateDetail(
                 CLAWXPERT_TEMPLATE_KEY,
-                (owner.preferredLanguage as LanguagesEnum) ?? LanguagesEnum.English
+                (user.preferredLanguage as LanguagesEnum) ?? LanguagesEnum.English
             )
             const pluginNames = this.readTemplateRequiredPluginNames(template.dependencies)
             for (const pluginName of pluginNames) {

--- a/packages/server-ai/src/initialization/initialization.module.ts
+++ b/packages/server-ai/src/initialization/initialization.module.ts
@@ -10,6 +10,7 @@ import { XpertWorkspaceModule } from '../xpert-workspace/workspace.module'
 import { MembershipModule } from '../membership'
 import { ModelAccessModule } from '../model-access'
 import { ModelGatewayModule } from '../model-gateway'
+import { AssistantBindingModule } from '../assistant-binding'
 import { AI_BOOTSTRAP_QUEUE } from './constants'
 import { ServerAIBootstrapProcessor } from './bootstrap.processor'
 import { ServerAIBootstrapService } from './bootstrap.service'
@@ -31,7 +32,8 @@ import { ServerAIBootstrapService } from './bootstrap.service'
         XpertTemplateModule,
         MembershipModule,
         ModelAccessModule,
-        ModelGatewayModule
+        ModelGatewayModule,
+        AssistantBindingModule
     ],
     providers: [ServerAIBootstrapProcessor, ServerAIBootstrapService]
 })


### PR DESCRIPTION
## Summary

- initialize a user-scoped ClawXpert after the personal workspace and default environment are ready when an LLM is available
- prepare template plugins on a best-effort basis, reuse or install and publish the ClawXpert template, then persist the assistant binding
- keep ClawXpert initialization best-effort so failures do not block the existing user organization bootstrap flow

## Validation

- `corepack pnpm nx test server-ai --testFile=packages/server-ai/src/initialization/bootstrap.service.spec.ts --runInBand`
- `corepack pnpm nx build server-ai`
- `git diff --check origin/develop...HEAD`