### PR TITLE
fix(copilot): attribute usage to billed users

### DIFF
--- a/packages/server-ai/src/copilot-usage/copilot-usage.service.spec.ts
+++ b/packages/server-ai/src/copilot-usage/copilot-usage.service.spec.ts
@@ -134,13 +134,13 @@ describe('CopilotUsageService', () => {
         expect(modelUsageLedger.totals).toHaveBeenCalledWith({ unit: 'generation' })
     })
 
-    it('summarizes user usage by xpert creator with current and grand totals', async () => {
+    it('summarizes user usage by the billed user with current and grand totals', async () => {
         const qb = createQueryBuilderMock<CopilotUser>([
             {
                 tenantId: 'tenant-1',
                 organizationId: 'org-1',
                 orgId: 'provider-org-1',
-                userId: 'owner-user',
+                userId: 'shared-user',
                 provider: 'openai',
                 model: 'gpt-4.1',
                 currency: 'USD',
@@ -152,8 +152,8 @@ describe('CopilotUsageService', () => {
                 runtimeUserCount: '2',
                 xpertCount: '3',
                 updatedAt: new Date('2026-06-01T00:00:00.000Z'),
-                userRelationId: 'owner-user',
-                userEmail: 'owner@example.com',
+                userRelationId: 'shared-user',
+                userEmail: 'shared@example.com',
                 organizationRelationId: 'org-1',
                 organizationName: 'Org 1',
                 total: '1'
@@ -177,7 +177,7 @@ describe('CopilotUsageService', () => {
             {
                 tenantId: 'tenant-1',
                 organizationId: 'org-1',
-                userId: 'owner-user',
+                userId: 'shared-user',
                 provider: 'openai',
                 model: 'gpt-4.1',
                 membershipPointsUsed: '0.0285'
@@ -199,23 +199,16 @@ describe('CopilotUsageService', () => {
                 end: '2026-06-01T23:59:59.999Z',
                 provider: 'openai',
                 model: 'gpt-4.1',
-                userId: 'owner-user',
+                userId: 'shared-user',
                 currency: 'USD'
             },
             { order: { updatedAt: OrderTypeEnum.DESC }, take: 20, skip: 0 }
         )
 
-        expect((qb as any).leftJoin).toHaveBeenCalledWith(
-            'xpert',
-            'usage_xpert',
-            '"usage_xpert"."id"::text = "usage"."xpertId"'
-        )
-        expect((qb as any).addSelect).toHaveBeenCalledWith(
-            'COALESCE("usage_xpert"."createdById"::text, "usage"."userId"::text)',
-            'userId'
-        )
-        expect((qb as any).addSelect).toHaveBeenCalledWith('COUNT(DISTINCT "usage"."userId")', 'runtimeUserCount')
-        expect((qb as any).addSelect).toHaveBeenCalledWith('COUNT(DISTINCT "usage"."xpertId")', 'xpertCount')
+        expect(qb.leftJoin).not.toHaveBeenCalledWith('xpert', expect.anything(), expect.anything())
+        expect(qb.addSelect).toHaveBeenCalledWith('"usage"."userId"::text', 'userId')
+        expect(qb.addSelect).toHaveBeenCalledWith('COUNT(DISTINCT "usage"."userId")', 'runtimeUserCount')
+        expect(qb.addSelect).toHaveBeenCalledWith('COUNT(DISTINCT "usage"."xpertId")', 'xpertCount')
         expect(qb.addSelect).not.toHaveBeenCalledWith(expect.stringContaining('usage_membership'), expect.anything())
         expect(qb.leftJoin).not.toHaveBeenCalledWith(expect.any(Function), 'usage_membership', expect.anything())
         expect(membershipQb.addSelect).toHaveBeenCalledWith('SUM(ABS(ledger.pointsDelta))', 'membershipPointsUsed')
@@ -227,7 +220,7 @@ describe('CopilotUsageService', () => {
             { membershipScopeOrganizationId: 'org-1' }
         )
         expect(membershipQb.andWhere).toHaveBeenCalledWith('ledger.userId = :membershipUserId', {
-            membershipUserId: 'owner-user'
+            membershipUserId: 'shared-user'
         })
         expect(membershipQb.andWhere).toHaveBeenCalledWith('ledger.provider = :provider', { provider: 'openai' })
         expect(membershipQb.andWhere).toHaveBeenCalledWith('ledger.model = :model', { model: 'gpt-4.1' })
@@ -243,17 +236,15 @@ describe('CopilotUsageService', () => {
                 membershipPageorg0: 'org-1',
                 membershipPageprovider0: 'openai',
                 membershipPagemodel0: 'gpt-4.1',
-                membershipPageuser0: 'owner-user'
+                membershipPageuser0: 'shared-user'
             })
         )
-        expect((qb as any).addGroupBy).toHaveBeenCalledWith(
-            'COALESCE("usage_xpert"."createdById"::text, "usage"."userId"::text)'
-        )
+        expect(qb.addGroupBy).toHaveBeenCalledWith('"usage"."userId"::text')
         expect(result.total).toBe(1)
         expect(result.items[0]).toMatchObject({
             dimension: 'user',
             organizationId: 'org-1',
-            userId: 'owner-user',
+            userId: 'shared-user',
             provider: 'openai',
             model: 'gpt-4.1',
             currency: 'USD',
@@ -271,7 +262,7 @@ describe('CopilotUsageService', () => {
         })
     })
 
-    it('filters usage summaries and totals by xpert creator user id', async () => {
+    it('filters usage summaries and totals by billed user id', async () => {
         const summaryQb = createQueryBuilderMock<CopilotUser>([])
         const totalsQb = createQueryBuilderMock<CopilotUser>([])
         const userRepository: RepositoryMock = {
@@ -290,14 +281,13 @@ describe('CopilotUsageService', () => {
         }
         const service = createService(userRepository, orgRepository)
 
-        await service.findSummaries({ dimension: 'user', userId: 'owner-user' })
-        await service.findTotals({ dimension: 'user', userId: 'owner-user' })
+        await service.findSummaries({ dimension: 'user', userId: 'shared-user' })
+        await service.findTotals({ dimension: 'user', userId: 'shared-user' })
 
         for (const qb of [summaryQb, totalsQb]) {
-            expect((qb as any).andWhere).toHaveBeenCalledWith(
-                'COALESCE("usage_xpert"."createdById"::text, "usage"."userId"::text) = :filterUserId',
-                { filterUserId: 'owner-user' }
-            )
+            expect((qb as any).andWhere).toHaveBeenCalledWith('"usage"."userId"::text = :filterUserId', {
+                filterUserId: 'shared-user'
+            })
         }
     })
 
@@ -478,10 +468,10 @@ describe('CopilotUsageService', () => {
         })
     })
 
-    it('filters user details by creator but returns runtime user usage rows', async () => {
+    it('filters user details by billed user', async () => {
         const detail = {
             id: 'detail-1',
-            userId: 'assistant-tech-user',
+            userId: 'shared-user',
             xpertId: 'xpert-1',
             provider: 'openai',
             model: 'gpt-4.1',
@@ -509,18 +499,17 @@ describe('CopilotUsageService', () => {
             dimension: 'user',
             organizationId: 'org-1',
             orgId: null,
-            userId: 'owner-user',
+            userId: 'shared-user',
             provider: 'openai',
             model: 'gpt-4.1',
             currency: 'USD'
         })
 
-        expect((qb as any).andWhere).toHaveBeenCalledWith(
-            'COALESCE("usage_xpert"."createdById"::text, "usage"."userId"::text) = :groupUserId',
-            { groupUserId: 'owner-user' }
-        )
+        expect((qb as any).andWhere).toHaveBeenCalledWith('"usage"."userId"::text = :groupUserId', {
+            groupUserId: 'shared-user'
+        })
         expect(result[0]).toMatchObject({
-            userId: 'assistant-tech-user',
+            userId: 'shared-user',
             xpertId: 'xpert-1'
         })
     })
@@ -600,7 +589,7 @@ describe('CopilotUsageService', () => {
         })
     })
 
-    it('rejects quota changes for creator-aggregated user usage', async () => {
+    it('adjusts quota for billed user usage', async () => {
         const quotaRow = {
             tenantId: 'tenant-1',
             organizationId: 'org-1',
@@ -636,17 +625,31 @@ describe('CopilotUsageService', () => {
                 groupKey: {
                     dimension: 'user',
                     organizationId: 'org-1',
-                    userId: 'owner-user',
+                    userId: 'user-1',
                     provider: 'openai',
                     model: 'gpt-4.1',
                     currency: 'USD'
                 },
                 tokenLimit: 50
             })
-        ).rejects.toThrow('Creator-aggregated user usage quota changes are not supported')
+        ).resolves.toBeNull()
 
-        expect(userRepository.find).not.toHaveBeenCalled()
-        expect(userRepository.save).not.toHaveBeenCalled()
+        expect(userRepository.find).toHaveBeenCalledWith({
+            where: expect.objectContaining({
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                userId: 'user-1',
+                provider: 'openai',
+                model: 'gpt-4.1',
+                currency: 'USD'
+            })
+        })
+        expect(userRepository.save).toHaveBeenCalledWith([
+            expect.objectContaining({
+                userId: 'user-1',
+                tokenLimit: 150
+            })
+        ])
     })
 
     it('renews organization quota by rolling current usage into total usage', async () => {

--- a/packages/server-ai/src/copilot-usage/copilot-usage.service.ts
+++ b/packages/server-ai/src/copilot-usage/copilot-usage.service.ts
@@ -26,7 +26,7 @@ import {
 import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { OrganizationPublicDTO, RequestContext, User, UserPublicDTO } from '@xpert-ai/server-core'
-import { FindOptionsWhere, IsNull, ObjectLiteral, Repository, SelectQueryBuilder } from 'typeorm'
+import { FindOptionsWhere, IsNull, ObjectLiteral, Repository } from 'typeorm'
 import { CopilotOrganization } from '../copilot-organization/copilot-organization.entity'
 import { CopilotUser } from '../copilot-user/copilot-user.entity'
 import { MembershipPointLedger } from '../membership/membership-point-ledger.entity'
@@ -188,7 +188,6 @@ export class CopilotUsageService {
             .where('usage.tenantId = :tenantId', { tenantId: scope.tenantId })
             .groupBy("COALESCE(usage.currency, '')")
 
-        this.leftJoinUsageXpert(qb, 'usage')
         this.applyScope(qb, 'usage', scope)
         this.applyUsageFilters(qb, 'usage', query)
 
@@ -348,7 +347,6 @@ export class CopilotUsageService {
             .orderBy('usage.updatedAt', OrderTypeEnum.DESC)
             .take(DETAIL_LIMIT)
 
-        this.leftJoinUsageXpert(qb, 'usage')
         this.applyScope(qb, 'usage', scope)
         this.applyGroupKeyFilters(qb, 'usage', { ...groupKey, dimension })
 
@@ -357,7 +355,6 @@ export class CopilotUsageService {
 
     async adjustQuota(input: TCopilotQuotaAdjustInput): Promise<ICopilotUsageSummary | null> {
         const dimension = this.normalizeQuotaDimension(input.dimension)
-        this.assertQuotaDimensionManageable(dimension)
         const records = await this.findQuotaRecords(dimension, input.groupKey, true)
         const tokenLimit = this.calculateAdjustedLimit(
             records.map((record) => record.tokenLimit),
@@ -385,7 +382,6 @@ export class CopilotUsageService {
 
     async renewQuota(input: TCopilotQuotaRenewInput): Promise<ICopilotUsageSummary | null> {
         const dimension = this.normalizeQuotaDimension(input.dimension)
-        this.assertQuotaDimensionManageable(dimension)
         const records = await this.findQuotaRecords(dimension, input.groupKey, true)
 
         for (const record of records) {
@@ -479,12 +475,12 @@ export class CopilotUsageService {
         options?: { take?: number; skip?: number; order?: { updatedAt?: unknown } }
     ): Promise<IPagination<ICopilotUsageSummary>> {
         const scope = this.resolveScope(query.organizationId)
-        const ownerUserIdSql = this.usageOwnerUserIdSql('usage')
+        const billedUserIdSql = this.billedUserIdSql('usage')
         const qb = this.baseUsageSummaryQuery(scope, query, options)
-            .leftJoin(User, 'usage_user', `"usage_user"."id"::text = ${ownerUserIdSql}`)
+            .leftJoin(User, 'usage_user', `"usage_user"."id"::text = ${billedUserIdSql}`)
             .leftJoin('usage.organization', 'usage_organization')
             .leftJoin('usage.org', 'usage_org')
-            .addSelect(ownerUserIdSql, 'userId')
+            .addSelect(billedUserIdSql, 'userId')
             .addSelect('usage.orgId', 'orgId')
             .addSelect('COUNT(DISTINCT "usage"."userId")', 'runtimeUserCount')
             .addSelect('COUNT(DISTINCT "usage"."xpertId")', 'xpertCount')
@@ -500,7 +496,7 @@ export class CopilotUsageService {
             .addSelect('usage_org.id', 'orgRelationId')
             .addSelect('usage_org.name', 'orgName')
             .addSelect('usage_org.imageUrl', 'orgImageUrl')
-            .addGroupBy(ownerUserIdSql)
+            .addGroupBy(billedUserIdSql)
             .addGroupBy('usage.orgId')
             .addGroupBy('"usage_user"."id"')
             .addGroupBy('"usage_user"."firstName"')
@@ -589,7 +585,6 @@ export class CopilotUsageService {
             .take(take)
             .skip(skip)
 
-        this.leftJoinUsageXpert(qb, 'usage')
         this.applyScope(qb, 'usage', scope)
         this.applyUsageFilters(qb, 'usage', query)
 
@@ -645,7 +640,6 @@ export class CopilotUsageService {
             .take(take)
             .skip(skip)
 
-        this.leftJoinUsageXpert(qb, 'usage')
         this.applyScope(qb, 'usage', scope)
         this.applyUsageFilters(qb, 'usage', query)
 
@@ -838,7 +832,7 @@ export class CopilotUsageService {
             qb.andWhere(`${alias}.currency = :currency`, { currency: query.currency })
         }
         if (!options?.skipUser && query.userId) {
-            qb.andWhere(`${this.usageOwnerUserIdSql(alias)} = :filterUserId`, { filterUserId: query.userId })
+            qb.andWhere(`${this.billedUserIdSql(alias)} = :filterUserId`, { filterUserId: query.userId })
         }
         if (!options?.skipTime) {
             const start = this.toUsageHour(query.start)
@@ -857,7 +851,7 @@ export class CopilotUsageService {
             if (!groupKey.userId) {
                 throw new BadRequestException('Missing required user usage group fields.')
             }
-            qb.andWhere(`${this.usageOwnerUserIdSql(alias)} = :groupUserId`, { groupUserId: groupKey.userId })
+            qb.andWhere(`${this.billedUserIdSql(alias)} = :groupUserId`, { groupUserId: groupKey.userId })
             if (groupKey.orgId) {
                 qb.andWhere(`${alias}.orgId = :groupOrgId`, { groupOrgId: groupKey.orgId })
             } else {
@@ -923,19 +917,6 @@ export class CopilotUsageService {
             return dimension
         }
         throw new BadRequestException('Quota changes are only supported for user or organization dimensions.')
-    }
-
-    private assertQuotaDimensionManageable(dimension: 'user' | 'organization') {
-        if (dimension === 'user') {
-            throw new BadRequestException(
-                'Creator-aggregated user usage quota changes are not supported. Use copilot user usage endpoints for runtime-user quota management.'
-            )
-        }
-    }
-
-    private leftJoinUsageXpert(qb: SelectQueryBuilder<CopilotUser>, alias: string) {
-        const xpertAlias = this.usageXpertAlias(alias)
-        qb.leftJoin('xpert', xpertAlias, `"${xpertAlias}"."id"::text = "${alias}"."xpertId"`)
     }
 
     private async withMembershipPoints(
@@ -1100,13 +1081,8 @@ export class CopilotUsageService {
         }
     }
 
-    private usageOwnerUserIdSql(alias: string) {
-        const xpertAlias = this.usageXpertAlias(alias)
-        return `COALESCE("${xpertAlias}"."createdById"::text, "${alias}"."userId"::text)`
-    }
-
-    private usageXpertAlias(alias: string) {
-        return `${alias}_xpert`
+    private billedUserIdSql(alias: string) {
+        return `"${alias}"."userId"::text`
     }
 
     private calculateAdjustedLimit(


### PR DESCRIPTION
## Background

When user B runs an Xpert created by user A, the billing ledger now records B as the billed user. Copilot Usage still grouped and filtered user-level data through the Xpert creator, so Usage Center could report the charge under A even though the ledger charged B.

## Summary

- group and filter user usage by the ledger `usage.userId`
- align usage details and membership-point overlays with the billed user
- allow user quota adjustment and renewal now that user summaries are no longer creator-aggregated

## Validation

- `NX_DAEMON=false corepack pnpm nx test server-ai --runInBand --testPathPatterns='copilot-usage.service.spec.ts'` (8 tests passed)
- `NX_DAEMON=false corepack pnpm nx build server-ai`
- `corepack pnpm exec eslint packages/server-ai/src/copilot-usage/copilot-usage.service.ts packages/server-ai/src/copilot-usage/copilot-usage.service.spec.ts` (0 errors, 4 warnings)
- `git diff --check`