### PR TITLE
fix(server-ai): allow same-origin workspace previews

### DIFF
--- a/packages/server-ai/src/workspace-file-access/workspace-file-access.service.spec.ts
+++ b/packages/server-ai/src/workspace-file-access/workspace-file-access.service.spec.ts
@@ -128,6 +128,19 @@ describe('WorkspaceFileAccessService', () => {
                 'preview'
             )
         ).toBeNull()
+        expect(
+            service.assertRequestOrigin(
+                authorization.session,
+                {
+                    headers: {
+                        'sec-fetch-site': 'same-origin',
+                        'sec-fetch-mode': 'no-cors',
+                        'sec-fetch-dest': 'image'
+                    }
+                },
+                'preview'
+            )
+        ).toBeNull()
         expect(() =>
             service.assertRequestOrigin(
                 authorization.session,

--- a/packages/server-ai/src/workspace-file-access/workspace-file-access.service.ts
+++ b/packages/server-ai/src/workspace-file-access/workspace-file-access.service.ts
@@ -292,7 +292,7 @@ export class WorkspaceFileAccessService {
         // consequently omits both Origin and Referer from an <img> request, but
         // still sends trustworthy Fetch Metadata. The request is already bound
         // to an HttpOnly session cookie and an opaque, short-lived grant; only
-        // admit the exact same-site image subresource shape for previews.
+        // admit the exact same-origin or same-site image subresource shape for previews.
         if (!origin && purpose === 'preview' && isSameSiteImageRequest(request.headers)) {
             return null
         }
@@ -516,8 +516,9 @@ function workspaceFileContentOrigin() {
 }
 
 function isSameSiteImageRequest(headers: Request['headers']) {
+    const fetchSite = headers['sec-fetch-site']
     return (
-        headers['sec-fetch-site'] === 'same-site' &&
+        (fetchSite === 'same-origin' || fetchSite === 'same-site') &&
         headers['sec-fetch-mode'] === 'no-cors' &&
         headers['sec-fetch-dest'] === 'image'
     )


### PR DESCRIPTION
## Summary

- allow sandboxed workspace preview images with same-origin Fetch Metadata
- preserve the existing same-site allowance and cross-site denial
- add regression coverage for the test-environment request shape

## Testing

- corepack pnpm exec jest --config packages/server-ai/jest.config.ts --runInBand --runTestsByPath packages/server-ai/src/workspace-file-access/workspace-file-access.service.spec.ts
- git diff --check origin/develop...HEAD
