### PR TITLE
fix(cloud): preserve organization and sidebar state

### DIFF
--- a/apps/cloud/src/app/@core/services/app-init-service.ts
+++ b/apps/cloud/src/app/@core/services/app-init-service.ts
@@ -62,7 +62,7 @@ export class AppInitService {
         const organizations = memberships.map(({ organization }) => organization)
         const preferredOrganizationId = memberships.find((membership) => membership.isDefault)?.organizationId ?? null
 
-        this.scopeService.initializeEntryScope(organizations, preferredOrganizationId)
+        await this.scopeService.initializeEntryScope(organizations, preferredOrganizationId)
 
         //tenant enabled/disabled features for relatives organizations
         const tenantFeatures = this.user.tenant?.featureOrganizations ?? []

--- a/apps/cloud/src/app/@core/services/scope.service.spec.ts
+++ b/apps/cloud/src/app/@core/services/scope.service.spec.ts
@@ -1,0 +1,158 @@
+import { HttpErrorResponse } from '@angular/common/http'
+import { TestBed } from '@angular/core/testing'
+import { Router } from '@angular/router'
+import { IOrganization, IUser, RequestScopeLevel, RolesEnum } from '@xpert-ai/contracts'
+import { BehaviorSubject, Observable, of, Subject, throwError } from 'rxjs'
+import { Store } from '../state/store.service'
+import { OrganizationsService } from './organizations.service'
+import { ScopeService } from './scope.service'
+
+describe('ScopeService organization restoration', () => {
+  const persistedOrganization: IOrganization = {
+    id: 'org-2',
+    name: 'Organization 2',
+    isActive: true
+  } as IOrganization
+
+  function setup({
+    role = RolesEnum.SUPER_ADMIN,
+    organizationResult = of(persistedOrganization)
+  }: {
+    role?: RolesEnum
+    organizationResult?: Observable<IOrganization>
+  } = {}) {
+    const user: IUser = {
+      id: 'user-1',
+      tenantId: 'tenant-1',
+      role: {
+        name: role
+      }
+    } as IUser
+    const activeScope = {
+      level: RequestScopeLevel.ORGANIZATION,
+      organizationId: persistedOrganization.id
+    } as const
+    const userSubject = new BehaviorSubject(user)
+    const activeScopeSubject = new BehaviorSubject(activeScope)
+    const routerEvents = new Subject()
+    const store = {
+      activeScope,
+      clearScopedSelections: jest.fn(),
+      getLastCompatibleRoute: jest.fn(() => null),
+      lastOrganizationId: persistedOrganization.id,
+      selectedOrganization: null,
+      selectActiveScope: jest.fn(() => activeScopeSubject.asObservable()),
+      setLastCompatibleRoute: jest.fn(),
+      setOrganizationScope: jest.fn(),
+      setTenantScope: jest.fn(),
+      user,
+      user$: userSubject.asObservable()
+    }
+    const organizationsService = {
+      getById: jest.fn(() => organizationResult)
+    }
+    const router = {
+      events: routerEvents.asObservable(),
+      navigateByUrl: jest.fn(() => Promise.resolve(true)),
+      routerState: {
+        snapshot: {
+          root: {
+            data: { scopeContext: 'dual-scope' },
+            firstChild: null,
+            pathFromRoot: []
+          }
+        }
+      },
+      url: '/chat'
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        ScopeService,
+        { provide: OrganizationsService, useValue: organizationsService },
+        { provide: Router, useValue: router },
+        { provide: Store, useValue: store }
+      ]
+    })
+
+    return {
+      organizationsService,
+      service: TestBed.inject(ScopeService),
+      store
+    }
+  }
+
+  afterEach(() => {
+    TestBed.resetTestingModule()
+  })
+
+  it('restores a super admin persisted organization outside membership results', async () => {
+    const { organizationsService, service, store } = setup()
+
+    await service.initializeEntryScope([])
+
+    expect(organizationsService.getById).toHaveBeenCalledWith(persistedOrganization.id, undefined, [
+      'featureOrganizations',
+      'featureOrganizations.feature'
+    ])
+    expect(store.setOrganizationScope).toHaveBeenCalledWith(persistedOrganization)
+    expect(store.setTenantScope).not.toHaveBeenCalled()
+  })
+
+  it('does not bypass membership validation for a regular user', async () => {
+    const fallbackOrganization = {
+      id: 'org-1',
+      name: 'Organization 1',
+      isActive: true,
+      isDefault: true
+    } as IOrganization
+    const { organizationsService, service, store } = setup({ role: RolesEnum.ADMIN })
+
+    await service.initializeEntryScope([fallbackOrganization], fallbackOrganization.id)
+
+    expect(organizationsService.getById).not.toHaveBeenCalled()
+    expect(store.setOrganizationScope).toHaveBeenCalledWith(fallbackOrganization)
+  })
+
+  it.each([403, 404])('falls back when the persisted organization is rejected with status %s', async (status) => {
+    const fallbackOrganization = {
+      id: 'org-1',
+      name: 'Organization 1',
+      isActive: true,
+      isDefault: true
+    } as IOrganization
+    const { service, store } = setup({
+      organizationResult: throwError(() => new HttpErrorResponse({ status }))
+    })
+
+    await service.initializeEntryScope([fallbackOrganization], fallbackOrganization.id)
+
+    expect(store.setOrganizationScope).toHaveBeenCalledWith(fallbackOrganization)
+  })
+
+  it.each([0, 500])('preserves the persisted organization when loading fails with status %s', async (status) => {
+    const fallbackOrganization = {
+      id: 'org-1',
+      name: 'Organization 1',
+      isActive: true,
+      isDefault: true
+    } as IOrganization
+    const { service, store } = setup({
+      organizationResult: throwError(() => new HttpErrorResponse({ status }))
+    })
+
+    await service.initializeEntryScope([fallbackOrganization], fallbackOrganization.id)
+
+    expect(store.setOrganizationScope).not.toHaveBeenCalled()
+    expect(store.setTenantScope).not.toHaveBeenCalled()
+  })
+
+  it('initializes the entry scope only once for the same signed-in user', async () => {
+    const { organizationsService, service } = setup()
+
+    await service.initializeEntryScope([])
+    await service.initializeEntryScope([])
+
+    expect(organizationsService.getById).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/cloud/src/app/@core/services/scope.service.ts
+++ b/apps/cloud/src/app/@core/services/scope.service.ts
@@ -1,11 +1,17 @@
+import { HttpErrorResponse } from '@angular/common/http'
 import { computed, effect, inject, Injectable } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
 import { ActivatedRouteSnapshot, NavigationEnd, Route, Router } from '@angular/router'
 import { RolesEnum } from '@xpert-ai/contracts'
-import { IOrganization, RequestScopeLevel, Store } from '@cloud/app/@core/state'
-import { distinctUntilChanged, filter, map, startWith } from 'rxjs'
+import { type ActiveScope, IOrganization, RequestScopeLevel, Store } from '@cloud/app/@core/state'
+import { distinctUntilChanged, filter, firstValueFrom, map, startWith } from 'rxjs'
+import { OrganizationsService } from './organizations.service'
 
 export type RouteScopeContext = 'tenant-only' | 'organization-only' | 'dual-scope'
+
+type PersistedOrganizationResolution =
+  | { status: 'resolved'; organization: IOrganization | null }
+  | { status: 'unavailable' }
 
 const DEFAULT_TENANT_ROUTE = '/settings/tenant'
 const DEFAULT_ORGANIZATION_ROUTE = '/chat'
@@ -14,6 +20,8 @@ const DEFAULT_ORGANIZATION_ROUTE = '/chat'
 export class ScopeService {
   readonly #router = inject(Router)
   readonly #store = inject(Store)
+  readonly #organizationsService = inject(OrganizationsService)
+  #entryScopeInitialization: { userId: string; promise: Promise<void> } | null = null
   readonly #currentUser = toSignal(this.#store.user$, {
     initialValue: this.#store.user
   })
@@ -56,6 +64,13 @@ export class ScopeService {
 
   constructor() {
     effect(() => {
+      const userId = this.#currentUser()?.id
+      if (!userId || (this.#entryScopeInitialization && this.#entryScopeInitialization.userId !== userId)) {
+        this.#entryScopeInitialization = null
+      }
+    })
+
+    effect(() => {
       const routeScope = this.currentRouteScope()
       const url = this.currentUrl()
       if (!url) {
@@ -92,16 +107,32 @@ export class ScopeService {
     })
   }
 
-  initializeEntryScope(organizations: IOrganization[], preferredOrganizationId?: string | null) {
+  async initializeEntryScope(organizations: IOrganization[], preferredOrganizationId?: string | null) {
+    const userId = this.#currentUser()?.id ?? this.#store.userId
+    if (userId && this.#entryScopeInitialization?.userId === userId) {
+      return this.#entryScopeInitialization.promise
+    }
+
+    const promise = this.initializeEntryScopeOnce(organizations, preferredOrganizationId)
+    if (userId) {
+      this.#entryScopeInitialization = { userId, promise }
+    }
+
+    return promise
+  }
+
+  private async initializeEntryScopeOnce(organizations: IOrganization[], preferredOrganizationId?: string | null) {
     const validOrganizations = this.resolveValidOrganizations(organizations)
     const scope = this.activeScope()
-    const persistedOrganization =
-      scope.level === RequestScopeLevel.ORGANIZATION
-        ? (validOrganizations.find((organization) => organization.id === scope.organizationId) ?? null)
-        : null
+    const persistedOrganizationResolution = await this.resolvePersistedOrganization(validOrganizations, scope)
+    if (persistedOrganizationResolution.status === 'unavailable') {
+      return
+    }
+
+    const persistedOrganization = persistedOrganizationResolution.organization
     const defaultOrganization = this.resolveDefaultOrganization(validOrganizations, preferredOrganizationId)
 
-    if (!validOrganizations.length) {
+    if (!validOrganizations.length && !persistedOrganization) {
       if (scope.level !== RequestScopeLevel.TENANT || this.#store.selectedOrganization) {
         this.#store.setTenantScope()
       }
@@ -202,6 +233,39 @@ export class ScopeService {
 
   private resolveOrganizationFallback() {
     return this.#store.getLastCompatibleRoute(RequestScopeLevel.ORGANIZATION) || DEFAULT_ORGANIZATION_ROUTE
+  }
+
+  private async resolvePersistedOrganization(
+    organizations: IOrganization[],
+    scope: ActiveScope
+  ): Promise<PersistedOrganizationResolution> {
+    if (scope.level !== RequestScopeLevel.ORGANIZATION) {
+      return { status: 'resolved', organization: null }
+    }
+
+    const membershipOrganization = organizations.find((organization) => organization.id === scope.organizationId)
+    if (membershipOrganization || !this.canUseTenantScope()) {
+      return { status: 'resolved', organization: membershipOrganization ?? null }
+    }
+
+    try {
+      const organization = await firstValueFrom(
+        this.#organizationsService.getById(scope.organizationId, undefined, [
+          'featureOrganizations',
+          'featureOrganizations.feature'
+        ])
+      )
+      return {
+        status: 'resolved',
+        organization: organization?.id === scope.organizationId && organization.isActive !== false ? organization : null
+      }
+    } catch (error) {
+      if (error instanceof HttpErrorResponse && (error.status === 403 || error.status === 404)) {
+        return { status: 'resolved', organization: null }
+      }
+
+      return { status: 'unavailable' }
+    }
   }
 
   private resolveScopeTransitionTarget(level: RequestScopeLevel) {

--- a/apps/cloud/src/app/@core/state/current-user-hydration.service.spec.ts
+++ b/apps/cloud/src/app/@core/state/current-user-hydration.service.spec.ts
@@ -378,6 +378,10 @@ describe('CurrentUserHydrationService', () => {
         }
       }
     ]
+    storeState.activeScope = {
+      level: RequestScopeLevel.ORGANIZATION,
+      organizationId: 'org-2'
+    }
     storeState.featureOrganizations = [orgFeature]
     usersService.getMe.mockResolvedValue(hydrationUser)
 
@@ -385,6 +389,34 @@ describe('CurrentUserHydrationService', () => {
 
     expect(storeState.selectedOrganization?.id).toBe('org-2')
     expect(storeState.featureOrganizations).toEqual([org2Feature])
+  })
+
+  it('keeps the active organization when feature hydration only contains another membership', async () => {
+    const activeOrganizationFeature = {
+      ...orgFeature,
+      id: 'org-2-feature',
+      organizationId: 'org-2',
+      featureId: 'feature-org-2',
+      feature: { id: 'feature-org-2', code: 'org-2-feature' }
+    } as IFeatureOrganization
+    const activeOrganization = {
+      ...createBootstrapUser().organizations[0].organization,
+      id: 'org-2',
+      name: 'Org 2',
+      featureOrganizations: [activeOrganizationFeature]
+    }
+    storeState.activeScope = {
+      level: RequestScopeLevel.ORGANIZATION,
+      organizationId: activeOrganization.id
+    }
+    storeState.selectedOrganization = activeOrganization
+    storeState.featureOrganizations = [activeOrganizationFeature]
+    usersService.getMe.mockResolvedValue(createHydrationUser())
+
+    await service.getFeatureHydration()
+
+    expect(storeState.selectedOrganization).toEqual(activeOrganization)
+    expect(storeState.featureOrganizations).toEqual([activeOrganizationFeature])
   })
 
   it('does not restore a selected organization while hydrating tenant scope', async () => {

--- a/apps/cloud/src/app/@core/state/current-user-hydration.service.ts
+++ b/apps/cloud/src/app/@core/state/current-user-hydration.service.ts
@@ -279,29 +279,35 @@ export class CurrentUserHydrationService {
   }
 
   private syncSelectedOrganizationFeatures(user: IUser) {
-    if (this.store.activeScope.level === RequestScopeLevel.TENANT) {
+    const activeScope = this.store.activeScope
+    if (activeScope.level === RequestScopeLevel.TENANT) {
       this.store.selectedOrganization = null
       this.store.featureOrganizations = []
       return
     }
 
-    const memberships = user.organizations ?? []
-    const selectedOrganizationId = this.store.selectedOrganization?.id
-    const membership = selectedOrganizationId
-      ? memberships.find((item) => getMembershipOrganizationId(item) === selectedOrganizationId)
-      : null
-    const nextMembership =
-      membership ??
-      memberships.find((item) => item.isDefault && item.organization) ??
-      memberships.find((item) => item.organization) ??
-      null
-    const organization = nextMembership?.organization ?? null
-    const featureOrganizations = Array.isArray(organization?.featureOrganizations)
-      ? organization.featureOrganizations
-      : []
+    const activeOrganizationId = activeScope.organizationId
+    const membership = (user.organizations ?? []).find(
+      (item) => getMembershipOrganizationId(item) === activeOrganizationId
+    )
+    if (membership?.organization) {
+      this.store.selectedOrganization = membership.organization
+      this.store.featureOrganizations = Array.isArray(membership.organization.featureOrganizations)
+        ? membership.organization.featureOrganizations
+        : []
+      return
+    }
 
-    this.store.selectedOrganization = organization
-    this.store.featureOrganizations = featureOrganizations
+    const selectedOrganization = this.store.selectedOrganization
+    if (selectedOrganization?.id === activeOrganizationId) {
+      if (Array.isArray(selectedOrganization.featureOrganizations)) {
+        this.store.featureOrganizations = selectedOrganization.featureOrganizations
+      }
+      return
+    }
+
+    this.store.selectedOrganization = null
+    this.store.featureOrganizations = []
   }
 
   private buildInFlightKey(userId: string, tenantId: string | null, relations: readonly string[]) {

--- a/apps/cloud/src/app/features/features.component.spec.ts
+++ b/apps/cloud/src/app/features/features.component.spec.ts
@@ -146,6 +146,7 @@ async function setup(options: FeatureTestOptions = {}) {
     level: RequestScopeLevel.ORGANIZATION,
     organizationId: 'org-1'
   })
+  const activeScopeSubject = new BehaviorSubject(activeScope())
   const store = {
     get user() {
       return userSubject.value
@@ -185,7 +186,7 @@ async function setup(options: FeatureTestOptions = {}) {
     featureContextHydrated$: of(true),
     preferences: signal(null),
     updatePreferences: jest.fn(),
-    selectActiveScope: jest.fn(() => of(activeScope())),
+    selectActiveScope: jest.fn(() => activeScopeSubject.asObservable()),
     hasFeatureEnabled: jest.fn((feature: AiFeatureEnum) => {
       if (feature === AiFeatureEnum.FEATURE_XPERT) {
         return options.hasXpertFeature ?? true
@@ -320,6 +321,7 @@ async function setup(options: FeatureTestOptions = {}) {
 
   return {
     component,
+    activeScopeSubject,
     store,
     router,
     selectedOrganizationSubject,
@@ -343,8 +345,10 @@ describe('FeaturesComponent sidebar organization default', () => {
     expect(component.sidebarCollapsed()).toBe(false)
   })
 
-  it('does not overwrite a manual choice until the organization changes', async () => {
-    const { component, selectedOrganizationSubject } = await setup({ sidebarExpandedByDefault: true })
+  it('does not overwrite a manual choice when the organization changes', async () => {
+    const { activeScopeSubject, component, selectedOrganizationSubject } = await setup({
+      sidebarExpandedByDefault: true
+    })
     component.sidebarCollapsed.set(true)
     await component.ngOnInit()
 
@@ -353,9 +357,10 @@ describe('FeaturesComponent sidebar organization default', () => {
 
     expect(component.sidebarCollapsed()).toBe(true)
 
+    activeScopeSubject.next({ level: RequestScopeLevel.ORGANIZATION, organizationId: 'org-2' })
     selectedOrganizationSubject.next({ id: 'org-2', sidebarExpandedByDefault: true })
 
-    expect(component.sidebarCollapsed()).toBe(false)
+    expect(component.sidebarCollapsed()).toBe(true)
   })
 })
 

--- a/apps/cloud/src/app/features/features.component.ts
+++ b/apps/cloud/src/app/features/features.component.ts
@@ -22,6 +22,7 @@ import {
   RouterOutlet
 } from '@angular/router'
 import {
+  type ActiveScope,
   CurrentUserHydrationService,
   CURRENT_USER_BOOTSTRAP_RELATIONS,
   CURRENT_USER_BOOTSTRAP_SELECT,
@@ -212,7 +213,7 @@ export class FeaturesComponent implements OnInit {
   #sidebarResizePointerId: number | null = null
   #sidebarResizeHandle: HTMLElement | null = null
   #sidebarResizeAbortController: AbortController | null = null
-  #sidebarDefaultScopeKey: string | null = null
+  #sidebarDefaultApplied = false
 
   constructor() {
     this.#router.events
@@ -263,7 +264,7 @@ export class FeaturesComponent implements OnInit {
       )
       .subscribe(([, , org, scope]) => {
         this.organization = org
-        this.applySidebarDefault(org, scope.level)
+        this.applySidebarDefault(org, scope)
         this.menus.set(getFeatureMenus(scope.level, org))
         this.loadItems()
         void this.maybeOpenEntryOnboardingGuide()
@@ -313,7 +314,7 @@ export class FeaturesComponent implements OnInit {
     const organizations = memberships.map(({ organization }) => organization)
     const preferredOrganizationId = memberships.find((membership) => membership.isDefault)?.organizationId ?? null
 
-    this.#scopeService.initializeEntryScope(organizations, preferredOrganizationId)
+    await this.#scopeService.initializeEntryScope(organizations, preferredOrganizationId)
 
     //tenant enabled/disabled features for relatives organizations
     const { tenant, role } = this.user
@@ -451,16 +452,19 @@ export class FeaturesComponent implements OnInit {
     this.sidebarCollapsed.set(collapsed)
   }
 
-  private applySidebarDefault(organization: IOrganization | null | undefined, scopeLevel: RequestScopeLevel) {
-    const organizationId = scopeLevel === RequestScopeLevel.ORGANIZATION ? organization?.id : null
-    const scopeKey = organizationId ? `organization:${organizationId}` : `scope:${scopeLevel}`
-
-    if (this.#sidebarDefaultScopeKey === scopeKey) {
+  private applySidebarDefault(organization: IOrganization | null | undefined, scope: ActiveScope) {
+    if (this.#sidebarDefaultApplied) {
       return
     }
 
-    this.#sidebarDefaultScopeKey = scopeKey
-    this.sidebarCollapsed.set(!organizationId || organization?.sidebarExpandedByDefault !== true)
+    if (scope.level === RequestScopeLevel.ORGANIZATION && organization?.id !== scope.organizationId) {
+      return
+    }
+
+    this.#sidebarDefaultApplied = true
+    this.sidebarCollapsed.set(
+      scope.level !== RequestScopeLevel.ORGANIZATION || organization?.sidebarExpandedByDefault !== true
+    )
   }
 
   startSidebarResize(event: PointerEvent) {


### PR DESCRIPTION
## Summary

- restore the persisted organization for tenant-scoped super admins when it is absent from membership hydration
- serialize and await entry-scope initialization so refresh does not fall back through a competing initialization path
- apply the organization sidebar default only on initial entry and keep feature hydration aligned with the active organization

## Testing

- 3 focused Cloud test suites, 29 tests passed
- Prettier check passed for all 7 files
- git diff --check passed

## Manual verification

- Browser verification was not run; please verify organization switching, sidebar state, and refresh behavior manually.