### PR TITLE
fix: release document sandbox runtime

### DIFF
--- a/.changeset/release-document-runtime.md
+++ b/.changeset/release-document-runtime.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/sandbox-runtime': patch
+---
+
+Release the document Sandbox Runtime image family.


### PR DESCRIPTION
## Summary

- add a patch Changeset for `@xpert-ai/sandbox-runtime`
- release the new `document` Runtime family through the existing Runtime Suite version workflow

The document family was added after Runtime Suite `1.2.0` had already been published, so it only had candidate tags and no immutable version tag. After this Changeset is versioned and the generated version PR is merged, the existing release workflow will publish Runtime Suite `1.2.1`, including `1.2.1-lo7` for document.

This PR intentionally does not change workflows, scripts, tests, or documentation. It also does not backfill `1.2.0-lo7` or rerun the existing `3.17.5` job.

## Validation

- `corepack pnpm changeset status --since=origin/main`
- Prettier check
- commit hooks
- `git diff --check origin/main...HEAD`
