### PR TITLE
fix: migrate scheduled jobs to Redis locks

### DIFF
--- a/packages/server-ai/src/membership/membership-period-scheduler.service.spec.ts
+++ b/packages/server-ai/src/membership/membership-period-scheduler.service.spec.ts
@@ -2,28 +2,19 @@ jest.mock('../xpert/xpert.entity', () => ({
     Xpert: class Xpert {}
 }))
 
-import { DataSource } from 'typeorm'
+import { RedisLockRunResult, RedisLockService } from '@xpert-ai/server-core'
 import { MembershipPeriodSchedulerService } from './membership-period-scheduler.service'
 import { MembershipService } from './membership.service'
 
-type QueryRunnerMock = {
-    query: jest.Mock<Promise<unknown>, [string, unknown[]?]>
-    connect: jest.Mock<Promise<void>, []>
-    release: jest.Mock<Promise<void>, []>
-}
-
-function createQueryRunner(): QueryRunnerMock {
-    return {
-        query: jest.fn(),
-        connect: jest.fn().mockResolvedValue(undefined),
-        release: jest.fn().mockResolvedValue(undefined)
-    }
-}
-
 function createService() {
-    const queryRunner = createQueryRunner()
-    const dataSource = {
-        createQueryRunner: jest.fn(() => queryRunner)
+    const runWithLock = jest.fn<Promise<RedisLockRunResult<unknown>>, [string, number, () => Promise<unknown>]>(
+        async (_key, _ttl, operation) => ({
+            acquired: true,
+            value: await operation()
+        })
+    )
+    const redisLockService = {
+        runWithLock
     }
     const membershipService = {
         processDueMembershipPeriods: jest.fn().mockResolvedValue({
@@ -34,11 +25,11 @@ function createService() {
         })
     }
     const service = new MembershipPeriodSchedulerService(
-        dataSource as unknown as DataSource,
-        membershipService as unknown as MembershipService
+        membershipService as unknown as MembershipService,
+        redisLockService as unknown as RedisLockService
     )
 
-    return { service, queryRunner, membershipService }
+    return { service, redisLockService, membershipService }
 }
 
 describe('MembershipPeriodSchedulerService', () => {
@@ -50,24 +41,25 @@ describe('MembershipPeriodSchedulerService', () => {
         )
     })
 
-    it('skips settlement while another instance holds the advisory lock', async () => {
-        const { service, queryRunner, membershipService } = createService()
-        queryRunner.query.mockResolvedValueOnce([{ locked: false }])
+    it('skips settlement while another instance holds the Redis lock', async () => {
+        const { service, redisLockService, membershipService } = createService()
+        redisLockService.runWithLock.mockResolvedValueOnce({ acquired: false })
 
         await service.settleDueMembershipPeriods()
 
         expect(membershipService.processDueMembershipPeriods).not.toHaveBeenCalled()
-        expect(queryRunner.release).toHaveBeenCalledTimes(1)
     })
 
-    it('settles due periods and releases the advisory lock', async () => {
-        const { service, queryRunner, membershipService } = createService()
-        queryRunner.query.mockResolvedValueOnce([{ locked: true }]).mockResolvedValueOnce([{ unlocked: true }])
+    it('settles due periods under a renewable Redis lock', async () => {
+        const { service, redisLockService, membershipService } = createService()
 
         await service.settleDueMembershipPeriods()
 
         expect(membershipService.processDueMembershipPeriods).toHaveBeenCalledTimes(1)
-        expect(queryRunner.query.mock.calls[1][0]).toContain('pg_advisory_unlock')
-        expect(queryRunner.release).toHaveBeenCalledTimes(1)
+        expect(redisLockService.runWithLock).toHaveBeenCalledWith(
+            'scheduler:membership-period-settlement',
+            5 * 60 * 1000,
+            expect.any(Function)
+        )
     })
 })

--- a/packages/server-ai/src/membership/membership-period-scheduler.service.ts
+++ b/packages/server-ai/src/membership/membership-period-scheduler.service.ts
@@ -1,79 +1,38 @@
 import { getErrorMessage } from '@xpert-ai/server-common'
+import { RedisLockService } from '@xpert-ai/server-core'
 import { Injectable, Logger } from '@nestjs/common'
 import { Cron } from '@nestjs/schedule'
-import { InjectDataSource } from '@nestjs/typeorm'
-import { DataSource, QueryRunner } from 'typeorm'
 import { MembershipService } from './membership.service'
 
-const MEMBERSHIP_PERIOD_SETTLEMENT_LOCK_KEY = 840_139_002
+const MEMBERSHIP_PERIOD_SETTLEMENT_LOCK_KEY = 'scheduler:membership-period-settlement'
+const MEMBERSHIP_PERIOD_SETTLEMENT_LOCK_TTL = 5 * 60 * 1000
 
 @Injectable()
 export class MembershipPeriodSchedulerService {
     readonly #logger = new Logger(MembershipPeriodSchedulerService.name)
 
     constructor(
-        @InjectDataSource()
-        private readonly dataSource: DataSource,
-        private readonly membershipService: MembershipService
+        private readonly membershipService: MembershipService,
+        private readonly redisLockService: RedisLockService
     ) {}
 
     @Cron('0 * * * * *')
     async settleDueMembershipPeriods(): Promise<void> {
-        const queryRunner = this.dataSource.createQueryRunner()
-        let connected = false
-
         try {
-            await queryRunner.connect()
-            connected = true
-
-            if (!(await this.acquireLock(queryRunner))) {
-                return
-            }
-
-            try {
-                const result = await this.membershipService.processDueMembershipPeriods()
-                if (result.scanned || result.failed) {
-                    this.#logger.log(
-                        `membership period settlement: scanned=${result.scanned}, settled=${result.settled}, skipped=${result.skipped}, failed=${result.failed}`
-                    )
+            await this.redisLockService.runWithLock(
+                MEMBERSHIP_PERIOD_SETTLEMENT_LOCK_KEY,
+                MEMBERSHIP_PERIOD_SETTLEMENT_LOCK_TTL,
+                async () => {
+                    const result = await this.membershipService.processDueMembershipPeriods()
+                    if (result.scanned || result.failed) {
+                        this.#logger.log(
+                            `membership period settlement: scanned=${result.scanned}, settled=${result.settled}, skipped=${result.skipped}, failed=${result.failed}`
+                        )
+                    }
                 }
-            } finally {
-                await this.releaseLock(queryRunner)
-            }
+            )
         } catch (error) {
             this.#logger.error(`membership period settlement failed: ${getErrorMessage(error)}`)
-        } finally {
-            if (connected) {
-                await queryRunner.release()
-            }
-        }
-    }
-
-    private async acquireLock(queryRunner: QueryRunner): Promise<boolean> {
-        try {
-            const rows: unknown = await queryRunner.query('select pg_try_advisory_lock($1) as locked', [
-                MEMBERSHIP_PERIOD_SETTLEMENT_LOCK_KEY
-            ])
-            if (!Array.isArray(rows) || !rows.length) {
-                return false
-            }
-            const first = rows[0]
-            if (!first || typeof first !== 'object' || !('locked' in first)) {
-                return false
-            }
-            const locked = first.locked
-            return locked === true || locked === 't' || locked === 1
-        } catch (error) {
-            this.#logger.warn(`membership period settlement lock unavailable: ${getErrorMessage(error)}`)
-            return false
-        }
-    }
-
-    private async releaseLock(queryRunner: QueryRunner): Promise<void> {
-        try {
-            await queryRunner.query('select pg_advisory_unlock($1)', [MEMBERSHIP_PERIOD_SETTLEMENT_LOCK_KEY])
-        } catch (error) {
-            this.#logger.warn(`membership period settlement unlock failed: ${getErrorMessage(error)}`)
         }
     }
 }

--- a/packages/server-ai/src/membership/membership.module.ts
+++ b/packages/server-ai/src/membership/membership.module.ts
@@ -6,6 +6,7 @@ import { BullModule } from '@nestjs/bull'
 import {
     FeatureOrganization,
     Organization,
+    RedisModule,
     TenantModule,
     TenantSetting,
     User,
@@ -43,6 +44,7 @@ import { MembershipBackfillQueueService, MEMBERSHIP_MAINTENANCE_QUEUE } from './
             Organization
         ]),
         TenantModule,
+        RedisModule,
         CqrsModule
     ],
     controllers: [MembershipController],

--- a/packages/server-ai/src/model-access/model-access-scheduler.service.spec.ts
+++ b/packages/server-ai/src/model-access/model-access-scheduler.service.spec.ts
@@ -1,26 +1,17 @@
-import { DataSource } from 'typeorm'
+import { RedisLockRunResult, RedisLockService } from '@xpert-ai/server-core'
 import { Cache } from 'cache-manager'
 import { ModelAccessSchedulerService } from './model-access-scheduler.service'
 import { ModelAccessService } from './model-access.service'
 
-type QueryRunnerMock = {
-    query: jest.Mock<Promise<unknown>, [string, unknown[]?]>
-    connect: jest.Mock<Promise<void>, []>
-    release: jest.Mock<Promise<void>, []>
-}
-
-function createQueryRunner(): QueryRunnerMock {
-    return {
-        query: jest.fn(),
-        connect: jest.fn().mockResolvedValue(undefined),
-        release: jest.fn().mockResolvedValue(undefined)
-    }
-}
-
 function createService() {
-    const queryRunner = createQueryRunner()
-    const dataSource = {
-        createQueryRunner: jest.fn(() => queryRunner)
+    const runWithLock = jest.fn<Promise<RedisLockRunResult<unknown>>, [string, number, () => Promise<unknown>]>(
+        async (_key, _ttl, operation) => ({
+            acquired: true,
+            value: await operation()
+        })
+    )
+    const redisLockService = {
+        runWithLock
     }
     const modelAccessService = {
         processAllDueGrants: jest.fn().mockResolvedValue(1),
@@ -36,12 +27,12 @@ function createService() {
         set: jest.fn().mockResolvedValue(undefined)
     }
     const service = new ModelAccessSchedulerService(
-        dataSource as unknown as DataSource,
         modelAccessService as unknown as ModelAccessService,
-        cacheManager as unknown as Cache
+        cacheManager as unknown as Cache,
+        redisLockService as unknown as RedisLockService
     )
 
-    return { service, queryRunner, modelAccessService, cacheManager }
+    return { service, redisLockService, modelAccessService, cacheManager }
 }
 
 describe('ModelAccessSchedulerService', () => {
@@ -53,20 +44,18 @@ describe('ModelAccessSchedulerService', () => {
         )
     })
 
-    it('skips reconciliation while another instance holds the advisory lock', async () => {
-        const { service, queryRunner, modelAccessService } = createService()
-        queryRunner.query.mockResolvedValueOnce([{ locked: false }])
+    it('skips reconciliation while another instance holds the Redis lock', async () => {
+        const { service, redisLockService, modelAccessService } = createService()
+        redisLockService.runWithLock.mockResolvedValueOnce({ acquired: false })
 
         await service.expireDueGrants()
 
         expect(modelAccessService.processAllDueGrants).not.toHaveBeenCalled()
         expect(modelAccessService.reconcileLifecycleBatch).not.toHaveBeenCalled()
-        expect(queryRunner.release).toHaveBeenCalledTimes(1)
     })
 
-    it('expires grants, reconciles lifecycle state, and releases the advisory lock', async () => {
-        const { service, queryRunner, modelAccessService } = createService()
-        queryRunner.query.mockResolvedValueOnce([{ locked: true }]).mockResolvedValueOnce([{ unlocked: true }])
+    it('expires grants and reconciles lifecycle state under a renewable Redis lock', async () => {
+        const { service, redisLockService, modelAccessService } = createService()
 
         await service.expireDueGrants()
 
@@ -76,13 +65,15 @@ describe('ModelAccessSchedulerService', () => {
             grantAfterId: null,
             limit: 200
         })
-        expect(queryRunner.query.mock.calls[1][0]).toContain('pg_advisory_unlock')
-        expect(queryRunner.release).toHaveBeenCalledTimes(1)
+        expect(redisLockService.runWithLock).toHaveBeenCalledWith(
+            'scheduler:model-access-lifecycle',
+            5 * 60 * 1000,
+            expect.any(Function)
+        )
     })
 
     it('continues from the shared lifecycle cursor and stores the next batch position', async () => {
-        const { service, queryRunner, modelAccessService, cacheManager } = createService()
-        queryRunner.query.mockResolvedValueOnce([{ locked: true }]).mockResolvedValueOnce([{ unlocked: true }])
+        const { service, modelAccessService, cacheManager } = createService()
         cacheManager.get.mockResolvedValueOnce({
             requestAfterId: 'request-100',
             grantAfterId: 'grant-100'

--- a/packages/server-ai/src/model-access/model-access-scheduler.service.ts
+++ b/packages/server-ai/src/model-access/model-access-scheduler.service.ts
@@ -1,13 +1,13 @@
 import { getErrorMessage } from '@xpert-ai/server-common'
+import { RedisLockService } from '@xpert-ai/server-core'
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { Cron } from '@nestjs/schedule'
-import { InjectDataSource } from '@nestjs/typeorm'
 import { Cache } from 'cache-manager'
-import { DataSource, QueryRunner } from 'typeorm'
 import { ModelAccessService } from './model-access.service'
 
-const MODEL_ACCESS_EXPIRATION_LOCK_KEY = 840_139_003
+const MODEL_ACCESS_EXPIRATION_LOCK_KEY = 'scheduler:model-access-lifecycle'
+const MODEL_ACCESS_EXPIRATION_LOCK_TTL = 5 * 60 * 1000
 const MODEL_ACCESS_LIFECYCLE_CURSOR_KEY = 'model-access:lifecycle-cursor:v1'
 const MODEL_ACCESS_LIFECYCLE_CURSOR_TTL = 24 * 60 * 60 * 1000
 const MODEL_ACCESS_LIFECYCLE_BATCH_SIZE = 200
@@ -26,48 +26,38 @@ export class ModelAccessSchedulerService {
     }
 
     constructor(
-        @InjectDataSource()
-        private readonly dataSource: DataSource,
         private readonly service: ModelAccessService,
         @Inject(CACHE_MANAGER)
-        private readonly cacheManager: Cache
+        private readonly cacheManager: Cache,
+        private readonly redisLockService: RedisLockService
     ) {}
 
     @Cron('0 * * * * *')
     async expireDueGrants(): Promise<void> {
-        const queryRunner = this.dataSource.createQueryRunner()
-        let connected = false
         try {
-            await queryRunner.connect()
-            connected = true
-            if (!(await this.acquireLock(queryRunner))) {
-                return
-            }
-            try {
-                const expired = await this.service.processAllDueGrants()
-                const cursor = await this.readLifecycleCursor()
-                const reconciled = await this.service.reconcileLifecycleBatch({
-                    ...cursor,
-                    limit: MODEL_ACCESS_LIFECYCLE_BATCH_SIZE
-                })
-                await this.writeLifecycleCursor({
-                    requestAfterId: reconciled.nextRequestAfterId,
-                    grantAfterId: reconciled.nextGrantAfterId
-                })
-                if (expired || reconciled.requests || reconciled.grants) {
-                    this.#logger.log(
-                        `model access lifecycle: expired=${expired}, requests=${reconciled.requests}, grants=${reconciled.grants}`
-                    )
+            await this.redisLockService.runWithLock(
+                MODEL_ACCESS_EXPIRATION_LOCK_KEY,
+                MODEL_ACCESS_EXPIRATION_LOCK_TTL,
+                async () => {
+                    const expired = await this.service.processAllDueGrants()
+                    const cursor = await this.readLifecycleCursor()
+                    const reconciled = await this.service.reconcileLifecycleBatch({
+                        ...cursor,
+                        limit: MODEL_ACCESS_LIFECYCLE_BATCH_SIZE
+                    })
+                    await this.writeLifecycleCursor({
+                        requestAfterId: reconciled.nextRequestAfterId,
+                        grantAfterId: reconciled.nextGrantAfterId
+                    })
+                    if (expired || reconciled.requests || reconciled.grants) {
+                        this.#logger.log(
+                            `model access lifecycle: expired=${expired}, requests=${reconciled.requests}, grants=${reconciled.grants}`
+                        )
+                    }
                 }
-            } finally {
-                await this.releaseLock(queryRunner)
-            }
+            )
         } catch (error) {
             this.#logger.error(`model access expiration failed: ${getErrorMessage(error)}`)
-        } finally {
-            if (connected) {
-                await queryRunner.release()
-            }
         }
     }
 
@@ -87,23 +77,14 @@ export class ModelAccessSchedulerService {
     private async writeLifecycleCursor(cursor: ModelAccessLifecycleCursor): Promise<void> {
         this.#lifecycleCursor = cursor
         try {
-            await this.cacheManager.set(
-                MODEL_ACCESS_LIFECYCLE_CURSOR_KEY,
-                cursor,
-                MODEL_ACCESS_LIFECYCLE_CURSOR_TTL
-            )
+            await this.cacheManager.set(MODEL_ACCESS_LIFECYCLE_CURSOR_KEY, cursor, MODEL_ACCESS_LIFECYCLE_CURSOR_TTL)
         } catch (error) {
             this.#logger.warn(`model access lifecycle cursor write failed: ${getErrorMessage(error)}`)
         }
     }
 
     private parseLifecycleCursor(value: unknown): ModelAccessLifecycleCursor | null {
-        if (
-            !value ||
-            typeof value !== 'object' ||
-            !('requestAfterId' in value) ||
-            !('grantAfterId' in value)
-        ) {
+        if (!value || typeof value !== 'object' || !('requestAfterId' in value) || !('grantAfterId' in value)) {
             return null
         }
         const requestAfterId = value.requestAfterId
@@ -116,33 +97,5 @@ export class ModelAccessSchedulerService {
 
     private isNullableCursorId(value: unknown): value is string | null {
         return value === null || typeof value === 'string'
-    }
-
-    private async acquireLock(queryRunner: QueryRunner): Promise<boolean> {
-        try {
-            const rows: unknown = await queryRunner.query('select pg_try_advisory_lock($1) as locked', [
-                MODEL_ACCESS_EXPIRATION_LOCK_KEY
-            ])
-            if (!Array.isArray(rows) || !rows.length) {
-                return false
-            }
-            const first = rows[0]
-            if (!first || typeof first !== 'object' || !('locked' in first)) {
-                return false
-            }
-            const locked = first.locked
-            return locked === true || locked === 't' || locked === 1
-        } catch (error) {
-            this.#logger.warn(`model access expiration lock unavailable: ${getErrorMessage(error)}`)
-            return false
-        }
-    }
-
-    private async releaseLock(queryRunner: QueryRunner): Promise<void> {
-        try {
-            await queryRunner.query('select pg_advisory_unlock($1)', [MODEL_ACCESS_EXPIRATION_LOCK_KEY])
-        } catch (error) {
-            this.#logger.warn(`model access expiration unlock failed: ${getErrorMessage(error)}`)
-        }
     }
 }

--- a/packages/server-ai/src/model-access/model-access.module.ts
+++ b/packages/server-ai/src/model-access/model-access.module.ts
@@ -1,4 +1,4 @@
-import { FeatureOrganization, Organization, User } from '@xpert-ai/server-core'
+import { FeatureOrganization, Organization, RedisModule, User } from '@xpert-ai/server-core'
 import { Module } from '@nestjs/common'
 import { CqrsModule } from '@nestjs/cqrs'
 import { RouterModule } from '@nestjs/core'
@@ -30,6 +30,7 @@ import { ModelGatewayPublication } from '../model-gateway/model-gateway-publicat
             FeatureOrganization
         ]),
         CqrsModule,
+        RedisModule,
         AIModelModule,
         MembershipModule
     ],

--- a/packages/server-ai/src/xpert-project/project.module.ts
+++ b/packages/server-ai/src/xpert-project/project.module.ts
@@ -1,4 +1,11 @@
-import { Feature, FeatureOrganization, FeatureModule, IntegrationModule, TenantModule } from '@xpert-ai/server-core'
+import {
+    Feature,
+    FeatureOrganization,
+    FeatureModule,
+    IntegrationModule,
+    RedisModule,
+    TenantModule
+} from '@xpert-ai/server-core'
 import { Module } from '@nestjs/common'
 import { CqrsModule } from '@nestjs/cqrs'
 import { TypeOrmModule } from '@nestjs/typeorm'
@@ -59,6 +66,7 @@ import { XpertWorkspaceModule } from '../xpert-workspace/workspace.module'
             FeatureOrganization
         ]),
         TenantModule,
+        RedisModule,
         FeatureModule,
         CqrsModule,
         IntegrationModule,

--- a/packages/server-ai/src/xpert-project/services/project-automation-scheduler.service.spec.ts
+++ b/packages/server-ai/src/xpert-project/services/project-automation-scheduler.service.spec.ts
@@ -1,0 +1,69 @@
+jest.mock('../entities/project-automation.entity', () => ({
+    XpertProjectAutomation: class XpertProjectAutomation {}
+}))
+
+jest.mock('./project-automation.service', () => ({
+    XpertProjectAutomationService: class XpertProjectAutomationService {}
+}))
+
+import { RedisLockRunResult, RedisLockService } from '@xpert-ai/server-core'
+import { Repository } from 'typeorm'
+import { XpertProjectAutomation } from '../entities/project-automation.entity'
+import { XpertProjectAutomationSchedulerService } from './project-automation-scheduler.service'
+import { XpertProjectAutomationService } from './project-automation.service'
+
+function createService() {
+    const queryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([])
+    }
+    const repository = {
+        createQueryBuilder: jest.fn(() => queryBuilder),
+        save: jest.fn()
+    }
+    const automationService = {
+        run: jest.fn()
+    }
+    const runWithLock = jest.fn<Promise<RedisLockRunResult<unknown>>, [string, number, () => Promise<unknown>]>(
+        async (_key, _ttl, operation) => ({
+            acquired: true,
+            value: await operation()
+        })
+    )
+    const redisLockService = {
+        runWithLock
+    }
+    const service = new XpertProjectAutomationSchedulerService(
+        repository as unknown as Repository<XpertProjectAutomation>,
+        automationService as unknown as XpertProjectAutomationService,
+        redisLockService as unknown as RedisLockService
+    )
+
+    return { queryBuilder, redisLockService, service }
+}
+
+describe('XpertProjectAutomationSchedulerService', () => {
+    it('scans due automations under a renewable Redis lock', async () => {
+        const { queryBuilder, redisLockService, service } = createService()
+
+        await service.scan()
+
+        expect(queryBuilder.getMany).toHaveBeenCalledTimes(1)
+        expect(redisLockService.runWithLock).toHaveBeenCalledWith(
+            'scheduler:xpert-project-automation',
+            5 * 60 * 1000,
+            expect.any(Function)
+        )
+    })
+
+    it('skips the database scan when another instance holds the Redis lock', async () => {
+        const { queryBuilder, redisLockService, service } = createService()
+        redisLockService.runWithLock.mockResolvedValueOnce({ acquired: false })
+
+        await service.scan()
+
+        expect(queryBuilder.getMany).not.toHaveBeenCalled()
+    })
+})

--- a/packages/server-ai/src/xpert-project/services/project-automation-scheduler.service.ts
+++ b/packages/server-ai/src/xpert-project/services/project-automation-scheduler.service.ts
@@ -2,29 +2,27 @@ import { Injectable, Logger } from '@nestjs/common'
 import { Cron } from '@nestjs/schedule'
 import { CronTime } from 'cron'
 import { InjectRepository } from '@nestjs/typeorm'
+import { RedisLockService } from '@xpert-ai/server-core'
 import { Repository } from 'typeorm'
 import { XpertProjectAutomation } from '../entities/project-automation.entity'
 import { XpertProjectAutomationService } from './project-automation.service'
 
+const PROJECT_AUTOMATION_LOCK_KEY = 'scheduler:xpert-project-automation'
+const PROJECT_AUTOMATION_LOCK_TTL = 5 * 60 * 1000
+
 @Injectable()
 export class XpertProjectAutomationSchedulerService {
     readonly #logger = new Logger(XpertProjectAutomationSchedulerService.name)
-    readonly #lockKey = 87124931
 
     constructor(
         @InjectRepository(XpertProjectAutomation) private readonly repository: Repository<XpertProjectAutomation>,
-        private readonly automationService: XpertProjectAutomationService
+        private readonly automationService: XpertProjectAutomationService,
+        private readonly redisLockService: RedisLockService
     ) {}
 
     @Cron('*/30 * * * * *')
     async scan() {
-        const queryRunner = this.repository.manager.connection.createQueryRunner()
-        await queryRunner.connect()
-        try {
-            const [{ locked }] = (await queryRunner.query('SELECT pg_try_advisory_lock($1) AS locked', [
-                this.#lockKey
-            ])) as Array<{ locked: boolean }>
-            if (!locked) return
+        await this.redisLockService.runWithLock(PROJECT_AUTOMATION_LOCK_KEY, PROJECT_AUTOMATION_LOCK_TTL, async () => {
             const due = await this.repository
                 .createQueryBuilder('automation')
                 .where('automation.enabled = :enabled', { enabled: true })
@@ -46,10 +44,7 @@ export class XpertProjectAutomationSchedulerService {
                     )
                 }
             }
-        } finally {
-            await queryRunner.query('SELECT pg_advisory_unlock($1)', [this.#lockKey]).catch(() => undefined)
-            await queryRunner.release()
-        }
+        })
     }
 }
 

--- a/packages/server-ai/src/xpert-task/xpert-task.module.ts
+++ b/packages/server-ai/src/xpert-task/xpert-task.module.ts
@@ -1,4 +1,4 @@
-import { ActorTokenModule, TenantModule } from '@xpert-ai/server-core'
+import { ActorTokenModule, RedisModule, TenantModule } from '@xpert-ai/server-core'
 import { Module, forwardRef } from '@nestjs/common'
 import { BullModule } from '@nestjs/bull'
 import { CqrsModule } from '@nestjs/cqrs'
@@ -32,6 +32,7 @@ import { XpertModule } from '../xpert/xpert.module'
             ScheduledTaskExecution
         ]),
         TenantModule,
+        RedisModule,
         ActorTokenModule,
         CqrsModule,
         forwardRef(() => XpertAgentModule),

--- a/packages/server-ai/src/xpert-task/xpert-task.service.spec.ts
+++ b/packages/server-ai/src/xpert-task/xpert-task.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@xpert-ai/contracts'
 import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import { SchedulerRegistry } from '@nestjs/schedule'
+import { RedisLockRunResult, RedisLockService } from '@xpert-ai/server-core'
 import { AgentMiddlewareRegistry } from '@xpert-ai/plugin-sdk'
 import { Repository, UpdateResult } from 'typeorm'
 import { of } from 'rxjs'
@@ -36,6 +37,33 @@ type AgentMiddlewareRegistryMock = {
 }
 
 describe('XpertTaskService', () => {
+    it('scans due auto tasks under a renewable Redis lock', async () => {
+        const autoTaskQuery = {
+            leftJoinAndSelect: jest.fn().mockReturnThis(),
+            where: jest.fn().mockReturnThis(),
+            andWhere: jest.fn().mockReturnThis(),
+            orderBy: jest.fn().mockReturnThis(),
+            take: jest.fn().mockReturnThis(),
+            getMany: jest.fn().mockResolvedValue([])
+        }
+        const autoTaskRepository = createRepositoryMock<AutoTask>()
+        jest.mocked(autoTaskRepository.createQueryBuilder).mockReturnValue(autoTaskQuery as never)
+        const redisLockService = createRedisLockServiceMock()
+        const service = createService(createCommandBusMock(), undefined, undefined, undefined, undefined, {
+            autoTaskRepository,
+            redisLockService
+        })
+
+        await service.runDueAutoTasks()
+
+        expect(autoTaskQuery.getMany).toHaveBeenCalledTimes(1)
+        expect(redisLockService.runWithLock).toHaveBeenCalledWith(
+            'scheduler:xpert-auto-task',
+            5 * 60 * 1000,
+            expect.any(Function)
+        )
+    })
+
     it('restores an archived task as paused without scheduling it', async () => {
         const service = createService(createCommandBusMock())
         const task = createTaskFixture({ status: ScheduleTaskStatus.ARCHIVED })
@@ -397,21 +425,40 @@ function createService(
     xpertService = createXpertServiceMock(),
     agentMiddlewareRegistry = createAgentMiddlewareRegistryMock(),
     repository = createRepositoryMock<XpertTask>(),
-    conversationRepository = createRepositoryMock<ChatConversation>()
+    conversationRepository = createRepositoryMock<ChatConversation>(),
+    options: {
+        autoTaskRepository?: Repository<AutoTask>
+        redisLockService?: ReturnType<typeof createRedisLockServiceMock>
+    } = {}
 ) {
+    const autoTaskRepository = options.autoTaskRepository ?? createRepositoryMock<AutoTask>()
+    const redisLockService = options.redisLockService ?? createRedisLockServiceMock()
     return new XpertTaskService(
         repository,
         createRepositoryMock<ScheduleNote>(),
         conversationRepository,
-        createRepositoryMock<AutoTask>(),
+        autoTaskRepository,
         createRepositoryMock<AutoTaskTemplate>(),
         createRepositoryMock<XpertTaskTemplate>(),
         createSchedulerRegistryMock(),
         xpertService as unknown as XpertService,
         agentMiddlewareRegistry as unknown as AgentMiddlewareRegistry,
         commandBus as unknown as CommandBus,
-        createQueryBusMock()
+        createQueryBusMock(),
+        redisLockService as unknown as RedisLockService
     )
+}
+
+function createRedisLockServiceMock() {
+    const runWithLock = jest.fn<Promise<RedisLockRunResult<unknown>>, [string, number, () => Promise<unknown>]>(
+        async (_key, _ttl, operation) => ({
+            acquired: true,
+            value: await operation()
+        })
+    )
+    return {
+        runWithLock
+    }
 }
 
 function createAgentMiddlewareRegistryMock(strategies: Record<string, unknown> = {}): AgentMiddlewareRegistryMock {

--- a/packages/server-ai/src/xpert-task/xpert-task.service.ts
+++ b/packages/server-ai/src/xpert-task/xpert-task.service.ts
@@ -22,7 +22,12 @@ import {
 import { AgentMiddlewareRegistry } from '@xpert-ai/plugin-sdk'
 import { getErrorMessage } from '@xpert-ai/server-common'
 import { ConfigService } from '@xpert-ai/server-config'
-import { OutboundActorTokenProvider, RequestContext, TenantOrganizationAwareCrudService } from '@xpert-ai/server-core'
+import {
+    OutboundActorTokenProvider,
+    RedisLockService,
+    RequestContext,
+    TenantOrganizationAwareCrudService
+} from '@xpert-ai/server-core'
 import { BadRequestException, Inject, Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common'
 import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import { Cron, SchedulerRegistry } from '@nestjs/schedule'
@@ -51,11 +56,12 @@ import {
 import { captureRequestContext, runWithCapturedRequestContext } from '../shared/request-context'
 
 const SCHEDULED_TASK_HEARTBEAT_MS = 60 * 1000
+const AUTO_TASK_CRON_LOCK_KEY = 'scheduler:xpert-auto-task'
+const AUTO_TASK_CRON_LOCK_TTL = 5 * 60 * 1000
 
 @Injectable()
 export class XpertTaskService extends TenantOrganizationAwareCrudService<XpertTask> implements OnModuleInit {
     readonly #logger = new Logger(XpertTaskService.name)
-    readonly #autoTaskCronLockKey = 90241001
 
     @Inject(ConfigService)
     protected readonly configService: ConfigService
@@ -78,6 +84,7 @@ export class XpertTaskService extends TenantOrganizationAwareCrudService<XpertTa
         private readonly agentMiddlewareRegistry: AgentMiddlewareRegistry,
         private readonly commandBus: CommandBus,
         private readonly queryBus: QueryBus,
+        private readonly redisLockService: RedisLockService,
         @Optional()
         private readonly outboundActorTokenProvider?: OutboundActorTokenProvider,
         @Optional()
@@ -157,10 +164,11 @@ export class XpertTaskService extends TenantOrganizationAwareCrudService<XpertTa
                     clearInterval(heartbeat)
                 }
                 if (scheduledExecution) {
-                    void this.finishScheduledTaskExecution(task, scheduledExecution, status, error)
-                        .catch((finishError) => {
+                    void this.finishScheduledTaskExecution(task, scheduledExecution, status, error).catch(
+                        (finishError) => {
                             this.#logger.error(`Scheduled task state update failed: ${getErrorMessage(finishError)}`)
-                        })
+                        }
+                    )
                 }
             }
 
@@ -350,17 +358,10 @@ export class XpertTaskService extends TenantOrganizationAwareCrudService<XpertTa
                     expiredExecution.scheduledAt
                 )
                 if (claimed) {
-                    await this.executeTask(
-                        task.id,
-                        { timeZone: task.timeZone },
-                        expiredExecution.scheduledAt,
-                        claimed
-                    )
+                    await this.executeTask(task.id, { timeZone: task.timeZone }, expiredExecution.scheduledAt, claimed)
                 }
             }).catch((error) => {
-                this.#logger.error(
-                    `Scheduled task recovery failed: ${expiredExecution.id} ${getErrorMessage(error)}`
-                )
+                this.#logger.error(`Scheduled task recovery failed: ${expiredExecution.id} ${getErrorMessage(error)}`)
             })
         }
     }
@@ -1683,13 +1684,8 @@ export class XpertTaskService extends TenantOrganizationAwareCrudService<XpertTa
 
     @Cron('0 * * * * *')
     async runDueAutoTasks() {
-        const lockAcquired = await this.acquireAutoTaskCronLock()
-        if (!lockAcquired) {
-            return
-        }
-
-        const now = new Date()
-        try {
+        await this.redisLockService.runWithLock(AUTO_TASK_CRON_LOCK_KEY, AUTO_TASK_CRON_LOCK_TTL, async () => {
+            const now = new Date()
             const dueTasks = await this.autoTaskRepository
                 .createQueryBuilder('task')
                 .leftJoinAndSelect('task.createdBy', 'createdBy')
@@ -1706,37 +1702,7 @@ export class XpertTaskService extends TenantOrganizationAwareCrudService<XpertTa
                     this.#logger.error(`Auto task execution failed: ${task.id} ${getErrorMessage(error)}`)
                 })
             }
-        } finally {
-            await this.releaseAutoTaskCronLock()
-        }
-    }
-
-    private async acquireAutoTaskCronLock(): Promise<boolean> {
-        try {
-            const rows = await this.autoTaskRepository.query('select pg_try_advisory_lock($1) as locked', [
-                this.#autoTaskCronLockKey
-            ])
-            if (!Array.isArray(rows) || rows.length === 0) {
-                return false
-            }
-            const first = rows[0]
-            if (!first || typeof first !== 'object' || !('locked' in first)) {
-                return false
-            }
-            const locked = first.locked
-            return locked === true || locked === 't' || locked === 1
-        } catch (error) {
-            this.#logger.warn(`Auto task cron lock unavailable, skip this tick: ${getErrorMessage(error)}`)
-            return false
-        }
-    }
-
-    private async releaseAutoTaskCronLock() {
-        try {
-            await this.autoTaskRepository.query('select pg_advisory_unlock($1)', [this.#autoTaskCronLockKey])
-        } catch (error) {
-            this.#logger.warn(`Auto task cron unlock failed: ${getErrorMessage(error)}`)
-        }
+        })
     }
 
     private async executeAutoTask(task: AutoTask) {

--- a/packages/server-ai/src/xpert/jobs/trigger-bootstrap-recovery.service.spec.ts
+++ b/packages/server-ai/src/xpert/jobs/trigger-bootstrap-recovery.service.spec.ts
@@ -3,229 +3,230 @@ import { XpertPublishTriggersCommand } from '../commands'
 import { XpertTriggerBootstrapRecoveryService } from './trigger-bootstrap-recovery.service'
 
 jest.mock('../xpert.entity', () => ({
-	Xpert: class MockXpert {}
+    Xpert: class MockXpert {}
 }))
 
 describe('XpertTriggerBootstrapRecoveryService', () => {
-	let logSpy: jest.SpyInstance
-	let warnSpy: jest.SpyInstance
-	let errorSpy: jest.SpyInstance
+    let logSpy: jest.SpyInstance
+    let warnSpy: jest.SpyInstance
+    let errorSpy: jest.SpyInstance
 
-	beforeEach(() => {
-		logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined)
-		warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined)
-		errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined)
-	})
+    beforeEach(() => {
+        logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined)
+        warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined)
+        errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined)
+    })
 
-	afterEach(() => {
-		jest.restoreAllMocks()
-	})
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
 
-	function createService(params?: {
-		xperts?: any[]
-		getProvider?: (provider: string) => any
-		lockId?: string | null
-		commandError?: Error | null
-	}) {
-		const repository = {
-			find: jest
-				.fn()
-				.mockResolvedValueOnce(params?.xperts ?? [])
-				.mockResolvedValueOnce([])
-		}
-		const commandBus = {
-			execute: params?.commandError
-				? jest.fn().mockRejectedValue(params.commandError)
-				: jest.fn().mockResolvedValue(undefined)
-		}
-		const triggerRegistry = {
-			get: jest.fn((provider: string) => params?.getProvider?.(provider))
-		}
-		const redisLockService = {
-			acquireLock: jest.fn().mockResolvedValue(params?.lockId ?? 'lock-id'),
-			releaseLock: jest.fn().mockResolvedValue(true)
-		}
+    function createService(params?: {
+        xperts?: any[]
+        getProvider?: (provider: string) => any
+        lockId?: string | null
+        commandError?: Error | null
+    }) {
+        const repository = {
+            find: jest
+                .fn()
+                .mockResolvedValueOnce(params?.xperts ?? [])
+                .mockResolvedValueOnce([])
+        }
+        const commandBus = {
+            execute: params?.commandError
+                ? jest.fn().mockRejectedValue(params.commandError)
+                : jest.fn().mockResolvedValue(undefined)
+        }
+        const triggerRegistry = {
+            get: jest.fn((provider: string) => params?.getProvider?.(provider))
+        }
+        const redisLockService = {
+            acquireLock: jest.fn().mockResolvedValue(params?.lockId ?? 'lock-id'),
+            releaseLock: jest.fn().mockResolvedValue(true)
+        }
 
-		const service = new XpertTriggerBootstrapRecoveryService(
-			repository as any,
-			commandBus as any,
-			triggerRegistry as any,
-			redisLockService as any
-		)
+        const service = new XpertTriggerBootstrapRecoveryService(
+            repository as any,
+            commandBus as any,
+            triggerRegistry as any,
+            redisLockService as any
+        )
 
-		return {
-			service,
-			repository,
-			commandBus,
-			triggerRegistry,
-			redisLockService
-		}
-	}
+        return {
+            service,
+            repository,
+            commandBus,
+            triggerRegistry,
+            redisLockService
+        }
+    }
 
-	it('replays only providers marked as replay_publish', async () => {
-		const owner = {
-			id: 'user-1',
-			tenantId: 'tenant-1',
-			preferredLanguage: 'en',
-			role: {
-				name: 'ADMIN'
-			}
-		}
-		const xpert = {
-			id: 'xpert-1',
-			tenantId: 'tenant-1',
-			organizationId: 'org-1',
-			createdBy: owner,
-			graph: {
-				nodes: [
-					{
-						type: 'workflow',
-						entity: {
-							type: 'trigger',
-							from: 'schedule',
-							config: { enabled: true, cron: '* * * * *', task: 'tick' }
-						}
-					},
-					{
-						type: 'workflow',
-						entity: {
-							type: 'trigger',
-							from: 'lark',
-							config: { enabled: true, integrationId: 'integration-1' }
-						}
-					}
-				]
-			}
-		}
+    it('replays only providers marked as replay_publish', async () => {
+        const owner = {
+            id: 'user-1',
+            tenantId: 'tenant-1',
+            preferredLanguage: 'en',
+            role: {
+                name: 'ADMIN'
+            }
+        }
+        const xpert = {
+            id: 'xpert-1',
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            createdBy: owner,
+            graph: {
+                nodes: [
+                    {
+                        type: 'workflow',
+                        entity: {
+                            type: 'trigger',
+                            from: 'schedule',
+                            config: { enabled: true, cron: '* * * * *', task: 'tick' }
+                        }
+                    },
+                    {
+                        type: 'workflow',
+                        entity: {
+                            type: 'trigger',
+                            from: 'lark',
+                            config: { enabled: true, integrationId: 'integration-1' }
+                        }
+                    }
+                ]
+            }
+        }
 
-		const { service, commandBus, redisLockService } = createService({
-			xperts: [xpert],
-			getProvider: (provider) => {
-				if (provider === 'schedule') {
-					return {
-						bootstrap: {
-							mode: 'replay_publish',
-							critical: false
-						}
-					}
-				}
-				if (provider === 'lark') {
-					return {
-						bootstrap: {
-							mode: 'skip',
-							critical: false
-						}
-					}
-				}
-				throw new Error(`Unexpected provider ${provider}`)
-			}
-		})
+        const { service, commandBus, redisLockService } = createService({
+            xperts: [xpert],
+            getProvider: (provider) => {
+                if (provider === 'schedule') {
+                    return {
+                        bootstrap: {
+                            mode: 'replay_publish',
+                            critical: false
+                        }
+                    }
+                }
+                if (provider === 'lark') {
+                    return {
+                        bootstrap: {
+                            mode: 'skip',
+                            critical: false
+                        }
+                    }
+                }
+                throw new Error(`Unexpected provider ${provider}`)
+            }
+        })
 
-		await service.onApplicationBootstrap()
+        await service.onApplicationBootstrap()
 
-		expect(commandBus.execute).toHaveBeenCalledTimes(1)
-		const [command] = commandBus.execute.mock.calls[0]
-		expect(command).toBeInstanceOf(XpertPublishTriggersCommand)
-		expect(command.options).toEqual(
-			expect.objectContaining({
-				strict: false,
-				providers: ['schedule'],
-				context: {
-					user: owner,
-					tenantId: 'tenant-1',
-					organizationId: 'org-1',
-					language: 'en'
-				}
-			})
-		)
-		expect(redisLockService.releaseLock).toHaveBeenCalledWith('job:trigger:xpert-1', 'lock-id')
-	})
+        expect(commandBus.execute).toHaveBeenCalledTimes(1)
+        const [command] = commandBus.execute.mock.calls[0]
+        expect(command).toBeInstanceOf(XpertPublishTriggersCommand)
+        expect(command.options).toEqual(
+            expect.objectContaining({
+                strict: false,
+                providers: ['schedule'],
+                context: {
+                    user: owner,
+                    tenantId: 'tenant-1',
+                    organizationId: 'org-1',
+                    language: 'en'
+                }
+            })
+        )
+        expect(redisLockService.acquireLock).toHaveBeenCalledWith('job:trigger:v2:xpert-1', 10000)
+        expect(redisLockService.releaseLock).toHaveBeenCalledWith('job:trigger:v2:xpert-1', 'lock-id')
+    })
 
-	it('fails open when provider is missing and records failure summary', async () => {
-		const { service, commandBus } = createService({
-			xperts: [
-				{
-					id: 'xpert-1',
-					graph: {
-						nodes: [
-							{
-								type: 'workflow',
-								entity: {
-									type: 'trigger',
-									from: 'unknown',
-									config: {}
-								}
-							}
-						]
-					}
-				}
-			],
-			getProvider: () => {
-				throw new Error('provider-not-found')
-			}
-		})
+    it('fails open when provider is missing and records failure summary', async () => {
+        const { service, commandBus } = createService({
+            xperts: [
+                {
+                    id: 'xpert-1',
+                    graph: {
+                        nodes: [
+                            {
+                                type: 'workflow',
+                                entity: {
+                                    type: 'trigger',
+                                    from: 'unknown',
+                                    config: {}
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            getProvider: () => {
+                throw new Error('provider-not-found')
+            }
+        })
 
-		await expect(service.onApplicationBootstrap()).resolves.toBeUndefined()
+        await expect(service.onApplicationBootstrap()).resolves.toBeUndefined()
 
-		expect(commandBus.execute).not.toHaveBeenCalled()
-		expect(
-			warnSpy.mock.calls.some(
-				([message]) =>
-					typeof message === 'string' &&
-					message.includes('"phase":"bootstrap_recovery"') &&
-					message.includes('"provider":"unknown"') &&
-					message.includes('"result":"failed"')
-			)
-		).toBe(true)
-		expect(
-			logSpy.mock.calls.some(
-				([message]) =>
-					typeof message === 'string' &&
-					message.includes('"phase":"bootstrap_recovery_summary"') &&
-					message.includes('"failed":1')
-			)
-		).toBe(true)
-	})
+        expect(commandBus.execute).not.toHaveBeenCalled()
+        expect(
+            warnSpy.mock.calls.some(
+                ([message]) =>
+                    typeof message === 'string' &&
+                    message.includes('"phase":"bootstrap_recovery"') &&
+                    message.includes('"provider":"unknown"') &&
+                    message.includes('"result":"failed"')
+            )
+        ).toBe(true)
+        expect(
+            logSpy.mock.calls.some(
+                ([message]) =>
+                    typeof message === 'string' &&
+                    message.includes('"phase":"bootstrap_recovery_summary"') &&
+                    message.includes('"failed":1')
+            )
+        ).toBe(true)
+    })
 
-	it('releases redis lock in finally when replay command fails', async () => {
-		const { service, redisLockService } = createService({
-			xperts: [
-				{
-					id: 'xpert-1',
-					graph: {
-						nodes: [
-							{
-								type: 'workflow',
-								entity: {
-									type: 'trigger',
-									from: 'schedule',
-									config: { enabled: true, cron: '* * * * *', task: 'tick' }
-								}
-							}
-						]
-					}
-				}
-			],
-			getProvider: () => ({
-				bootstrap: {
-					mode: 'replay_publish',
-					critical: false
-				}
-			}),
-			commandError: new Error('publish failed')
-		})
+    it('releases redis lock in finally when replay command fails', async () => {
+        const { service, redisLockService } = createService({
+            xperts: [
+                {
+                    id: 'xpert-1',
+                    graph: {
+                        nodes: [
+                            {
+                                type: 'workflow',
+                                entity: {
+                                    type: 'trigger',
+                                    from: 'schedule',
+                                    config: { enabled: true, cron: '* * * * *', task: 'tick' }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            getProvider: () => ({
+                bootstrap: {
+                    mode: 'replay_publish',
+                    critical: false
+                }
+            }),
+            commandError: new Error('publish failed')
+        })
 
-		await expect(service.onApplicationBootstrap()).resolves.toBeUndefined()
+        await expect(service.onApplicationBootstrap()).resolves.toBeUndefined()
 
-		expect(redisLockService.releaseLock).toHaveBeenCalledWith('job:trigger:xpert-1', 'lock-id')
-		expect(
-			errorSpy.mock.calls.some(
-				([message]) =>
-					typeof message === 'string' &&
-					message.includes('"phase":"bootstrap_recovery"') &&
-					message.includes('"result":"failed"') &&
-					message.includes('publish failed')
-			)
-		).toBe(true)
-	})
+        expect(redisLockService.releaseLock).toHaveBeenCalledWith('job:trigger:v2:xpert-1', 'lock-id')
+        expect(
+            errorSpy.mock.calls.some(
+                ([message]) =>
+                    typeof message === 'string' &&
+                    message.includes('"phase":"bootstrap_recovery"') &&
+                    message.includes('"result":"failed"') &&
+                    message.includes('publish failed')
+            )
+        ).toBe(true)
+    })
 })

--- a/packages/server-ai/src/xpert/jobs/trigger-bootstrap-recovery.service.ts
+++ b/packages/server-ai/src/xpert/jobs/trigger-bootstrap-recovery.service.ts
@@ -5,256 +5,257 @@ import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common'
 import { CommandBus } from '@nestjs/cqrs'
 import { InjectRepository } from '@nestjs/typeorm'
 import {
-	IWorkflowTriggerStrategy,
-	TWorkflowTriggerBootstrapConfig,
-	WorkflowTriggerRegistry
+    IWorkflowTriggerStrategy,
+    TWorkflowTriggerBootstrapConfig,
+    WorkflowTriggerRegistry
 } from '@xpert-ai/plugin-sdk'
 import { IsNull, Not, Repository } from 'typeorm'
 import { XpertPublishTriggersCommand } from '../commands'
 import { Xpert } from '../xpert.entity'
 
 type TRecoveryCounters = {
-	scanned_xperts: number
-	replayed: number
-	skipped: number
-	failed: number
+    scanned_xperts: number
+    replayed: number
+    skipped: number
+    failed: number
 }
 
 type TResolvedBootstrap = {
-	missing: boolean
-	bootstrap: TWorkflowTriggerBootstrapConfig
+    missing: boolean
+    bootstrap: TWorkflowTriggerBootstrapConfig
 }
 
 const DEFAULT_BOOTSTRAP: TWorkflowTriggerBootstrapConfig = {
-	mode: 'replay_publish',
-	critical: false
+    mode: 'replay_publish',
+    critical: false
 }
+
+// v1 keys can be persistent because the former node-redis call did not apply PX.
+const TRIGGER_BOOTSTRAP_LOCK_PREFIX = 'job:trigger:v2'
 
 @Injectable()
 export class XpertTriggerBootstrapRecoveryService implements OnApplicationBootstrap {
-	readonly #logger = new Logger(XpertTriggerBootstrapRecoveryService.name)
-	readonly #batchSize = 50
-	readonly #providerBootstrapCache = new Map<string, TResolvedBootstrap>()
+    readonly #logger = new Logger(XpertTriggerBootstrapRecoveryService.name)
+    readonly #batchSize = 50
+    readonly #providerBootstrapCache = new Map<string, TResolvedBootstrap>()
 
-	constructor(
-		@InjectRepository(Xpert)
-		private readonly repository: Repository<Xpert>,
-		private readonly commandBus: CommandBus,
-		private readonly triggerRegistry: WorkflowTriggerRegistry,
-		private readonly redisLockService: RedisLockService
-	) {}
+    constructor(
+        @InjectRepository(Xpert)
+        private readonly repository: Repository<Xpert>,
+        private readonly commandBus: CommandBus,
+        private readonly triggerRegistry: WorkflowTriggerRegistry,
+        private readonly redisLockService: RedisLockService
+    ) {}
 
-	async onApplicationBootstrap() {
-		const counters: TRecoveryCounters = {
-			scanned_xperts: 0,
-			replayed: 0,
-			skipped: 0,
-			failed: 0
-		}
+    async onApplicationBootstrap() {
+        const counters: TRecoveryCounters = {
+            scanned_xperts: 0,
+            replayed: 0,
+            skipped: 0,
+            failed: 0
+        }
 
-		let page = 0
-		while (true) {
-			const items = await this.repository.find({
-				where: {
-					latest: true,
-					publishAt: Not(IsNull())
-				},
-				relations: ['createdBy', 'createdBy.role'],
-				order: {
-					createdAt: 'ASC'
-				},
-				skip: page * this.#batchSize,
-				take: this.#batchSize
-			})
-			if (!items.length) {
-				break
-			}
+        let page = 0
+        while (true) {
+            const items = await this.repository.find({
+                where: {
+                    latest: true,
+                    publishAt: Not(IsNull())
+                },
+                relations: ['createdBy', 'createdBy.role'],
+                order: {
+                    createdAt: 'ASC'
+                },
+                skip: page * this.#batchSize,
+                take: this.#batchSize
+            })
+            if (!items.length) {
+                break
+            }
 
-			for (const xpert of items) {
-				counters.scanned_xperts += 1
-				await this.recoverXpert(xpert, counters)
-			}
+            for (const xpert of items) {
+                counters.scanned_xperts += 1
+                await this.recoverXpert(xpert, counters)
+            }
 
-			if (items.length < this.#batchSize) {
-				break
-			}
-			page += 1
-		}
+            if (items.length < this.#batchSize) {
+                break
+            }
+            page += 1
+        }
 
-		this.#logger.log(
-			JSON.stringify({
-				phase: 'bootstrap_recovery_summary',
-				...counters
-			})
-		)
-	}
+        this.#logger.log(
+            JSON.stringify({
+                phase: 'bootstrap_recovery_summary',
+                ...counters
+            })
+        )
+    }
 
-	private async recoverXpert(xpert: Xpert, counters: TRecoveryCounters) {
-		const providers = this.listTriggerProviders(xpert)
-		if (!providers.length) {
-			return
-		}
+    private async recoverXpert(xpert: Xpert, counters: TRecoveryCounters) {
+        const providers = this.listTriggerProviders(xpert)
+        if (!providers.length) {
+            return
+        }
 
-		const replayProviders: string[] = []
-		for (const providerName of providers) {
-			const resolved = this.resolveBootstrap(providerName)
-			if (resolved.missing) {
-				counters.failed += 1
-				this.logEvent('warn', {
-					xpertId: xpert.id,
-					provider: providerName,
-					result: 'failed',
-					error: `Trigger provider "${providerName}" not found`
-				})
-				continue
-			}
+        const replayProviders: string[] = []
+        for (const providerName of providers) {
+            const resolved = this.resolveBootstrap(providerName)
+            if (resolved.missing) {
+                counters.failed += 1
+                this.logEvent('warn', {
+                    xpertId: xpert.id,
+                    provider: providerName,
+                    result: 'failed',
+                    error: `Trigger provider "${providerName}" not found`
+                })
+                continue
+            }
 
-			if (resolved.bootstrap.mode === 'skip') {
-				counters.skipped += 1
-				this.logEvent('log', {
-					xpertId: xpert.id,
-					provider: providerName,
-					result: 'skipped'
-				})
-				continue
-			}
+            if (resolved.bootstrap.mode === 'skip') {
+                counters.skipped += 1
+                this.logEvent('log', {
+                    xpertId: xpert.id,
+                    provider: providerName,
+                    result: 'skipped'
+                })
+                continue
+            }
 
-			replayProviders.push(providerName)
-		}
+            replayProviders.push(providerName)
+        }
 
-		if (!replayProviders.length) {
-			return
-		}
+        if (!replayProviders.length) {
+            return
+        }
 
-		const lockKey = 'job:trigger:' + xpert.id
-		const lockId = await this.redisLockService.acquireLock(lockKey, 10000)
-		if (!lockId) {
-			counters.skipped += replayProviders.length
-			for (const provider of replayProviders) {
-				this.logEvent('warn', {
-					xpertId: xpert.id,
-					provider,
-					result: 'skipped',
-					error: 'Lock not acquired'
-				})
-			}
-			return
-		}
+        const lockKey = `${TRIGGER_BOOTSTRAP_LOCK_PREFIX}:${xpert.id}`
+        const lockId = await this.redisLockService.acquireLock(lockKey, 10000)
+        if (!lockId) {
+            counters.skipped += replayProviders.length
+            for (const provider of replayProviders) {
+                this.logEvent('warn', {
+                    xpertId: xpert.id,
+                    provider,
+                    result: 'skipped',
+                    error: 'Lock not acquired'
+                })
+            }
+            return
+        }
 
-		try {
-			await this.commandBus.execute(
-				new XpertPublishTriggersCommand(xpert, {
-					strict: false,
-					providers: replayProviders,
-					context: {
-						user: xpert.createdBy ?? null,
-						tenantId: xpert.tenantId,
-						organizationId: xpert.organizationId,
-						language: xpert.createdBy?.preferredLanguage
-					}
-				})
-			)
+        try {
+            await this.commandBus.execute(
+                new XpertPublishTriggersCommand(xpert, {
+                    strict: false,
+                    providers: replayProviders,
+                    context: {
+                        user: xpert.createdBy ?? null,
+                        tenantId: xpert.tenantId,
+                        organizationId: xpert.organizationId,
+                        language: xpert.createdBy?.preferredLanguage
+                    }
+                })
+            )
 
-			counters.replayed += replayProviders.length
-			for (const provider of replayProviders) {
-				this.logEvent('log', {
-					xpertId: xpert.id,
-					provider,
-					result: 'replayed'
-				})
-			}
-		} catch (error) {
-			counters.failed += replayProviders.length
-			for (const provider of replayProviders) {
-				this.logEvent('error', {
-					xpertId: xpert.id,
-					provider,
-					result: 'failed',
-					error: getErrorMessage(error)
-				})
-			}
-		} finally {
-			try {
-				await this.redisLockService.releaseLock(lockKey, lockId)
-			} catch (error) {
-				this.logEvent('warn', {
-					xpertId: xpert.id,
-					provider: replayProviders.join(','),
-					result: 'failed',
-					error: `Release lock failed: ${getErrorMessage(error)}`
-				})
-			}
-		}
-	}
+            counters.replayed += replayProviders.length
+            for (const provider of replayProviders) {
+                this.logEvent('log', {
+                    xpertId: xpert.id,
+                    provider,
+                    result: 'replayed'
+                })
+            }
+        } catch (error) {
+            counters.failed += replayProviders.length
+            for (const provider of replayProviders) {
+                this.logEvent('error', {
+                    xpertId: xpert.id,
+                    provider,
+                    result: 'failed',
+                    error: getErrorMessage(error)
+                })
+            }
+        } finally {
+            try {
+                await this.redisLockService.releaseLock(lockKey, lockId)
+            } catch (error) {
+                this.logEvent('warn', {
+                    xpertId: xpert.id,
+                    provider: replayProviders.join(','),
+                    result: 'failed',
+                    error: `Release lock failed: ${getErrorMessage(error)}`
+                })
+            }
+        }
+    }
 
-	private resolveBootstrap(providerName: string): TResolvedBootstrap {
-		if (this.#providerBootstrapCache.has(providerName)) {
-			return this.#providerBootstrapCache.get(providerName)!
-		}
+    private resolveBootstrap(providerName: string): TResolvedBootstrap {
+        if (this.#providerBootstrapCache.has(providerName)) {
+            return this.#providerBootstrapCache.get(providerName)!
+        }
 
-		let resolved: TResolvedBootstrap = {
-			missing: false,
-			bootstrap: DEFAULT_BOOTSTRAP
-		}
+        let resolved: TResolvedBootstrap = {
+            missing: false,
+            bootstrap: DEFAULT_BOOTSTRAP
+        }
 
-		try {
-			const provider = this.triggerRegistry.get(providerName)
-			resolved = {
-				missing: false,
-				bootstrap: this.normalizeBootstrap(provider)
-			}
-		} catch {
-			resolved = {
-				missing: true,
-				bootstrap: DEFAULT_BOOTSTRAP
-			}
-		}
+        try {
+            const provider = this.triggerRegistry.get(providerName)
+            resolved = {
+                missing: false,
+                bootstrap: this.normalizeBootstrap(provider)
+            }
+        } catch {
+            resolved = {
+                missing: true,
+                bootstrap: DEFAULT_BOOTSTRAP
+            }
+        }
 
-		this.#providerBootstrapCache.set(providerName, resolved)
-		return resolved
-	}
+        this.#providerBootstrapCache.set(providerName, resolved)
+        return resolved
+    }
 
-	private normalizeBootstrap(
-		provider: IWorkflowTriggerStrategy<any>
-	): TWorkflowTriggerBootstrapConfig {
-		if (!provider.bootstrap) {
-			return DEFAULT_BOOTSTRAP
-		}
-		return {
-			mode: provider.bootstrap.mode ?? 'replay_publish',
-			critical: provider.bootstrap.critical ?? false
-		}
-	}
+    private normalizeBootstrap(provider: IWorkflowTriggerStrategy<any>): TWorkflowTriggerBootstrapConfig {
+        if (!provider.bootstrap) {
+            return DEFAULT_BOOTSTRAP
+        }
+        return {
+            mode: provider.bootstrap.mode ?? 'replay_publish',
+            critical: provider.bootstrap.critical ?? false
+        }
+    }
 
-	private listTriggerProviders(xpert: Xpert): string[] {
-		const providers = new Set<string>()
-		for (const node of xpert.graph?.nodes ?? []) {
-			if (node.type !== 'workflow') {
-				continue
-			}
-			if (node.entity.type !== WorkflowNodeTypeEnum.TRIGGER) {
-				continue
-			}
-			const trigger = node.entity as IWFNTrigger
-			if (!trigger.from || trigger.from === 'chat') {
-				continue
-			}
-			providers.add(trigger.from)
-		}
-		return Array.from(providers.values())
-	}
+    private listTriggerProviders(xpert: Xpert): string[] {
+        const providers = new Set<string>()
+        for (const node of xpert.graph?.nodes ?? []) {
+            if (node.type !== 'workflow') {
+                continue
+            }
+            if (node.entity.type !== WorkflowNodeTypeEnum.TRIGGER) {
+                continue
+            }
+            const trigger = node.entity as IWFNTrigger
+            if (!trigger.from || trigger.from === 'chat') {
+                continue
+            }
+            providers.add(trigger.from)
+        }
+        return Array.from(providers.values())
+    }
 
-	private logEvent(level: 'log' | 'warn' | 'error', payload: Record<string, string>) {
-		const message = JSON.stringify({
-			phase: 'bootstrap_recovery',
-			...payload
-		})
-		if (level === 'error') {
-			this.#logger.error(message)
-		} else if (level === 'warn') {
-			this.#logger.warn(message)
-		} else {
-			this.#logger.log(message)
-		}
-	}
+    private logEvent(level: 'log' | 'warn' | 'error', payload: Record<string, string>) {
+        const message = JSON.stringify({
+            phase: 'bootstrap_recovery',
+            ...payload
+        })
+        if (level === 'error') {
+            this.#logger.error(message)
+        } else if (level === 'warn') {
+            this.#logger.warn(message)
+        } else {
+            this.#logger.log(message)
+        }
+    }
 }

--- a/packages/server/src/core/redis/redis-lock.service.spec.ts
+++ b/packages/server/src/core/redis/redis-lock.service.spec.ts
@@ -1,0 +1,73 @@
+import { RedisLockService } from './redis-lock.service'
+
+function createService() {
+	const redis = {
+		set: jest.fn().mockResolvedValue('OK'),
+		eval: jest.fn().mockResolvedValue(1)
+	}
+	const service = new RedisLockService()
+	Reflect.set(service, 'redis', redis)
+
+	return { redis, service }
+}
+
+describe('RedisLockService', () => {
+	afterEach(() => {
+		jest.useRealTimers()
+	})
+
+	it('skips the operation when the lock is already held', async () => {
+		const { redis, service } = createService()
+		redis.set.mockResolvedValueOnce(null)
+		const operation = jest.fn()
+
+		await expect(service.runWithLock('scheduler:test', 300, operation)).resolves.toEqual({ acquired: false })
+
+		expect(operation).not.toHaveBeenCalled()
+		expect(redis.eval).not.toHaveBeenCalled()
+	})
+
+	it('refreshes a long-running lock and releases it after the operation completes', async () => {
+		jest.useFakeTimers()
+		const { redis, service } = createService()
+		let finishOperation: () => void = () => undefined
+		const operation = jest.fn(
+			() =>
+				new Promise<string>((resolve) => {
+					finishOperation = () => resolve('done')
+				})
+		)
+
+		const resultPromise = service.runWithLock('scheduler:test', 300, operation)
+		await Promise.resolve()
+		await jest.advanceTimersByTimeAsync(100)
+
+		expect(redis.set).toHaveBeenCalledWith('scheduler:test', expect.any(String), { PX: 300, NX: true })
+		expect(redis.eval).toHaveBeenCalledWith(expect.stringContaining('pexpire'), {
+			keys: ['scheduler:test'],
+			arguments: [expect.any(String), '300']
+		})
+
+		finishOperation()
+		await expect(resultPromise).resolves.toEqual({ acquired: true, value: 'done' })
+		expect(redis.eval).toHaveBeenCalledWith(expect.stringContaining('del'), {
+			keys: ['scheduler:test'],
+			arguments: [expect.any(String)]
+		})
+	})
+
+	it('releases the lock when the operation fails', async () => {
+		const { redis, service } = createService()
+
+		await expect(
+			service.runWithLock('scheduler:test', 300, async () => {
+				throw new Error('operation failed')
+			})
+		).rejects.toThrow('operation failed')
+
+		expect(redis.eval).toHaveBeenCalledWith(expect.stringContaining('del'), {
+			keys: ['scheduler:test'],
+			arguments: [expect.any(String)]
+		})
+	})
+})

--- a/packages/server/src/core/redis/redis-lock.service.ts
+++ b/packages/server/src/core/redis/redis-lock.service.ts
@@ -1,6 +1,7 @@
-import { Inject, Injectable } from '@nestjs/common'
+import { Inject, Injectable, Logger } from '@nestjs/common'
 import { randomUUID } from 'crypto'
-import { Redis } from 'ioredis'
+import type { RedisClientType } from 'redis'
+import { getErrorMessage } from '@xpert-ai/server-common'
 import { REDIS_CLIENT } from './types'
 
 const RELEASE_LOCK_SCRIPT = `
@@ -21,27 +22,91 @@ const REFRESH_LOCK_SCRIPT = `
   end
 `
 
+export type RedisLockRunResult<T> = { acquired: false } | { acquired: true; value: T }
+
 @Injectable()
 export class RedisLockService {
+	readonly #logger = new Logger(RedisLockService.name)
+
 	@Inject(REDIS_CLIENT)
-	private redis: Redis
+	private redis: RedisClientType
 
 	// Try to acquire lock
 	async acquireLock(key: string, ttl = 30000): Promise<string | null> {
 		const lockId = randomUUID()
-		const result = await this.redis.set(key, lockId, 'PX', ttl, 'NX')
+		const result = await this.redis.set(key, lockId, { PX: ttl, NX: true })
 		return result === 'OK' ? lockId : null
 	}
 
 	// Release lock (only if lockId matches)
 	async releaseLock(key: string, lockId: string): Promise<boolean> {
-		const result = await this.redis.eval(RELEASE_LOCK_SCRIPT, 1, key, lockId)
+		const result = await this.redis.eval(RELEASE_LOCK_SCRIPT, {
+			keys: [key],
+			arguments: [lockId]
+		})
 		return result === 1
 	}
 
 	// Refresh lock TTL (only if lockId matches)
 	async refreshLock(key: string, lockId: string, ttl: number): Promise<boolean> {
-		const result = await this.redis.eval(REFRESH_LOCK_SCRIPT, 1, key, lockId, `${ttl}`)
+		const result = await this.redis.eval(REFRESH_LOCK_SCRIPT, {
+			keys: [key],
+			arguments: [lockId, `${ttl}`]
+		})
 		return result === 1
+	}
+
+	async runWithLock<T>(key: string, ttl: number, operation: () => Promise<T>): Promise<RedisLockRunResult<T>> {
+		let acquiredLockId: string | null
+		try {
+			acquiredLockId = await this.acquireLock(key, ttl)
+		} catch (error) {
+			this.#logger.warn(`Redis lock '${key}' unavailable: ${getErrorMessage(error)}`)
+			return { acquired: false }
+		}
+		if (!acquiredLockId) {
+			return { acquired: false }
+		}
+		const lockId = acquiredLockId
+
+		let refreshInFlight: Promise<void> | null = null
+		const refreshInterval = setInterval(
+			() => {
+				if (refreshInFlight) {
+					return
+				}
+				refreshInFlight = this.refreshLock(key, lockId, ttl)
+					.then((refreshed) => {
+						if (!refreshed) {
+							this.#logger.warn(`Redis lock '${key}' was lost while the operation was still running`)
+						}
+					})
+					.catch((error) => {
+						this.#logger.warn(`Redis lock '${key}' refresh failed: ${getErrorMessage(error)}`)
+					})
+					.finally(() => {
+						refreshInFlight = null
+					})
+			},
+			Math.max(1, Math.floor(ttl / 3))
+		)
+		refreshInterval.unref()
+
+		try {
+			return { acquired: true, value: await operation() }
+		} finally {
+			clearInterval(refreshInterval)
+			if (refreshInFlight) {
+				await refreshInFlight
+			}
+			try {
+				const released = await this.releaseLock(key, lockId)
+				if (!released) {
+					this.#logger.warn(`Redis lock '${key}' was not released because ownership had changed`)
+				}
+			} catch (error) {
+				this.#logger.warn(`Redis lock '${key}' release failed: ${getErrorMessage(error)}`)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- replace PostgreSQL session advisory locks in four scheduled jobs with the existing `RedisLockService`
- fix `RedisLockService` to use node-redis lock options, token-safe renewal, and token-safe release
- version the trigger bootstrap recovery lock key so legacy non-expiring keys cannot block recovery forever
- add focused scheduler and Redis lock tests

## Why

The scheduled jobs held PostgreSQL session locks on pooled connections. In particular, a lock could be acquired and released through different pooled sessions, leaving a connection occupied and starving login requests when the local pool was small. Redis provides a shared lock without reserving database connections.

The existing Redis helper also passed ioredis-style positional arguments to node-redis, so `NX`/`PX` were not reliably applied. This change uses the node-redis API and identifies each lock with a unique token before renewal or release.

## Validation

- 24 focused Jest tests passed across `server` and `server-ai`
- real Redis smoke covered mutual exclusion, positive TTL, renewal, ownership-safe release, and cleanup
- `server-ai` build passed in the source checkout
- pre-commit hook ran normally and reformatted all 16 staged files as unchanged
- hardcoded color check, TypeORM column type check, and `git diff --check` passed

The isolated worktree reused the source checkout through a `node_modules` symlink. A second build there reached unchanged `xpert-tool` files and reported TS2742 paths pointing back to the source checkout; this is a worktree dependency-path limitation, not a Redis lock compilation error.
