### PR TITLE
feat(workspace): consolidate ClawXpert settings

### DIFF
--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-overview.component.spec.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-overview.component.spec.ts
@@ -143,16 +143,8 @@ jest.mock('./clawxpert-preferences-editor.component', () => ({
   ClawXpertPreferencesEditorComponent: mockOverviewChild('xp-clawxpert-preferences-editor')
 }))
 
-jest.mock('./clawxpert-scheduled-tasks.component', () => ({
-  ClawXpertScheduledTasksComponent: mockOverviewChild('xp-clawxpert-scheduled-tasks')
-}))
-
 jest.mock('./clawxpert-trigger-config-editor.component', () => ({
   ClawXpertTriggerConfigEditorComponent: mockOverviewChild('xp-clawxpert-trigger-config-editor')
-}))
-
-jest.mock('./clawxpert-tool-preferences.component', () => ({
-  ClawXpertToolPreferencesComponent: mockOverviewChild('xp-clawxpert-tool-preferences')
 }))
 
 import { signal } from '@angular/core'

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-overview.component.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-overview.component.ts
@@ -10,15 +10,13 @@ import {
   ZardIconComponent,
   ZardMenuImports
 } from '@xpert-ai/headless-ui'
-import { AiModelTypeEnum, ICopilotModel, IXpert, XpertTypeEnum } from '../../../@core'
+import { AiModelTypeEnum, ICopilotModel, IXpert } from '../../../@core'
 import { EmojiAvatarComponent } from '../../../@shared/avatar'
 import { CopilotModelSelectComponent } from '../../../@shared/copilot'
 import { countDisplayTextUnits } from '../../../@shared/text-count.utils'
 import { ClawXpertBindingWizardComponent } from './clawxpert-binding-wizard.component'
 import { ClawXpertFacade } from './clawxpert.facade'
 import { ClawXpertPreferencesEditorComponent } from './clawxpert-preferences-editor.component'
-import { ClawXpertScheduledTasksComponent } from './clawxpert-scheduled-tasks.component'
-import { ClawXpertToolPreferencesComponent } from './clawxpert-tool-preferences.component'
 import { ClawXpertTriggerConfigEditorComponent } from './clawxpert-trigger-config-editor.component'
 import { buildHeatmapLegend, buildHeatmapStyles } from './clawxpert-heatmap.utils'
 
@@ -76,9 +74,7 @@ const HEATMAP_DAY_LABEL_INDEXES = new Set([0, 2, 4, 6])
     CopilotModelSelectComponent,
     EmojiAvatarComponent,
     ClawXpertPreferencesEditorComponent,
-    ClawXpertScheduledTasksComponent,
     ClawXpertTriggerConfigEditorComponent,
-    ClawXpertToolPreferencesComponent,
     ClawXpertBindingWizardComponent,
     ...ZardMenuImports,
     ...ZardCardImports
@@ -438,8 +434,6 @@ const HEATMAP_DAY_LABEL_INDEXES = new Set([0, 2, 4, 6])
           <div class="flex-1 min-h-0 p-4 flex flex-col gap-4 overflow-hidden">
             <xp-clawxpert-preferences-editor />
             <xp-clawxpert-trigger-config-editor />
-            <xp-clawxpert-scheduled-tasks />
-            <xp-clawxpert-tool-preferences />
           </div>
         </div>
       }

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-overview.component.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-overview.component.ts
@@ -262,7 +262,7 @@ const HEATMAP_DAY_LABEL_INDEXES = new Set([0, 2, 4, 6])
                   </button>
 
                   <button type="button" z-menu-item (click)="openXpertOrchestration()">
-                    {{ 'XP.Chat.ClawXpert.OpenOrchestration' | translate: { Default: '编排 ClawXpert' } }}
+                    {{ 'XP.Chat.ClawXpert.OpenOrchestration' | translate: { Default: 'Open ClawXpert orchestration' } }}
                   </button>
 
                   <z-divider zSpacing="sm"></z-divider>

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.component.spec.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.component.spec.ts
@@ -207,7 +207,7 @@ describe('buildCloudSidebarMenuGroups', () => {
         link: '/xpert/w/workspace%2F1/clawxpert-knowledges',
         data: { workspaceSection: 'knowledges' }
       },
-      { title: '工作区设置', link: '/xpert/w/workspace%2F1/settings', data: { workspaceSection: 'settings' } }
+      { title: '工作区设置', link: '/chat/clawxpert', data: { workspaceSection: 'settings' } }
     ])
   })
 
