### PR TITLE
fix: harden sandbox runtime releases

### DIFF
--- a/.changeset/quiet-runtimes-release.md
+++ b/.changeset/quiet-runtimes-release.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/sandbox-runtime': patch
+---
+
+Require release metadata for Runtime image changes and add guarded immutable-tag recovery.

--- a/.github/workflows/sandbox-runtime-publish.yml
+++ b/.github/workflows/sandbox-runtime-publish.yml
@@ -20,6 +20,23 @@ on:
         required: false
         type: boolean
         default: false
+      promote_version_tag:
+        description: Promote one verified sha-<commit> candidate to a missing immutable Runtime Suite version tag
+        required: false
+        type: boolean
+        default: false
+      runtime_family:
+        description: Image family to promote, for example document
+        required: false
+        type: string
+      runtime_version:
+        description: Runtime Suite version to promote, for example 1.2.0
+        required: false
+        type: string
+      source_sha:
+        description: Full commit SHA of the verified candidate image
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -40,9 +57,28 @@ jobs:
 
       - name: Select image families
         id: matrix
+        env:
+          PROMOTE_VERSION_TAG: ${{ inputs.promote_version_tag }}
+          PUBLISH_CANDIDATE: ${{ inputs.publish_candidate }}
+          RUNTIME_FAMILY: ${{ inputs.runtime_family }}
+          RUNTIME_VERSION: ${{ inputs.runtime_version }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$PROMOTE_VERSION_TAG" == "true" ]]; then
+            if [[ "$PUBLISH_CANDIDATE" == "true" ]]; then
+              echo "publish_candidate and promote_version_tag cannot both be enabled" >&2
+              exit 1
+            fi
+            if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "source_sha must be a full lowercase commit SHA" >&2
+              exit 1
+            fi
+            git cat-file -e "${SOURCE_SHA}^{commit}"
+            matrix=$(node packages/sandbox-runtime/scripts/build-matrix.mjs \
+              --family "$RUNTIME_FAMILY" \
+              --version "$RUNTIME_VERSION")
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             matrix=$(node packages/sandbox-runtime/scripts/build-matrix.mjs --changed-from "${{ github.event.pull_request.base.sha }}")
           elif [[ "${{ github.ref }}" == refs/heads/develop ]]; then
             matrix=$(node packages/sandbox-runtime/scripts/build-matrix.mjs --changed-from "${{ github.event.before }}")
@@ -52,6 +88,12 @@ jobs:
           count=$(jq '.include | length' <<< "$matrix")
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           [[ "$count" -gt 0 ]] && echo "changed=true" >> "$GITHUB_OUTPUT" || echo "changed=false" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Runtime Suite release metadata
+        if: github.event_name == 'pull_request'
+        run: >-
+          node packages/sandbox-runtime/scripts/verify-release-change.mjs
+          --changed-from "${{ github.event.pull_request.base.sha }}"
 
       - name: Verify Runtime Suite catalog
         if: steps.matrix.outputs.changed == 'true'
@@ -64,7 +106,11 @@ jobs:
       needs.prepare.outputs.changed == 'true' &&
       (
         github.event_name == 'pull_request' ||
-        (github.event_name == 'workflow_dispatch' && inputs.publish_candidate != true)
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.publish_candidate != true &&
+          inputs.promote_version_tag != true
+        )
       )
     runs-on: ubuntu-latest
     strategy:
@@ -92,7 +138,11 @@ jobs:
       needs.prepare.outputs.changed == 'true' &&
       (
         github.ref == 'refs/heads/develop' ||
-        (github.event_name == 'workflow_dispatch' && inputs.publish_candidate == true)
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.publish_candidate == true &&
+          inputs.promote_version_tag != true
+        )
       )
     runs-on: ubuntu-latest
     environment: production
@@ -147,10 +197,138 @@ jobs:
             done
           done
 
