### PR TITLE
fix(tasks): validate scheduled task setup

### DIFF
--- a/apps/cloud/src/app/@shared/chat/task-dialog/task-dialog.component.html
+++ b/apps/cloud/src/app/@shared/chat/task-dialog/task-dialog.component.html
@@ -1,23 +1,26 @@
-<div class="flex flex-col space-y-1.5 text-center sm:text-left p-4">
-  <h2 class="text-lg font-semibold leading-none tracking-tight">
-    <div class="flex w-full items-center justify-between">
+<div class="flex flex-col space-y-1.5 p-4 text-center sm:text-left">
+  <div class="flex w-full items-start justify-between gap-4">
+    <label class="flex min-w-0 grow flex-col gap-2 text-left" for="scheduled-task-name">
+      <span class="text-sm font-semibold text-text-primary">
+        {{ 'XP.Xpert.TaskNameOptional' | translate: { Default: 'Task name (optional)' } }}
+      </span>
       <input
-        [placeholder]="'XP.Xpert.NameOfTask' | translate: { Default: 'Name of task' }"
-        class="p-1 w-full focus-visible:outline-none bg-transparent rounded-xl"
+        id="scheduled-task-name"
+        [placeholder]="'XP.Xpert.TaskNamePlaceholder' | translate: { Default: 'e.g. Daily news summary' }"
+        class="h-11 w-full rounded-xl border border-input-border bg-components-card-bg px-3 text-base text-text-primary outline-none transition-shadow placeholder:text-text-tertiary focus-visible:ring-1 focus-visible:ring-ring"
         type="text"
         [(ngModel)]="name"
       />
-      <div class="flex items-center gap-1">
-        <button
-          class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium leading-[normal] cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-60 disabled:cursor-not-allowed transition-colors duration-100 [&amp;_svg]:shrink-0 select-none text-text-primary hover:bg-hover-bg disabled:hover:bg-transparent border border-transparent h-10 w-10 rounded-xl"
-          type="button"
-          (click)="close()"
-        >
-          <i class="ri-close-large-line"></i>
-        </button>
-      </div>
-    </div>
-  </h2>
+    </label>
+    <button
+      class="inline-flex h-10 w-10 shrink-0 cursor-pointer select-none items-center justify-center rounded-xl border border-transparent text-sm font-medium leading-[normal] text-text-primary transition-colors duration-100 hover:bg-hover-bg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      type="button"
+      [attr.aria-label]="'XP.ACTIONS.CLOSE' | translate: { Default: 'Close' }"
+      (click)="close()"
+    >
+      <i class="ri-close-large-line" aria-hidden="true"></i>
+    </button>
+  </div>
 </div>
 
 <div class="relative gap-3 flex flex-col px-6">

