### PR TITLE
fix: honor workbench layout defaults and draft views

### DIFF
--- a/apps/cloud/src/app/@core/services/view-extension-api.service.spec.ts
+++ b/apps/cloud/src/app/@core/services/view-extension-api.service.spec.ts
@@ -19,6 +19,26 @@ describe('ViewExtensionApiService', () => {
     httpMock.verify()
   })
 
+  it('requests draft-aware slot views only when explicitly enabled', () => {
+    service.getSlotViews('agent', 'assistant/1', 'agent.workbench.fixed', { isDraft: true }).subscribe()
+
+    const request = httpMock.expectOne(
+      'http://localhost:3000/api/view-hosts/agent/assistant%2F1/slots/agent.workbench.fixed/views?isDraft=true'
+    )
+    expect(request.request.method).toBe('GET')
+    request.flush([])
+  })
+
+  it('keeps slot view discovery published by default', () => {
+    service.getSlotViews('agent', 'assistant-1', 'agent.workbench.fixed').subscribe()
+
+    const request = httpMock.expectOne(
+      'http://localhost:3000/api/view-hosts/agent/assistant-1/slots/agent.workbench.fixed/views'
+    )
+    expect(request.request.method).toBe('GET')
+    request.flush([])
+  })
+
   it('accepts the HttpOnly cookie returned when creating a view file session', () => {
     service.createViewFileAccessSession('assistant', 'assistant-1', 'cut-workbench').subscribe()
 

--- a/apps/cloud/src/app/@core/services/view-extension-api.service.ts
+++ b/apps/cloud/src/app/@core/services/view-extension-api.service.ts
@@ -19,9 +19,15 @@ export class ViewExtensionApiService {
   private readonly baseUrl = `${this.apiBaseUrl}${API_PREFIX}/view-hosts`
   private readonly workspaceFilesBaseUrl = `${this.apiBaseUrl}${API_PREFIX}/workspace-files`
 
-  getSlotViews(hostType: string, hostId: string, slot: string) {
+  getSlotViews(hostType: string, hostId: string, slot: string, options: { isDraft?: boolean } = {}) {
+    let params = new HttpParams()
+    if (options.isDraft) {
+      params = params.set('isDraft', 'true')
+    }
+
     return this.httpClient.get<XpertExtensionViewManifest[]>(
-      `${this.baseUrl}/${encodeURIComponent(hostType)}/${encodeURIComponent(hostId)}/slots/${encodeURIComponent(slot)}/views`
+      `${this.baseUrl}/${encodeURIComponent(hostType)}/${encodeURIComponent(hostId)}/slots/${encodeURIComponent(slot)}/views`,
+      { params }
     )
   }
 

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.spec.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.spec.ts
@@ -302,10 +302,13 @@ const TEST_FILE_LIST_ICON = {
 } satisfies IconDefinition
 
 const WORKBENCH_LAYOUT_TEST_ASSISTANT_IDS = ['assistant-1', 'assistant-2']
+const WORKBENCH_LAYOUT_TEST_USER_IDS = ['user-1', 'user-2']
 
 function clearWorkbenchLayoutTestStorage() {
-  WORKBENCH_LAYOUT_TEST_ASSISTANT_IDS.forEach((assistantId) => {
-    localStorage.removeItem(getClawXpertWorkbenchLayoutStorageKey(assistantId))
+  WORKBENCH_LAYOUT_TEST_USER_IDS.forEach((userId) => {
+    WORKBENCH_LAYOUT_TEST_ASSISTANT_IDS.forEach((assistantId) => {
+      localStorage.removeItem(getClawXpertWorkbenchLayoutStorageKey(userId, assistantId))
+    })
   })
 }
 
@@ -416,6 +419,7 @@ describe('ClawXpertConversationDetailComponent', () => {
   let facade: {
     definition: { titleKey: string; defaultTitle: string }
     identity: ReturnType<typeof signal<string | null>>
+    userId: ReturnType<typeof signal<string | null>>
     assistantId: ReturnType<typeof signal<string | null>>
     loading: ReturnType<typeof signal<boolean>>
     loadingUserPreference: ReturnType<typeof signal<boolean>>
@@ -488,6 +492,7 @@ describe('ClawXpertConversationDetailComponent', () => {
         defaultTitle: 'ClawXpert'
       },
       identity: signal('clawxpert'),
+      userId: signal('user-1'),
       assistantId: signal('assistant-1'),
       loading: signal(false),
       loadingUserPreference: signal(false),
@@ -618,7 +623,7 @@ describe('ClawXpertConversationDetailComponent', () => {
     jest.clearAllMocks()
   })
 
-  it('keeps ChatKit maximized without opening the files tab while resolving conversation context', async () => {
+  it('uses the default two-column layout without opening the files tab while resolving conversation context', async () => {
     const fixture = TestBed.createComponent(ClawXpertConversationDetailComponent)
     await settle(fixture)
 
@@ -626,22 +631,22 @@ describe('ClawXpertConversationDetailComponent', () => {
     expect(aiThreadService.getThread).toHaveBeenCalledWith('thread-1')
     expect(conversationService.getById).toHaveBeenCalledWith('conversation-1', { relations: ['messages'] })
     expect(facade.setActiveConversation).toHaveBeenLastCalledWith(expect.objectContaining({ id: 'conversation-1' }))
-    expect(fixture.componentInstance.showDetailPanel()).toBe(false)
+    expect(fixture.componentInstance.showDetailPanel()).toBe(true)
     expect(fixture.componentInstance.workspaceMaximized()).toBe(false)
-    expect(fixture.componentInstance.detailPanelShellClasses()).toContain('opacity-0')
-    expect(fixture.componentInstance.detailPanelContentClasses()).toContain('opacity-0')
+    expect(fixture.componentInstance.detailPanelShellClasses()).toContain('opacity-100')
+    expect(fixture.componentInstance.detailPanelContentClasses()).toContain('opacity-100')
 
     expect(fixture.componentInstance.workspaceTabs().some((tab) => tab.kind === 'files')).toBe(false)
     expect(fixture.debugElement.query(By.directive(ClawXpertConversationFilesComponent))).toBeNull()
     ;(fixture.nativeElement.querySelector('[data-toggle-detail-panel]') as HTMLButtonElement).click()
     await settle(fixture)
 
-    expect(fixture.componentInstance.showDetailPanel()).toBe(true)
-    expect(fixture.componentInstance.detailPanelContentClasses()).toContain('opacity-100')
+    expect(fixture.componentInstance.showDetailPanel()).toBe(false)
+    expect(fixture.componentInstance.detailPanelContentClasses()).toContain('opacity-0')
     ;(fixture.nativeElement.querySelector('[data-toggle-detail-panel]') as HTMLButtonElement).click()
     await settle(fixture)
 
-    expect(fixture.componentInstance.showDetailPanel()).toBe(false)
+    expect(fixture.componentInstance.showDetailPanel()).toBe(true)
     expect(fixture.debugElement.query(By.directive(ClawXpertConversationFilesComponent))).toBeNull()
   })
 
@@ -988,8 +993,8 @@ describe('ClawXpertConversationDetailComponent', () => {
         viewKey: 'metrics'
       })
     ])
-    expect(fixture.componentInstance.activeTab()).toBeNull()
-    expect(fixture.componentInstance.showDetailPanel()).toBe(false)
+    expect(fixture.componentInstance.activeFixedViewTab()?.viewKey).toBe('bom')
+    expect(fixture.componentInstance.showDetailPanel()).toBe(true)
     expect(fixture.nativeElement.querySelector('[data-panel-button="files"]')).toBeNull()
   })
 
@@ -1091,9 +1096,11 @@ describe('ClawXpertConversationDetailComponent', () => {
 
     expect(fixedViewTabs).toHaveLength(1)
     expect(fixture.componentInstance.workspaceTabs().some((tab) => tab.kind === 'files')).toBe(false)
-    expect(fixture.componentInstance.activeTab()).toBeNull()
-    expect(fixture.componentInstance.showDetailPanel()).toBe(false)
-    expect(outlet).toBeNull()
+    expect(fixture.componentInstance.activeFixedViewTab()?.viewKey).toBe(
+      'bom_document_intake_provider__bom_document_intake__review'
+    )
+    expect(fixture.componentInstance.showDetailPanel()).toBe(true)
+    expect(outlet).not.toBeNull()
 
     fixture.componentInstance.openFixedViewTab(fixture.componentInstance.fixedViewMenuItems()[0])
     await settle(fixture)
@@ -1766,8 +1773,8 @@ describe('ClawXpertConversationDetailComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-chatkit-resize-handle]')).not.toBeNull()
   })
 
-  it('defaults back to ChatKit maximized when reopening or switching assistants', async () => {
-    const assistantOneKey = getClawXpertWorkbenchLayoutStorageKey('assistant-1')
+  it('persists and restores the workspace layout independently for each user and assistant', async () => {
+    const userOneAssistantOneKey = getClawXpertWorkbenchLayoutStorageKey('user-1', 'assistant-1')
     const firstFixture = TestBed.createComponent(ClawXpertConversationDetailComponent)
     await settle(firstFixture)
 
@@ -1775,48 +1782,41 @@ describe('ClawXpertConversationDetailComponent', () => {
     firstFixture.componentInstance.toggleWorkspaceMaximized()
     await settle(firstFixture)
 
-    expect(localStorage.getItem(assistantOneKey)).toBe('maximized')
+    expect(localStorage.getItem(userOneAssistantOneKey)).toBe('maximized')
     firstFixture.destroy()
 
     const reopenedFixture = TestBed.createComponent(ClawXpertConversationDetailComponent)
     await settle(reopenedFixture)
 
-    expect(reopenedFixture.componentInstance.showDetailPanel()).toBe(false)
+    expect(reopenedFixture.componentInstance.showDetailPanel()).toBe(true)
+    expect(reopenedFixture.componentInstance.workspaceMaximized()).toBe(true)
+
+    facade.userId.set('user-2')
+    await settle(reopenedFixture)
+
+    expect(reopenedFixture.componentInstance.showDetailPanel()).toBe(true)
     expect(reopenedFixture.componentInstance.workspaceMaximized()).toBe(false)
+
+    reopenedFixture.componentInstance.closeDetailPanel()
+    await settle(reopenedFixture)
+    expect(localStorage.getItem(getClawXpertWorkbenchLayoutStorageKey('user-2', 'assistant-1'))).toBe('minimized')
+
+    facade.userId.set('user-1')
+    await settle(reopenedFixture)
+
+    expect(reopenedFixture.componentInstance.showDetailPanel()).toBe(true)
+    expect(reopenedFixture.componentInstance.workspaceMaximized()).toBe(true)
 
     facade.assistantId.set('assistant-2')
     facade.xpertId.set('assistant-2')
     await settle(reopenedFixture)
 
-    expect(reopenedFixture.componentInstance.showDetailPanel()).toBe(false)
-    expect(reopenedFixture.componentInstance.workspaceMaximized()).toBe(false)
-
-    facade.assistantId.set('assistant-1')
-    facade.xpertId.set('assistant-1')
-    await settle(reopenedFixture)
-
-    expect(reopenedFixture.componentInstance.showDetailPanel()).toBe(false)
-    expect(reopenedFixture.componentInstance.workspaceMaximized()).toBe(false)
-
-    facade.assistantId.set('assistant-2')
-    facade.xpertId.set('assistant-2')
-    await settle(reopenedFixture)
-
-    expect(reopenedFixture.componentInstance.showDetailPanel()).toBe(false)
+    expect(reopenedFixture.componentInstance.showDetailPanel()).toBe(true)
     expect(reopenedFixture.componentInstance.workspaceMaximized()).toBe(false)
   })
 
-  it('keeps ChatKit maximized even when the xpert config requests a maximized Workbench', async () => {
+  it('uses the xpert Workbench initial layout when the user has no saved preference', async () => {
     facade.initialLayout.set(XpertWorkbenchInitialLayoutEnum.WorkbenchMaximized)
-
-    const fixture = TestBed.createComponent(ClawXpertConversationDetailComponent)
-    await settle(fixture)
-
-    expect(fixture.componentInstance.showDetailPanel()).toBe(false)
-    expect(fixture.componentInstance.workspaceMaximized()).toBe(false)
-  })
-
-  it('loads configured extension views without opening one as the initial Workbench tab', async () => {
     facade.defaultViewKey.set('metrics')
     viewExtensionApi.getSlotViews.mockReturnValue(
       of([buildFixedViewManifest('review', { order: 10 }), buildFixedViewManifest('metrics', { order: 20 })])
@@ -1825,14 +1825,41 @@ describe('ClawXpertConversationDetailComponent', () => {
     const fixture = TestBed.createComponent(ClawXpertConversationDetailComponent)
     await settle(fixture)
 
-    expect(fixture.componentInstance.activeFixedViewTab()).toBeNull()
-    expect(fixture.componentInstance.activeTab()).toBeNull()
+    expect(fixture.componentInstance.activeFixedViewTab()?.viewKey).toBe('metrics')
+    expect(fixture.componentInstance.showDetailPanel()).toBe(true)
+    expect(fixture.componentInstance.workspaceMaximized()).toBe(true)
+    expect(localStorage.getItem(getClawXpertWorkbenchLayoutStorageKey('user-1', 'assistant-1'))).toBeNull()
+  })
+
+  it('opens the configured extension view as the initial Workbench tab', async () => {
+    facade.defaultViewKey.set('metrics')
+    viewExtensionApi.getSlotViews.mockReturnValue(
+      of([buildFixedViewManifest('review', { order: 10 }), buildFixedViewManifest('metrics', { order: 20 })])
+    )
+
+    const fixture = TestBed.createComponent(ClawXpertConversationDetailComponent)
+    await settle(fixture)
+
+    expect(fixture.componentInstance.activeFixedViewTab()?.viewKey).toBe('metrics')
     expect(fixture.componentInstance.workspaceTabs().some((tab) => tab.kind === 'files')).toBe(false)
-    expect(fixture.componentInstance.showDetailPanel()).toBe(false)
+    expect(fixture.componentInstance.showDetailPanel()).toBe(true)
     expect(fixture.componentInstance.workspaceMaximized()).toBe(false)
   })
 
-  it('keeps ChatKit maximized after the bound xpert configuration becomes ready', async () => {
+  it('opens the first extension view when the configured default is unavailable', async () => {
+    facade.defaultViewKey.set('missing')
+    viewExtensionApi.getSlotViews.mockReturnValue(
+      of([buildFixedViewManifest('review', { order: 10 }), buildFixedViewManifest('metrics', { order: 20 })])
+    )
+
+    const fixture = TestBed.createComponent(ClawXpertConversationDetailComponent)
+    await settle(fixture)
+
+    expect(fixture.componentInstance.activeFixedViewTab()?.viewKey).toBe('review')
+    expect(fixture.componentInstance.showDetailPanel()).toBe(true)
+  })
+
+  it('waits for the bound xpert configuration before applying its initial layout', async () => {
     facade.viewState.set('wizard')
     const fixture = TestBed.createComponent(ClawXpertConversationDetailComponent)
     await settle(fixture)
@@ -1841,8 +1868,8 @@ describe('ClawXpertConversationDetailComponent', () => {
     facade.viewState.set('ready')
     await settle(fixture)
 
-    expect(fixture.componentInstance.showDetailPanel()).toBe(false)
-    expect(fixture.componentInstance.workspaceMaximized()).toBe(false)
+    expect(fixture.componentInstance.showDetailPanel()).toBe(true)
+    expect(fixture.componentInstance.workspaceMaximized()).toBe(true)
   })
 
   it('keeps ChatKit maximized when configured as the initial layout and fixed views load', async () => {
@@ -1865,7 +1892,7 @@ describe('ClawXpertConversationDetailComponent', () => {
 
   it('keeps a stored minimized workspace closed after fixed views load', async () => {
     facade.initialLayout.set(XpertWorkbenchInitialLayoutEnum.WorkbenchMaximized)
-    localStorage.setItem(getClawXpertWorkbenchLayoutStorageKey('assistant-1'), 'minimized')
+    localStorage.setItem(getClawXpertWorkbenchLayoutStorageKey('user-1', 'assistant-1'), 'minimized')
     viewExtensionApi.getSlotViews.mockReturnValue(
       of([
         buildFixedViewManifest('review', {
@@ -1879,7 +1906,27 @@ describe('ClawXpertConversationDetailComponent', () => {
 
     expect(fixture.componentInstance.fixedViewTabs()).toHaveLength(1)
     expect(fixture.componentInstance.showDetailPanel()).toBe(false)
-    expect(localStorage.getItem(getClawXpertWorkbenchLayoutStorageKey('assistant-1'))).toBe('minimized')
+    expect(localStorage.getItem(getClawXpertWorkbenchLayoutStorageKey('user-1', 'assistant-1'))).toBe('minimized')
+  })
+
+  it('keeps a stored minimized workspace closed when the selected fixed view remains in the URL', async () => {
+    facade.initialLayout.set(XpertWorkbenchInitialLayoutEnum.WorkbenchMaximized)
+    workbenchViewUrlState.viewKey.set('review')
+    localStorage.setItem(getClawXpertWorkbenchLayoutStorageKey('user-1', 'assistant-1'), 'minimized')
+    viewExtensionApi.getSlotViews.mockReturnValue(
+      of([
+        buildFixedViewManifest('review', {
+          title: { en_US: 'Review', zh_Hans: '审核' }
+        })
+      ])
+    )
+
+    const fixture = TestBed.createComponent(ClawXpertConversationDetailComponent)
+    await settle(fixture)
+
+    expect(fixture.componentInstance.activeFixedViewTab()?.viewKey).toBe('review')
+    expect(fixture.componentInstance.showDetailPanel()).toBe(false)
+    expect(localStorage.getItem(getClawXpertWorkbenchLayoutStorageKey('user-1', 'assistant-1'))).toBe('minimized')
   })
 
   it('resizes the ChatKit panel from its left edge and clamps the width', async () => {

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.ts
@@ -5,7 +5,7 @@ import { Router } from '@angular/router'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { ChatKit, type ChatKitControl } from '@xpert-ai/chatkit-angular'
 import type { ChatKitQuoteReference, ChatKitReference, RuntimeCapabilitiesSelection } from '@xpert-ai/chatkit-types'
-import { ASSISTANT_CITATION_OPEN_EVENT } from '@xpert-ai/contracts'
+import { ASSISTANT_CITATION_OPEN_EVENT, XpertWorkbenchInitialLayoutEnum } from '@xpert-ai/contracts'
 import type {
   IconDefinition,
   I18nObject,
@@ -754,9 +754,9 @@ export class ClawXpertConversationDetailComponent implements OnDestroy {
   #fixedViewsHostId: string | null = null
   #markReadRequestVersion = 0
   #chatkitResizeCleanup: (() => void) | null = null
-  #activeWorkbenchLayoutAssistantId: string | null = null
-  #initializedWorkbenchLayoutAssistantId: string | null = null
-  #pendingWorkbenchLayoutRestore: { assistantId: string | null; state: ClawXpertWorkbenchLayoutState } | null = null
+  #activeWorkbenchLayoutPreferenceKey: string | null = null
+  #initializedWorkbenchLayoutPreferenceKey: string | null = null
+  #pendingWorkbenchLayoutRestore: { preferenceKey: string; state: ClawXpertWorkbenchLayoutState } | null = null
   #lastNonFixedTabId: string | null = null
   #activeChatkitControl: ChatKitControl | null = null
   #lastSyncedRoutedThreadId: string | null = null
@@ -1009,35 +1009,42 @@ export class ClawXpertConversationDetailComponent implements OnDestroy {
 
     effect(() => {
       const assistantId = this.#workbenchLayoutAssistantId()
+      const userId = this.facade.userId()?.trim() || null
       const viewState = this.facade.viewState()
+      const configuredInitialLayout = this.facade.initialLayout()
       const currentState = this.#workbenchLayoutState()
+      const preferenceKey = assistantId ? JSON.stringify([userId, assistantId]) : null
 
-      if (assistantId !== this.#activeWorkbenchLayoutAssistantId) {
-        this.#activeWorkbenchLayoutAssistantId = assistantId
-        this.#initializedWorkbenchLayoutAssistantId = null
+      if (preferenceKey !== this.#activeWorkbenchLayoutPreferenceKey) {
+        this.#activeWorkbenchLayoutPreferenceKey = preferenceKey
+        this.#initializedWorkbenchLayoutPreferenceKey = null
         this.#pendingWorkbenchLayoutRestore = null
       }
 
-      if (!assistantId || viewState !== 'ready') {
+      if (!assistantId || !preferenceKey || viewState !== 'ready') {
         return
       }
 
-      if (assistantId !== this.#initializedWorkbenchLayoutAssistantId) {
-        this.#initializedWorkbenchLayoutAssistantId = assistantId
-        const nextState: ClawXpertWorkbenchLayoutState = 'minimized'
-        this.#pendingWorkbenchLayoutRestore = { assistantId, state: nextState }
+      if (preferenceKey !== this.#initializedWorkbenchLayoutPreferenceKey) {
+        this.#initializedWorkbenchLayoutPreferenceKey = preferenceKey
+        const restoredState = userId ? this.#workbenchLayoutStorage.load(userId, assistantId) : null
+        const configuredState = toConfiguredWorkbenchLayoutState(configuredInitialLayout)
+        const nextState = restoredState ?? configuredState ?? 'minimized'
+        this.#pendingWorkbenchLayoutRestore = { preferenceKey, state: nextState }
         this.applyWorkbenchLayoutState(nextState)
         return
       }
 
       const pendingRestore = this.#pendingWorkbenchLayoutRestore
-      if (pendingRestore?.assistantId === assistantId && pendingRestore.state === currentState) {
+      if (pendingRestore?.preferenceKey === preferenceKey && pendingRestore.state === currentState) {
         this.#pendingWorkbenchLayoutRestore = null
         return
       }
 
       this.#pendingWorkbenchLayoutRestore = null
-      this.#workbenchLayoutStorage.save(assistantId, currentState)
+      if (userId) {
+        this.#workbenchLayoutStorage.save(userId, assistantId, currentState)
+      }
     })
 
     effect(() => {
@@ -1503,7 +1510,9 @@ export class ClawXpertConversationDetailComponent implements OnDestroy {
         void this.#workbenchViewUrlState.setViewKey(null, { replaceUrl: urlMode === 'replace' })
       }
     }
-    this.openDetailPanel()
+    if (urlMode !== 'none') {
+      this.openDetailPanel()
+    }
   }
 
   private findLastNonFixedTab() {
@@ -1935,14 +1944,16 @@ export class ClawXpertConversationDetailComponent implements OnDestroy {
 
     if (requestedTab) {
       this.activeTabId.set(requestedTab.id)
+    } else if (!activeTabId) {
+      const initialTab =
+        nextNonFixedTabs[0] ?? findFixedViewTab(nextFixedTabs, this.facade.defaultViewKey()) ?? nextFixedTabs[0]
+      this.activeTabId.set(initialTab?.id ?? '')
     } else if (activeTabId && !nextTabs.some((tab) => tab.id === activeTabId)) {
       const selectedTab = nextNonFixedTabs[0] ?? nextTabs[0]
       this.activeTabId.set(selectedTab?.id ?? '')
     }
 
-    if (requestedTab) {
-      this.openDetailPanel()
-    } else if (nextFixedTabs.length === 0 && requestedViewKey) {
+    if (nextFixedTabs.length === 0 && requestedViewKey) {
       void this.#workbenchViewUrlState.setViewKey(null, { replaceUrl: true })
     }
   }
@@ -2283,6 +2294,21 @@ function resolveConversationId(metadata?: { id?: string }) {
 
 function clampChatkitWidth(width: number) {
   return Math.min(CLAWXPERT_CHATKIT_MAX_WIDTH_PX, Math.max(CLAWXPERT_CHATKIT_MIN_WIDTH_PX, Math.round(width)))
+}
+
+function toConfiguredWorkbenchLayoutState(
+  layout: XpertWorkbenchInitialLayoutEnum | null
+): ClawXpertWorkbenchLayoutState | null {
+  if (layout === null || layout === XpertWorkbenchInitialLayoutEnum.TwoColumns) {
+    return 'normal'
+  }
+  if (layout === XpertWorkbenchInitialLayoutEnum.ChatkitMaximized) {
+    return 'minimized'
+  }
+  if (layout === XpertWorkbenchInitialLayoutEnum.WorkbenchMaximized) {
+    return 'maximized'
+  }
+  return null
 }
 
 function isMatchingBrowserTab(tab: ClawXpertBrowserTab, target: ClawXpertSandboxPreviewTarget) {

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-workbench-layout-storage.service.spec.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-workbench-layout-storage.service.spec.ts
@@ -4,7 +4,9 @@ import {
   getClawXpertWorkbenchLayoutStorageKey
 } from './clawxpert-workbench-layout-storage.service'
 
+const USER_IDS = ['user-1', 'user-2']
 const ASSISTANT_IDS = ['assistant-1', 'assistant-2']
+const LEGACY_ASSISTANT_ONE_KEY = 'xpert.clawxpert.workbench.layout.v1:assistant-1'
 
 describe('ClawXpertWorkbenchLayoutStorage', () => {
   let storage: ClawXpertWorkbenchLayoutStorage
@@ -20,27 +22,40 @@ describe('ClawXpertWorkbenchLayoutStorage', () => {
     clearTestStorage()
   })
 
-  it('stores layout states under assistant-specific local storage keys', () => {
-    expect(storage.save('assistant-1', 'maximized')).toBe(true)
-    expect(storage.save('assistant-2', 'minimized')).toBe(true)
+  it('stores layout states under user- and assistant-specific local storage keys', () => {
+    expect(storage.save('user-1', 'assistant-1', 'maximized')).toBe(true)
+    expect(storage.save('user-1', 'assistant-2', 'minimized')).toBe(true)
+    expect(storage.save('user-2', 'assistant-1', 'normal')).toBe(true)
 
-    expect(storage.load('assistant-1')).toBe('maximized')
-    expect(storage.load('assistant-2')).toBe('minimized')
-    expect(localStorage.getItem(getClawXpertWorkbenchLayoutStorageKey('assistant-1'))).toBe('maximized')
-    expect(localStorage.getItem(getClawXpertWorkbenchLayoutStorageKey('assistant-2'))).toBe('minimized')
+    expect(storage.load('user-1', 'assistant-1')).toBe('maximized')
+    expect(storage.load('user-1', 'assistant-2')).toBe('minimized')
+    expect(storage.load('user-2', 'assistant-1')).toBe('normal')
+    expect(localStorage.getItem(getClawXpertWorkbenchLayoutStorageKey('user-1', 'assistant-1'))).toBe('maximized')
+    expect(localStorage.getItem(getClawXpertWorkbenchLayoutStorageKey('user-1', 'assistant-2'))).toBe('minimized')
   })
 
-  it('ignores empty assistant ids and unsupported stored values', () => {
-    localStorage.setItem(getClawXpertWorkbenchLayoutStorageKey('assistant-1'), 'expanded')
+  it('ignores empty ids and unsupported stored values', () => {
+    localStorage.setItem(getClawXpertWorkbenchLayoutStorageKey('user-1', 'assistant-1'), 'expanded')
 
-    expect(storage.load('assistant-1')).toBeNull()
-    expect(storage.load('  ')).toBeNull()
-    expect(storage.save('  ', 'normal')).toBe(false)
+    expect(storage.load('user-1', 'assistant-1')).toBeNull()
+    expect(storage.load('  ', 'assistant-1')).toBeNull()
+    expect(storage.load('user-1', '  ')).toBeNull()
+    expect(storage.save('  ', 'assistant-1', 'normal')).toBe(false)
+    expect(storage.save('user-1', '  ', 'normal')).toBe(false)
+  })
+
+  it('does not reuse legacy assistant-only layout preferences', () => {
+    localStorage.setItem(LEGACY_ASSISTANT_ONE_KEY, 'maximized')
+
+    expect(storage.load('user-1', 'assistant-1')).toBeNull()
   })
 })
 
 function clearTestStorage() {
-  ASSISTANT_IDS.forEach((assistantId) => {
-    localStorage.removeItem(getClawXpertWorkbenchLayoutStorageKey(assistantId))
+  localStorage.removeItem(LEGACY_ASSISTANT_ONE_KEY)
+  USER_IDS.forEach((userId) => {
+    ASSISTANT_IDS.forEach((assistantId) => {
+      localStorage.removeItem(getClawXpertWorkbenchLayoutStorageKey(userId, assistantId))
+    })
   })
 }

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-workbench-layout-storage.service.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-workbench-layout-storage.service.ts
@@ -3,41 +3,43 @@ import { inject, Injectable } from '@angular/core'
 
 export type ClawXpertWorkbenchLayoutState = 'minimized' | 'normal' | 'maximized'
 
-const STORAGE_KEY_PREFIX = 'xpert.clawxpert.workbench.layout.v1:'
+const STORAGE_KEY_PREFIX = 'xpert.clawxpert.workbench.layout.v2:'
 
-export function getClawXpertWorkbenchLayoutStorageKey(assistantId: string) {
-  return `${STORAGE_KEY_PREFIX}${encodeURIComponent(assistantId.trim())}`
+export function getClawXpertWorkbenchLayoutStorageKey(userId: string, assistantId: string) {
+  return `${STORAGE_KEY_PREFIX}${encodeURIComponent(userId.trim())}:${encodeURIComponent(assistantId.trim())}`
 }
 
 @Injectable({ providedIn: 'root' })
 export class ClawXpertWorkbenchLayoutStorage {
   readonly #document = inject(DOCUMENT)
 
-  load(assistantId: string): ClawXpertWorkbenchLayoutState | null {
+  load(userId: string, assistantId: string): ClawXpertWorkbenchLayoutState | null {
+    const normalizedUserId = userId.trim()
     const normalizedAssistantId = assistantId.trim()
     const storage = this.getStorage()
-    if (!normalizedAssistantId || !storage) {
+    if (!normalizedUserId || !normalizedAssistantId || !storage) {
       return null
     }
 
     try {
       return normalizeWorkbenchLayoutState(
-        storage.getItem(getClawXpertWorkbenchLayoutStorageKey(normalizedAssistantId))
+        storage.getItem(getClawXpertWorkbenchLayoutStorageKey(normalizedUserId, normalizedAssistantId))
       )
     } catch {
       return null
     }
   }
 
-  save(assistantId: string, state: ClawXpertWorkbenchLayoutState): boolean {
+  save(userId: string, assistantId: string, state: ClawXpertWorkbenchLayoutState): boolean {
+    const normalizedUserId = userId.trim()
     const normalizedAssistantId = assistantId.trim()
     const storage = this.getStorage()
-    if (!normalizedAssistantId || !storage) {
+    if (!normalizedUserId || !normalizedAssistantId || !storage) {
       return false
     }
 
     try {
-      storage.setItem(getClawXpertWorkbenchLayoutStorageKey(normalizedAssistantId), state)
+      storage.setItem(getClawXpertWorkbenchLayoutStorageKey(normalizedUserId, normalizedAssistantId), state)
       return true
     } catch {
       return false

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert.facade.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert.facade.ts
@@ -131,6 +131,7 @@ export class ClawXpertFacade implements WorkbenchChatFacade {
   readonly organizationId = toSignal(this.#store.selectOrganizationId(), {
     initialValue: this.#store.organizationId ?? null
   })
+  readonly userId = signal(this.#store.userId ?? null)
   readonly currentUrl = toSignal(
     this.#router.events.pipe(
       filter((event): event is NavigationEnd => event instanceof NavigationEnd),

--- a/apps/cloud/src/app/features/chat/workbench-chat/workbench-chat.facade.ts
+++ b/apps/cloud/src/app/features/chat/workbench-chat/workbench-chat.facade.ts
@@ -13,6 +13,7 @@ export type WorkbenchChatDefinition = {
 export type WorkbenchChatFacade = {
   definition: WorkbenchChatDefinition
   identity: Signal<string | null>
+  userId: Signal<string | null>
   assistantId: Signal<string | null>
   xpertId: Signal<string | null>
   initialLayout: Signal<XpertWorkbenchInitialLayoutEnum | null>

--- a/apps/cloud/src/app/features/chat/xpert-workbench/xpert-workbench.facade.ts
+++ b/apps/cloud/src/app/features/chat/xpert-workbench/xpert-workbench.facade.ts
@@ -39,6 +39,7 @@ export class XpertWorkbenchFacade implements WorkbenchChatFacade {
   readonly organizationId = toSignal(this.#store.selectOrganizationId(), {
     initialValue: this.#store.organizationId ?? null
   })
+  readonly userId = signal(this.#store.userId ?? null)
   readonly currentUrl = toSignal(
     this.#router.events.pipe(
       filter((event): event is NavigationEnd => event instanceof NavigationEnd),

--- a/apps/cloud/src/app/features/project/project.facade.spec.ts
+++ b/apps/cloud/src/app/features/project/project.facade.spec.ts
@@ -1,0 +1,50 @@
+import { HttpErrorResponse } from '@angular/common/http'
+import { TestBed } from '@angular/core/testing'
+import { throwError } from 'rxjs'
+import { XpertProjectApiService } from './project-api.service'
+import { XpertProjectFacade } from './project.facade'
+
+describe('XpertProjectFacade', () => {
+  let api: {
+    list: jest.Mock
+  }
+
+  beforeEach(() => {
+    api = {
+      list: jest.fn()
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        XpertProjectFacade,
+        {
+          provide: XpertProjectApiService,
+          useValue: api
+        }
+      ]
+    })
+  })
+
+  afterEach(() => {
+    TestBed.resetTestingModule()
+  })
+
+  it('preserves the server error when loading projects fails', async () => {
+    api.list.mockReturnValue(
+      throwError(
+        () =>
+          new HttpErrorResponse({
+            status: 403,
+            error: { message: 'Project permission is required' }
+          })
+      )
+    )
+
+    const facade = TestBed.inject(XpertProjectFacade)
+
+    await facade.loadProjects()
+
+    expect(facade.projects()).toEqual([])
+    expect(facade.error()).toBe('Project permission is required')
+  })
+})

--- a/apps/cloud/src/app/features/project/project.facade.ts
+++ b/apps/cloud/src/app/features/project/project.facade.ts
@@ -12,6 +12,7 @@ import type {
   IXpertProjectTask
 } from '@xpert-ai/contracts'
 import { firstValueFrom } from 'rxjs'
+import { getErrorMessage } from '@cloud/app/@core'
 import { XpertProjectApiService, XpertProjectOverview, XpertProjectTaskRelations } from './project-api.service'
 
 const itemsOf = <T>(value: T[] | { items: T[]; total: number } | undefined) =>
@@ -49,7 +50,7 @@ export class XpertProjectFacade {
       this.projects.set(response.items ?? [])
       return response.items ?? []
     } catch (error) {
-      this.error.set(error instanceof Error ? error.message : 'Failed to load projects')
+      this.error.set(getErrorMessage(error) || 'Failed to load projects')
       return []
     } finally {
       this.loading.set(false)
@@ -71,7 +72,7 @@ export class XpertProjectFacade {
       return overview
     } catch (error) {
       if (sequence !== this.#projectLoadSequence) return null
-      const message = error instanceof Error ? error.message : 'Failed to load project'
+      const message = getErrorMessage(error) || 'Failed to load project'
       this.projectError.set(message)
       this.error.set(message)
       return null
@@ -98,7 +99,7 @@ export class XpertProjectFacade {
       this.conversations.set(items)
       return items
     } catch (error) {
-      this.conversationsError.set(error instanceof Error ? error.message : 'Failed to load conversations')
+      this.conversationsError.set(getErrorMessage(error) || 'Failed to load conversations')
       this.conversations.set([])
       return []
     } finally {
@@ -283,7 +284,7 @@ export class XpertProjectFacade {
       if (!options.parentId) this.assetCount.set(response.total ?? items.length)
       return response
     } catch (error) {
-      this.assetsError.set(error instanceof Error ? error.message : 'Failed to load assets')
+      this.assetsError.set(getErrorMessage(error) || 'Failed to load assets')
       return { items: [], total: skip }
     } finally {
       this.assetsLoading.set(false)

--- a/apps/cloud/src/app/features/xpert/studio/header/workbench-initial-layout-settings.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/studio/header/workbench-initial-layout-settings.component.spec.ts
@@ -111,7 +111,9 @@ describe('XpertWorkbenchInitialLayoutSettingsComponent', () => {
     const fixture = TestBed.createComponent(XpertWorkbenchInitialLayoutSettingsComponent)
     await settle(fixture)
 
-    expect(viewExtensionApi.getSlotViews).toHaveBeenCalledWith('agent', 'xpert-1', 'agent.workbench.fixed')
+    expect(viewExtensionApi.getSlotViews).toHaveBeenCalledWith('agent', 'xpert-1', 'agent.workbench.fixed', {
+      isDraft: true
+    })
     expect(fixture.componentInstance.viewOptions()).toEqual([
       { key: 'provider__review', label: 'Review' },
       { key: 'provider__metrics', label: 'Metrics' }

--- a/apps/cloud/src/app/features/xpert/studio/header/workbench-initial-layout-settings.component.ts
+++ b/apps/cloud/src/app/features/xpert/studio/header/workbench-initial-layout-settings.component.ts
@@ -256,7 +256,7 @@ export class XpertWorkbenchInitialLayoutSettingsComponent {
     this.loadingViews.set(true)
     try {
       const manifests = await firstValueFrom(
-        this.#viewExtensionApi.getSlotViews('agent', xpertId, AGENT_WORKBENCH_FIXED_SLOT)
+        this.#viewExtensionApi.getSlotViews('agent', xpertId, AGENT_WORKBENCH_FIXED_SLOT, { isDraft: true })
       )
       if (requestId !== this.#viewLoadRequestId) {
         return

--- a/packages/server-ai/src/knowledgebase/dto/knowledgebase-public.dto.spec.ts
+++ b/packages/server-ai/src/knowledgebase/dto/knowledgebase-public.dto.spec.ts
@@ -1,0 +1,19 @@
+import { KnowledgebaseTypeEnum } from '@xpert-ai/contracts'
+import { instanceToPlain } from 'class-transformer'
+import { KnowledgebasePublicDTO } from './knowledgebase-public.dto'
+
+describe('KnowledgebasePublicDTO', () => {
+    it('exposes workspaceId so scoped consumers can retain matching knowledgebases', () => {
+        const dto = new KnowledgebasePublicDTO({
+            id: 'knowledgebase-1',
+            name: 'Knowledgebase',
+            type: KnowledgebaseTypeEnum.Standard,
+            workspaceId: 'workspace-1'
+        })
+
+        expect(instanceToPlain(dto)).toMatchObject({
+            id: 'knowledgebase-1',
+            workspaceId: 'workspace-1'
+        })
+    })
+})

--- a/packages/server-ai/src/knowledgebase/dto/knowledgebase-public.dto.ts
+++ b/packages/server-ai/src/knowledgebase/dto/knowledgebase-public.dto.ts
@@ -1,49 +1,52 @@
 import {
-	IKnowledgebase,
-	IUser,
-	KBMetadataFieldDef,
-	KnowledgebasePermission,
-	KnowledgebaseStatusEnum,
-	TAvatar
+    IKnowledgebase,
+    IUser,
+    KBMetadataFieldDef,
+    KnowledgebasePermission,
+    KnowledgebaseStatusEnum,
+    TAvatar
 } from '@xpert-ai/contracts'
 import { Exclude, Expose } from 'class-transformer'
 
 @Exclude()
 export class KnowledgebasePublicDTO implements Partial<IKnowledgebase> {
-	@Expose()
-	declare id: string
+    @Expose()
+    declare id: string
 
-	@Expose()
-	declare name: string
+    @Expose()
+    declare workspaceId?: string
 
-	@Expose()
-	declare language?: 'Chinese' | 'English'
+    @Expose()
+    declare name: string
 
-	@Expose()
-	declare avatar?: TAvatar
+    @Expose()
+    declare language?: 'Chinese' | 'English'
 
-	@Expose()
-	declare description?: string
+    @Expose()
+    declare avatar?: TAvatar
 
-	@Expose()
-	declare status: KnowledgebaseStatusEnum
+    @Expose()
+    declare description?: string
 
-	@Expose()
-	metadataSchema?: KBMetadataFieldDef[];
+    @Expose()
+    declare status: KnowledgebaseStatusEnum
 
-	@Expose()
-	declare permission?: KnowledgebasePermission
+    @Expose()
+    metadataSchema?: KBMetadataFieldDef[]
 
-	@Expose()
-	declare createdBy?: IUser
+    @Expose()
+    declare permission?: KnowledgebasePermission
 
-	@Expose()
-	pipelineId?: string
+    @Expose()
+    declare createdBy?: IUser
 
-	@Expose()
-	declare createdAt: Date
+    @Expose()
+    pipelineId?: string
 
-	constructor(partial: IKnowledgebase) {
-		Object.assign(this, partial)
-	}
+    @Expose()
+    declare createdAt: Date
+
+    constructor(partial: IKnowledgebase) {
+        Object.assign(this, partial)
+    }
 }

--- a/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.spec.ts
+++ b/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.spec.ts
@@ -213,7 +213,7 @@ describe('AgentViewHostDefinition', () => {
         )
         const permission = jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(false)
         const context = { hostId: 'agent-host-1' } as XpertViewHostContext
-        const resolution = {} as ViewHostResolution
+        const resolution = { workspaceId: 'draft-workspace-2' } as ViewHostResolution
 
         await expect(definition.canRead(context, resolution, { isDraft: true })).resolves.toBe(false)
         expect(xpertService.assertCanAuthorById).not.toHaveBeenCalled()
@@ -222,7 +222,7 @@ describe('AgentViewHostDefinition', () => {
         permission.mockReturnValue(true)
         xpertService.assertCanAuthorById.mockRejectedValueOnce(new ForbiddenException('Access denied to workspace'))
         await expect(definition.canRead(context, resolution, { isDraft: true })).resolves.toBe(false)
-        expect(xpertService.assertCanAuthorById).toHaveBeenCalledWith('agent-host-1')
+        expect(xpertService.assertCanAuthorById).toHaveBeenCalledWith('agent-host-1', 'draft-workspace-2')
 
         xpertService.assertCanAuthorById.mockResolvedValueOnce(undefined)
         await expect(definition.canRead(context, resolution, { isDraft: true })).resolves.toBe(true)

--- a/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.spec.ts
+++ b/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.spec.ts
@@ -1,4 +1,6 @@
-import { WorkflowNodeTypeEnum, XpertTypeEnum } from '@xpert-ai/contracts'
+import { WorkflowNodeTypeEnum, XpertTypeEnum, type XpertViewHostContext } from '@xpert-ai/contracts'
+import { RequestContext, type ViewHostResolution } from '@xpert-ai/server-core'
+import { ForbiddenException } from '@nestjs/common'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -95,6 +97,141 @@ describe('AgentViewHostDefinition', () => {
             }
         })
         expect((resolved?.hostSnapshot as any).agent.key).toBe('Agent_BusinessAssistant')
+    })
+
+    it('derives view capabilities from the draft graph only when draft resolution is requested', async () => {
+        const xpertService = {
+            findOneByIdWithinTenant: jest.fn().mockResolvedValue({
+                id: 'agent-host-1',
+                type: XpertTypeEnum.Agent,
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                workspaceId: 'workspace-1',
+                name: 'Published Assistant',
+                active: true,
+                agent: {
+                    key: 'Agent_Published'
+                },
+                graph: {
+                    nodes: [
+                        {
+                            key: 'Agent_Published',
+                            type: 'agent',
+                            entity: {
+                                key: 'Agent_Published',
+                                name: 'Published Assistant'
+                            }
+                        }
+                    ],
+                    connections: []
+                },
+                draft: {
+                    team: {
+                        name: 'Story Studio',
+                        agent: {
+                            key: 'Agent_StoryStudio'
+                        }
+                    },
+                    nodes: [
+                        {
+                            key: 'Agent_StoryStudio',
+                            type: 'agent',
+                            entity: {
+                                key: 'Agent_StoryStudio',
+                                name: 'Story Studio'
+                            }
+                        },
+                        {
+                            key: 'Middleware_StoryStudio',
+                            type: 'workflow',
+                            entity: {
+                                type: WorkflowNodeTypeEnum.MIDDLEWARE,
+                                provider: 'StoryStudioMiddleware'
+                            }
+                        }
+                    ],
+                    connections: [
+                        {
+                            key: 'Agent_StoryStudio/Middleware_StoryStudio',
+                            type: 'workflow',
+                            from: 'Agent_StoryStudio',
+                            to: 'Middleware_StoryStudio'
+                        }
+                    ]
+                }
+            })
+        }
+        const middlewareRegistry = {
+            get: jest.fn().mockReturnValue({
+                meta: {
+                    features: ['story-studio']
+                }
+            })
+        }
+        const definition = new AgentViewHostDefinition(
+            xpertService as unknown as ConstructorParameters<typeof AgentViewHostDefinition>[0],
+            {} as ConstructorParameters<typeof AgentViewHostDefinition>[1],
+            middlewareRegistry as unknown as ConstructorParameters<typeof AgentViewHostDefinition>[2],
+            {} as ConstructorParameters<typeof AgentViewHostDefinition>[3]
+        )
+
+        const published = await definition.resolve('agent-host-1')
+        const draft = await definition.resolve('agent-host-1', { isDraft: true })
+
+        expect(published?.context).toMatchObject({
+            capabilities: { features: [] },
+            hostState: {
+                agent: {
+                    key: 'Agent_Published',
+                    middlewareProviders: []
+                }
+            }
+        })
+        expect(draft?.context).toMatchObject({
+            capabilities: { features: ['story-studio'] },
+            hostState: {
+                agent: {
+                    key: 'Agent_StoryStudio',
+                    middlewareProviders: ['StoryStudioMiddleware']
+                }
+            }
+        })
+    })
+
+    it('requires edit permission and xpert authoring access for draft view discovery', async () => {
+        const xpertService = {
+            assertCanAuthorById: jest.fn()
+        }
+        const publishedXpertAccessService = {
+            getAccessiblePublishedXpert: jest.fn()
+        }
+        const definition = new AgentViewHostDefinition(
+            xpertService as unknown as ConstructorParameters<typeof AgentViewHostDefinition>[0],
+            publishedXpertAccessService as unknown as ConstructorParameters<typeof AgentViewHostDefinition>[1],
+            {} as ConstructorParameters<typeof AgentViewHostDefinition>[2],
+            {} as ConstructorParameters<typeof AgentViewHostDefinition>[3]
+        )
+        const permission = jest.spyOn(RequestContext, 'hasPermission').mockReturnValue(false)
+        const context = { hostId: 'agent-host-1' } as XpertViewHostContext
+        const resolution = {} as ViewHostResolution
+
+        await expect(definition.canRead(context, resolution, { isDraft: true })).resolves.toBe(false)
+        expect(xpertService.assertCanAuthorById).not.toHaveBeenCalled()
+        expect(publishedXpertAccessService.getAccessiblePublishedXpert).not.toHaveBeenCalled()
+
+        permission.mockReturnValue(true)
+        xpertService.assertCanAuthorById.mockRejectedValueOnce(new ForbiddenException('Access denied to workspace'))
+        await expect(definition.canRead(context, resolution, { isDraft: true })).resolves.toBe(false)
+        expect(xpertService.assertCanAuthorById).toHaveBeenCalledWith('agent-host-1')
+
+        xpertService.assertCanAuthorById.mockResolvedValueOnce(undefined)
+        await expect(definition.canRead(context, resolution, { isDraft: true })).resolves.toBe(true)
+        expect(publishedXpertAccessService.getAccessiblePublishedXpert).not.toHaveBeenCalled()
+
+        xpertService.assertCanAuthorById.mockRejectedValueOnce(new Error('database unavailable'))
+        await expect(definition.canRead(context, resolution, { isDraft: true })).rejects.toThrow('database unavailable')
+
+        permission.mockRestore()
     })
 
     it('uploads workspace file actions into the xpert workspace before provider execution', async () => {

--- a/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.ts
+++ b/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.ts
@@ -93,14 +93,14 @@ export class AgentViewHostDefinition implements ViewHostDefinitionContract {
         }
     }
 
-    async canRead(context: XpertViewHostContext, _resolution: ViewHostResolution, options?: ViewHostResolutionOptions) {
+    async canRead(context: XpertViewHostContext, resolution: ViewHostResolution, options?: ViewHostResolutionOptions) {
         if (options?.isDraft) {
             if (!RequestContext.hasPermission(AIPermissionsEnum.XPERT_EDIT, false)) {
                 return false
             }
 
             try {
-                await this.xpertService.assertCanAuthorById(context.hostId)
+                await this.xpertService.assertCanAuthorById(context.hostId, resolution.workspaceId)
                 return true
             } catch (error) {
                 if (error instanceof ForbiddenException || error instanceof NotFoundException) {

--- a/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.ts
+++ b/packages/server-ai/src/view-extension/hosts/agent-view-host.definition.ts
@@ -1,14 +1,15 @@
 import {
     AIPermissionsEnum,
-    figureOutXpert,
     getAgentMiddlewareNodes,
     IWFNMiddleware,
     IXpert,
     normalizeMiddlewareProvider,
+    resolveRuntimeXpert,
     type TXpertTeamNode,
     TXpertFeatures,
     XpertResolvedViewHostContext,
     XpertViewActionRequest,
+    XpertViewHostContext,
     XpertTypeEnum,
     XpertViewHostCapabilities,
     XpertViewHostState,
@@ -19,10 +20,12 @@ import {
     RequestContext,
     ViewExtensionFileActionFile,
     ViewHostDefinition,
-    ViewHostDefinitionContract
+    ViewHostDefinitionContract,
+    ViewHostResolution,
+    ViewHostResolutionOptions
 } from '@xpert-ai/server-core'
 import { normalizeUploadedFileName } from '@xpert-ai/server-common'
-import { Inject, Injectable } from '@nestjs/common'
+import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common'
 import { XpertService } from '../../xpert/xpert.service'
 import { PublishedXpertAccessService } from '../../xpert/published-xpert-access.service'
 import { VOLUME_CLIENT, VolumeClient, VolumeSubtreeClient } from '../../shared/volume'
@@ -58,7 +61,7 @@ export class AgentViewHostDefinition implements ViewHostDefinitionContract {
         private readonly volumeClient: VolumeClient
     ) {}
 
-    async resolve(hostId: string) {
+    async resolve(hostId: string, options?: ViewHostResolutionOptions) {
         const xpert = await this.xpertService.findOneByIdWithinTenant(hostId, {
             relations: ['agent']
         })
@@ -66,18 +69,19 @@ export class AgentViewHostDefinition implements ViewHostDefinitionContract {
             return null
         }
 
-        const agentContext = this.resolveAgentContext(xpert as IXpert)
+        const runtimeXpert = resolveRuntimeXpert(xpert as IXpert, options?.isDraft === true)
+        const agentContext = this.resolveAgentContext(runtimeXpert)
 
         return {
-            workspaceId: xpert.workspaceId ?? null,
+            workspaceId: runtimeXpert.workspaceId ?? null,
             hostSnapshot: {
-                id: xpert.id,
-                name: xpert.name,
-                title: xpert.title ?? null,
-                type: xpert.type,
-                active: xpert.active ?? true,
-                environmentId: xpert.environmentId ?? null,
-                workspaceId: xpert.workspaceId ?? null,
+                id: runtimeXpert.id,
+                name: runtimeXpert.name,
+                title: runtimeXpert.title ?? null,
+                type: runtimeXpert.type,
+                active: runtimeXpert.active ?? true,
+                environmentId: runtimeXpert.environmentId ?? null,
+                workspaceId: runtimeXpert.workspaceId ?? null,
                 agent: {
                     key: agentContext.agentKey ?? null
                 }
@@ -89,7 +93,23 @@ export class AgentViewHostDefinition implements ViewHostDefinitionContract {
         }
     }
 
-    async canRead(context: Parameters<ViewHostDefinitionContract['canRead']>[0]) {
+    async canRead(context: XpertViewHostContext, _resolution: ViewHostResolution, options?: ViewHostResolutionOptions) {
+        if (options?.isDraft) {
+            if (!RequestContext.hasPermission(AIPermissionsEnum.XPERT_EDIT, false)) {
+                return false
+            }
+
+            try {
+                await this.xpertService.assertCanAuthorById(context.hostId)
+                return true
+            } catch (error) {
+                if (error instanceof ForbiddenException || error instanceof NotFoundException) {
+                    return false
+                }
+                throw error
+            }
+        }
+
         if (RequestContext.hasPermission(AIPermissionsEnum.XPERT_EDIT, false)) {
             return true
         }
@@ -165,13 +185,12 @@ export class AgentViewHostDefinition implements ViewHostDefinitionContract {
         capabilities: XpertViewHostCapabilities
         hostState: XpertViewHostState
     } {
-        const runtimeXpert = figureOutXpert(xpert, false) as IXpert
-        const features = new Set<string>(this.getEnabledXpertFeatures(runtimeXpert.features))
+        const features = new Set<string>(this.getEnabledXpertFeatures(xpert.features))
         const middlewareProviders = new Set<string>()
         const middlewareNodeKeys = new Set<string>()
-        const graph = runtimeXpert.graph
-        const agentKey = runtimeXpert.agent?.key ?? this.findPrimaryAgentKey(graph)
-        const knowledgebaseIds = runtimeXpert.agent?.knowledgebaseIds ?? []
+        const graph = xpert.graph
+        const agentKey = xpert.agent?.key ?? this.findPrimaryAgentKey(graph)
+        const knowledgebaseIds = xpert.agent?.knowledgebaseIds ?? []
 
         if (graph && agentKey) {
             for (const node of getAgentMiddlewareNodes(graph, agentKey)) {

--- a/packages/server-ai/src/xpert/xpert.service.spec.ts
+++ b/packages/server-ai/src/xpert/xpert.service.spec.ts
@@ -39,6 +39,7 @@ jest.mock('./types', () => ({
     }
 }))
 
+import { ForbiddenException } from '@nestjs/common'
 import { RequestContext } from '@xpert-ai/server-core'
 import { XpertPublishCommand } from './commands'
 import { XpertService } from './xpert.service'
@@ -72,6 +73,7 @@ describe('XpertService command facade', () => {
             findAll: jest.fn()
         }
         const workspaceAccessService = {
+            assertCanAuthor: jest.fn(),
             buildAccess: jest.fn(async (workspace: { id: string; organizationId?: string | null }) => ({
                 workspace,
                 capabilities: {
@@ -158,6 +160,29 @@ describe('XpertService command facade', () => {
                 createdAt: 'DESC'
             }
         })
+    })
+
+    it('requires target workspace authoring access for an xpert draft', async () => {
+        jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
+        const { service, repository, workspaceAccessService } = createService()
+        repository.findOne.mockResolvedValue({
+            id: 'xpert-1',
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            workspaceId: 'workspace-1',
+            createdById: 'owner-1'
+        })
+        workspaceAccessService.assertCanAuthor.mockRejectedValue(new ForbiddenException('Access denied to workspace'))
+
+        await expect(service.assertCanAuthorById('xpert-1')).rejects.toBeInstanceOf(ForbiddenException)
+        expect(repository.findOne).toHaveBeenCalledWith({
+            select: ['id', 'organizationId', 'workspaceId', 'createdById'],
+            where: {
+                id: 'xpert-1',
+                tenantId: 'tenant-1'
+            }
+        })
+        expect(workspaceAccessService.assertCanAuthor).toHaveBeenCalledWith('workspace-1')
     })
 
     it('publish forwards to XpertPublishCommand', async () => {

--- a/packages/server-ai/src/xpert/xpert.service.spec.ts
+++ b/packages/server-ai/src/xpert/xpert.service.spec.ts
@@ -185,6 +185,41 @@ describe('XpertService command facade', () => {
         expect(workspaceAccessService.assertCanAuthor).toHaveBeenCalledWith('workspace-1')
     })
 
+    it('also requires authoring access when the resolved draft workspace differs from the persisted workspace', async () => {
+        jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
+        const { service, repository, workspaceAccessService } = createService()
+        repository.findOne.mockResolvedValue({
+            id: 'xpert-1',
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            workspaceId: 'workspace-1',
+            createdById: 'owner-1'
+        })
+        workspaceAccessService.assertCanAuthor
+            .mockResolvedValueOnce(undefined)
+            .mockRejectedValueOnce(new ForbiddenException('Access denied to workspace'))
+
+        await expect(service.assertCanAuthorById('xpert-1', 'workspace-2')).rejects.toBeInstanceOf(ForbiddenException)
+        expect(workspaceAccessService.assertCanAuthor.mock.calls).toEqual([['workspace-1'], ['workspace-2']])
+    })
+
+    it('falls back to legacy creator and organization checks when no workspace is resolved', async () => {
+        jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
+        jest.spyOn(RequestContext, 'currentUserId').mockReturnValue('owner-1')
+        jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('org-1')
+        const { service, repository, workspaceAccessService } = createService()
+        repository.findOne.mockResolvedValue({
+            id: 'xpert-1',
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            workspaceId: null,
+            createdById: 'owner-1'
+        })
+
+        await expect(service.assertCanAuthorById('xpert-1', null)).resolves.toBeUndefined()
+        expect(workspaceAccessService.assertCanAuthor).not.toHaveBeenCalled()
+    })
+
     it('publish forwards to XpertPublishCommand', async () => {
         const { service, commandBus } = createService()
 

--- a/packages/server-ai/src/xpert/xpert.service.ts
+++ b/packages/server-ai/src/xpert/xpert.service.ts
@@ -18,7 +18,7 @@ import {
 } from '@xpert-ai/contracts'
 import { getErrorMessage } from '@xpert-ai/server-common'
 import { OptionParams, PaginationParams, RequestContext, transformWhere, UserGroupService } from '@xpert-ai/server-core'
-import { HttpException, HttpStatus, Inject, Injectable, NotFoundException } from '@nestjs/common'
+import { ForbiddenException, HttpException, HttpStatus, Inject, Injectable, NotFoundException } from '@nestjs/common'
 import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { InjectRepository } from '@nestjs/typeorm'
@@ -314,6 +314,23 @@ export class XpertService extends XpertWorkspaceBaseService<Xpert> {
         }
 
         return entity
+    }
+
+    async assertCanAuthorById(id: string): Promise<void> {
+        const xpert = await this.findOneByIdWithinTenant(id, {
+            select: ['id', 'organizationId', 'workspaceId', 'createdById']
+        })
+
+        if (xpert.workspaceId) {
+            await this.workspaceAccessService.assertCanAuthor(xpert.workspaceId)
+            return
+        }
+
+        const isCreator = xpert.createdById === RequestContext.currentUserId()
+        const isCurrentOrganization = (xpert.organizationId ?? null) === (RequestContext.getOrganizationId() ?? null)
+        if (!isCreator || !isCurrentOrganization) {
+            throw new ForbiddenException('Access denied to xpert')
+        }
     }
 
     async save(entity: Xpert) {

--- a/packages/server-ai/src/xpert/xpert.service.ts
+++ b/packages/server-ai/src/xpert/xpert.service.ts
@@ -316,20 +316,26 @@ export class XpertService extends XpertWorkspaceBaseService<Xpert> {
         return entity
     }
 
-    async assertCanAuthorById(id: string): Promise<void> {
+    async assertCanAuthorById(id: string, resolvedWorkspaceId?: string | null): Promise<void> {
         const xpert = await this.findOneByIdWithinTenant(id, {
             select: ['id', 'organizationId', 'workspaceId', 'createdById']
         })
 
-        if (xpert.workspaceId) {
-            await this.workspaceAccessService.assertCanAuthor(xpert.workspaceId)
-            return
+        const persistedWorkspaceId = xpert.workspaceId?.trim()
+        if (persistedWorkspaceId) {
+            await this.workspaceAccessService.assertCanAuthor(persistedWorkspaceId)
+        } else {
+            const isCreator = xpert.createdById === RequestContext.currentUserId()
+            const isCurrentOrganization =
+                (xpert.organizationId ?? null) === (RequestContext.getOrganizationId() ?? null)
+            if (!isCreator || !isCurrentOrganization) {
+                throw new ForbiddenException('Access denied to xpert')
+            }
         }
 
-        const isCreator = xpert.createdById === RequestContext.currentUserId()
-        const isCurrentOrganization = (xpert.organizationId ?? null) === (RequestContext.getOrganizationId() ?? null)
-        if (!isCreator || !isCurrentOrganization) {
-            throw new ForbiddenException('Access denied to xpert')
+        const targetWorkspaceId = resolvedWorkspaceId?.trim()
+        if (targetWorkspaceId && targetWorkspaceId !== persistedWorkspaceId) {
+            await this.workspaceAccessService.assertCanAuthor(targetWorkspaceId)
         }
     }
 

--- a/packages/server/src/view-extension/host-definition.interface.ts
+++ b/packages/server/src/view-extension/host-definition.interface.ts
@@ -18,13 +18,24 @@ export interface ViewHostResolution {
 	context?: Record<string, unknown>
 }
 
+export interface ViewHostResolutionOptions {
+	isDraft?: boolean
+}
+
 export interface ViewHostDefinitionContract {
 	readonly hostType: string
 	readonly slots: XpertViewSlot[]
 
-	resolve(hostId: string): Promise<ViewHostResolution | null> | ViewHostResolution | null
+	resolve(
+		hostId: string,
+		options?: ViewHostResolutionOptions
+	): Promise<ViewHostResolution | null> | ViewHostResolution | null
 
-	canRead(context: XpertViewHostContext, resolution: ViewHostResolution): Promise<boolean> | boolean
+	canRead(
+		context: XpertViewHostContext,
+		resolution: ViewHostResolution,
+		options?: ViewHostResolutionOptions
+	): Promise<boolean> | boolean
 
 	prepareFileAction?(
 		context: XpertResolvedViewHostContext,

--- a/packages/server/src/view-extension/view-extension.controller.spec.ts
+++ b/packages/server/src/view-extension/view-extension.controller.spec.ts
@@ -1,5 +1,6 @@
 import { ApiKeyOrClientSecretAuthGuard } from '../shared/guards'
 import { ViewExtensionController } from './view-extension.controller'
+import { ViewExtensionService } from './view-extension.service'
 
 describe('ViewExtensionController authentication', () => {
 	it('routes API keys and ChatKit client secrets through the mixed auth guard', () => {
@@ -7,5 +8,28 @@ describe('ViewExtensionController authentication', () => {
 
 		expect(Reflect.getMetadata('isPublic', ViewExtensionController)).toBe(true)
 		expect(guards).toContain(ApiKeyOrClientSecretAuthGuard)
+	})
+})
+
+describe('ViewExtensionController slot view discovery', () => {
+	it('forwards an explicit draft query without changing the default published request', async () => {
+		const service = {
+			listSlotViews: jest.fn().mockResolvedValue([])
+		}
+		const controller = new ViewExtensionController(service as unknown as ViewExtensionService)
+
+		await controller.getSlotViews('agent', 'assistant-1', 'agent.workbench.fixed', 'true')
+		await controller.getSlotViews('agent', 'assistant-1', 'agent.workbench.fixed', undefined)
+
+		expect(service.listSlotViews).toHaveBeenNthCalledWith(1, 'agent', 'assistant-1', 'agent.workbench.fixed', {
+			isDraft: true
+		})
+		expect(service.listSlotViews).toHaveBeenNthCalledWith(
+			2,
+			'agent',
+			'assistant-1',
+			'agent.workbench.fixed',
+			undefined
+		)
 	})
 })

--- a/packages/server/src/view-extension/view-extension.controller.ts
+++ b/packages/server/src/view-extension/view-extension.controller.ts
@@ -16,6 +16,7 @@ import { FileInterceptor } from '@nestjs/platform-express'
 import { IsObject, IsOptional, IsString } from 'class-validator'
 import type { Response } from 'express'
 import { SecretTokenBindingType, type XpertViewScalar } from '@xpert-ai/contracts'
+import { parseQueryBoolean } from '@xpert-ai/server-common'
 import { TransformInterceptor } from '../core/interceptors'
 import { AllowClientSecretBindings, Public } from '../shared/decorators'
 import { ApiKeyOrClientSecretAuthGuard } from '../shared/guards'
@@ -58,9 +59,11 @@ export class ViewExtensionController {
 	async getSlotViews(
 		@Param('hostType') hostType: string,
 		@Param('hostId') hostId: string,
-		@Param('slot') slot: string
+		@Param('slot') slot: string,
+		@Query('isDraft') isDraftQuery?: string | string[]
 	) {
-		return this.service.listSlotViews(hostType, hostId, slot)
+		const isDraft = parseQueryBoolean(isDraftQuery)
+		return this.service.listSlotViews(hostType, hostId, slot, isDraft ? { isDraft: true } : undefined)
 	}
 
 	@Get(':hostType/:hostId/views/:viewKey/data')

--- a/packages/server/src/view-extension/view-extension.permission.service.ts
+++ b/packages/server/src/view-extension/view-extension.permission.service.ts
@@ -1,16 +1,17 @@
 import { ForbiddenException, Injectable } from '@nestjs/common'
 import { XpertExtensionViewManifest, XpertViewActionDefinition, XpertViewHostContext } from '@xpert-ai/contracts'
 import { RequestContext } from '../core/context'
-import { ViewHostDefinitionContract, ViewHostResolution } from './host-definition.interface'
+import { ViewHostDefinitionContract, ViewHostResolution, ViewHostResolutionOptions } from './host-definition.interface'
 
 @Injectable()
 export class ViewExtensionPermissionService {
 	assertHostReadable(
 		definition: ViewHostDefinitionContract,
 		context: XpertViewHostContext,
-		resolution: ViewHostResolution
+		resolution: ViewHostResolution,
+		options?: ViewHostResolutionOptions
 	) {
-		return Promise.resolve(definition.canRead(context, resolution)).then((readable) => {
+		return Promise.resolve(definition.canRead(context, resolution, options)).then((readable) => {
 			if (readable) {
 				return
 			}

--- a/packages/server/src/view-extension/view-extension.service.spec.ts
+++ b/packages/server/src/view-extension/view-extension.service.spec.ts
@@ -69,7 +69,8 @@ describe('ViewExtensionService file actions', () => {
 			}))
 		}
 		const providerRegistry = {
-			get: jest.fn(() => provider)
+			get: jest.fn(() => provider),
+			listEntries: jest.fn(() => [{ providerKey: 'provider', provider }])
 		}
 		const hostDefinition = {
 			slots: [{ key: 'main', order: 1 }],
@@ -86,10 +87,12 @@ describe('ViewExtensionService file actions', () => {
 		}
 		const permissionService = {
 			assertHostReadable: jest.fn(),
+			filterVisibleManifests: jest.fn((manifests) => manifests),
 			ensureManifestVisible: jest.fn(),
 			ensureActionVisible: jest.fn()
 		}
 		const cacheService = {
+			getOrSetSlotViews: jest.fn(async (_context, _slot, _ttl, loader) => loader()),
 			invalidateView: jest.fn()
 		}
 		const service = new ViewExtensionService(
@@ -98,8 +101,22 @@ describe('ViewExtensionService file actions', () => {
 			permissionService as any,
 			cacheService as any
 		)
-		return { service, provider, cacheService }
+		return { service, provider, hostDefinition, permissionService, cacheService }
 	}
+
+	it('propagates draft resolution options through host discovery and permission checks', async () => {
+		const { service, hostDefinition, permissionService } = createService()
+
+		await service.listSlotViews('agent', 'assistant-1', 'main', { isDraft: true })
+
+		expect(hostDefinition.resolve).toHaveBeenCalledWith('assistant-1', { isDraft: true })
+		expect(permissionService.assertHostReadable).toHaveBeenCalledWith(
+			hostDefinition,
+			expect.objectContaining({ hostType: 'agent', hostId: 'assistant-1' }),
+			expect.any(Object),
+			{ isDraft: true }
+		)
+	})
 
 	it('loads remote component entries for vue runtime views', async () => {
 		const { service, provider } = createService()

--- a/packages/server/src/view-extension/view-extension.service.ts
+++ b/packages/server/src/view-extension/view-extension.service.ts
@@ -17,7 +17,7 @@ import {
 } from '@xpert-ai/contracts'
 import { RequestContext } from '../core/context'
 import { ViewHostDefinitionRegistry } from './host-definition.registry'
-import { ViewExtensionFileActionFile } from './host-definition.interface'
+import { ViewExtensionFileActionFile, ViewHostResolutionOptions } from './host-definition.interface'
 import { ViewExtensionPermissionService } from './view-extension.permission.service'
 import { ViewExtensionCacheService } from './view-extension.cache.service'
 import {
@@ -40,8 +40,8 @@ export class ViewExtensionService {
 		private readonly cacheService: ViewExtensionCacheService
 	) {}
 
-	async listSlotViews(hostType: string, hostId: string, slot: string) {
-		const context = await this.resolveHostContext(hostType, hostId)
+	async listSlotViews(hostType: string, hostId: string, slot: string, options?: ViewHostResolutionOptions) {
+		const context = await this.resolveHostContext(hostType, hostId, options)
 		this.ensureSlotExists(context, slot)
 
 		return this.cacheService.getOrSetSlotViews(context, slot, 60 * 1000, async () => {
@@ -331,7 +331,7 @@ export class ViewExtensionService {
 		throw new NotFoundException(`View '${publicViewKey}' was not found`)
 	}
 
-	private async resolveHostContext(hostType: string, hostId: string) {
+	private async resolveHostContext(hostType: string, hostId: string, options?: ViewHostResolutionOptions) {
 		this.assertEnterpriseXpertViewHost(hostType, hostId)
 		const definition = this.hostDefinitionRegistry.get(hostType)
 		if (!definition) {
@@ -339,13 +339,13 @@ export class ViewExtensionService {
 		}
 
 		const baseContext = buildBaseViewHostContext(hostType, hostId)
-		const resolution = await Promise.resolve(definition.resolve(hostId))
+		const resolution = await Promise.resolve(definition.resolve(hostId, options))
 
 		if (!resolution) {
 			throw new NotFoundException(`View host '${hostType}:${hostId}' was not found`)
 		}
 
-		await this.permissionService.assertHostReadable(definition, baseContext, resolution)
+		await this.permissionService.assertHostReadable(definition, baseContext, resolution, options)
 
 		const contextExtension = isRecord(resolution.context) ? resolution.context : {}
 


### PR DESCRIPTION
## Summary

- honor each assistant initial Workbench layout and persist later layout choices by user and assistant
- discover Studio Workbench views from the unpublished Xpert draft while keeping runtime discovery on the published graph
- require both `XPERT_EDIT` and target Xpert Workspace authoring access before exposing draft view capabilities

## Validation

- Cloud focused tests: 4 suites, 76 tests passed
- Server focused tests: 2 suites, 10 tests passed
- Server AI focused tests: 2 suites, 17 tests passed
- `nx build server --skip-nx-cache`
- `nx build server-ai --skip-nx-cache`
- `nx build cloud --configuration=development --skip-nx-cache`
- `git diff --check origin/develop...HEAD`

Production Cloud build reached font inlining but was blocked by the local CA error fetching Google Fonts; the development build completed successfully.