### PR TITLE
chore: prepare Xpert 3.18.0 release

### DIFF
--- a/.changeset/prepare-xpert-3-18.md
+++ b/.changeset/prepare-xpert-3-18.md
@@ -1,0 +1,7 @@
+---
+'@xpert-ai/contracts': minor
+'@xpert-ai/plugin-sdk': minor
+'@xpert-ai/xpert-ui': minor
+---
+
+Release Xpert 3.18.0.


### PR DESCRIPTION
## Summary

- Add the platform minor Changeset for Xpert 3.18.0.
- Keep Contracts, Plugin SDK, and the private Web version source aligned at 3.18.0.
- Keep Sandbox Runtime at the already published 1.2.1 release; this develop train has no Runtime Suite changes.

## Changesets preview

The requested platform packages resolve as follows:

- @xpert-ai/contracts: 3.17.6 -> 3.18.0 (minor)
- @xpert-ai/plugin-sdk: 3.17.6 -> 3.18.0 (minor)
- @xpert-ai/xpert-ui: 3.17.6 -> 3.18.0 (minor, private Web version source)

Existing workspace peer dependency rules also produce the established minor-release propagation:

- @xpert-ai/plugin-draft: 11.0.6 -> 12.0.0
- @xpert-ai/plugin-vlm-default: 10.0.6 -> 11.0.0
- @xpert-ai/server-core: 3.9.45 -> 3.9.46
- @xpert-ai/server-ai: 3.9.30 -> 3.9.31

The two private plugin major bumps match the repository history for prior Plugin SDK minor releases.

## Release sequence

1. Merge this Changeset PR into develop.
2. Create and review the develop-to-main release PR.
3. Review and merge the generated Changesets version PR on main.
4. Verify npm packages and application images before creating the 3.18.0 platform tag.

## Validation

- Changesets status against origin/main
- pnpm 10.24.0 frozen lockfile verification in offline mode
- repository pre-commit formatting, hardcoded-color, and TypeORM checks
- git diff --check
- independent read-only audit of the Changesets dependency propagation

## Scope

One commit and one new Changeset file. Existing local WIP is not included.