### PR TITLE
fix: align membership model options with provider configuration

### DIFF
--- a/apps/cloud/src/app/@core/services/membership.service.spec.ts
+++ b/apps/cloud/src/app/@core/services/membership.service.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http'
 import { TestBed } from '@angular/core/testing'
 import { Store } from '@cloud/app/@core/state'
+import { AiModelTypeEnum } from '@xpert-ai/contracts'
 import { BehaviorSubject, of } from 'rxjs'
 import { MembershipService } from './membership.service'
 import { CopilotServerService } from './copilot-server.service'
@@ -54,5 +55,27 @@ describe('MembershipService', () => {
     expect(http.get).toHaveBeenCalledTimes(2)
 
     subscription.unsubscribe()
+  })
+
+  it('loads every model type for membership plan configuration', () => {
+    http.get.mockImplementation((_url, options) =>
+      of([
+        {
+          id: `copilot-${options.params.type}`,
+          providerWithModels: {
+            provider: 'provider',
+            models: [{ model: `model-${options.params.type}`, model_type: options.params.type }]
+          }
+        }
+      ])
+    )
+    const modelTypes = Object.values(AiModelTypeEnum)
+    const results: Array<{ id: string }> = []
+
+    service.getModelOptions().subscribe((models) => results.push(...models))
+
+    expect(http.get).toHaveBeenCalledTimes(modelTypes.length)
+    expect(http.get.mock.calls.map(([, options]) => options.params.type)).toEqual(modelTypes)
+    expect(results.map(({ id }) => id)).toEqual(modelTypes.map((type) => `copilot-${type}`))
   })
 })

--- a/apps/cloud/src/app/@core/services/membership.service.ts
+++ b/apps/cloud/src/app/@core/services/membership.service.ts
@@ -24,7 +24,7 @@ import {
   TMembershipPlanReassignInput,
   TMembershipPointAdjustInput
 } from '@xpert-ai/contracts'
-import { BehaviorSubject, catchError, combineLatest, map, of, switchMap, tap } from 'rxjs'
+import { BehaviorSubject, catchError, combineLatest, forkJoin, map, of, switchMap, tap } from 'rxjs'
 import { API_COPILOT, API_MEMBERSHIP } from '../constants/app.constants'
 import { CopilotServerService } from './copilot-server.service'
 
