### PR TITLE
[codex] decouple membership model catalog from defaults

### DIFF
--- a/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.spec.ts
+++ b/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.spec.ts
@@ -1,4 +1,4 @@
-import { AiModelTypeEnum, FetchFrom } from '@xpert-ai/contracts'
+import { AiModelTypeEnum, AiProviderRole, FetchFrom } from '@xpert-ai/contracts'
 import { RequestContext } from '@xpert-ai/server-core'
 import { CopilotModelCatalogMode, FindCopilotModelsQuery } from '../copilot-model-find.query'
 import { FindCopilotModelsHandler } from './copilot-model-find.handler'
@@ -380,7 +380,7 @@ describe('FindCopilotModelsHandler', () => {
         })
     })
 
-    it('loads current-organization provider models for membership management without requiring a matching default model', async () => {
+    it('matches membership provider catalogs to copilot roles without requiring a default model', async () => {
         jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
         jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('org-1')
         const service = {
@@ -389,50 +389,120 @@ describe('FindCopilotModelsHandler', () => {
                 {
                     id: 'copilot-tenant',
                     organizationId: null,
+                    role: AiProviderRole.Primary,
                     modelProvider: {
                         id: 'provider-tenant',
                         providerName: 'openai-compatible'
                     }
                 },
                 {
-                    id: 'copilot-without-default',
+                    id: 'copilot-primary',
                     organizationId: 'org-1',
+                    role: AiProviderRole.Primary,
                     copilotModel: null,
                     modelProvider: {
-                        id: 'provider-without-default',
+                        id: 'provider-primary',
                         providerName: 'openai-compatible'
                     }
                 },
                 {
-                    id: 'copilot-with-other-default-type',
+                    id: 'copilot-secondary',
                     organizationId: 'org-1',
+                    role: AiProviderRole.Secondary,
+                    copilotModel: null,
+                    modelProvider: {
+                        id: 'provider-secondary',
+                        providerName: 'openai-compatible'
+                    }
+                },
+                {
+                    id: 'copilot-embedding',
+                    organizationId: 'org-1',
+                    role: AiProviderRole.Embedding,
                     copilotModel: {
-                        model: 'embedding-model',
-                        modelType: AiModelTypeEnum.TEXT_EMBEDDING
+                        model: 'llm-model',
+                        modelType: AiModelTypeEnum.LLM
                     },
                     modelProvider: {
-                        id: 'provider-with-other-default-type',
+                        id: 'provider-embedding',
+                        providerName: 'openai-compatible'
+                    }
+                },
+                {
+                    id: 'copilot-reasoning',
+                    organizationId: 'org-1',
+                    role: AiProviderRole.Reasoning,
+                    copilotModel: null,
+                    modelProvider: {
+                        id: 'provider-reasoning',
+                        providerName: 'openai-compatible'
+                    }
+                },
+                {
+                    id: 'copilot-legacy-rerank',
+                    organizationId: 'org-1',
+                    role: null,
+                    copilotModel: {
+                        model: 'rerank-model',
+                        modelType: AiModelTypeEnum.RERANK
+                    },
+                    modelProvider: {
+                        id: 'provider-legacy-rerank',
                         providerName: 'openai-compatible'
                     }
                 }
             ])
         }
-        const providersService = {
-            getProvider: jest.fn().mockReturnValue({
-                getProviderModels: jest.fn().mockReturnValue([
+        const getProviderModels = jest.fn((modelType: AiModelTypeEnum) => {
+            if (modelType === AiModelTypeEnum.LLM) {
+                return [
                     {
-                        model: 'paid-model',
+                        model: 'llm-model',
                         model_type: AiModelTypeEnum.LLM,
                         fetch_from: FetchFrom.PREDEFINED_MODEL,
                         model_properties: {},
                         features: [],
-                        label: { zh_Hans: 'Paid', en_US: 'Paid' }
+                        label: { zh_Hans: 'LLM', en_US: 'LLM' }
                     }
-                ]),
+                ]
+            }
+            if (modelType === AiModelTypeEnum.TEXT_EMBEDDING) {
+                return [
+                    {
+                        model: 'embedding-model',
+                        model_type: AiModelTypeEnum.TEXT_EMBEDDING,
+                        fetch_from: FetchFrom.PREDEFINED_MODEL,
+                        model_properties: {},
+                        features: [],
+                        label: { zh_Hans: 'Embedding', en_US: 'Embedding' }
+                    }
+                ]
+            }
+            if (modelType === AiModelTypeEnum.RERANK) {
+                return [
+                    {
+                        model: 'rerank-model',
+                        model_type: AiModelTypeEnum.RERANK,
+                        fetch_from: FetchFrom.PREDEFINED_MODEL,
+                        model_properties: {},
+                        features: [],
+                        label: { zh_Hans: 'Rerank', en_US: 'Rerank' }
+                    }
+                ]
+            }
+            return []
+        })
+        const providersService = {
+            getProvider: jest.fn().mockReturnValue({
+                getProviderModels,
                 getProviderSchema: jest.fn().mockReturnValue({
                     provider: 'openai-compatible',
                     label: { zh_Hans: 'OpenAI Compatible', en_US: 'OpenAI Compatible' },
-                    supported_model_types: [AiModelTypeEnum.LLM],
+                    supported_model_types: [
+                        AiModelTypeEnum.LLM,
+                        AiModelTypeEnum.TEXT_EMBEDDING,
+                        AiModelTypeEnum.RERANK
+                    ],
                     models: []
                 })
             })
@@ -450,18 +520,30 @@ describe('FindCopilotModelsHandler', () => {
             value: { get: jest.fn().mockReturnValue('http://localhost:3000') }
         })
 
-        const result = await handler.execute(
+        const llmResult = await handler.execute(
             new FindCopilotModelsQuery(AiModelTypeEnum.LLM, CopilotModelCatalogMode.MembershipManagement)
         )
+        const embeddingResult = await handler.execute(
+            new FindCopilotModelsQuery(AiModelTypeEnum.TEXT_EMBEDDING, CopilotModelCatalogMode.MembershipManagement)
+        )
+        const rerankResult = await handler.execute(
+            new FindCopilotModelsQuery(AiModelTypeEnum.RERANK, CopilotModelCatalogMode.MembershipManagement)
+        )
 
-        expect(result.map((copilot) => copilot.id)).toEqual([
-            'copilot-without-default',
-            'copilot-with-other-default-type'
+        expect(llmResult.map((copilot) => copilot.id)).toEqual([
+            'copilot-primary',
+            'copilot-secondary',
+            'copilot-reasoning'
         ])
-        expect(result.map((copilot) => copilot.providerWithModels.models.map((model) => model.model))).toEqual([
-            ['paid-model'],
-            ['paid-model']
+        expect(llmResult.map((copilot) => copilot.providerWithModels.models.map((model) => model.model))).toEqual([
+            ['llm-model'],
+            ['llm-model'],
+            ['llm-model']
         ])
+        expect(embeddingResult.map((copilot) => copilot.id)).toEqual(['copilot-embedding'])
+        expect(embeddingResult[0].providerWithModels.models.map((model) => model.model)).toEqual(['embedding-model'])
+        expect(rerankResult.map((copilot) => copilot.id)).toEqual(['copilot-legacy-rerank'])
+        expect(rerankResult[0].providerWithModels.models.map((model) => model.model)).toEqual(['rerank-model'])
         expect(service.findAllAvailablesCopilots).not.toHaveBeenCalled()
         expect(service.findAllEnabledCopilotsWithoutMembership).toHaveBeenCalledWith('tenant-1', 'org-1')
         expect(modelAccessService.canUseCatalogModels).not.toHaveBeenCalled()

--- a/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.spec.ts
+++ b/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.spec.ts
@@ -380,7 +380,7 @@ describe('FindCopilotModelsHandler', () => {
         })
     })
 
-    it('loads only current-organization models matching the configured model type for membership management', async () => {
+    it('loads current-organization provider models for membership management without requiring a matching default model', async () => {
         jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
         jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('org-1')
         const service = {
@@ -395,26 +395,23 @@ describe('FindCopilotModelsHandler', () => {
                     }
                 },
                 {
-                    id: 'copilot-organization',
+                    id: 'copilot-without-default',
                     organizationId: 'org-1',
-                    copilotModel: {
-                        model: 'paid-model',
-                        modelType: AiModelTypeEnum.LLM
-                    },
+                    copilotModel: null,
                     modelProvider: {
-                        id: 'provider-organization',
+                        id: 'provider-without-default',
                         providerName: 'openai-compatible'
                     }
                 },
                 {
-                    id: 'copilot-embedding',
+                    id: 'copilot-with-other-default-type',
                     organizationId: 'org-1',
                     copilotModel: {
                         model: 'embedding-model',
                         modelType: AiModelTypeEnum.TEXT_EMBEDDING
                     },
                     modelProvider: {
-                        id: 'provider-embedding',
+                        id: 'provider-with-other-default-type',
                         providerName: 'openai-compatible'
                     }
                 }
@@ -457,8 +454,14 @@ describe('FindCopilotModelsHandler', () => {
             new FindCopilotModelsQuery(AiModelTypeEnum.LLM, CopilotModelCatalogMode.MembershipManagement)
         )
 
-        expect(result.map((copilot) => copilot.id)).toEqual(['copilot-organization'])
-        expect(result[0].providerWithModels.models.map((model) => model.model)).toEqual(['paid-model'])
+        expect(result.map((copilot) => copilot.id)).toEqual([
+            'copilot-without-default',
+            'copilot-with-other-default-type'
+        ])
+        expect(result.map((copilot) => copilot.providerWithModels.models.map((model) => model.model))).toEqual([
+            ['paid-model'],
+            ['paid-model']
+        ])
         expect(service.findAllAvailablesCopilots).not.toHaveBeenCalled()
         expect(service.findAllEnabledCopilotsWithoutMembership).toHaveBeenCalledWith('tenant-1', 'org-1')
         expect(modelAccessService.canUseCatalogModels).not.toHaveBeenCalled()

--- a/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.ts
+++ b/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.ts
@@ -38,11 +38,7 @@ export class FindCopilotModelsHandler implements IQueryHandler<FindCopilotModels
         const managementCopilots = await this.service.findAllEnabledCopilotsWithoutMembership(tenantId, organizationId)
         const copilots =
             command.catalogMode === CopilotModelCatalogMode.MembershipManagement
-                ? managementCopilots.filter(
-                      (copilot) =>
-                          (copilot.organizationId ?? null) === (organizationId ?? null) &&
-                          copilot.copilotModel?.modelType === command.type
-                  )
+                ? managementCopilots.filter((copilot) => (copilot.organizationId ?? null) === (organizationId ?? null))
                 : managementCopilots
         const copilotSchemas: CopilotWithProviderDto[] = []
         for (const copilot of copilots) {

--- a/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.ts
+++ b/packages/server-ai/src/copilot/queries/handlers/copilot-model-find.handler.ts
@@ -1,4 +1,11 @@
-import { AiModelTypeEnum, FetchFrom, ICopilotProviderModel, ModelFeature, ProviderModel } from '@xpert-ai/contracts'
+import {
+    AiModelTypeEnum,
+    AiProviderRole,
+    FetchFrom,
+    ICopilotProviderModel,
+    ModelFeature,
+    ProviderModel
+} from '@xpert-ai/contracts'
 import { ConfigService } from '@xpert-ai/server-config'
 import { RequestContext } from '@xpert-ai/server-core'
 import { IQueryHandler, QueryBus, QueryHandler } from '@nestjs/cqrs'
@@ -38,7 +45,11 @@ export class FindCopilotModelsHandler implements IQueryHandler<FindCopilotModels
         const managementCopilots = await this.service.findAllEnabledCopilotsWithoutMembership(tenantId, organizationId)
         const copilots =
             command.catalogMode === CopilotModelCatalogMode.MembershipManagement
-                ? managementCopilots.filter((copilot) => (copilot.organizationId ?? null) === (organizationId ?? null))
+                ? managementCopilots.filter(
+                      (copilot) =>
+                          (copilot.organizationId ?? null) === (organizationId ?? null) &&
+                          (modelTypeForCopilotRole(copilot.role) ?? copilot.copilotModel?.modelType) === command.type
+                  )
                 : managementCopilots
         const copilotSchemas: CopilotWithProviderDto[] = []
         for (const copilot of copilots) {
@@ -147,6 +158,19 @@ export class FindCopilotModelsHandler implements IQueryHandler<FindCopilotModels
             )
         }
         return copilots.filter((copilot) => copilot.providerWithModels.models.length)
+    }
+}
+
+function modelTypeForCopilotRole(role: AiProviderRole | null | undefined): AiModelTypeEnum | null {
+    switch (role) {
+        case AiProviderRole.Primary:
+        case AiProviderRole.Secondary:
+        case AiProviderRole.Reasoning:
+            return AiModelTypeEnum.LLM
+        case AiProviderRole.Embedding:
+            return AiModelTypeEnum.TEXT_EMBEDDING
+        default:
+            return null
     }
 }
 


### PR DESCRIPTION
## Summary

- make membership model configuration derive LLM and embedding catalogs from the Copilot provider role instead of requiring a saved default model
- keep the saved model type only as a compatibility fallback for legacy Copilots that have no role
- preserve current-organization scoping and requested model-type filtering

## Problem

Membership model configuration previously required `copilotModel.modelType` to exist and match the requested catalog type. A configured provider such as OpenRouter therefore had no membership options until an unrelated default model was selected.

Simply removing that check exposed every supported catalog through every Copilot using the same provider plugin. For example, Tongyi LLM models could appear under an Embedding provider.

## Fix

For membership-management catalogs, resolve the effective model type in this order:

1. Map the Copilot role: Primary, Secondary, and Reasoning to LLM; Embedding to Text Embedding.
2. Only when the role is absent or unknown, fall back to the saved model type for legacy data.

The provider catalog is then loaded only when that effective type matches the requested type. Membership authorization remains concerned only with whether a concrete model is allowed; it no longer requires or follows the configured default model for normal role-based providers.

## Validation

- `corepack pnpm nx test server-ai --runInBand --testPathPatterns=copilot-model-find.handler.spec.ts` - 6 tests passed
- `corepack pnpm nx build server-ai` - passed
- targeted ESLint - no errors (existing warnings only)
- Prettier and `git diff --check` - passed
- commit hooks: Prettier, hardcoded color usage check, and TypeORM column type check passed

Regression coverage includes provider roles with no default model, an Embedding provider carrying a conflicting LLM default, organization scoping, and a roleless legacy Rerank provider.
