### PR TITLE
[codex] Fix MCP OAuth apps and ChatKit elicitation

### DIFF
--- a/apps/cloud/src/app/@shared/mcp/server/server.component.ts
+++ b/apps/cloud/src/app/@shared/mcp/server/server.component.ts
@@ -152,7 +152,7 @@ export class MCPServerFormComponent {
       workspaceId: this.workspaceId(),
       category: XpertToolsetCategoryEnum.MCP,
       type: this.types()[0],
-      id: this.#tempId(),
+      id: this.toolsetId() ?? this.#tempId(),
       schema: JSON.stringify({
         mcpServers: {
           '': {

--- a/packages/server-ai/src/ai/queries/handlers/thread-find.handler.spec.ts
+++ b/packages/server-ai/src/ai/queries/handlers/thread-find.handler.spec.ts
@@ -1,0 +1,53 @@
+import { QueryBus } from '@nestjs/cqrs'
+import { FindThreadQuery } from '../thread-find.query'
+import { FindThreadHandler } from './thread-find.handler'
+
+describe('FindThreadHandler', () => {
+    it('returns an empty thread state before the first checkpoint is created', async () => {
+        const queryBus = Object.create(QueryBus.prototype) as QueryBus
+        queryBus.execute = jest
+            .fn()
+            .mockResolvedValueOnce({
+                id: 'conversation-1',
+                threadId: 'thread-1',
+                status: 'idle',
+                xpertId: 'xpert-1'
+            })
+            .mockResolvedValueOnce(undefined)
+        const handler = new FindThreadHandler(queryBus)
+
+        await expect(handler.execute(new FindThreadQuery('thread-1'))).resolves.toMatchObject({
+            threadId: 'thread-1',
+            metadata: {
+                assistant_id: 'xpert-1'
+            },
+            values: {}
+        })
+    })
+
+    it('returns the persisted state when a checkpoint exists', async () => {
+        const queryBus = Object.create(QueryBus.prototype) as QueryBus
+        queryBus.execute = jest
+            .fn()
+            .mockResolvedValueOnce({
+                id: 'conversation-1',
+                threadId: 'thread-1',
+                status: 'idle',
+                xpertId: 'xpert-1'
+            })
+            .mockResolvedValueOnce({
+                checkpoint: {
+                    channel_values: {
+                        messages: [{ id: 'message-1' }]
+                    }
+                }
+            })
+        const handler = new FindThreadHandler(queryBus)
+
+        await expect(handler.execute(new FindThreadQuery('thread-1'))).resolves.toMatchObject({
+            values: {
+                messages: [{ id: 'message-1' }]
+            }
+        })
+    })
+})

--- a/packages/server-ai/src/ai/queries/handlers/thread-find.handler.ts
+++ b/packages/server-ai/src/ai/queries/handlers/thread-find.handler.ts
@@ -7,21 +7,21 @@ import { FindThreadQuery } from '../thread-find.query'
 
 @QueryHandler(FindThreadQuery)
 export class FindThreadHandler implements IQueryHandler<FindThreadQuery> {
-	constructor(private readonly queryBus: QueryBus) {}
+    constructor(private readonly queryBus: QueryBus) {}
 
-	public async execute(command: FindThreadQuery): Promise<ThreadDTO> {
-		const chatConversation = await this.queryBus.execute(
-			new GetChatConversationQuery({ threadId: command.threadId }, command.relations)
-		)
-		assertPublicXpertSessionConversationAccess(chatConversation)
+    public async execute(command: FindThreadQuery): Promise<ThreadDTO> {
+        const chatConversation = await this.queryBus.execute(
+            new GetChatConversationQuery({ threadId: command.threadId }, command.relations)
+        )
+        assertPublicXpertSessionConversationAccess(chatConversation)
 
-		const tuple = await this.queryBus.execute(
-			new CopilotCheckpointGetTupleQuery({
-				thread_id: command.threadId,
-				checkpoint_ns: ''
-			})
-		)
+        const tuple = await this.queryBus.execute(
+            new CopilotCheckpointGetTupleQuery({
+                thread_id: command.threadId,
+                checkpoint_ns: ''
+            })
+        )
 
-		return new ThreadDTO(chatConversation, tuple.checkpoint.channel_values)
-	}
+        return new ThreadDTO(chatConversation, tuple?.checkpoint.channel_values ?? {})
+    }
 }

--- a/packages/server-ai/src/mcp-consumer/connection/langchain-mcp-connection.spec.ts
+++ b/packages/server-ai/src/mcp-consumer/connection/langchain-mcp-connection.spec.ts
@@ -1,4 +1,5 @@
-import type { MultiServerMCPClient } from '@langchain/mcp-adapters'
+import { MultiServerMCPClient } from '@langchain/mcp-adapters'
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { applicationTracing } from '../../tracing/application-tracing'
 import { LangChainMcpConnection } from './langchain-mcp-connection'
@@ -79,6 +80,65 @@ describe('LangChainMcpConnection', () => {
                 })
             })
         )
+    })
+
+    it('uses a runtime OAuth provider without serializing its circular service graph', async () => {
+        const serviceGraph: { manager?: object } = {}
+        serviceGraph.manager = serviceGraph
+        const provider = {
+            serviceGraph,
+            redirectUrl: 'http://localhost/oauth/callback',
+            clientMetadata: {
+                redirect_uris: ['http://localhost/oauth/callback']
+            },
+            state: jest.fn(() => 'state'),
+            clientInformation: jest.fn(),
+            saveClientInformation: jest.fn(),
+            tokens: jest.fn().mockResolvedValue({ access_token: 'oauth-token', token_type: 'Bearer' }),
+            saveTokens: jest.fn(),
+            redirectToAuthorization: jest.fn(),
+            saveCodeVerifier: jest.fn(),
+            codeVerifier: jest.fn()
+        } satisfies OAuthClientProvider & { serviceGraph: typeof serviceGraph }
+        const adapter = new MultiServerMCPClient({
+            mcpServers: {
+                generic: {
+                    transport: 'http',
+                    url: 'https://mcp.example.test/rpc',
+                    authProvider: provider
+                }
+            }
+        })
+        expect(() => adapter.config).toThrow('Converting circular structure to JSON')
+        global.fetch = jest.fn().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 'response-1',
+                    result: {
+                        resultType: 'complete',
+                        taskId: 'task-1',
+                        status: 'completed',
+                        createdAt: '2026-08-20T00:00:00.000Z',
+                        lastUpdatedAt: '2026-08-20T00:00:01.000Z',
+                        ttlMs: 59_000,
+                        result: { ok: true }
+                    }
+                }),
+                { status: 200, headers: { 'content-type': 'application/json' } }
+            )
+        )
+        const connection = new LangChainMcpConnection(adapter)
+
+        await connection.requestExtension(
+            'generic',
+            { method: 'tasks/get', params: { taskId: 'task-1' } },
+            mcpTaskResultSchema,
+            { routing: { method: 'tasks/get', name: 'task-1' } }
+        )
+
+        const [, init] = jest.mocked(global.fetch).mock.calls[0]
+        expect(new Headers(init?.headers).get('Authorization')).toBe('Bearer oauth-token')
     })
 
     it('parses subscription notifications from an SSE response', async () => {

--- a/packages/server-ai/src/mcp-consumer/connection/langchain-mcp-connection.ts
+++ b/packages/server-ai/src/mcp-consumer/connection/langchain-mcp-connection.ts
@@ -51,7 +51,7 @@ export class LangChainMcpConnection implements McpConsumerConnection {
     constructor(readonly adapter: MultiServerMCPClient) {}
 
     serverNames(): string[] {
-        return Object.keys(this.adapter.config.mcpServers ?? {})
+        return Object.keys(adapterConfig(this.adapter).mcpServers ?? {})
     }
 
     resolveServerName(serverName?: string): string {
@@ -75,10 +75,9 @@ export class LangChainMcpConnection implements McpConsumerConnection {
 
     formatToolName(serverName: string, toolName: string): string {
         const resolvedName = this.resolveServerName(serverName)
-        const additionalPrefix = this.adapter.config.additionalToolNamePrefix
-            ? `${this.adapter.config.additionalToolNamePrefix}__`
-            : ''
-        const serverPrefix = this.adapter.config.prefixToolNameWithServerName ? `${resolvedName}__` : ''
+        const config = adapterConfig(this.adapter)
+        const additionalPrefix = config.additionalToolNamePrefix ? `${config.additionalToolNamePrefix}__` : ''
+        const serverPrefix = config.prefixToolNameWithServerName ? `${resolvedName}__` : ''
         return `${additionalPrefix}${serverPrefix}${toolName}`
     }
 
@@ -206,7 +205,7 @@ export class LangChainMcpConnection implements McpConsumerConnection {
     }
 
     private connection(serverName: string): Connection {
-        const connection = this.adapter.config.mcpServers?.[serverName]
+        const connection = adapterConfig(this.adapter).mcpServers?.[serverName]
         if (!connection) {
             throw new Error(`MCP server '${serverName}' is not configured`)
         }
@@ -316,6 +315,17 @@ export class LangChainMcpConnection implements McpConsumerConnection {
             throw error
         }
     }
+}
+
+function adapterConfig(adapter: MultiServerMCPClient): MultiServerMCPClient['config'] {
+    const runtimeConfig = Reflect.get(adapter, '_config')
+    return isAdapterConfig(runtimeConfig) ? runtimeConfig : adapter.config
+}
+
+function isAdapterConfig(value: unknown): value is MultiServerMCPClient['config'] {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+    const mcpServers = Reflect.get(value, 'mcpServers')
+    return typeof mcpServers === 'object' && mcpServers !== null && !Array.isArray(mcpServers)
 }
 
 function modernRequestParams(params?: object) {

--- a/packages/server-ai/src/mcp-consumer/mcp-consumer.spec.ts
+++ b/packages/server-ai/src/mcp-consumer/mcp-consumer.spec.ts
@@ -2,6 +2,13 @@ import type { DynamicStructuredTool } from '@langchain/core/tools'
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { MCP_APP_RESOURCE_MIME_TYPE } from '@xpert-ai/contracts'
 import { z } from 'zod'
+
+const mockInterrupt = jest.fn()
+
+jest.mock('@langchain/langgraph', () => ({
+    ...jest.requireActual('@langchain/langgraph'),
+    interrupt: (value: unknown) => mockInterrupt(value)
+}))
 import {
     McpConsumerConnection,
     McpConsumerExtensionRequest,
@@ -440,6 +447,68 @@ describe('McpConsumer', () => {
                 inputResponses: {
                     details: { action: 'accept', content: { topic: 'MCP' } }
                 }
+            })
+        )
+    })
+
+    it('maps a boolean approval elicitation to the ChatKit HITL interrupt when no host input API exists', async () => {
+        const connection = new FakeConnection(createSdkClient(), ['generic'], true)
+        connection.extensionResponses.push(
+            { resultType: 'complete', tools: [{ name: 'approve_action', inputSchema: { type: 'object' } }] },
+            {
+                resultType: 'input_required',
+                inputRequests: {
+                    approval: {
+                        method: 'elicitation/create',
+                        params: {
+                            mode: 'form',
+                            message: 'Approve OAuth MCP tool test',
+                            requestedSchema: {
+                                type: 'object',
+                                properties: { approved: { type: 'boolean', title: 'Approve' } },
+                                required: ['approved']
+                            }
+                        }
+                    }
+                },
+                requestState: 'state-1'
+            },
+            { resultType: 'complete', content: [{ type: 'text', text: 'accepted false' }] }
+        )
+        mockInterrupt.mockReturnValue({ decisions: [{ type: 'reject', message: 'No write' }] })
+        const [tool] = await new McpConsumer(connection).tools.asLangChain()
+
+        await expect(tool.func({})).resolves.toEqual(['accepted false', []])
+        expect(mockInterrupt).toHaveBeenCalledWith({
+            elicitation: {
+                kind: 'mcp_elicitation',
+                actionName: 'MCP Elicitation',
+                field: {
+                    name: 'approved',
+                    type: 'boolean',
+                    title: 'Approve',
+                    required: true
+                }
+            },
+            actionRequests: [
+                {
+                    name: 'MCP Elicitation',
+                    args: { approved: false },
+                    description: 'Approve OAuth MCP tool test'
+                }
+            ],
+            reviewConfigs: [
+                {
+                    actionName: 'MCP Elicitation',
+                    allowedDecisions: ['approve', 'reject'],
+                    argsSchema: expect.objectContaining({ type: 'object' })
+                }
+            ]
+        })
+        expect(connection.extensionCalls[2].request.params).toEqual(
+            expect.objectContaining({
+                requestState: 'state-1',
+                inputResponses: { approval: { action: 'accept', content: { approved: false } } }
             })
         )
     })

--- a/packages/server-ai/src/mcp-consumer/tools/mcp-consumer-tools.ts
+++ b/packages/server-ai/src/mcp-consumer/tools/mcp-consumer-tools.ts
@@ -1,8 +1,10 @@
 import { DynamicStructuredTool } from '@langchain/core/tools'
 import type { ToolSchemaBase } from '@langchain/core/tools'
 import type { RunnableConfig } from '@langchain/core/runnables'
+import { interrupt } from '@langchain/langgraph'
 import type { Tool } from '@modelcontextprotocol/sdk/types.js'
 import { ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import type { HITLRequest, HITLResponse } from '@xpert-ai/contracts'
 import { z } from 'zod'
 import {
     MCP_CLIENT_CAPABILITIES_META_KEY,
@@ -12,10 +14,25 @@ import {
 import { McpConsumerTaskStart, mcpTaskStartResultSchema } from '../tasks/task-schemas'
 import type {
     McpConsumerElicitationHandler,
-    McpConsumerElicitationRequest
+    McpConsumerElicitationRequest,
+    McpConsumerElicitationResult
 } from '../elicitation/mcp-consumer-elicitation'
 import { McpConsumerCallToolResult, mcpConsumerCallToolResultSchema } from './mcp-consumer-call-tool-result'
 import { createMcpToolAppMeta, type McpToolLike } from '../../xpert-toolset/provider/mcp/app-support'
+
+// Release bridge until xpert-pro consumes the ChatKit package with this additive metadata contract.
+type MCPBooleanElicitationHITLRequest = HITLRequest & {
+    elicitation: {
+        kind: 'mcp_elicitation'
+        actionName: string
+        field: {
+            name: string
+            type: 'boolean'
+            title?: string
+            required: true
+        }
+    }
+}
 
 export class McpConsumerTools {
     private taskRunner?: (
@@ -309,14 +326,14 @@ function isTextBlock(value: unknown): value is { type: 'text'; text: string } {
 function elicitationHandlerFromConfig(config?: RunnableConfig): McpConsumerElicitationHandler | undefined {
     const executionContext = config?.configurable?.toolExecutionContext
     if (typeof executionContext !== 'object' || executionContext === null || Array.isArray(executionContext)) {
-        return undefined
+        return approvalInterruptHandler
     }
     const host = Reflect.get(executionContext, 'host')
-    if (typeof host !== 'object' || host === null || Array.isArray(host)) return undefined
+    if (typeof host !== 'object' || host === null || Array.isArray(host)) return approvalInterruptHandler
     const input = Reflect.get(host, 'input')
-    if (typeof input !== 'object' || input === null || Array.isArray(input)) return undefined
+    if (typeof input !== 'object' || input === null || Array.isArray(input)) return approvalInterruptHandler
     const requestInput = Reflect.get(input, 'request')
-    if (typeof requestInput !== 'function') return undefined
+    if (typeof requestInput !== 'function') return approvalInterruptHandler
 
     return async (request) => {
         const response = await Reflect.apply(requestInput, input, [toToolInputRequest(request)])
@@ -326,6 +343,77 @@ function elicitationHandlerFromConfig(config?: RunnableConfig): McpConsumerElici
         }
         return { action: 'accept', content: Object.fromEntries(Object.entries(response)) }
     }
+}
+
+async function approvalInterruptHandler(request: McpConsumerElicitationRequest): Promise<McpConsumerElicitationResult> {
+    const field = approvalBooleanField(request)
+    if (!field) {
+        throw new Error('ChatKit MCP Elicitation currently supports one required boolean approval field')
+    }
+    const actionName = 'MCP Elicitation'
+    const hitlRequest: MCPBooleanElicitationHITLRequest = {
+        elicitation: {
+            kind: 'mcp_elicitation',
+            actionName,
+            field: {
+                name: field.name,
+                type: 'boolean',
+                ...(field.title ? { title: field.title } : {}),
+                required: true
+            }
+        },
+        actionRequests: [
+            {
+                name: actionName,
+                args: { [field.name]: false },
+                description: request.message
+            }
+        ],
+        reviewConfigs: [
+            {
+                actionName,
+                allowedDecisions: ['approve', 'reject'],
+                argsSchema: field.schema
+            }
+        ]
+    }
+    const response = interrupt(hitlRequest) as HITLResponse
+    const decision = response.decisions?.[0]
+    if (decision?.type === 'approve') {
+        return { action: 'accept', content: { [field.name]: true } }
+    }
+    if (decision?.type === 'reject') {
+        return { action: 'accept', content: { [field.name]: false } }
+    }
+    throw new Error('ChatKit MCP Elicitation returned an unsupported approval decision')
+}
+
+function approvalBooleanField(
+    request: McpConsumerElicitationRequest
+): { name: string; title?: string; schema: Record<string, unknown> } | null {
+    if (request.mode === 'url') return null
+    const properties = Reflect.get(request.requestedSchema, 'properties')
+    const required = Reflect.get(request.requestedSchema, 'required')
+    if (
+        typeof properties !== 'object' ||
+        properties === null ||
+        Array.isArray(properties) ||
+        !Array.isArray(required)
+    ) {
+        return null
+    }
+    const names = Object.keys(properties)
+    if (names.length !== 1 || required.length !== 1 || required[0] !== names[0]) return null
+    const property = Reflect.get(properties, names[0])
+    if (typeof property !== 'object' || property === null || Array.isArray(property)) return null
+    const title = Reflect.get(property, 'title')
+    return Reflect.get(property, 'type') === 'boolean'
+        ? {
+              name: names[0],
+              ...(typeof title === 'string' && title.trim() ? { title: title.trim() } : {}),
+              schema: Object.fromEntries(Object.entries(request.requestedSchema))
+          }
+        : null
 }
 
 function toToolInputRequest(request: McpConsumerElicitationRequest) {

--- a/packages/server-ai/src/xpert-toolset/provider/mcp/app-support.spec.ts
+++ b/packages/server-ai/src/xpert-toolset/provider/mcp/app-support.spec.ts
@@ -507,4 +507,29 @@ describe('MCP App instance lifecycle', () => {
         ])
         detachMcpAppInstancesForClient(client)
     })
+
+    it('lists app metadata without cloning a stateful OAuth provider', async () => {
+        const authProvider = {}
+        Reflect.set(authProvider, 'manager', authProvider)
+        const runtimeConfig = {
+            mcpServers: {
+                default: {
+                    transport: 'http',
+                    url: 'https://mcp.example.test/rpc',
+                    authProvider
+                }
+            }
+        }
+        const client = {
+            _config: runtimeConfig,
+            get config() {
+                return JSON.parse(JSON.stringify(runtimeConfig))
+            },
+            getClient: jest.fn().mockResolvedValue({
+                listTools: jest.fn().mockResolvedValue({ tools: [] })
+            })
+        } as unknown as MultiServerMCPClient
+
+        await expect(listMcpToolAppMetadata(client)).resolves.toEqual([])
+    })
 })

--- a/packages/server-ai/src/xpert-toolset/provider/mcp/app-support.ts
+++ b/packages/server-ai/src/xpert-toolset/provider/mcp/app-support.ts
@@ -718,11 +718,10 @@ async function listClientTools(
 }
 
 export async function listMcpToolAppMetadata(client: MultiServerMCPClient): Promise<TMcpToolAppMeta[]> {
-    const config = client.config
-    const serverNames = Object.keys(config.mcpServers ?? {})
+    const connection = new LangChainMcpConnection(client)
+    const serverNames = connection.serverNames()
     const loadOptions = (client as unknown as McpClientPrivateState)._loadToolsOptions ?? {}
     const metadata: TMcpToolAppMeta[] = []
-    const connection = new LangChainMcpConnection(client)
 
     for (const serverName of serverNames) {
         for (const tool of await listClientTools(client, connection, serverName)) {

--- a/packages/server-ai/src/xpert-toolset/provider/mcp/mcp-toolset.ts
+++ b/packages/server-ai/src/xpert-toolset/provider/mcp/mcp-toolset.ts
@@ -167,7 +167,8 @@ export class MCPToolset extends _BaseToolset {
                   this.params.commandBus,
                   JSON.parse(this.toolset.schema),
                   this.params.env,
-                  this.params?.xpertId
+                  this.params?.xpertId,
+                  this.params
               )
             : await createMCPClient(
                   this.toolset,

--- a/packages/server-ai/src/xpert-toolset/provider/mcp/pro.ts
+++ b/packages/server-ai/src/xpert-toolset/provider/mcp/pro.ts
@@ -1,14 +1,17 @@
-import { IXpertToolset, TMCPSchema } from "@xpert-ai/contracts";
+import { IXpertToolset, TMCPSchema } from '@xpert-ai/contracts'
 import { CommandBus } from '@nestjs/cqrs'
+import type { TBuiltinToolsetParams } from '../../../shared'
 
 export async function createProMCPClient(
-	toolset: Partial<IXpertToolset>,
-	signal: AbortSignal,
-	commandBus: CommandBus,
-	schema: TMCPSchema,
-	envState: Record<string, unknown>,
-	xpertId?: string
+    toolset: Partial<IXpertToolset>,
+    signal: AbortSignal,
+    commandBus: CommandBus,
+    schema: TMCPSchema,
+    envState: Record<string, unknown>,
+    xpertId?: string,
+    _runtimeContext: Partial<TBuiltinToolsetParams> = {}
 ) {
+    void _runtimeContext
     // PRO
-    return {client: null, destroy: null, logs: null}
+    return { client: null, destroy: null, logs: null }
 }


### PR DESCRIPTION
## Summary

This change moves the shared MCP consumer fixes from the Pro checkout into the open-source runtime. It keeps the current ChatKit dependency versions unchanged so the specialized Elicitation UI can be adopted separately after the new packages are published.

## Problem

Fresh ChatKit conversations could be read before their first checkpoint existed, causing thread loading to fail. Stateful OAuth providers also expose circular service graphs, while `MultiServerMCPClient.config` clones the configuration through JSON serialization; reading that public getter therefore broke MCP discovery and MCP Apps metadata loading. Finally, ChatKit executions without a host input API had no fallback for MCP boolean Elicitation requests, so a tool call could remain paused without a usable review flow.

## Changes

- Return an empty thread state when no checkpoint exists yet.
- Read the validated MCP adapter runtime configuration without cloning stateful OAuth providers.
- Reuse the connection abstraction when listing MCP Apps metadata.
- Map a supported single required boolean MCP Elicitation request to the existing LangGraph HITL approve/reject flow.
- Preserve the real toolset ID during MCP discovery and pass runtime identity context through the Pro extension seam.
- Add focused regression coverage for fresh threads, stateful OAuth providers, MCP Apps metadata, and Elicitation resume decisions.

Existing host input handling remains unchanged. The no-host fallback intentionally accepts only a single required boolean field and rejects other Elicitation shapes explicitly. This PR does not update `@xpert-ai/chatkit-*` package versions; the specialized True/False Elicitation panel remains a follow-up after the new ChatKit packages are published. Until then, the current ChatKit UI uses its generic action-review presentation.

## Validation

- `corepack pnpm exec jest --config packages/server-ai/jest.config.ts --runInBand packages/server-ai/src/ai/queries/handlers/thread-find.handler.spec.ts packages/server-ai/src/mcp-consumer/connection/langchain-mcp-connection.spec.ts packages/server-ai/src/mcp-consumer/mcp-consumer.spec.ts packages/server-ai/src/xpert-toolset/provider/mcp/app-support.spec.ts packages/server-ai/src/xpert-toolset/provider/mcp/client-factory.spec.ts` (5 suites, 42 tests passed)
- `corepack pnpm exec tsc --noEmit -p packages/server-ai/tsconfig.lib.json`
- `corepack pnpm exec ngc -p apps/cloud/tsconfig.app.json`
- `git diff --check origin/develop...HEAD`

Browser validation was intentionally left for the follow-up that updates the published ChatKit packages.