--- a/apps/cloud/src/app/@shared/chat/task-dialog/task-dialog.component.ts
+++ b/apps/cloud/src/app/@shared/chat/task-dialog/task-dialog.component.ts
@@ -178,7 +178,7 @@ export class XpertTaskDialogComponent {
     this.taskAPI
       .upsert({
         ...(currentTask.id ? { id: currentTask.id } : {}),
-        name: this.name(),
+        name: this.name()?.trim() || undefined,
         timeZone: currentTask.timeZone,
         prompt: this.prompt(),
         options: {

--- a/apps/cloud/src/app/@shared/chat/task-dialog/task-dialog.component.ts
+++ b/apps/cloud/src/app/@shared/chat/task-dialog/task-dialog.component.ts
@@ -31,6 +31,7 @@ import { NgxPermissionsService } from 'ngx-permissions'
 import { catchError, map, of } from 'rxjs'
 import { ScheduleFormComponent } from '../../schedule'
 import { buildJsonSchemaDefaults, hasJsonSchemaRequiredErrors } from '../../workflow/trigger-config/trigger-config.util'
+import { isScheduleComplete } from './task-dialog.utils'
 
 @Component({
   selector: 'xpert-task-new-blank',
@@ -120,6 +121,7 @@ export class XpertTaskDialogComponent {
     () =>
       !this.prompt() ||
       !this.xpertId() ||
+      !isScheduleComplete(this.options()) ||
       hasJsonSchemaRequiredErrors(this.runtimeStateSchema(), this.runtimeStateValue()) ||
       this.loading() ||
       this.isTrialTaskLimitPending() ||
@@ -164,6 +166,10 @@ export class XpertTaskDialogComponent {
 
     if (this.isTrialTaskLimitReached()) {
       this.#toastr.error('Trial users can schedule a maximum of 10 tasks')
+      return
+    }
+
+    if (this.isSubmitDisabled()) {
       return
     }
 

--- a/apps/cloud/src/app/@shared/chat/task-dialog/task-dialog.utils.spec.ts
+++ b/apps/cloud/src/app/@shared/chat/task-dialog/task-dialog.utils.spec.ts
@@ -1,0 +1,28 @@
+import { TaskFrequency } from '@cloud/app/@core'
+import { isScheduleComplete } from './task-dialog.utils'
+
+describe('isScheduleComplete', () => {
+  it('requires both time and date for a one-time task', () => {
+    expect(isScheduleComplete({ frequency: TaskFrequency.Once })).toBe(false)
+    expect(isScheduleComplete({ frequency: TaskFrequency.Once, time: '09:30' })).toBe(false)
+    expect(isScheduleComplete({ frequency: TaskFrequency.Once, date: '2026-08-28' })).toBe(false)
+    expect(isScheduleComplete({ frequency: TaskFrequency.Once, time: '09:30', date: '2026-08-28' })).toBe(true)
+  })
+
+  it('requires a valid time for a daily task', () => {
+    expect(isScheduleComplete({ frequency: TaskFrequency.Daily, time: '24:00' })).toBe(false)
+    expect(isScheduleComplete({ frequency: TaskFrequency.Daily, time: '08:05' })).toBe(true)
+  })
+
+  it('requires the frequency-specific day selection', () => {
+    expect(isScheduleComplete({ frequency: TaskFrequency.Weekly, time: '08:05' })).toBe(false)
+    expect(isScheduleComplete({ frequency: TaskFrequency.Weekly, time: '08:05', dayOfWeek: 0 })).toBe(true)
+    expect(isScheduleComplete({ frequency: TaskFrequency.Monthly, time: '08:05', dayOfMonth: 32 })).toBe(false)
+    expect(isScheduleComplete({ frequency: TaskFrequency.Monthly, time: '08:05', dayOfMonth: 31 })).toBe(true)
+  })
+
+  it('requires a date for a yearly task', () => {
+    expect(isScheduleComplete({ frequency: TaskFrequency.Yearly, time: '08:05' })).toBe(false)
+    expect(isScheduleComplete({ frequency: TaskFrequency.Yearly, time: '08:05', date: '2026-08-28' })).toBe(true)
+  })
+})

--- a/apps/cloud/src/app/@shared/chat/task-dialog/task-dialog.utils.ts
+++ b/apps/cloud/src/app/@shared/chat/task-dialog/task-dialog.utils.ts
@@ -1,0 +1,27 @@
+import { TaskFrequency, type TScheduleOptions } from '@cloud/app/@core'
+
+export function isScheduleComplete(options?: Partial<TScheduleOptions> | null): boolean {
+  const frequency = options?.frequency ?? TaskFrequency.Once
+
+  if (!isValidTime(options?.time)) {
+    return false
+  }
+
+  switch (frequency) {
+    case TaskFrequency.Once:
+    case TaskFrequency.Yearly:
+      return !!options?.date
+    case TaskFrequency.Weekly:
+      return Number.isInteger(options?.dayOfWeek) && options.dayOfWeek >= 0 && options.dayOfWeek <= 6
+    case TaskFrequency.Monthly:
+      return Number.isInteger(options?.dayOfMonth) && options.dayOfMonth >= 1 && options.dayOfMonth <= 31
+    case TaskFrequency.Daily:
+      return true
+    default:
+      return false
+  }
+}
+
+function isValidTime(time?: string): boolean {
+  return typeof time === 'string' && /^(?:[01]\d|2[0-3]):[0-5]\d$/.test(time)
+}

--- a/apps/cloud/src/app/@shared/schedule/form/form.component.html
+++ b/apps/cloud/src/app/@shared/schedule/form/form.component.html
@@ -58,15 +58,15 @@
     }
 
     @if (frequency() === eTaskFrequency.Monthly) {
-      <div class="flex items-center gap-3 font-medium">
-        <div class="flex flex-col">
+      <div class="flex min-w-[15rem] shrink-0 items-center justify-between gap-4 font-medium">
+        <div class="flex min-w-0 flex-col">
           <label class="text-sm">{{ 'XP.Xpert.DayinMonth' | translate: { Default: 'Day in month to run' } }}:</label>
           <label class="text-xs text-text-secondary">{{
             'XP.Xpert.WillRunClosestDay' | translate: { Default: 'Will run on closest day' }
           }}</label>
         </div>
         <input
-          class="grow py-1 px-4 rounded-xl bg-transparent border border-input-border stretch h-full"
+          class="h-full w-20 shrink-0 rounded-xl border border-input-border bg-transparent px-3 py-1 text-center"
           min="1"
           max="31"
           aria-label="Day in month to run:"

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -3878,6 +3878,8 @@
       "Unarchive": "Unarchive",
       "Records": "records",
       "NameOfTask": "Name of task",
+      "TaskNameOptional": "Task name (optional)",
+      "TaskNamePlaceholder": "e.g. Daily news summary",
       "SelectExpert": "Select Expert",
       "EditXpert": "Edit Xpert",
       "ScheduleSendTarget": "Send target",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -6895,6 +6895,8 @@
       "Unarchive": "取消归档",
       "Time": "时间",
       "NameOfTask": "任务名称",
+      "TaskNameOptional": "任务名称（选填）",
+      "TaskNamePlaceholder": "例如：每日新闻摘要",
       "DayinMonth": "每月运行的日期",
       "WillRunClosestDay": "将在最近一天运行",
       "EnterPromptHere": "在这里输入提示词",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -5202,6 +5202,8 @@
       "Archive": "歸檔",
       "Time": "時間",
       "NameOfTask": "任務名稱",
+      "TaskNameOptional": "任務名稱（選填）",
+      "TaskNamePlaceholder": "例如：每日新聞摘要",
       "DayinMonth": "每月運行的日期",
       "WillRunClosestDay": "將在最近一天運行",
       "EnterPromptHere": "在這裏輸入提示詞",


### PR DESCRIPTION
## Summary

- disable task creation until the selected schedule has all frequency-specific required fields
- guard the submission handler against incomplete schedules
- keep task names optional while making the field more discoverable with a labeled input and example placeholder
- prevent the monthly `1-31` range placeholder from being clipped
- add matching English, Simplified Chinese, and Traditional Chinese translations

## Commit structure

1. `fix(tasks): validate schedule before submission`
2. `feat(tasks): clarify optional task naming`

## Validation

- `corepack pnpm exec nx test cloud --runInBand --testPathPatterns=apps/cloud/src/app/@shared/chat/task-dialog/task-dialog.utils.spec.ts` (4 tests passed)
- `corepack pnpm exec nx build cloud --configuration=development`
- `node tools/scripts/check-hardcoded-colors.cjs`
- ESLint passed for the new schedule validation utility and tests
- verified that changed templates contain no Chinese `Default` fallback text
- verified that no design or QA artifacts are included