@@ -44,9 +44,13 @@ export class MembershipService {
   }
 
   getModelOptions() {
-    return this.#http.get<ICopilotWithProvider[]>(`${API_COPILOT}/membership-models`, {
-      params: { type: AiModelTypeEnum.LLM }
-    })
+    return forkJoin(
+      Object.values(AiModelTypeEnum).map((type) =>
+        this.#http.get<ICopilotWithProvider[]>(`${API_COPILOT}/membership-models`, {
+          params: { type }
+        })
+      )
+    ).pipe(map((modelsByType) => modelsByType.flat()))
   }
 
   initializeScope() {

--- a/apps/cloud/src/app/features/setting/membership/membership.component.spec.ts
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.spec.ts
@@ -6,6 +6,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   AiModelTypeEnum,
+  AiProviderRole,
   IMembershipPlan,
   MembershipBulkActionEnum,
   MembershipPeriodEnum,
@@ -186,7 +187,7 @@ describe('MembershipAdminComponent', () => {
       of([
         {
           id: 'copilot-1',
-          name: 'Primary provider',
+          role: AiProviderRole.Primary,
           providerWithModels: {
             provider: 'tongyi',
             models: [{ model: 'qwen3.7-plus', model_type: AiModelTypeEnum.LLM }]
@@ -194,7 +195,8 @@ describe('MembershipAdminComponent', () => {
         },
         {
           id: 'copilot-2',
-          name: 'Backup provider',
+          role: AiProviderRole.Embedding,
+          name: 'kimikimi',
           providerWithModels: {
             provider: 'tongyi',
             models: [{ model: 'qwen3.7-plus', model_type: AiModelTypeEnum.LLM }]
@@ -210,6 +212,12 @@ describe('MembershipAdminComponent', () => {
       .filter((option) => option.provider === 'tongyi' && option.model === 'qwen3.7-plus')
     expect(options).toHaveLength(2)
     expect(options[0].value).not.toBe(options[1].value)
+    expect(component.modelTargetLabel(options[0])).toBe(
+      'XP.KEY_WORDS.Primary XP.KEY_WORDS.Provider · tongyi · qwen3.7-plus'
+    )
+    expect(component.modelTargetLabel(options[1])).toBe('kimikimi · tongyi · qwen3.7-plus')
+    expect(component.modelTargetLabel(options[0])).not.toContain('copilot-1')
+    expect(component.modelTargetLabel(options[1])).not.toContain('copilot-2')
 
     component.setAllowedModelValues(options[0].value)
     expect(component.allowedModels).toEqual([

--- a/apps/cloud/src/app/features/setting/membership/membership.component.ts
+++ b/apps/cloud/src/app/features/setting/membership/membership.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule, Validators 
 import { RouterLink } from '@angular/router'
 import { MembershipService, getErrorMessage, injectToastr } from '../../../@core'
 import {
+  AiProviderRole,
   ICopilotWithProvider,
   IMembershipAdminUser,
   IMembershipAllowedModel,
@@ -51,6 +52,12 @@ type MembershipModelOption = {
 type MembershipAdminTab = 'plans' | 'users'
 
 const MEMBERSHIP_RATE_LIMIT_PERIODS: TMembershipRateLimitPeriod[] = ['hour', 'day', 'week', 'cycle']
+const COPILOT_ROLE_NAMES: Record<AiProviderRole, string> = {
+  [AiProviderRole.Primary]: 'Primary',
+  [AiProviderRole.Secondary]: 'Secondary',
+  [AiProviderRole.Embedding]: 'Embedding',
+  [AiProviderRole.Reasoning]: 'Reasoning'
+}
 
 @Component({
   standalone: true,
@@ -809,8 +816,8 @@ export class MembershipAdminComponent implements OnInit {
     } else {
       label = `${option.provider} · ${option.model}`
     }
-    if (option.copilotId) {
-      label = `${label} · ${option.copilotLabel || option.copilotId}`
+    if (option.copilotLabel) {
+      label = `${option.copilotLabel} · ${label}`
     }
     return option.available
       ? label
@@ -916,7 +923,7 @@ export class MembershipAdminComponent implements OnInit {
       if (!provider || !copilotId) {
         continue
       }
-      const copilotLabel = copilot.name?.trim() || copilotId
+      const copilotLabel = this.copilotProviderLabel(copilot)
       addAllowedModelOption(options, provider, '*', copilotId, copilotLabel, true)
       for (const model of copilot.providerWithModels.models ?? []) {
         const modelName = model.model?.trim()
@@ -926,6 +933,18 @@ export class MembershipAdminComponent implements OnInit {
       }
     }
     return sortModelOptions(Array.from(options.values()))
+  }
+
+  private copilotProviderLabel(copilot: ICopilotWithProvider) {
+    const name = copilot.name?.trim()
+    if (name) {
+      return name
+    }
+
+    const roleName = COPILOT_ROLE_NAMES[copilot.role]
+    const roleLabel = this.#translate.instant(`XP.KEY_WORDS.${roleName}`, { Default: roleName })
+    const providerLabel = this.#translate.instant('XP.KEY_WORDS.Provider', { Default: 'Provider' })
+    return `${roleLabel} ${providerLabel}`
   }
 
   private includeStoredModelOptions() {

--- a/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.spec.ts
+++ b/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.spec.ts
@@ -380,7 +380,7 @@ describe('FindCopilotModelsHandler', () => {
         })
     })
 
-    it('loads only models from the current organization scope for membership management', async () => {
+    it('loads only current-organization models matching the configured model type for membership management', async () => {
         jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
         jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('org-1')
         const service = {
@@ -397,8 +397,24 @@ describe('FindCopilotModelsHandler', () => {
                 {
                     id: 'copilot-organization',
                     organizationId: 'org-1',
+                    copilotModel: {
+                        model: 'paid-model',
+                        modelType: AiModelTypeEnum.LLM
+                    },
                     modelProvider: {
                         id: 'provider-organization',
+                        providerName: 'openai-compatible'
+                    }
+                },
+                {
+                    id: 'copilot-embedding',
+                    organizationId: 'org-1',
+                    copilotModel: {
+                        model: 'embedding-model',
+                        modelType: AiModelTypeEnum.TEXT_EMBEDDING
+                    },
+                    modelProvider: {
+                        id: 'provider-embedding',
                         providerName: 'openai-compatible'
                     }
                 }

--- a/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.ts
+++ b/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.ts
@@ -38,7 +38,11 @@ export class FindCopilotModelsHandler implements IQueryHandler<FindCopilotModels
         const managementCopilots = await this.service.findAllEnabledCopilotsWithoutMembership(tenantId, organizationId)
         const copilots =
             command.catalogMode === CopilotModelCatalogMode.MembershipManagement
-                ? managementCopilots.filter((copilot) => (copilot.organizationId ?? null) === (organizationId ?? null))
+                ? managementCopilots.filter(
+                      (copilot) =>
+                          (copilot.organizationId ?? null) === (organizationId ?? null) &&
+                          copilot.copilotModel?.modelType === command.type
+                  )
                 : managementCopilots
         const copilotSchemas: CopilotWithProviderDto[] = []
         for (const copilot of copilots) {


### PR DESCRIPTION
## Summary

- load membership plan model options across all supported model types
- restrict each provider entry to the model type selected in its Copilot configuration
- show the provider configuration display name in model labels while keeping Copilot IDs internal

## Validation

- server-ai handler tests: 6 passed
- cloud membership tests: 20 passed
- Cloud development build passed
- server-ai build passed
- ESLint completed with no errors; 3 existing warnings remain

## Manual verification

- Browser verification not run; please verify the membership model selector in the deployed UI.