### PR TITLE
[codex] Fix view events without crypto.randomUUID

### DIFF
--- a/apps/cloud/src/app/@shared/view-extension/renderers/remote-component-renderer.component.spec.ts
+++ b/apps/cloud/src/app/@shared/view-extension/renderers/remote-component-renderer.component.spec.ts
@@ -210,6 +210,56 @@ describe('RemoteComponentRendererComponent', () => {
     expect(api.getRemoteComponentEntry).toHaveBeenCalledTimes(1)
   })
 
+  it('publishes data changes when browser crypto.randomUUID is unavailable', async () => {
+    api.executeAction.mockReturnValue(of({ success: true, data: { id: 'document-1' } }))
+
+    const fixture = TestBed.createComponent(RemoteComponentRendererComponent)
+    fixture.componentRef.setInput('hostType', 'agent')
+    fixture.componentRef.setInput('hostId', 'assistant-1')
+    fixture.componentRef.setInput('manifest', {
+      ...manifest,
+      actions: [
+        {
+          key: 'create_document',
+          label: { en_US: 'New document' },
+          actionType: 'invoke',
+          requiredHostAccess: 'edit'
+        }
+      ]
+    })
+    await flushRemoteEntry(fixture)
+
+    const component = fixture.componentInstance as unknown as {
+      handleActionRequest(message: Record<string, unknown>): Promise<unknown>
+    }
+    const publish = jest.spyOn(hostEvents, 'publish')
+    const randomUuidDescriptor = Object.getOwnPropertyDescriptor(globalThis.crypto, 'randomUUID')
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+      configurable: true,
+      value: undefined
+    })
+
+    try {
+      await expect(component.handleActionRequest({ actionKey: 'create_document' })).resolves.toEqual({
+        success: true,
+        data: { id: 'document-1' }
+      })
+      expect(publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expect.stringMatching(/^\d+-[0-9a-f]+$/),
+          type: 'view.data.changed',
+          data: expect.objectContaining({ actionKey: 'create_document' })
+        })
+      )
+    } finally {
+      if (randomUuidDescriptor) {
+        Object.defineProperty(globalThis.crypto, 'randomUUID', randomUuidDescriptor)
+      } else {
+        Reflect.deleteProperty(globalThis.crypto, 'randomUUID')
+      }
+    }
+  })
+
   it('allows same-origin access inside sandboxed remote component iframes', async () => {
     const fixture = TestBed.createComponent(RemoteComponentRendererComponent)
     fixture.componentRef.setInput('hostType', 'agent')

--- a/apps/cloud/src/app/@shared/view-extension/renderers/remote-component-renderer.component.ts
+++ b/apps/cloud/src/app/@shared/view-extension/renderers/remote-component-renderer.component.ts
@@ -117,7 +117,7 @@ export class RemoteComponentRendererComponent {
     }
     return this.viewportBound() ? Math.min(requested, this.viewportHeight()) : requested
   })
-  readonly #instanceNonce = signal(createInstanceNonce())
+  readonly #instanceNonce = signal(createBrowserId())
   readonly instanceId = computed(() => `${this.manifest().key}:${this.#instanceNonce()}`)
   readonly remoteThemeMode = computed<RemoteComponentThemeMode>(() =>
     this.#themeService.themeClass() === 'dark' ? 'dark' : 'light'
@@ -190,7 +190,7 @@ export class RemoteComponentRendererComponent {
     this.requestedHeight.set(520)
     this.viewportBound.set(false)
     this.updateViewportHeight()
-    this.#instanceNonce.set(createInstanceNonce())
+    this.#instanceNonce.set(createBrowserId())
     this.resetFileAccessSession()
 
     try {
@@ -391,7 +391,7 @@ export class RemoteComponentRendererComponent {
       return
     }
     this.#hostEvents.publish({
-      id: crypto.randomUUID(),
+      id: createBrowserId(),
       type: 'view.data.changed',
       source: 'view-extension',
       receivedAt: new Date().toISOString(),
@@ -786,9 +786,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
 }
 
-function createInstanceNonce() {
-  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
-    ? crypto.randomUUID()
+function createBrowserId() {
+  return typeof globalThis.crypto?.randomUUID === 'function'
+    ? globalThis.crypto.randomUUID()
     : `${Date.now()}-${Math.random().toString(16).slice(2)}`
 }
 


### PR DESCRIPTION
## Issue

Creating a document from a remote component can complete on the backend but still report `crypto.randomUUID is not a function` to the iframe. The host throws while publishing the follow-up `view.data.changed` event, so the document list does not refresh and users may retry an action that already succeeded.

This occurs in browsers that do not expose `crypto.randomUUID`, including Xpert environments served from an insecure HTTP IP origin.

## Root cause

The remote component host used `crypto.randomUUID()` directly for data-change event IDs. The same component already had a fallback-capable ID generator for iframe instance nonces, but the event path bypassed it and its feature check did not verify that `randomUUID` was callable.

## Fix

Use one browser-compatible ID helper for both iframe instance nonces and `view.data.changed` events. It calls `globalThis.crypto.randomUUID()` when available and otherwise generates a timestamp-and-random fallback ID.

Add a regression test that removes `crypto.randomUUID`, executes an edit action, and verifies that the action result resolves and the data-change event is still published with a fallback ID.

## Validation

- Remote component renderer tests: 18 passed
- ESLint on the changed implementation and spec: 0 errors
- `git diff --check`
- `nx build cloud --configuration=development`: passed

Browser verification was not run and remains a manual follow-up on the HTTP IP test environment.
