### PR TITLE
feat(connectors): refine the ClawXpert connector experience

### DIFF
--- a/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.html
+++ b/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.html
@@ -1,250 +1,387 @@
-<div class="relative min-h-full bg-background-body px-8 py-8 xl:px-12">
-  <header class="flex flex-wrap items-start justify-between gap-4 border-b border-divider-regular pb-6">
-    <div class="flex min-w-0 items-start gap-3">
-      <div
-        class="flex size-10 shrink-0 items-center justify-center rounded-xl border border-divider-regular bg-background-default-subtle"
-      >
-        <z-icon [zType]="connectorIcon" class="text-xl text-text-primary"></z-icon>
-      </div>
-      <div class="min-w-0">
-        <h1 class="text-2xl font-semibold tracking-normal text-text-primary">
-          {{ 'XP.Xpert.Connectors' | translate: { Default: 'Connectors' } }}
-        </h1>
-        <p class="mt-1 max-w-3xl text-sm text-text-secondary">
-          {{
-            'XP.Xpert.ConnectorsDescription'
-              | translate
-                : {
-                    Default:
-                      'Connect external services to the workspace with authorization and credentials managed by xpert.'
-                  }
-          }}
-        </p>
-      </div>
-    </div>
-  </header>
-
-  <section class="mt-8 space-y-4">
-    <div class="flex flex-wrap items-start justify-between gap-3">
-      <div class="space-y-1">
-        <h2 class="text-base font-medium text-text-primary">
-          {{ 'XP.Xpert.ConnectorCatalogTitle' | translate: { Default: 'Connector catalog' } }}
-        </h2>
-        <p class="text-sm text-text-secondary">
-          {{
-            'XP.Xpert.ConnectorCatalogDescription'
-              | translate
-                : {
-                    Default:
-                      'Choose an authentication method and configure a connection. Status stays synchronized with xpert.'
-                  }
-          }}
-        </p>
-      </div>
-      <button z-button zType="outline" zSize="sm" type="button" (click)="refresh()">
-        <z-icon [zType]="refreshIcon"></z-icon>
-        {{ 'XP.ACTIONS.Refresh' | translate: { Default: 'Refresh' } }}
-      </button>
-    </div>
-
+<div class="relative min-h-full bg-background-body px-5 py-5 lg:px-8 xl:px-10">
+  <div class="mx-auto w-full max-w-[1440px]">
     @if (errorMessage(); as error) {
       <div
         class="flex items-start gap-2 rounded-lg border border-danger-500/30 bg-danger-500/10 px-3 py-2 text-sm text-text-danger"
       >
-        <z-icon [zType]="errorIcon" class="mt-0.5 size-4 shrink-0"></z-icon>
+        <z-icon [zType]="errorIcon" class="mt-0.5 size-4 shrink-0" />
         <span>{{ error }}</span>
       </div>
     }
 