@@ -246,7 +246,8 @@ describe('cloud sidebar menu helpers', () => {
     expect(buildWorkspaceModuleMenuLink('knowledges', 'workspace/1')).toBe(
       '/xpert/w/workspace%2F1/clawxpert-knowledges'
     )
-    expect(buildWorkspaceModuleMenuLink('settings', 'workspace/1')).toBe('/xpert/w/workspace%2F1/settings')
+    expect(buildWorkspaceModuleMenuLink('settings', 'workspace/1')).toBe('/chat/clawxpert')
+    expect(buildWorkspaceModuleMenuLink('settings')).toBe('/chat/clawxpert')
     expect(getWorkspaceModuleSection(menu({ data: { workspaceSection: 'skills' }, link: '/chat/clawxpert/c' }))).toBe(
       'skills'
     )

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.navigation.spec.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.navigation.spec.ts
@@ -41,7 +41,7 @@ describe('CloudSidebarMenuComponent workspace navigation', () => {
     ['connectors', '/xpert/w/workspace-1/clawxpert-connectors'],
     ['files', '/xpert/w/workspace-1/files'],
     ['knowledges', '/xpert/w/workspace-1/clawxpert-knowledges'],
-    ['settings', '/xpert/w/workspace-1/settings']
+    ['settings', '/chat/clawxpert']
   ] as const)('navigates the %s entry directly to its original workspace page', async (section, expectedUrl) => {
     const fixture = TestBed.createComponent(CloudSidebarMenuComponent)
     const component = fixture.componentInstance

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.utils.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.utils.ts
@@ -196,6 +196,10 @@ export function isNewClawXpertTaskMenuItem(item: CloudMenuItem) {
 }
 
 export function buildWorkspaceModuleMenuLink(section: CloudWorkspaceModuleSection, workspaceId?: string | null) {
+  if (section === 'settings') {
+    return '/chat/clawxpert'
+  }
+
   const normalizedWorkspaceId = workspaceId?.trim()
   return normalizedWorkspaceId
     ? `/xpert/w/${encodeURIComponent(normalizedWorkspaceId)}/${workspaceModuleRouteSegment(section)}`
@@ -243,7 +247,7 @@ function createWorkspaceChild(
     title,
     icon,
     link: buildWorkspaceModuleMenuLink(section, workspaceId),
-    pathMatch: 'prefix',
+    pathMatch: section === 'settings' ? 'full' : 'prefix',
     data: {
       translationKey,
       workspaceSection: section

--- a/apps/cloud/src/app/features/xpert/workspace/routes.ts
+++ b/apps/cloud/src/app/features/xpert/workspace/routes.ts
@@ -15,7 +15,6 @@ import { XpertWorkspaceSkillsComponent } from './skills/skills.component'
 import { XpertWorkspacePromptWorkflowsComponent } from './prompt-workflows/workflows.component'
 import { ClawXpertConnectorsComponent, XpertConnectorsComponent } from './connectors/connectors.component'
 import { XpertWorkspaceFilesComponent } from './files/files.component'
-import { XpertWorkspaceSettingsPageComponent } from './settings/settings-page.component'
 
 function redirectToSelectedWorkspace(route: ActivatedRouteSnapshot) {
   const router = inject(Router)
@@ -111,7 +110,8 @@ export default [
       },
       {
         path: 'settings',
-        component: XpertWorkspaceSettingsPageComponent
+        redirectTo: '/chat/clawxpert',
+        pathMatch: 'full'
       },
       {
         path: 'prompt-workflows',


### PR DESCRIPTION
## Summary

- route the workspace Settings entry and legacy settings URL to `/chat/clawxpert`
- keep the consolidated ClawXpert page focused on binding and core configuration
- remove scheduled tasks and tool/skill preference modules from the settings view
- replace the remaining Chinese `Default` fallback in the touched ClawXpert view with English

## Commit structure

1. `feat(workspace): route settings to ClawXpert configuration`
2. `feat(clawxpert): focus workspace settings on configuration`
3. `fix(i18n): use English ClawXpert fallbacks`

## Validation

- `corepack pnpm exec nx test cloud --runInBand --testPathPatterns=...` (3 suites, 26 tests passed)
- `corepack pnpm exec nx build cloud --configuration=development`
- `node tools/scripts/check-hardcoded-colors.cjs`
- verified that touched files contain no Chinese `Default` fallback text