### PR TITLE
fix(cloud): avoid duplicate Tailwind preflight

### DIFF
--- a/apps/cloud/src/styles.scss
+++ b/apps/cloud/src/styles.scss
@@ -2,7 +2,11 @@
 /* You can add global styles to this file, and also import other style files */
 
 @config "../tailwind.config.js";
-@import 'tailwindcss' source(none);
+// `packages/ui/styles.css` already owns the shared Tailwind preflight. This
+// stylesheet only needs the theme registry and utilities for Cloud sources;
+// importing preflight again here resets tokenized borders to `currentColor`.
+@import 'tailwindcss/theme' layer(theme) source(none);
+@import 'tailwindcss/utilities' layer(utilities) source(none);
 @custom-variant dark (&:where([data-theme='dark'], [data-theme='dark'] *));
 @source "./app/**/*.{ts,html,scss,sass,css}";
 @source "../../../libs/**/*.{ts,html,scss,sass,css}";


### PR DESCRIPTION
## Background

`packages/ui/styles.css` already loads the shared Tailwind theme, Preflight, and utilities. Cloud also loaded the complete Tailwind bundle from `apps/cloud/src/styles.scss`. After the UI stylesheet stopped being reloaded inside the Cloud stylesheet, Cloud's later Preflight reset tokenized border colors to `currentColor`.

## Summary

- keep the shared Preflight owned by `packages/ui/styles.css`
- load only Tailwind theme registration and generated utilities from the Cloud stylesheet
- preserve Cloud source scanning and dark-mode variant behavior

## Validation

- `NX_DAEMON=false corepack pnpm nx build cloud --configuration=development`
- `corepack pnpm exec prettier --check apps/cloud/src/styles.scss`
- `git diff --check`

Browser verification was not run.