### PR TITLE
[codex] restrict agent message history variables

### DIFF
--- a/apps/cloud/src/app/features/xpert/studio/panel/xpert-agent/agent.component.html
+++ b/apps/cloud/src/app/features/xpert/studio/panel/xpert-agent/agent.component.html
@@ -200,7 +200,7 @@
         <xpert-state-variable-select
           nullable
           [varOptions]="varOptions()"
-          [type]="eXpertParameterTypeEnum.ARRAY"
+          [type]="eXpertParameterTypeEnum.ARRAY_MESSAGE"
           [(ngModel)]="historyVariable"
         />
       </div>

--- a/packages/contracts/src/agent/graph.spec.ts
+++ b/packages/contracts/src/agent/graph.spec.ts
@@ -1,4 +1,28 @@
-import { getWorkspaceFromRunnable } from './graph'
+import { IXpertAgent, TXpertGraph } from '../ai'
+import { getAgentVarGroup, getWorkspaceFromRunnable } from './graph'
+
+describe('getAgentVarGroup', () => {
+  it('exposes agent messages as a dedicated message-list variable', () => {
+    const graph: TXpertGraph = {
+      nodes: [
+        {
+          key: 'agent-1',
+          type: 'agent',
+          position: { x: 0, y: 0 },
+          entity: {
+            key: 'agent-1',
+            name: 'Agent 1'
+          } as IXpertAgent
+        }
+      ],
+      connections: []
+    }
+
+    const messages = getAgentVarGroup('agent-1', graph).variables.find((variable) => variable.name === 'messages')
+
+    expect(messages?.type).toBe('array[message]')
+  })
+})
 
 describe('getWorkspaceFromRunnable', () => {
   it('returns the shared project workspace root for project runs', () => {

--- a/packages/contracts/src/agent/graph.ts
+++ b/packages/contracts/src/agent/graph.ts
@@ -245,7 +245,7 @@ export function getAgentVarGroup(key: string, graph: TXpertGraph): TWorkflowVarG
 
   variables.push({
     name: `messages`,
-    type: XpertParameterTypeEnum.ARRAY,
+    type: XpertParameterTypeEnum.ARRAY_MESSAGE,
     description: {
       zh_Hans: `消息列表`,
       en_US: `Message List`

--- a/packages/contracts/src/ai/xpert.model.ts
+++ b/packages/contracts/src/ai/xpert.model.ts
@@ -561,6 +561,7 @@ export enum XpertParameterTypeEnum {
   ARRAY = 'array[object]',
   ARRAY_FILE = 'array[file]',
   ARRAY_DOCUMENT = 'array[document]',
+  ARRAY_MESSAGE = 'array[message]',
 
   BOOLEAN = 'boolean',
   SECRET = 'secret'


### PR DESCRIPTION
## Summary

The Agent Message History selector currently accepts every `array[object]` workflow variable. This allows outputs such as Knowledge Retrieval `result` to be selected even though the model runtime expects a LangChain message list.

This change introduces a dedicated `array[message]` parameter type, marks each Agent channel's `messages` variable with that type, and restricts the Message History selector to it. General workflow arrays, including knowledge retrieval results, remain available to prompt-variable selectors but no longer appear as message-history choices.

## Root cause

Agent message lists and unrelated workflow arrays shared the same `array[object]` discriminator, so the generic state-variable selector had no machine-readable way to distinguish them.

## Validation

- Added a focused contract regression test for the Agent `messages` variable type.
- `corepack pnpm exec jest packages/contracts/src/agent/graph.spec.ts --config packages/contracts/jest.config.ts --runInBand`
- `corepack pnpm nx build cloud --configuration=development --skip-nx-cache`
- ESLint on the four changed files completed with no errors; only pre-existing warnings remain.

## Scope note

This PR intentionally does not add backend runtime validation or migrate already persisted invalid selections. Existing drafts that selected a non-message variable must be reconfigured through the corrected selector.
