### PR TITLE
chore: prepare Xpert 3.17.6 release

### DIFF
--- a/.changeset/release-xpert-3-17-6.md
+++ b/.changeset/release-xpert-3-17-6.md
@@ -1,0 +1,7 @@
+---
+'@xpert-ai/contracts': patch
+'@xpert-ai/plugin-sdk': patch
+'@xpert-ai/xpert-ui': patch
+---
+
+Release Xpert 3.17.6 after publishing the complete Sandbox Runtime image suite.


### PR DESCRIPTION
## Summary

- add a patch changeset for @xpert-ai/contracts, @xpert-ai/plugin-sdk, and @xpert-ai/xpert-ui
- prepare the normal Xpert 3.17.6 release path
- keep @xpert-ai/sandbox-runtime at the already published 1.2.1 release

## Changesets preview

The three requested packages resolve to 3.17.6. Existing internal dependency rules also patch the dependent platform packages plugin-draft, server-core, server-ai, and plugin-vlm-default in the generated version PR.

## Release sequence

1. Merge this changeset PR.
2. Review and merge the generated chore: version packages PR.
3. Verify @xpert-ai/contracts@3.17.6 and @xpert-ai/plugin-sdk@3.17.6 in npm.
4. Tag the resulting main commit as 3.17.6.
5. Verify the platform tag workflow aliases document runtime 1.2.1-lo7 successfully.

## Validation

- changeset status --since=origin/main
- changeset version preview
- repository pre-commit hooks
- git diff --check