### PR TITLE
fix(i18n): localize ClawXpert orchestration action

### DIFF
--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -2226,6 +2226,7 @@
         "Title": "ClawXpert",
         "Shell": "ClawXpert Shell",
         "Change": "Change ClawXpert",
+        "OpenOrchestration": "Open ClawXpert orchestration",
         "Clear": "Clear ClawXpert",
         "MoreActions": "More actions",
         "Loading": "Preparing ClawXpert…",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -5738,6 +5738,7 @@
         "SidebarStatusSetup": "前往设置",
         "SidebarSettings": "ClawXpert 设置",
         "Change": "更换 ClawXpert",
+        "OpenOrchestration": "打开 ClawXpert 编排",
         "Clear": "清除 ClawXpert",
         "MoreActions": "更多操作",
         "Loading": "正在准备 ClawXpert…",


### PR DESCRIPTION
## Summary

- define the ClawXpert orchestration action in the English catalog
- add the Simplified Chinese translation so the menu no longer falls back to English

## Validation

- parsed both JSON catalogs and asserted the new values
- ran git diff --check
- passed the repository pre-commit formatting and static checks

Browser validation was not run.