### PR TITLE
fix(cloud): open the personal knowledgebase workbench

### DIFF
--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.component.spec.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.component.spec.ts
@@ -204,8 +204,8 @@ describe('buildCloudSidebarMenuGroups', () => {
       { title: '资源库', link: '/xpert/w/workspace%2F1/files', data: { workspaceSection: 'files' } },
       {
         title: '我的知识库',
-        link: '/xpert/w/workspace%2F1/clawxpert-knowledges',
-        data: { workspaceSection: 'knowledges' }
+        link: '/xpert/knowledges',
+        data: { translationKey: 'My knowledgebases' }
       },
       { title: '工作区设置', link: '/chat/clawxpert', data: { workspaceSection: 'settings' } }
     ])

--- a/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.utils.ts
+++ b/apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.utils.ts
@@ -166,7 +166,15 @@ export function addWorkspaceMoreMenuItem(groups: CloudSidebarMenuGroup[], worksp
     },
     children: [
       createWorkspaceChild('资源库', 'Library', 'ri-book-open-line', 'files', normalizedWorkspaceId),
-      createWorkspaceChild('我的知识库', 'My knowledgebases', 'ri-book-2-line', 'knowledges', normalizedWorkspaceId),
+      {
+        title: '我的知识库',
+        icon: 'ri-book-2-line',
+        link: '/xpert/knowledges',
+        pathMatch: 'prefix',
+        data: {
+          translationKey: 'My knowledgebases'
+        }
+      },
       createWorkspaceChild('工作区设置', 'Workspace settings', 'ri-equalizer-line', 'settings', normalizedWorkspaceId)
     ]
   }


### PR DESCRIPTION
## Summary

- route the **My knowledgebases** sidebar entry to the standalone personal knowledgebase workbench
- keep workspace knowledgebase navigation separate from the personal workbench
- update the sidebar regression test for the standalone route

## Testing

- `pnpm exec jest --config apps/cloud/jest.config.ts apps/cloud/src/app/features/sidebar/cloud-sidebar-menu.component.spec.ts --runInBand`