-  alias-platform-release:
-    name: Alias Runtime Suite / ${{ matrix.family }}
+  promote-version-tag:
+    name: Promote Runtime Suite version / ${{ matrix.family }}
+    needs: prepare
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.promote_version_tag == true &&
+      needs.prepare.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    environment: production
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Aliyun ACR
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Promote a verified candidate without overwriting immutable content
+        env:
+          REPOSITORIES: ${{ toJSON(matrix.repositories) }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          VERSION_TAG: ${{ matrix.versionTag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image_digest() {
+            docker buildx imagetools inspect "$1" --format '{{json .Manifest.Digest}}'
+          }
+
+          declare -a missing_targets=()
+          for repository in $(jq -r '.[]' <<< "$REPOSITORIES"); do
+            source="$repository:sha-$SOURCE_SHA"
+            target="$repository:$VERSION_TAG"
+            source_digest=$(image_digest "$source")
+            if target_digest=$(image_digest "$target" 2>/dev/null); then
+              if [[ "$target_digest" != "$source_digest" ]]; then
+                echo "Refusing to overwrite $target with different content" >&2
+                exit 1
+              fi
+              echo "$target already points to $source_digest"
+            else
+              missing_targets+=("$repository")
+            fi
+          done
+
+          for repository in "${missing_targets[@]}"; do
+            source="$repository:sha-$SOURCE_SHA"
+            target="$repository:$VERSION_TAG"
+            source_digest=$(image_digest "$source")
+            docker buildx imagetools create --tag "$target" "$source"
+            published_digest=$(image_digest "$target")
+            if [[ "$published_digest" != "$source_digest" ]]; then
+              echo "$target digest $published_digest does not match $source digest $source_digest" >&2
+              exit 1
+            fi
+          done
+
+  preflight-platform-release:
+    name: Preflight Runtime Suite release / ${{ matrix.family }}
     needs: prepare
     if: startsWith(github.ref, 'refs/tags/') && needs.prepare.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    environment: production
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Aliyun ACR
+        uses: docker/login-action@v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Verify every immutable source exists
+        env:
+          REPOSITORIES: ${{ toJSON(matrix.repositories) }}
+          VERSION_TAG: ${{ matrix.versionTag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for repository in $(jq -r '.[]' <<< "$REPOSITORIES"); do
+            docker buildx imagetools inspect "$repository:$VERSION_TAG" >/dev/null
+          done
+
+  alias-platform-release:
+    name: Alias Runtime Suite / ${{ matrix.family }}
+    needs:
+      - prepare
+      - preflight-platform-release
+    if: >-
+      startsWith(github.ref, 'refs/tags/') &&
+      needs.prepare.outputs.changed == 'true' &&
+      needs.preflight-platform-release.result == 'success'
     runs-on: ubuntu-latest
     environment: production
     strategy:

--- a/packages/sandbox-runtime/README.md
+++ b/packages/sandbox-runtime/README.md
@@ -2,11 +2,11 @@
 
 This private package is the single source of truth for Xpert Sandbox OCI images, local Runtime assets, immutable Runtime Artifact catalogs, build metadata, and smoke tests. Provider-neutral Runtime Definitions are embedded in OSS Core so production API processes can perform capability discovery without installing this package. Runtime Suite tooling consumes those Definitions when validating images and producing release catalogs.
 
-The suite contains three provider-neutral profiles. `browser/playwright-1.61/v1` supplies Node.js 20.20.2 for general browser automation. `browser/ai-playwright-1.61/v1` adds an immutable, hash-verified AI resource catalog (initially multilingual `Xenova/whisper-tiny:q4` and ONNX Runtime Web) without putting models in plugin packages. `browser/video-playwright-1.61/v1` supplies Node.js 22.17.1, Playwright 1.61.0 with matching Chromium, FFmpeg 6.1, CJK/Emoji fonts, and larger media-oriented resource limits. All profiles use the same generic Runner Host. Plugins contribute versioned Sandbox Action Bundles; they never select an image or pass a command.
+The suite contains four provider-neutral profiles. `browser/playwright-1.61/v1` supplies Node.js 20.20.2 for general browser automation. `browser/ai-playwright-1.61/v1` adds an immutable, hash-verified AI resource catalog (initially multilingual `Xenova/whisper-tiny:q4` and ONNX Runtime Web) without putting models in plugin packages. `browser/video-playwright-1.61/v1` supplies Node.js 22.17.1, Playwright 1.61.0 with matching Chromium, FFmpeg 6.1, CJK/Emoji fonts, and larger media-oriented resource limits. `document/libreoffice-7/v1` supplies headless LibreOffice for document conversion. All profiles use the same generic Runner Host. Plugins contribute versioned Sandbox Action Bundles; they never select an image or pass a command.
 
 ## Add an image family
 
-Add the family below `images/`, declare it once in `images/catalog.json`, and implement its image manifest, Artifact Catalog template, Dockerfile, and smoke tests. Add its provider-neutral Runtime Definition to the OSS Core catalog and reference that file from `image.json`. Release workflows derive their build matrix only from the image catalog.
+Add the family below `images/`, declare it once in `images/catalog.json`, and implement its image manifest, Artifact Catalog template, Dockerfile, and smoke tests. Add its provider-neutral Runtime Definition to the OSS Core catalog and reference that file from `image.json`. Release workflows derive their build matrix only from the image catalog. Every image-affecting change must also include a Changeset for `@xpert-ai/sandbox-runtime`; otherwise the immutable source tag required by a platform release cannot be produced.
 
 ## Local verification
 
@@ -41,6 +41,10 @@ Application images and Runtime images intentionally use different workflows:
 - `.github/workflows/publish-npm-packages.yml` publishes immutable Runtime Suite version tags when `@xpert-ai/sandbox-runtime` is versioned.
 
 Pull requests that touch `packages/sandbox-runtime/**` or Runtime Definitions build and smoke-test the affected image families but do not push images. Pushes to `develop` for the same paths build, smoke-test, and push only `develop-candidate` and `sha-<commit>` aliases. Platform git tags do not rebuild Runtime images; they create `xpert-<tag>` aliases for already-published Runtime Suite version tags.
+
+Before creating any platform aliases, the tag workflow verifies that every family-specific immutable source exists in all configured registries. A missing source therefore stops the release without creating a partial set of platform aliases.
+
+For recovery of a candidate that passed the existing build and smoke-test workflow but missed immutable promotion, manually dispatch this workflow with `promote_version_tag`, `runtime_family`, `runtime_version`, and the full candidate `source_sha`. The recovery job derives the family-specific version tag from the catalog, verifies the candidate in every registry, and refuses to replace an immutable tag with different content. It does not create a platform alias; rerun the failed platform-tag jobs after the immutable source has been restored.
 
 ## Ownership boundary
 

--- a/packages/sandbox-runtime/project.json
+++ b/packages/sandbox-runtime/project.json
@@ -18,6 +18,9 @@
       "options": {
         "commands": [
           "node packages/sandbox-runtime/scripts/verify-catalog.mjs",
+          "node packages/sandbox-runtime/scripts/build-matrix.test.mjs",
+          "node packages/sandbox-runtime/scripts/release-workflow.test.mjs",
+          "node packages/sandbox-runtime/scripts/verify-release-change.test.mjs",
           "node packages/sandbox-runtime/scripts/install-ai-resources.test.mjs",
           "node packages/sandbox-runtime/images/browser/tests/runner-host.test.mjs",
           "node packages/sandbox-runtime/images/browser-video/tests/runtime-contract.test.mjs",

--- a/packages/sandbox-runtime/scripts/build-matrix.mjs
+++ b/packages/sandbox-runtime/scripts/build-matrix.mjs
@@ -6,21 +6,32 @@ import { promisify } from 'node:util'
 const packageRoot = new URL('../', import.meta.url)
 const catalog = JSON.parse(await readFile(new URL('images/catalog.json', packageRoot), 'utf8'))
 const packageJson = JSON.parse(await readFile(new URL('package.json', packageRoot), 'utf8'))
-const changedFromIndex = process.argv.indexOf('--changed-from')
-const changedFrom = changedFromIndex >= 0 ? process.argv[changedFromIndex + 1] : ''
+const changedFrom = optionValue('--changed-from')
+const selectedFamily = optionValue('--family')
+const runtimeSuiteVersion = optionValue('--version') || packageJson.version
+
+if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(runtimeSuiteVersion)) {
+  throw new Error(`Invalid Sandbox Runtime Suite version: ${runtimeSuiteVersion}`)
+}
+
+if (selectedFamily && !catalog.images.some((entry) => entry.family === selectedFamily)) {
+  throw new Error(`Unknown Sandbox Runtime image family: ${selectedFamily}`)
+}
+
 const changedFiles = changedFrom ? await listChangedFiles(changedFrom) : null
 const include = []
 for (const entry of catalog.images) {
+  if (selectedFamily && entry.family !== selectedFamily) continue
   const image = JSON.parse(await readFile(new URL(entry.definition, packageRoot), 'utf8'))
   if (changedFiles && !familyChanged(entry.family, image, changedFiles)) continue
   include.push({
     family: image.imageFamily,
     dockerfile: `packages/sandbox-runtime/${image.dockerfile}`,
     context: '.',
-    version: packageJson.version,
+    version: runtimeSuiteVersion,
     versionTag: image.playwrightVersion
-      ? `${packageJson.version}-pw${image.playwrightVersion}`
-      : `${packageJson.version}-lo${image.libreOfficeMajorVersion}`,
+      ? `${runtimeSuiteVersion}-pw${image.playwrightVersion}`
+      : `${runtimeSuiteVersion}-lo${image.libreOfficeMajorVersion}`,
     profileName: image.profileName,
     repositories: image.repositories,
     smokeCommand: image.smokeCommand.join(' '),
@@ -28,6 +39,14 @@ for (const entry of catalog.images) {
   })
 }
 process.stdout.write(`${JSON.stringify({ include })}\n`)
+
+function optionValue(name) {
+  const index = process.argv.indexOf(name)
+  if (index < 0) return ''
+  const value = process.argv[index + 1]
+  if (!value || value.startsWith('--')) throw new Error(`Missing value for ${name}`)
+  return value
+}
 
 async function listChangedFiles(reference) {
   const { stdout } = await promisify(execFile)('git', [

--- a/packages/sandbox-runtime/scripts/build-matrix.test.mjs
+++ b/packages/sandbox-runtime/scripts/build-matrix.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import test from 'node:test'
+
+const script = path.resolve('packages/sandbox-runtime/scripts/build-matrix.mjs')
+
+function buildMatrix(...args) {
+  return JSON.parse(
+    execFileSync(process.execPath, [script, ...args], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+  )
+}
+
+test('selects one family and derives its immutable tag from an explicit suite version', () => {
+  const matrix = buildMatrix('--family', 'document', '--version', '1.2.0')
+
+  assert.equal(matrix.include.length, 1)
+  assert.equal(matrix.include[0].family, 'document')
+  assert.equal(matrix.include[0].version, '1.2.0')
+  assert.equal(matrix.include[0].versionTag, '1.2.0-lo7')
+})
+
+test('rejects an unknown image family', () => {
+  assert.throws(
+    () => buildMatrix('--family', 'missing-runtime'),
+    /Unknown Sandbox Runtime image family: missing-runtime/
+  )
+})
+
+test('rejects an invalid explicit suite version', () => {
+  assert.throws(() => buildMatrix('--version', 'latest'), /Invalid Sandbox Runtime Suite version: latest/)
+})

--- a/packages/sandbox-runtime/scripts/release-workflow.test.mjs
+++ b/packages/sandbox-runtime/scripts/release-workflow.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const workflow = await readFile('.github/workflows/sandbox-runtime-publish.yml', 'utf8')
+
+test('preflights every immutable source before platform aliases can start', () => {
+  assert.match(workflow, /\n  preflight-platform-release:\n/)
+
+  const aliasJob = workflow.slice(workflow.indexOf('\n  alias-platform-release:\n'))
+  assert.match(aliasJob, /needs:\n\s+- prepare\n\s+- preflight-platform-release\n/)
+  assert.match(aliasJob, /needs\.preflight-platform-release\.result == 'success'/)
+})
+
+test('provides a controlled immutable version-tag recovery job', () => {
+  assert.match(workflow, /\n      promote_version_tag:\n/)
+  assert.match(workflow, /\n  promote-version-tag:\n/)
+  assert.match(workflow, /--format '\{\{json \.Manifest\.Digest\}\}'/)
+  assert.match(workflow, /Refusing to overwrite .* with different content/)
+})

--- a/packages/sandbox-runtime/scripts/verify-release-change.mjs
+++ b/packages/sandbox-runtime/scripts/verify-release-change.mjs
@@ -1,0 +1,80 @@
+import { execFile } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const packageName = '@xpert-ai/sandbox-runtime'
+const packageJsonPath = 'packages/sandbox-runtime/package.json'
+const packageRoot = 'packages/sandbox-runtime/'
+const runtimeDefinitionRoot = 'packages/server-ai/src/sandbox/sandbox-job/runtime-definitions/'
+
+export function validateRuntimeReleaseChange({ changedFiles, baseVersion, currentVersion, changesetContents }) {
+  const releaseInputs = changedFiles.filter(isRuntimeReleaseInput)
+  if (releaseInputs.length === 0 || baseVersion !== currentVersion) return
+  if (changesetContents.some((content) => changesetReleasesPackage(content))) return
+
+  throw new Error(
+    `Sandbox Runtime release inputs (${releaseInputs.join(', ')}) must include a Changeset for ${packageName}. ` +
+      'Run "corepack pnpm changeset" and select a patch, minor, or major release.'
+  )
+}
+
+async function verifyReleaseChange(changedFrom) {
+  const [{ stdout: changedFilesOutput }, { stdout: basePackageOutput }, { stdout: changesetFilesOutput }] =
+    await Promise.all([
+      execFileAsync('git', ['diff', '--name-only', changedFrom, 'HEAD', '--', packageRoot, runtimeDefinitionRoot]),
+      execFileAsync('git', ['show', `${changedFrom}:${packageJsonPath}`]),
+      execFileAsync('git', ['diff', '--name-only', '--diff-filter=AM', changedFrom, 'HEAD', '--', '.changeset'])
+    ])
+
+  const basePackage = JSON.parse(basePackageOutput)
+  const currentPackage = JSON.parse(await readFile(packageJsonPath, 'utf8'))
+  const changedFiles = changedFilesOutput.split(/\r?\n/).filter(Boolean)
+  const changesetFiles = changesetFilesOutput
+    .split(/\r?\n/)
+    .filter((file) => file.endsWith('.md') && path.basename(file) !== 'README.md')
+  const changesetContents = await Promise.all(changesetFiles.map((file) => readFile(file, 'utf8')))
+
+  validateRuntimeReleaseChange({
+    changedFiles,
+    baseVersion: basePackage.version,
+    currentVersion: currentPackage.version,
+    changesetContents
+  })
+}
+
+function isRuntimeReleaseInput(file) {
+  if (file === packageJsonPath || file.startsWith(runtimeDefinitionRoot)) return true
+  if (file.startsWith(`${packageRoot}scripts/`)) return !file.endsWith('.test.mjs')
+  if (!file.startsWith(`${packageRoot}images/`)) return false
+  return !file.includes('/tests/')
+}
+
+function changesetReleasesPackage(content) {
+  const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
+  if (!frontmatter) return false
+  return new RegExp(`^\\s*["']?${escapeRegExp(packageName)}["']?\\s*:\\s*["']?(patch|minor|major)["']?\\s*$`, 'm').test(
+    frontmatter[1]
+  )
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function optionValue(name) {
+  const index = process.argv.indexOf(name)
+  if (index < 0) return ''
+  const value = process.argv[index + 1]
+  if (!value || value.startsWith('--')) throw new Error(`Missing value for ${name}`)
+  return value
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : ''
+if (invokedPath === import.meta.url) {
+  const changedFrom = optionValue('--changed-from')
+  if (!changedFrom) throw new Error('Usage: verify-release-change.mjs --changed-from <git-reference>')
+  await verifyReleaseChange(changedFrom)
+}

--- a/packages/sandbox-runtime/scripts/verify-release-change.test.mjs
+++ b/packages/sandbox-runtime/scripts/verify-release-change.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { validateRuntimeReleaseChange } from './verify-release-change.mjs'
+
+const changedFiles = ['packages/sandbox-runtime/images/document/Dockerfile']
+
+test('requires a Sandbox Runtime Changeset when image inputs change without a version bump', () => {
+  assert.throws(
+    () =>
+      validateRuntimeReleaseChange({
+        changedFiles,
+        baseVersion: '1.2.0',
+        currentVersion: '1.2.0',
+        changesetContents: []
+      }),
+    /must include a Changeset for @xpert-ai\/sandbox-runtime/
+  )
+})
+
+test('accepts a changed Changeset for the Sandbox Runtime package', () => {
+  assert.doesNotThrow(() =>
+    validateRuntimeReleaseChange({
+      changedFiles,
+      baseVersion: '1.2.0',
+      currentVersion: '1.2.0',
+      changesetContents: ['---\n"@xpert-ai/sandbox-runtime": patch\n---\n\nRelease a new image family.\n']
+    })
+  )
+})
+
+test('accepts the generated version commit without a remaining Changeset', () => {
+  assert.doesNotThrow(() =>
+    validateRuntimeReleaseChange({
+      changedFiles,
+      baseVersion: '1.2.0',
+      currentVersion: '1.2.1',
+      changesetContents: []
+    })
+  )
+})
+
+test('does not require release metadata when no image family changed', () => {
+  assert.doesNotThrow(() =>
+    validateRuntimeReleaseChange({
+      changedFiles: [],
+      baseVersion: '1.2.0',
+      currentVersion: '1.2.0',
+      changesetContents: []
+    })
+  )
+})
+
+test('does not require a release for test-only changes', () => {
+  assert.doesNotThrow(() =>
+    validateRuntimeReleaseChange({
+      changedFiles: ['packages/sandbox-runtime/images/document/tests/runtime-contract.test.mjs'],
+      baseVersion: '1.2.0',
+      currentVersion: '1.2.0',
+      changesetContents: []
+    })
+  )
+})


### PR DESCRIPTION
## Summary

- require image-affecting Sandbox Runtime changes to include a Changeset for `@xpert-ai/sandbox-runtime`
- preflight every family-specific immutable source in every registry before creating any platform-version alias
- add a production-gated, single-family recovery path that promotes an existing verified `sha-<commit>` candidate without overwriting different immutable content
- add focused tests for release metadata, recovery inputs, and workflow ordering

## Root cause

The new `document` Runtime family was built and smoke-tested on `develop`, but it was added after Runtime Suite `1.2.0` had already been released and did not include a Sandbox Runtime Changeset. Candidate tags existed, while the immutable `1.2.0-lo7` source expected by platform tags did not. Platform tag jobs then created aliases for the existing browser families before failing on `document`.

## Recovery after merge

Dispatch `Publish Sandbox Runtime images` with:

- `promote_version_tag`: `true`
- `runtime_family`: `document`
- `runtime_version`: `1.2.0`
- `source_sha`: `e982a515773a04b53512345f18e500e803348aff`

After all three registries contain `1.2.0-lo7`, rerun the failed `3.17.5` document job. This PR itself does not publish images or rerun release jobs.

## Validation

- `corepack pnpm nx test sandbox-runtime`
- focused release metadata integration check against `origin/develop`
- Prettier check for all changed workflow and script files
- `git diff --check origin/develop...HEAD`
- read-only registry verification that the Docker Hub and Aliyun candidates share digest `sha256:c2987f3aed5c83138c9c4bf21a7f99915352dcfaf56b214f21848c637e442979` and both immutable targets are currently absent