-    @if (loading() && definitions().length === 0) {
-      <div class="grid gap-4 lg:grid-cols-2">
-        @for (card of skeletonCards; track card) {
-          <div class="h-72 animate-pulse rounded-xl border border-divider-regular bg-components-card-bg"></div>
-        }
-      </div>
-    } @else if (definitions().length === 0) {
-      <div
-        class="rounded-xl border border-dashed border-divider-regular px-4 py-14 text-center text-sm text-text-secondary"
-      >
-        {{
-          'XP.Xpert.NoConnectorsAvailable' | translate: { Default: 'No connectors are currently available from xpert.' }
-        }}
-      </div>
-    } @else {
-      <div class="grid gap-4 xl:grid-cols-2">
-        @for (definition of definitions(); track definition.provider) {
-          @let connector = connectorFor(definition);
-          @let status = statusLabelFor(connector);
-          @let authMethods = authMethodsFor(definition);
-          @let authMethod = selectedAuthMethod(definition);
-          @let credentialForm = credentialFormFor(authMethod);
+    <section aria-label="Connector catalog">
+      @if (loading() && definitions().length === 0) {
+        <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          @for (card of skeletonCards; track card) {
+            <div class="h-[116px] animate-pulse rounded-lg border border-divider-regular bg-components-card-bg"></div>
+          }
+        </div>
+      } @else if (definitions().length === 0) {
+        <div class="flex min-h-56 flex-col items-center justify-center gap-2 text-center">
+          <z-icon [zType]="connectorIcon" class="size-8 text-text-tertiary" />
+          <p class="text-sm font-medium text-text-primary">
+            {{ 'XP.Xpert.NoConnectorsAvailable' | translate: { Default: 'No connectors are currently available.' } }}
+          </p>
+        </div>
+      } @else if (filteredDefinitions().length === 0) {
+        <div class="flex min-h-56 flex-col items-center justify-center gap-2 text-center">
+          <z-icon zType="search" class="size-8 text-text-tertiary" />
+          <p class="text-sm font-medium text-text-primary">
+            {{ 'XP.Xpert.NoMatchingConnectors' | translate: { Default: 'No matching connectors found.' } }}
+          </p>
+          <button z-button zType="ghost" zSize="sm" type="button" (click)="searchQuery.set('')">
+            {{ 'XP.ACTIONS.Clear' | translate: { Default: 'Clear search' } }}
+          </button>
+        </div>
+      } @else {
+        <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          @for (definition of filteredDefinitions(); track definition.provider) {
+            @let connector = connectorFor(definition);
+            @let status = statusLabelFor(connector);
 
-          <div class="relative min-w-0 rounded-xl border border-divider-regular bg-components-card-bg">
-            <div class="space-y-5 p-5">
-              <div class="flex items-start justify-between gap-3">
-                <div class="flex min-w-0 items-center gap-3">
-                  <div
-                    class="flex size-11 shrink-0 items-center justify-center rounded-xl border border-divider-regular bg-background-default-subtle"
-                  >
-                    @if (iconImageUrl(definition); as iconUrl) {
-                      <img class="size-7 rounded-md object-contain" [src]="iconUrl" [alt]="definition.provider" />
-                    } @else {
-                      <z-icon [zType]="connectorIcon" class="size-6 text-text-secondary"></z-icon>
-                    }
-                  </div>
-                  <div class="min-w-0">
-                    <h3 class="truncate font-medium text-text-primary">
-                      {{ definition.label | i18n }}
-                    </h3>
-                    <p class="mt-0.5 line-clamp-2 text-sm text-text-secondary">
-                      {{ descriptionFor(definition) | i18n }}
-                    </p>
-                  </div>
-                </div>
-                <z-badge class="shrink-0" [zType]="statusBadgeType(connector)" zShape="pill">
-                  {{ status.key | translate: { Default: status.defaultLabel } }}
-                </z-badge>
-              </div>
-
-              @if (authMethods.length > 1 || !connector) {
-                <form class="grid gap-3" [formGroup]="formFor(definition)">
-                  @if (authMethods.length > 1) {
-                    <z-form-field>
-                      <z-form-label>
-                        {{ 'XP.Xpert.ConnectorAuthenticationMethod' | translate: { Default: 'Authentication method' } }}
-                      </z-form-label>
-                      <z-select
-                        class="w-full"
-                        formControlName="authMethodId"
-                        [zDisabled]="!!connector || !canManageWorkspace()"
-                        (zSelectionChange)="selectAuthMethod(definition, $event)"
-                      >
-                        @for (method of authMethods; track method.id) {
-                          <z-select-item [zValue]="method.id">{{ method.label | i18n }}</z-select-item>
-                        }
-                      </z-select>
-                    </z-form-field>
+            <article
+              [class]="
+                connector
+                  ? 'group relative flex min-h-[116px] items-start gap-2 rounded-lg border border-divider-regular bg-background-default-subtle p-4 transition-colors'
+                  : 'group relative flex min-h-[116px] items-start gap-2 rounded-lg border border-divider-regular bg-components-card-bg p-4 transition-colors hover:bg-background-default-subtle'
+              "
+              [attr.data-connector-provider]="definition.provider"
+            >
+              <button
+                type="button"
+                class="flex min-w-0 flex-1 cursor-pointer items-start gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40"
+                [attr.aria-label]="definition.label | i18n"
+                (click)="openConnectorDialog(definition)"
+              >
+                <div
+                  class="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-divider-regular bg-components-card-bg"
+                >
+                  @if (definition.icon; as icon) {
+                    <xp-icon
+                      [icon]="icon"
+                      [size]="28"
+                      class="flex size-7 items-center justify-center text-2xl leading-none"
+                    />
+                  } @else {
+                    <z-icon [zType]="connectorIcon" class="size-5 text-text-secondary" />
                   }
+                </div>
 
-                  @if (!connector) {
-                    <div class="grid gap-3 sm:grid-cols-2">
-                      @for (field of credentialFieldsFor(authMethod); track field.name) {
-                        <z-form-field>
-                          <z-form-label>
-                            {{ field.label | i18n }}
-                            @if (field.required) {
-                              <span aria-hidden="true"> *</span>
-                            }
-                          </z-form-label>
-                          <input
-                            z-input
-                            [attr.data-credential-field]="field.name"
-                            [type]="field.type === 'password' || field.secret ? 'password' : 'text'"
-                            [formControlName]="field.name"
-                            [placeholder]="field.placeholder ? (field.placeholder | i18n) : ''"
-                            [attr.autocomplete]="field.type === 'password' || field.secret ? 'new-password' : 'off'"
-                            [attr.disabled]="!canManageWorkspace() ? true : null"
-                          />
-                          @if (field.description) {
-                            <z-form-message>{{ field.description | i18n }}</z-form-message>
-                          }
-                          @if (
-                            fieldControl(definition, field)?.touched &&
-                            fieldControl(definition, field)?.hasError('required')
-                          ) {
-                            <z-form-message>
-                              {{
-                                'XP.Xpert.ConnectorCredentialRequired'
-                                  | translate: { Default: 'This field is required.' }
-                              }}
-                            </z-form-message>
-                          }
-                        </z-form-field>
-                      }
-                    </div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex min-w-0 items-center gap-2">
+                    <h2 class="truncate text-base font-semibold text-text-primary">{{ definition.label | i18n }}</h2>
+                    <span class="inline-flex shrink-0 items-center gap-1.5 text-sm text-text-secondary">
+                      <span class="size-1.5 rounded-full" [class]="statusDotClass(connector)"></span>
+                      {{ status.key | translate: { Default: status.defaultLabel } }}
+                    </span>
+                  </div>
+                  <p class="mt-1.5 line-clamp-2 text-sm leading-5 text-text-secondary">
+                    {{ descriptionFor(definition) | i18n }}
+                  </p>
+                </div>
+              </button>
 
-                    @if (credentialForm?.help; as help) {
-                      <a
-                        class="w-fit text-xs text-text-secondary underline underline-offset-2"
-                        [href]="help.url"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {{ help.label | i18n }}
-                      </a>
-                    }
+              @if (connector?.status !== 'active' && connector?.status !== 'pending') {
+                <button
+                  z-button
+                  zType="ghost"
+                  zSize="icon-sm"
+                  type="button"
+                  class="!size-10 shrink-0 cursor-pointer rounded-lg !bg-hover-bg text-text-secondary transition-[background-color,color,transform] hover:!bg-components-list-option-active-bg hover:text-text-primary active:scale-95 disabled:cursor-default"
+                  data-connector-action="quick-connect"
+                  [zDisabled]="loading() || isConnecting(definition) || !canManageWorkspace()"
+                  [attr.aria-label]="'XP.Xpert.ConnectConnector' | translate: { Default: 'Connect connector' }"
+                  [title]="'XP.Xpert.ConnectConnector' | translate: { Default: 'Connect connector' }"
+                  (click)="quickConnect(definition)"
+                >
+                  @if (isConnecting(definition)) {
+                    <z-icon [zType]="loadingIcon" class="!size-5 animate-spin" />
+                  } @else {
+                    <z-icon zType="plus" class="!size-5" />
                   }
-                </form>
+                </button>
+              } @else if (connector?.status === 'active') {
+                <button
+                  z-button
+                  zType="ghost"
+                  zSize="icon-sm"
+                  type="button"
+                  class="!size-10 shrink-0 cursor-pointer rounded-lg !bg-hover-bg text-text-secondary transition-[background-color,color,transform] hover:!bg-status-error-bg hover:text-text-destructive active:scale-95 disabled:cursor-default"
+                  data-connector-action="quick-disconnect"
+                  [zDisabled]="loading() || isDisconnecting(connector) || !canManageWorkspace()"
+                  [attr.aria-label]="'XP.Xpert.ConnectorDisconnect' | translate: { Default: 'Disconnect connector' }"
+                  [title]="'XP.Xpert.ConnectorDisconnect' | translate: { Default: 'Disconnect connector' }"
+                  (click)="disconnect(connector)"
+                >
+                  @if (isDisconnecting(connector)) {
+                    <z-icon [zType]="loadingIcon" class="!size-5 animate-spin" />
+                  } @else {
+                    <z-icon [zType]="disconnectIcon" class="!size-5" />
+                  }
+                </button>
+              } @else if (connector?.status === 'pending' && pendingAuthorizationUrl(connector)) {
+                <button
+                  z-button
+                  zType="ghost"
+                  zSize="sm"
+                  type="button"
+                  class="!h-10 shrink-0 cursor-pointer gap-1.5 rounded-lg !bg-hover-bg px-3 text-text-primary transition-[background-color,color,transform] hover:!bg-components-list-option-active-bg active:scale-[0.98] disabled:cursor-default"
+                  data-connector-action="continue-authorization"
+                  [zDisabled]="loading() || !canManageWorkspace()"
+                  (click)="openPendingAuthorizationUrl(connector)"
+                >
+                  <z-icon zType="arrow-up-right" class="!size-5" />
+                  {{ 'XP.Xpert.ConnectorOpenAuthorization' | translate: { Default: 'Continue authorization' } }}
+                </button>
               }
+            </article>
+          }
+        </div>
+      }
+    </section>
+  </div>
+</div>
 
-              @if (!canManageWorkspace()) {
-                <div class="text-xs text-text-secondary">
-                  {{
-                    'XP.Xpert.ConnectorsReadonly'
-                      | translate
-                        : { Default: 'Only workspace managers can connect or disconnect workspace connectors.' }
-                  }}
-                </div>
-              }
+@if (selectedDefinition(); as definition) {
+  @let connector = connectorFor(definition);
+  @let status = statusLabelFor(connector);
+  @let authMethods = authMethodsFor(definition);
+  @let authMethod = selectedAuthMethod(definition);
+  @let credentialForm = credentialFormFor(authMethod);
 
-              @if (connector?.profile) {
-                <div class="rounded-lg border border-divider-regular bg-background-default-subtle px-3 py-2.5 text-sm">
-                  <span class="text-text-secondary">
-                    {{ 'XP.Xpert.ConnectorConnectedAccount' | translate: { Default: 'Connected account:' } }}
-                  </span>
-                  <span class="font-medium text-text-primary">{{ profileLabel(connector) }}</span>
-                </div>
-              }
-
-              @if (connector?.lastError) {
-                <p class="text-sm text-text-danger">{{ connector.lastError }}</p>
-              }
-
-              <div class="flex justify-end">
-                @if (connector) {
-                  <button
-                    z-button
-                    zType="outline"
-                    zSize="sm"
-                    type="button"
-                    data-connector-action="disconnect"
-                    [zDisabled]="!canManageWorkspace() || loading() || isDisconnecting(connector)"
-                    (click)="disconnect(connector)"
-                  >
-                    @if (isDisconnecting(connector)) {
-                      <z-icon [zType]="loadingIcon" class="animate-spin"></z-icon>
-                    } @else {
-                      <z-icon [zType]="disconnectActionIcon"></z-icon>
-                    }
-                    {{ 'XP.Xpert.ConnectorDisconnect' | translate: { Default: 'Disconnect' } }}
-                  </button>
-                } @else {
-                  <button
-                    z-button
-                    zType="default"
-                    zSize="sm"
-                    type="button"
-                    data-connector-action="connect"
-                    [zDisabled]="!canManageWorkspace() || loading() || isConnecting(definition)"
-                    (click)="connect(definition)"
-                  >
-                    @if (isConnecting(definition)) {
-                      <z-icon [zType]="loadingIcon" class="animate-spin"></z-icon>
-                    } @else {
-                      <z-icon [zType]="connectorIcon"></z-icon>
-                    }
-                    {{ 'XP.Xpert.ConnectorConnect' | translate: { Default: 'Connect' } }}
-                  </button>
-                }
-              </div>
-            </div>
-
-            @if (loading()) {
-              <xp-spin class="absolute top-0 left-0 h-full w-full"></xp-spin>
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-[var(--color-overlay-backdrop-strong)] p-4"
+    role="dialog"
+    aria-modal="true"
+    [attr.aria-label]="definition.label | i18n"
+    data-connector-dialog
+    (click)="closeConnectorDialog()"
+  >
+    <div
+      class="max-h-[min(760px,calc(100vh-32px))] w-full max-w-lg overflow-auto rounded-lg border border-divider-regular bg-components-card-bg shadow-2xl"
+      (click)="$event.stopPropagation()"
+    >
+      <header class="flex items-start justify-between gap-4 border-b border-divider-regular px-5 py-4">
+        <div class="flex min-w-0 items-center gap-3">
+          <div
+            class="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-divider-regular bg-background-default-subtle"
+          >
+            @if (definition.icon; as icon) {
+              <xp-icon
+                [icon]="icon"
+                [size]="32"
+                class="flex size-8 items-center justify-center text-3xl leading-none"
+              />
+            } @else {
+              <z-icon [zType]="connectorIcon" class="size-6 text-text-secondary" />
             }
           </div>
+          <div class="min-w-0">
+            <h2 class="truncate text-base font-semibold text-text-primary">{{ definition.label | i18n }}</h2>
+            <div class="mt-1 flex items-center gap-1.5 text-xs text-text-secondary">
+              <span class="size-1.5 rounded-full" [class]="statusDotClass(connector)"></span>
+              {{ status.key | translate: { Default: status.defaultLabel } }}
+            </div>
+          </div>
+        </div>
+        <button
+          z-button
+          zType="ghost"
+          zSize="icon-sm"
+          type="button"
+          class="size-8 shrink-0"
+          [attr.aria-label]="'XP.ACTIONS.Close' | translate: { Default: 'Close' }"
+          [title]="'XP.ACTIONS.Close' | translate: { Default: 'Close' }"
+          (click)="closeConnectorDialog()"
+        >
+          <z-icon zType="x" />
+        </button>
+      </header>
+
+      <div class="space-y-5 px-5 py-5">
+        <p class="text-sm leading-6 text-text-secondary">{{ descriptionFor(definition) | i18n }}</p>
+
+        @if (!canManageWorkspace()) {
+          <div class="rounded-lg bg-background-default-subtle px-3 py-2.5 text-xs text-text-secondary">
+            {{
+              'XP.Xpert.ConnectorsReadonly'
+                | translate: { Default: 'Only workspace managers can connect or disconnect workspace connectors.' }
+            }}
+          </div>
+        }
+
+        @if (connector?.status === 'active' || connector?.status === 'pending') {
+          <div class="divide-y divide-divider-regular rounded-lg border border-divider-regular">
+            <div class="flex items-center justify-between gap-4 px-3 py-3 text-sm">
+              <span class="text-text-secondary">{{ 'XP.KEY_WORDS.Status' | translate: { Default: 'Status' } }}</span>
+              <span class="inline-flex items-center gap-1.5 font-medium text-text-primary">
+                <span class="size-1.5 rounded-full" [class]="statusDotClass(connector)"></span>
+                {{ status.key | translate: { Default: status.defaultLabel } }}
+              </span>
+            </div>
+            @if (connector.profile) {
+              <div class="flex items-center justify-between gap-4 px-3 py-3 text-sm">
+                <span class="text-text-secondary">
+                  {{ 'XP.Xpert.ConnectorConnectedAccount' | translate: { Default: 'Connected account' } }}
+                </span>
+                <span class="max-w-[65%] truncate font-medium text-text-primary">{{ profileLabel(connector) }}</span>
+              </div>
+            }
+            @if (connector.authMethodId) {
+              <div class="flex items-center justify-between gap-4 px-3 py-3 text-sm">
+                <span class="text-text-secondary">
+                  {{ 'XP.Xpert.ConnectorAuthenticationMethod' | translate: { Default: 'Authentication method' } }}
+                </span>
+                <span class="max-w-[65%] truncate font-medium text-text-primary">{{ connector.authMethodId }}</span>
+              </div>
+            }
+          </div>
+
+          @if (connector.lastError) {
+            <div class="flex items-start gap-2 rounded-lg bg-danger-500/10 px-3 py-2.5 text-sm text-text-danger">
+              <z-icon [zType]="errorIcon" class="mt-0.5 size-4 shrink-0" />
+              <span>{{ connector.lastError }}</span>
+            </div>
+          }
+
+          @if (connector.status === 'pending') {
+            <div class="flex flex-wrap items-center gap-2">
+              @if (pendingAuthorizationUrl(connector)) {
+                <button
+                  z-button
+                  type="button"
+                  zType="default"
+                  zSize="sm"
+                  (click)="openPendingAuthorizationUrl(connector)"
+                >
+                  <z-icon zType="arrow-up-right" />
+                  {{ 'XP.Xpert.ConnectorOpenAuthorization' | translate: { Default: 'Continue authorization' } }}
+                </button>
+              }
+              @if (isPolling(connector)) {
+                <span class="inline-flex items-center gap-1.5 text-xs text-text-tertiary">
+                  <z-icon [zType]="loadingIcon" class="animate-spin" />
+                  {{
+                    'XP.Xpert.ConnectorAuthorizationPending'
+                      | translate: { Default: 'Waiting for authorization to complete' }
+                  }}
+                </span>
+              }
+            </div>
+          }
+        } @else {
+          @if (connector?.lastError) {
+            <div class="flex items-start gap-2 rounded-lg bg-danger-500/10 px-3 py-2.5 text-sm text-text-danger">
+              <z-icon [zType]="errorIcon" class="mt-0.5 size-4 shrink-0" />
+              <span>{{ connector.lastError }}</span>
+            </div>
+          }
+
+          <form class="grid gap-4" [formGroup]="formFor(definition)" (ngSubmit)="connect(definition)">
+            @if (authMethods.length > 1) {
+              <z-form-field>
+                <z-form-label>
+                  {{ 'XP.Xpert.ConnectorAuthenticationMethod' | translate: { Default: 'Authentication method' } }}
+                </z-form-label>
+                <z-select
+                  class="w-full"
+                  formControlName="authMethodId"
+                  [zDisabled]="!canManageWorkspace()"
+                  (zSelectionChange)="selectAuthMethod(definition, $event)"
+                >
+                  @for (method of authMethods; track method.id) {
+                    <z-select-item [zValue]="method.id">{{ method.label | i18n }}</z-select-item>
+                  }
+                </z-select>
+              </z-form-field>
+            }
+
+            @for (field of credentialFieldsFor(authMethod); track field.name) {
+              <z-form-field>
+                <z-form-label>
+                  {{ field.label | i18n }}
+                  @if (field.required) {
+                    <span aria-hidden="true"> *</span>
+                  }
+                </z-form-label>
+                <input
+                  z-input
+                  [attr.data-credential-field]="field.name"
+                  [type]="field.type === 'password' || field.secret ? 'password' : 'text'"
+                  [formControlName]="field.name"
+                  [placeholder]="field.placeholder ? (field.placeholder | i18n) : ''"
+                  [attr.autocomplete]="field.type === 'password' || field.secret ? 'new-password' : 'off'"
+                  [attr.disabled]="!canManageWorkspace() ? true : null"
+                />
+                @if (field.description) {
+                  <z-form-message>{{ field.description | i18n }}</z-form-message>
+                }
+                @if (
+                  fieldControl(definition, field)?.touched && fieldControl(definition, field)?.hasError('required')
+                ) {
+                  <z-form-message>
+                    {{ 'XP.Xpert.ConnectorCredentialRequired' | translate: { Default: 'This field is required.' } }}
+                  </z-form-message>
+                }
+              </z-form-field>
+            }
+
+            @if (credentialForm?.help; as help) {
+              <a
+                class="inline-flex w-fit items-center gap-1 text-xs text-text-secondary underline underline-offset-2"
+                [href]="help.url"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{ help.label | i18n }}
+                <z-icon zType="arrow-up-right" class="size-3.5" />
+              </a>
+            }
+          </form>
         }
       </div>
-    }
-  </section>
-</div>
+
+      <footer class="flex flex-wrap items-center justify-end gap-2 border-t border-divider-regular px-5 py-4">
+        <button z-button zType="ghost" zSize="sm" type="button" (click)="closeConnectorDialog()">
+          {{ 'XP.ACTIONS.Cancel' | translate: { Default: 'Cancel' } }}
+        </button>
+        @if (connector?.status === 'active' || connector?.status === 'pending') {
+          <button
+            z-button
+            zType="outline"
+            zSize="sm"
+            type="button"
+            class="text-text-danger"
+            data-connector-action="disconnect"
+            [zDisabled]="!canManageWorkspace() || loading() || isDisconnecting(connector)"
+            (click)="disconnect(connector)"
+          >
+            @if (isDisconnecting(connector)) {
+              <z-icon [zType]="loadingIcon" class="animate-spin" />
+            } @else {
+              <z-icon [zType]="disconnectIcon" />
+            }
+            {{ 'XP.Xpert.ConnectorDisconnect' | translate: { Default: 'Disconnect connector' } }}
+          </button>
+        } @else {
+          <button
+            z-button
+            zType="default"
+            zSize="sm"
+            type="button"
+            data-connector-action="connect"
+            [zDisabled]="!canManageWorkspace() || loading() || isConnecting(definition)"
+            (click)="connect(definition)"
+          >
+            @if (isConnecting(definition)) {
+              <z-icon [zType]="loadingIcon" class="animate-spin" />
+            } @else {
+              <z-icon [zType]="connectorIcon" />
+            }
+            {{ 'XP.Xpert.ConnectorConnect' | translate: { Default: 'Connect' } }}
+          </button>
+        }
+      </footer>
+    </div>
+  </div>
+}

--- a/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.html
+++ b/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.html
@@ -8,12 +8,16 @@
       </div>
       <div class="min-w-0">
         <h1 class="text-2xl font-semibold tracking-normal text-text-primary">
-          {{ 'XP.Xpert.Connectors' | translate: { Default: '连接器' } }}
+          {{ 'XP.Xpert.Connectors' | translate: { Default: 'Connectors' } }}
         </h1>
         <p class="mt-1 max-w-3xl text-sm text-text-secondary">
           {{
             'XP.Xpert.ConnectorsDescription'
-              | translate: { Default: '连接工作空间所需的外部服务，授权和凭据由 xpert 平台统一管理。' }
+              | translate
+                : {
+                    Default:
+                      'Connect external services to the workspace with authorization and credentials managed by xpert.'
+                  }
           }}
         </p>
       </div>
@@ -24,18 +28,22 @@
     <div class="flex flex-wrap items-start justify-between gap-3">
       <div class="space-y-1">
         <h2 class="text-base font-medium text-text-primary">
-          {{ 'XP.Xpert.ConnectorCatalogTitle' | translate: { Default: '连接器目录' } }}
+          {{ 'XP.Xpert.ConnectorCatalogTitle' | translate: { Default: 'Connector catalog' } }}
         </h2>
         <p class="text-sm text-text-secondary">
           {{
             'XP.Xpert.ConnectorCatalogDescription'
-              | translate: { Default: '选择授权方式并配置连接，连接状态会从 xpert 平台实时同步。' }
+              | translate
+                : {
+                    Default:
+                      'Choose an authentication method and configure a connection. Status stays synchronized with xpert.'
+                  }
           }}
         </p>
       </div>
       <button z-button zType="outline" zSize="sm" type="button" (click)="refresh()">
         <z-icon [zType]="refreshIcon"></z-icon>
-        {{ 'XP.ACTIONS.Refresh' | translate: { Default: '刷新' } }}
+        {{ 'XP.ACTIONS.Refresh' | translate: { Default: 'Refresh' } }}
       </button>
     </div>
 
@@ -58,7 +66,9 @@
       <div
         class="rounded-xl border border-dashed border-divider-regular px-4 py-14 text-center text-sm text-text-secondary"
       >
-        {{ 'XP.Xpert.NoConnectorsAvailable' | translate: { Default: '当前 xpert 平台没有可用的连接器定义。' } }}
+        {{
+          'XP.Xpert.NoConnectorsAvailable' | translate: { Default: 'No connectors are currently available from xpert.' }
+        }}
       </div>
     } @else {
       <div class="grid gap-4 xl:grid-cols-2">
@@ -101,7 +111,7 @@
                   @if (authMethods.length > 1) {
                     <z-form-field>
                       <z-form-label>
-                        {{ 'XP.Xpert.ConnectorAuthenticationMethod' | translate: { Default: '授权方式' } }}
+                        {{ 'XP.Xpert.ConnectorAuthenticationMethod' | translate: { Default: 'Authentication method' } }}
                       </z-form-label>
                       <z-select
                         class="w-full"
@@ -143,7 +153,10 @@
                             fieldControl(definition, field)?.hasError('required')
                           ) {
                             <z-form-message>
-                              {{ 'XP.Xpert.ConnectorCredentialRequired' | translate: { Default: '此字段为必填项。' } }}
+                              {{
+                                'XP.Xpert.ConnectorCredentialRequired'
+                                  | translate: { Default: 'This field is required.' }
+                              }}
                             </z-form-message>
                           }
                         </z-form-field>
@@ -168,7 +181,8 @@
                 <div class="text-xs text-text-secondary">
                   {{
                     'XP.Xpert.ConnectorsReadonly'
-                      | translate: { Default: '只有工作区管理员可以连接或断开工作区连接器。' }
+                      | translate
+                        : { Default: 'Only workspace managers can connect or disconnect workspace connectors.' }
                   }}
                 </div>
               }
@@ -176,7 +190,7 @@
               @if (connector?.profile) {
                 <div class="rounded-lg border border-divider-regular bg-background-default-subtle px-3 py-2.5 text-sm">
                   <span class="text-text-secondary">
-                    {{ 'XP.Xpert.ConnectorConnectedAccount' | translate: { Default: '已连接账号：' } }}
+                    {{ 'XP.Xpert.ConnectorConnectedAccount' | translate: { Default: 'Connected account:' } }}
                   </span>
                   <span class="font-medium text-text-primary">{{ profileLabel(connector) }}</span>
                 </div>
@@ -202,7 +216,7 @@
                     } @else {
                       <z-icon [zType]="disconnectActionIcon"></z-icon>
                     }
-                    {{ 'XP.Xpert.ConnectorDisconnect' | translate: { Default: '断开连接' } }}
+                    {{ 'XP.Xpert.ConnectorDisconnect' | translate: { Default: 'Disconnect' } }}
                   </button>
                 } @else {
                   <button
@@ -219,7 +233,7 @@
                     } @else {
                       <z-icon [zType]="connectorIcon"></z-icon>
                     }
-                    {{ 'XP.Xpert.ConnectorConnect' | translate: { Default: '连接' } }}
+                    {{ 'XP.Xpert.ConnectorConnect' | translate: { Default: 'Connect' } }}
                   </button>
                 }
               </div>

--- a/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.spec.ts
@@ -117,6 +117,7 @@ async function setup(options?: {
   pollResponse?: ConnectorOAuthStatusResponse
 }) {
   const workspace = signal<{ id: string } | null>(options?.workspaceId ? { id: options.workspaceId } : null)
+  const connectorSearchQuery = signal('')
   const pollResponse = options?.pollResponse ?? {
     connector: pendingConnector,
     authorizationUrl: 'https://accounts.example.com/oauth/continue',
@@ -141,7 +142,8 @@ async function setup(options?: {
       {
         provide: XpertWorkspaceHomeComponent,
         useValue: {
-          workspace
+          workspace,
+          connectorSearchQuery
         }
       },
       {
@@ -260,7 +262,7 @@ describe('XpertConnectorsComponent', () => {
     fixture.destroy()
   })
 
-  it('renders active connectors with description, profile text, and disconnect label', async () => {
+  it('opens active connector details with profile text and disconnect action', async () => {
     const { component, fixture, workspace } = await setup({
       connectors: [activeConnector]
     })
@@ -268,17 +270,161 @@ describe('XpertConnectorsComponent', () => {
     workspace.set({ id: 'workspace-1' })
     component.definitions.set([connectorDefinition])
     component.connectors.set([activeConnector])
+    component.openConnectorDialog(connectorDefinition)
     fixture.detectChanges()
 
     const host = fixture.nativeElement as HTMLElement
     expect(host.textContent).toContain('Connect an external workspace service')
     expect(host.textContent).toContain('Example User')
     expect(host.textContent).toContain('XP.Xpert.ConnectorDisconnect')
+    expect(host.querySelector('[data-connector-dialog]')).not.toBeNull()
 
     const button = host.querySelector('button[data-connector-action="disconnect"]')
     expect(button?.textContent).toContain('XP.Xpert.ConnectorDisconnect')
     expect(button?.querySelector('lucide-angular')).not.toBeNull()
-    expect(host.querySelector('.rounded-xl')).not.toBeNull()
+
+    fixture.destroy()
+  })
+
+  it('filters connector cards by provider and translated metadata', async () => {
+    const secondDefinition: ConnectorStrategyDefinition = {
+      ...connectorDefinition,
+      provider: 'calendar',
+      label: 'Calendar',
+      description: 'Schedule meetings'
+    }
+    const { component, fixture } = await setup({
+      definitions: [connectorDefinition, secondDefinition],
+      connectors: []
+    })
+
+    component.definitions.set([connectorDefinition, secondDefinition])
+    component.searchQuery.set('schedule')
+    fixture.detectChanges()
+
+    const host = fixture.nativeElement as HTMLElement
+    expect(host.querySelector('[data-connector-provider="example"]')).toBeNull()
+    expect(host.querySelector('[data-connector-provider="calendar"]')).not.toBeNull()
+
+    fixture.destroy()
+  })
+
+  it('starts an OAuth connector directly from the card quick-connect action', async () => {
+    const { component, fixture } = await setup({
+      workspaceId: 'workspace-1',
+      definitions: [connectorDefinition],
+      connectors: []
+    })
+    const connectSpy = jest.spyOn(component, 'connect').mockResolvedValue()
+
+    await fixture.whenStable()
+    component.definitions.set([connectorDefinition])
+    component.connectors.set([])
+    fixture.detectChanges()
+
+    const button = fixture.nativeElement.querySelector<HTMLButtonElement>(
+      'button[data-connector-action="quick-connect"]'
+    )
+    if (!button) {
+      throw new Error('Expected quick-connect action to be rendered')
+    }
+
+    button.click()
+    await fixture.whenStable()
+
+    expect(connectSpy).toHaveBeenCalledWith(connectorDefinition)
+    expect(component.selectedDefinition()).toBeNull()
+
+    fixture.destroy()
+  })
+
+  it('opens credential configuration from quick connect when required fields are present', async () => {
+    const { component, fixture } = await setup({
+      workspaceId: 'workspace-1',
+      definitions: [githubDefinition],
+      connectors: []
+    })
+    const connectSpy = jest.spyOn(component, 'connect').mockResolvedValue()
+
+    await fixture.whenStable()
+    component.definitions.set([githubDefinition])
+    component.connectors.set([])
+    fixture.detectChanges()
+
+    const button = fixture.nativeElement.querySelector<HTMLButtonElement>(
+      'button[data-connector-action="quick-connect"]'
+    )
+    if (!button) {
+      throw new Error('Expected quick-connect action to be rendered')
+    }
+
+    button.click()
+    fixture.detectChanges()
+
+    expect(connectSpy).not.toHaveBeenCalled()
+    expect(component.selectedDefinition()?.provider).toBe('github')
+    expect(fixture.nativeElement.querySelector('[data-connector-dialog]')).not.toBeNull()
+
+    fixture.destroy()
+  })
+
+  it('replaces quick connect with a direct disconnect action for active connectors', async () => {
+    const { component, fixture } = await setup({
+      workspaceId: 'workspace-1',
+      definitions: [connectorDefinition],
+      connectors: [activeConnector]
+    })
+    const disconnectSpy = jest.spyOn(component, 'disconnect').mockResolvedValue()
+
+    await fixture.whenStable()
+    component.definitions.set([connectorDefinition])
+    component.connectors.set([activeConnector])
+    fixture.detectChanges()
+
+    const host = fixture.nativeElement as HTMLElement
+    const button = host.querySelector<HTMLButtonElement>('button[data-connector-action="quick-disconnect"]')
+    if (!button) {
+      throw new Error('Expected quick-disconnect action to be rendered')
+    }
+
+    expect(host.querySelector('button[data-connector-action="quick-connect"]')).toBeNull()
+    expect(button.textContent?.trim()).toBe('')
+    expect(button.getAttribute('aria-label')).toBe('XP.Xpert.ConnectorDisconnect')
+    expect(button.querySelector('lucide-angular')).not.toBeNull()
+
+    button.click()
+    await fixture.whenStable()
+
+    expect(disconnectSpy).toHaveBeenCalledWith(activeConnector)
+
+    fixture.destroy()
+  })
+
+  it('shows pending authorization as a top-right card action', async () => {
+    const { component, fixture } = await setup({
+      definitions: [connectorDefinition],
+      connectors: [pendingConnector]
+    })
+    const continueSpy = jest.spyOn(component, 'openPendingAuthorizationUrl').mockImplementation()
+
+    component.definitions.set([connectorDefinition])
+    component.connectors.set([pendingConnector])
+    component.pendingAuthorizationUrls.set({
+      [pendingConnector.id]: 'https://accounts.example.com/oauth/continue'
+    })
+    fixture.detectChanges()
+
+    const host = fixture.nativeElement as HTMLElement
+    const button = host.querySelector<HTMLButtonElement>('button[data-connector-action="continue-authorization"]')
+    if (!button) {
+      throw new Error('Expected continue-authorization action to be rendered')
+    }
+
+    expect(host.querySelector('button[data-connector-action="quick-connect"]')).toBeNull()
+    expect(button.textContent).toContain('XP.Xpert.ConnectorOpenAuthorization')
+
+    button.click()
+    expect(continueSpy).toHaveBeenCalledWith(pendingConnector)
 
     fixture.destroy()
   })
@@ -377,6 +523,7 @@ describe('XpertConnectorsComponent', () => {
 
     component.definitions.set([githubDefinition])
     component.connectors.set([])
+    component.openConnectorDialog(githubDefinition)
     fixture.detectChanges()
 
     const host = fixture.nativeElement as HTMLElement
@@ -398,6 +545,7 @@ describe('XpertConnectorsComponent', () => {
 
     component.definitions.set([githubDefinition])
     component.connectors.set([])
+    component.openConnectorDialog(githubDefinition)
     fixture.detectChanges()
 
     const form = component.formFor(githubDefinition)
@@ -448,6 +596,8 @@ describe('XpertConnectorsComponent', () => {
     })
 
     await fixture.whenStable()
+    fixture.detectChanges()
+    component.openConnectorDialog(githubDefinition)
     fixture.detectChanges()
     component.selectAuthMethod(githubDefinition, 'pat')
     fixture.detectChanges()

--- a/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.ts
+++ b/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.ts
@@ -1,14 +1,12 @@
-import { Component, DestroyRef, computed, effect, inject, signal } from '@angular/core'
+import { Component, DestroyRef, HostListener, computed, effect, inject, signal } from '@angular/core'
 import { FormControl, FormRecord, ReactiveFormsModule, Validators } from '@angular/forms'
 import {
-  ZardBadgeComponent,
   ZardButtonComponent,
   ZardFormImports,
   ZardIconComponent,
   ZardInputDirective,
   ZardSelectImports
 } from '@xpert-ai/headless-ui'
-import { XpSpinComponent } from '@xpert-ai/headless-ui'
 import { XpI18nPipe } from '@xpert-ai/headless-ui'
 import { TranslateModule } from '@ngx-translate/core'
 import { getConnectorAuthMethods } from '@xpert-ai/plugin-sdk/connector'
@@ -19,9 +17,10 @@ import type {
   ConnectorInstance,
   ConnectorStrategyDefinition
 } from '@xpert-ai/plugin-sdk/connector'
-import { AlertCircle, Cable, Link2Off, LoaderCircle, RefreshCw, Unplug } from 'lucide-angular'
+import { AlertCircle, Cable, Link2Off, LoaderCircle } from 'lucide-angular'
 import { firstValueFrom } from 'rxjs'
 import { getErrorMessage, injectToastr, XpertConnectorService, XpertWorkspaceService } from 'apps/cloud/src/app/@core'
+import { IconComponent } from 'apps/cloud/src/app/@shared/avatar'
 import { XpertWorkspaceHomeComponent } from '../home/home.component'
 
 type ConnectorStatusLabel = {
@@ -36,15 +35,14 @@ type ConnectorStatusLabel = {
     ReactiveFormsModule,
     TranslateModule,
     XpI18nPipe,
-    XpSpinComponent,
-    ZardBadgeComponent,
+    IconComponent,
     ZardButtonComponent,
     ZardIconComponent,
     ZardInputDirective,
     ...ZardFormImports,
     ...ZardSelectImports
   ],
-  templateUrl: './workspace-connectors.component.html'
+  templateUrl: './connectors.component.html'
 })
 export class XpertConnectorsComponent {
   readonly #connectorService = inject(XpertConnectorService)
@@ -59,6 +57,29 @@ export class XpertConnectorsComponent {
 
   readonly definitions = signal<ConnectorStrategyDefinition[]>([])
   readonly connectors = signal<ConnectorInstance[]>([])
+  readonly searchQuery = this.homeComponent.connectorSearchQuery
+  readonly selectedProvider = signal<string | null>(null)
+  readonly filteredDefinitions = computed(() => {
+    const query = this.searchQuery().trim().toLocaleLowerCase()
+    if (!query) {
+      return this.definitions()
+    }
+
+    return this.definitions().filter((definition) => {
+      const searchableText = [
+        definition.provider,
+        this.searchableText(definition.label),
+        this.searchableText(this.descriptionFor(definition))
+      ]
+        .join(' ')
+        .toLocaleLowerCase()
+      return searchableText.includes(query)
+    })
+  })
+  readonly selectedDefinition = computed(() => {
+    const provider = this.selectedProvider()
+    return provider ? (this.definitions().find((definition) => definition.provider === provider) ?? null) : null
+  })
   readonly loading = signal(false)
   readonly errorMessage = signal<string | null>(null)
   readonly connectingProvider = signal<string | null>(null)
@@ -68,8 +89,6 @@ export class XpertConnectorsComponent {
   readonly reloadKey = signal(0)
   readonly skeletonCards = [0, 1, 2, 3]
   readonly connectorIcon = Cable
-  readonly refreshIcon = RefreshCw
-  readonly disconnectActionIcon = Unplug
   readonly errorIcon = AlertCircle
   readonly loadingIcon = LoaderCircle
   readonly disconnectIcon = Link2Off
@@ -117,9 +136,27 @@ export class XpertConnectorsComponent {
     }
   }
 
-  refresh() {
-    if (this.workspaceId()) {
-      this.reloadKey.update((value) => value + 1)
+  openConnectorDialog(definition: ConnectorStrategyDefinition) {
+    this.selectedProvider.set(definition.provider)
+  }
+
+  async quickConnect(definition: ConnectorStrategyDefinition) {
+    if (this.credentialFieldsFor(this.selectedAuthMethod(definition)).length) {
+      this.openConnectorDialog(definition)
+      return
+    }
+
+    await this.connect(definition)
+  }
+
+  closeConnectorDialog() {
+    this.selectedProvider.set(null)
+  }
+
+  @HostListener('document:keydown.escape')
+  closeConnectorDialogOnEscape() {
+    if (this.selectedProvider()) {
+      this.closeConnectorDialog()
     }
   }
 
@@ -190,6 +227,9 @@ export class XpertConnectorsComponent {
     try {
       await firstValueFrom(this.#connectorService.disconnect(workspaceId, connector.id))
       this.clearPendingAuthorizationUrl(connector.id)
+      if (this.selectedProvider() === connector.provider) {
+        this.closeConnectorDialog()
+      }
       this.reloadKey.update((value) => value + 1)
       this.#toastr.success('XP.Messages.UpdatedSuccessfully', { Default: 'Updated successfully' })
     } catch (error) {
@@ -270,8 +310,18 @@ export class XpertConnectorsComponent {
     }
   }
 
-  iconImageUrl(definition: ConnectorStrategyDefinition) {
-    return definition.icon?.type === 'image' && typeof definition.icon.value === 'string' ? definition.icon.value : null
+  statusDotClass(connector?: ConnectorInstance | null) {
+    switch (connector?.status) {
+      case 'active':
+        return 'bg-[var(--color-status-success-indicator-bg)]'
+      case 'pending':
+      case 'expired':
+        return 'bg-[var(--color-status-warning-indicator-bg)]'
+      case 'error':
+        return 'bg-[var(--color-status-error-indicator-bg)]'
+      default:
+        return 'bg-text-tertiary'
+    }
   }
 
   descriptionFor(definition: ConnectorStrategyDefinition) {
@@ -376,6 +426,18 @@ export class XpertConnectorsComponent {
       }
     }
     return Object.keys(values).length ? values : undefined
+  }
+
+  private searchableText(value: unknown): string {
+    if (typeof value === 'string') {
+      return value
+    }
+    if (value && typeof value === 'object') {
+      return Object.values(value)
+        .filter((item): item is string => typeof item === 'string')
+        .join(' ')
+    }
+    return ''
   }
 
   private openAuthorizationPopup() {
@@ -491,8 +553,7 @@ export class XpertConnectorsComponent {
     ReactiveFormsModule,
     TranslateModule,
     XpI18nPipe,
-    XpSpinComponent,
-    ZardBadgeComponent,
+    IconComponent,
     ZardButtonComponent,
     ZardIconComponent,
     ZardInputDirective,

--- a/apps/cloud/src/app/features/xpert/workspace/home/home.component.html
+++ b/apps/cloud/src/app/features/xpert/workspace/home/home.component.html
@@ -1,3 +1,56 @@
+@if (isMarketplaceWorkspaceRoute()) {
+  <header class="sticky top-0 z-20 border-b border-border/70 bg-background/95 px-6 py-3 backdrop-blur-xl xl:px-10">
+    <div class="mx-auto flex w-full max-w-[1440px] flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <nav
+        class="flex w-fit max-w-full items-center gap-1 overflow-x-auto rounded-lg border border-border/70 bg-muted/50 p-1"
+        aria-label="{{ 'XP.Explore.NavigationLabel' | translate: { Default: 'Marketplace navigation' } }}"
+      >
+        <a
+          class="inline-flex h-9 shrink-0 items-center gap-2 rounded-md px-3 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          [routerLink]="['/explore']"
+          [queryParams]="{ tab: 'agent-square' }"
+        >
+          <i class="ri-team-line"></i>
+          {{ 'XP.Explore.ExpertsTab' | translate: { Default: 'Experts' } }}
+        </a>
+        <a
+          [class]="
+            currentUrl().includes('clawxpert-skills')
+              ? 'inline-flex h-9 shrink-0 items-center gap-2 rounded-md bg-background px-3 text-sm font-medium text-foreground transition-colors'
+              : 'inline-flex h-9 shrink-0 items-center gap-2 rounded-md px-3 text-sm font-medium text-muted-foreground transition-colors'
+          "
+          [routerLink]="['/explore']"
+          [queryParams]="{ tab: 'skills' }"
+        >
+          <i class="ri-pencil-ruler-line"></i>
+          {{ 'XP.Explore.SkillsTab' | translate: { Default: 'Skills' } }}
+        </a>
+        <a
+          [class]="
+            currentUrl().includes('clawxpert-connectors')
+              ? 'inline-flex h-9 shrink-0 items-center gap-2 rounded-md bg-background px-3 text-sm font-medium text-foreground transition-colors'
+              : 'inline-flex h-9 shrink-0 items-center gap-2 rounded-md px-3 text-sm font-medium text-muted-foreground transition-colors'
+          "
+          [routerLink]="['/xpert/w', paramId(), 'clawxpert-connectors']"
+        >
+          <i class="ri-plug-line"></i>
+          {{ 'XP.Explore.ConnectorsTab' | translate: { Default: 'Connectors' } }}
+        </a>
+      </nav>
+
+      @if (currentUrl().includes('clawxpert-connectors')) {
+        <z-search-input
+          class="w-full sm:w-64"
+          [placeholder]="'XP.Xpert.SearchConnectors' | translate: { Default: 'Search connectors' }"
+          [clearLabel]="'XP.ACTIONS.Clear' | translate: { Default: 'Clear search' }"
+          [ngModel]="connectorSearchQuery()"
+          (ngModelChange)="connectorSearchQuery.set($event)"
+        />
+      }
+    </div>
+  </header>
+}
+
 @if (!isStandaloneWorkspaceRoute()) {
   <div
     class="sticky top-0 flex justify-between items-center gap-4 pt-4 px-12 pb-2 leading-[56px] z-20 flex-wrap gap-y-2 bg-background-body"

--- a/apps/cloud/src/app/features/xpert/workspace/home/home.component.ts
+++ b/apps/cloud/src/app/features/xpert/workspace/home/home.component.ts
@@ -117,6 +117,9 @@ export class XpertWorkspaceHomeComponent {
   readonly isStandaloneWorkspaceRoute = computed(() =>
     /\/(?:clawxpert-connectors|clawxpert-skills|files|clawxpert-knowledges|settings)(?:\/|$)/.test(this.currentUrl())
   )
+  readonly isMarketplaceWorkspaceRoute = computed(() =>
+    /\/xpert\/w\/[^/]+\/clawxpert-(?:connectors|skills)(?:\/|$)/.test(this.currentUrl())
+  )
 
   readonly loading = signal(true)
   readonly loadingDefaultWorkspace = signal(true)
@@ -185,6 +188,7 @@ export class XpertWorkspaceHomeComponent {
 
   readonly searchControl = new FormControl()
   readonly searchText = toSignal(this.searchControl.valueChanges.pipe(debounceTime(300), startWith('')))
+  readonly connectorSearchQuery = signal('')
 
   // Search for workspaces
   readonly searchWorkspace = model<string>('')

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -4010,6 +4010,7 @@
       "WorkspaceApiKeyDescription": "Keys created here belong to the current workspace and can access published assistants in this workspace.",
       "Connectors": "Connectors",
       "ConnectorsDescription": "Connect external services needed by this workspace. Authorization and credentials are managed centrally by xpert.",
+      "SearchConnectors": "Search connectors",
       "ConnectorCatalogTitle": "Connector catalog",
       "ConnectorCatalogDescription": "Choose an authorization method and configure the connection. Connection status is synchronized in real time from xpert.",
       "ConnectorConnectedAccount": "Connected account:",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -7424,6 +7424,7 @@
       "WorkspaceApiKeyDescription": "在这里创建的密钥属于当前工作区，可访问该工作区内已发布的专家。",
       "Connectors": "连接器",
       "ConnectorsDescription": "连接工作空间所需的外部服务，授权和凭据由 xpert 平台统一管理。",
+      "SearchConnectors": "搜索连接器",
       "ConnectorCatalogTitle": "连接器目录",
       "ConnectorCatalogDescription": "选择授权方式并配置连接，连接状态会从 xpert 平台实时同步。",
       "ConnectorConnectedAccount": "已连接账号：",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -5699,6 +5699,7 @@
       "WorkspaceApiKeys": "工作區 API 密鑰",
       "WorkspaceApiKeyDescription": "在這裡創建的密鑰屬於當前工作區，可訪問該工作區內已發布的專家。",
       "Connectors": "連接器",
+      "SearchConnectors": "搜尋連接器",
       "ConnectorIntegration": "應用整合",
       "NoConnectorIntegration": "暫無可用應用整合",
       "NoConnectorsAvailable": "暫無可用工作區連接器。",


### PR DESCRIPTION
## Summary

- add a compact Experts, Skills, and Connectors navigation header with connector search
- redesign connector cards around plugin repository icons and focused detail dialogs
- provide direct connect, disconnect, and continue-authorization actions based on connector state
- replace Chinese `Default` fallback strings in the connector templates with English
- expand coverage for search, quick connection, credential configuration, disconnect, and pending authorization states

## Commit structure

1. `fix(i18n): use English connector fallbacks`
2. `feat(connectors): add catalog navigation and search`
3. `feat(connectors): improve connector cards and authorization actions`

## Validation

- `corepack pnpm exec nx build cloud --configuration=development`
- `node tools/scripts/check-hardcoded-colors.cjs`
- verified no Chinese text remains in connector `Default` fallbacks

## Test note

The focused Jest run is currently blocked before test execution by the existing `@milkdown/crepe` CommonJS entry importing ESM `lodash-es` through the shared files barrel (`SyntaxError: Unexpected token export`). The Angular development build completes successfully.