### PR TITLE
fix: streamline workspace connector management

### DIFF
--- a/apps/cloud/src/app/@core/services/xpert-connector.service.ts
+++ b/apps/cloud/src/app/@core/services/xpert-connector.service.ts
@@ -82,6 +82,12 @@ export class XpertConnectorService {
     })
   }
 
+  cancelBindingAuthorization(bindingId: string, xpertId?: string) {
+    return this.#http.post<void>(`${API_CONNECTOR}/bindings/${bindingId}/cancel-authorization`, {
+      ...(xpertId ? { xpertId } : {})
+    })
+  }
+
   consentToBinding(bindingId: string, xpertId?: string) {
     return this.#http.post<ConnectorBinding>(`${API_CONNECTOR}/bindings/${bindingId}/consent`, {
       ...(xpertId ? { xpertId } : {})

--- a/apps/cloud/src/app/features/project/project-connectors-dialog.component.spec.ts
+++ b/apps/cloud/src/app/features/project/project-connectors-dialog.component.spec.ts
@@ -12,6 +12,12 @@ const sharedDefinition = {
   authorizationModes: ['shared', 'personal']
 } satisfies ConnectorStrategyDefinition
 
+const legacyDefinition = {
+  provider: 'legacy-provider',
+  label: { en_US: 'Legacy provider' },
+  auth: { type: 'oauth2' }
+} satisfies ConnectorStrategyDefinition
+
 const personalBinding = {
   id: 'personal-binding',
   provider: 'shared-provider',
@@ -60,6 +66,20 @@ describe('XpertProjectConnectorsDialogComponent', () => {
       provider: sharedDefinition.provider,
       authorizationMode: 'personal'
     })
+  })
+
+  it('only offers an authorization mode choice for providers that support multiple modes', async () => {
+    const { component } = await createComponent({
+      canManage: true,
+      definitions: [legacyDefinition, sharedDefinition],
+      bindings: []
+    })
+
+    component.selectProvider(legacyDefinition.provider)
+    expect(component.canSelectAuthorizationMode()).toBe(false)
+
+    component.selectProvider(sharedDefinition.provider)
+    expect(component.canSelectAuthorizationMode()).toBe(true)
   })
 
   it('keeps binding administration manager-only while allowing a member to consent personally', async () => {

--- a/apps/cloud/src/app/features/project/project-connectors-dialog.component.ts
+++ b/apps/cloud/src/app/features/project/project-connectors-dialog.component.ts
@@ -61,7 +61,13 @@ type ProjectConnectorsDialogData = {
                 {{ 'XP.XProject.AddProjectConnectorDescription' | translate }}
               </p>
             </div>
-            <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_10rem_auto]">
+            <div
+              [class]="
+                canSelectAuthorizationMode()
+                  ? 'grid gap-2 sm:grid-cols-[minmax(0,1fr)_10rem_auto]'
+                  : 'grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]'
+              "
+            >
               <z-select
                 [zValue]="selectedProvider()"
                 [zDisabled]="busy() || !availableDefinitions().length"
@@ -72,11 +78,13 @@ type ProjectConnectorsDialogData = {
                   <z-select-item [zValue]="definition.provider">{{ definition.label | i18n }}</z-select-item>
                 }
               </z-select>
-              <z-select [zValue]="selectedMode()" [zDisabled]="busy()" (zSelectionChange)="selectMode($event)">
-                @for (mode of selectedDefinitionModes(); track mode) {
-                  <z-select-item [zValue]="mode">{{ modeLabel(mode) | translate }}</z-select-item>
-                }
-              </z-select>
+              @if (canSelectAuthorizationMode()) {
+                <z-select [zValue]="selectedMode()" [zDisabled]="busy()" (zSelectionChange)="selectMode($event)">
+                  @for (mode of selectedDefinitionModes(); track mode) {
+                    <z-select-item [zValue]="mode">{{ modeLabel(mode) | translate }}</z-select-item>
+                  }
+                </z-select>
+              }
               <button
                 z-button
                 zType="default"
@@ -87,7 +95,9 @@ type ProjectConnectorsDialogData = {
                 {{ 'XP.XProject.AddConnector' | translate }}
               </button>
             </div>
-            <p class="text-xs text-text-tertiary">{{ modeDescription(selectedMode()) | translate }}</p>
+            @if (canSelectAuthorizationMode()) {
+              <p class="text-xs text-text-tertiary">{{ modeDescription(selectedMode()) | translate }}</p>
+            }
           </section>
         }
 
@@ -237,6 +247,7 @@ export class XpertProjectConnectorsDialogComponent {
     const definition = this.definitionFor(this.selectedProvider())
     return definition ? getConnectorAuthorizationModes(definition) : (['shared'] as ConnectorAuthorizationMode[])
   })
+  readonly canSelectAuthorizationMode = computed(() => this.selectedDefinitionModes().length > 1)
   readonly #forms = new Map<string, FormRecord<FormControl<string>>>()
   readonly #pollTimers = new Map<string, ReturnType<typeof setTimeout>>()
 

--- a/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.spec.ts
@@ -1,3 +1,4 @@
+import { Clipboard } from '@angular/cdk/clipboard'
 import { Component, signal } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
 import type {
@@ -7,7 +8,7 @@ import type {
   ConnectorStrategyDefinition
 } from '@xpert-ai/plugin-sdk'
 import { TranslateModule } from '@ngx-translate/core'
-import { of } from 'rxjs'
+import { of, throwError } from 'rxjs'
 import { ToastrService, XpertConnectorService, XpertWorkspaceService } from 'apps/cloud/src/app/@core'
 import { XpertWorkspaceHomeComponent } from '../home/home.component'
 import { ClawXpertConnectorsComponent, XpertConnectorsComponent } from './connectors.component'
@@ -90,12 +91,36 @@ const githubDefinition: ConnectorStrategyDefinition = {
   ]
 }
 
-const personalBinding: ConnectorBinding = {
-  id: 'personal-binding',
+const embeddedDefinition: ConnectorStrategyDefinition = {
+  provider: 'wecom',
+  label: 'WeCom',
+  description: 'Connect WeCom with a QR code',
+  authorizationModes: ['personal', 'shared'],
+  authMethods: [
+    {
+      id: 'wecom-qr',
+      type: 'oauth2',
+      label: 'WeCom QR',
+      authorizationPresentation: {
+        mode: 'embedded_qr',
+        title: 'Scan to authorize',
+        description: 'Use WeCom to scan this QR code.',
+        ariaLabel: 'WeCom authorization QR code',
+        completionHint: 'This window closes after authorization.',
+        cancelLabel: 'Cancel authorization',
+        copyLinkLabel: 'Copy authorization link',
+        copyLinkError: 'Could not copy authorization link.'
+      }
+    }
+  ]
+}
+
+const workspaceBinding: ConnectorBinding = {
+  id: 'workspace-binding',
   workspaceId: 'workspace-1',
   scopeType: 'workspace',
   scope: workspaceScope,
-  authorizationMode: 'personal',
+  authorizationMode: 'shared',
   provider: 'example',
   status: 'disconnected'
 }
@@ -116,9 +141,20 @@ const githubBinding: ConnectorBinding = {
   workspaceId: 'workspace-1',
   scopeType: 'workspace',
   scope: workspaceScope,
-  authorizationMode: 'personal',
+  authorizationMode: 'shared',
   provider: 'github',
   authMethodId: 'pat',
+  status: 'disconnected'
+}
+
+const embeddedBinding: ConnectorBinding = {
+  id: 'wecom-binding',
+  workspaceId: 'workspace-1',
+  scopeType: 'workspace',
+  scope: workspaceScope,
+  authorizationMode: 'shared',
+  provider: 'wecom',
+  authMethodId: 'wecom-qr',
   status: 'disconnected'
 }
 
@@ -135,7 +171,7 @@ function createAuthorizationPopup() {
     focus,
     location
   } as unknown as Window
-  return { popup, navigate, focus }
+  return { popup, navigate, focus, close }
 }
 
 async function setup(options?: {
@@ -146,32 +182,50 @@ async function setup(options?: {
   pollResponse?: ConnectorOAuthStatusResponse
 }) {
   const workspace = signal({ id: 'workspace-1' })
+  const connectorSearchQuery = signal('')
   const connectorService = {
     scopedDefinitions: jest.fn(() => of(options?.definitions ?? [connectorDefinition])),
     listBindings: jest.fn(() => of(options?.bindings ?? [])),
-    createBinding: jest.fn(() => of(personalBinding)),
-    deleteBinding: jest.fn(() => of(null)),
+    connect: jest.fn(() =>
+      of(
+        options?.connectResponse ?? {
+          status: 'active',
+          connector: { ...workspaceBinding, status: 'active', profile: { name: 'Connected Account' } }
+        }
+      )
+    ),
+    disconnect: jest.fn(() => of(null)),
     connectBinding: jest.fn(() =>
       of(
         options?.connectResponse ?? {
           status: 'active',
-          connector: { ...personalBinding, status: 'active', profile: { name: 'My Account' } }
+          connector: { ...workspaceBinding, status: 'active', profile: { name: 'Connected Account' } }
         }
       )
     ),
     bindingAuthorizationStatus: jest.fn(() =>
       of(
         options?.pollResponse ?? {
-          connector: { ...personalBinding, status: 'active' },
+          connector: { ...workspaceBinding, status: 'active' },
           granted: true
         }
       )
     ),
-    consentToBinding: jest.fn(() => of({ ...personalBinding, status: 'active', profile: { name: 'Existing Account' } }))
+    cancelBindingAuthorization: jest.fn(() => of(null))
   }
   const toastr = {
     success: jest.fn(),
     error: jest.fn()
+  }
+  const clipboard = {
+    copy: jest.fn(() => true)
+  }
+
+  if (typeof URL.createObjectURL !== 'function') {
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(() => 'blob:qrcode')
+    })
   }
 
   TestBed.resetTestingModule()
@@ -180,7 +234,7 @@ async function setup(options?: {
     providers: [
       {
         provide: XpertWorkspaceHomeComponent,
-        useValue: { workspace }
+        useValue: { workspace, connectorSearchQuery }
       },
       {
         provide: XpertConnectorService,
@@ -193,6 +247,10 @@ async function setup(options?: {
       {
         provide: ToastrService,
         useValue: toastr
+      },
+      {
+        provide: Clipboard,
+        useValue: clipboard
       }
     ]
   }).compileComponents()
@@ -201,7 +259,7 @@ async function setup(options?: {
   fixture.detectChanges()
   await fixture.whenStable()
 
-  return { fixture, component: fixture.componentInstance, connectorService, toastr }
+  return { fixture, component: fixture.componentInstance, connectorService, toastr, clipboard, connectorSearchQuery }
 }
 
 describe('XpertConnectorsComponent', () => {
@@ -212,86 +270,118 @@ describe('XpertConnectorsComponent', () => {
   })
 
   it('loads workspace definitions and bindings through the scope-aware APIs', async () => {
-    const { component, connectorService, fixture } = await setup({ bindings: [personalBinding] })
+    const { component, connectorService, fixture } = await setup({ bindings: [workspaceBinding] })
 
     await component.load('workspace-1')
 
     expect(connectorService.scopedDefinitions).toHaveBeenCalledWith('workspace', 'workspace-1')
     expect(connectorService.listBindings).toHaveBeenCalledWith('workspace', 'workspace-1')
-    expect(component.bindingFor(connectorDefinition)).toEqual(personalBinding)
+    expect(component.bindingFor(connectorDefinition)).toEqual(workspaceBinding)
     fixture.destroy()
   })
 
-  it('lets a workspace manager create a personal binding explicitly', async () => {
-    const { component, connectorService, fixture } = await setup()
-    component.definitions.set([connectorDefinition])
-    component.bindings.set([])
-    component.selectMode(connectorDefinition, 'personal')
+  it('connects an unconfigured Workspace connector in one action without enable or delete controls', async () => {
+    jest.spyOn(window, 'open').mockReturnValue(null)
+    const { component, connectorService, fixture } = await setup({ definitions: [connectorDefinition] })
+    component.openConnectorDialog(connectorDefinition)
+    fixture.detectChanges()
 
-    await component.createBinding(connectorDefinition)
+    const host = fixture.nativeElement as HTMLElement
+    const connectButton = host.querySelector<HTMLButtonElement>('[data-connector-action="connect"]')
+    const text = host.textContent
+    expect(connectButton).not.toBeNull()
+    expect(host.querySelector('[data-connector-action="create"]')).toBeNull()
+    expect(host.querySelector('[data-connector-action="delete"]')).toBeNull()
+    expect(text).not.toContain('XP.Xpert.ConnectorEnable')
+    expect(text).not.toContain('XP.Xpert.ConnectorAuthorizationMode')
+    expect(text).not.toContain('XP.Xpert.ConnectorPersonalAuthorization')
+    expect(text).not.toContain('XP.Xpert.ConnectorSharedAuthorization')
 
-    expect(connectorService.createBinding).toHaveBeenCalledWith({
-      scope: workspaceScope,
-      provider: 'example',
-      authorizationMode: 'personal'
-    })
+    connectButton?.click()
+    await fixture.whenStable()
+
+    expect(connectorService.connect).toHaveBeenCalledWith('workspace-1', 'example', { authMethodId: 'oauth2' })
+    expect(component.bindingFor(connectorDefinition)?.status).toBe('active')
     fixture.destroy()
   })
 
   it('keeps providers without an authorizationModes declaration shared-only', async () => {
-    const { component, connectorService, fixture } = await setup({ definitions: [legacyDefinition] })
+    jest.spyOn(window, 'open').mockReturnValue(null)
+    const { component, connectorService, fixture } = await setup({
+      definitions: [legacyDefinition],
+      connectResponse: {
+        status: 'active',
+        connector: { ...workspaceBinding, provider: 'legacy', status: 'active' }
+      }
+    })
     component.definitions.set([legacyDefinition])
     component.bindings.set([])
+    connectorService.listBindings.mockReturnValueOnce(
+      of([{ ...workspaceBinding, provider: 'legacy', status: 'active' as const }])
+    )
 
-    expect(component.authorizationModesFor(legacyDefinition)).toEqual(['shared'])
-    await component.createBinding(legacyDefinition)
+    await component.connect(null, legacyDefinition)
 
-    expect(connectorService.createBinding).toHaveBeenCalledWith({
-      scope: workspaceScope,
-      provider: 'legacy',
-      authorizationMode: 'shared'
-    })
+    expect(connectorService.connect).toHaveBeenCalledWith('workspace-1', 'legacy', { authMethodId: 'oauth2' })
+    expect(component.bindingFor(legacyDefinition)?.authorizationMode).toBe('shared')
+
+    component.openConnectorDialog(legacyDefinition)
+    fixture.detectChanges()
+    expect((fixture.nativeElement as HTMLElement).textContent).not.toContain('XP.Xpert.ConnectorAuthorizationMode')
     fixture.destroy()
   })
 
-  it('lets a workspace member connect and consent only their own personal account', async () => {
-    const openSpy = jest.spyOn(window, 'open').mockReturnValue(null)
-    const { component, connectorService, fixture } = await setup({ canManage: false, bindings: [personalBinding] })
-    component.definitions.set([connectorDefinition])
-    component.bindings.set([personalBinding])
+  it('does not expose authorization modes in Workspace when a provider supports multiple Project modes', async () => {
+    const { component, fixture } = await setup({ definitions: [connectorDefinition] })
 
-    expect(component.canConnect(personalBinding)).toBe(true)
-    await component.consent(personalBinding)
-    await component.connect(personalBinding, connectorDefinition)
+    component.openConnectorDialog(connectorDefinition)
+    fixture.detectChanges()
 
-    expect(connectorService.consentToBinding).toHaveBeenCalledWith('personal-binding')
-    expect(connectorService.connectBinding).toHaveBeenCalledWith('personal-binding', { authMethodId: 'oauth2' })
-    expect(openSpy).toHaveBeenCalledWith('', '_blank')
+    const text = (fixture.nativeElement as HTMLElement).textContent
+    expect(text).not.toContain('XP.Xpert.ConnectorAuthorizationMode')
+    expect(text).not.toContain('XP.Xpert.ConnectorPersonalAuthorization')
+    expect(text).not.toContain('XP.Xpert.ConnectorSharedAuthorization')
+    fixture.destroy()
+  })
+
+  it('keeps authorization mode presentation hidden for an existing Workspace binding', async () => {
+    const { component, fixture } = await setup({
+      definitions: [connectorDefinition],
+      bindings: [workspaceBinding]
+    })
+    component.openConnectorDialog(connectorDefinition)
+    fixture.detectChanges()
+
+    const host = fixture.nativeElement as HTMLElement
+    const connectButton = host.querySelector<HTMLButtonElement>('[data-connector-action="connect"]')
+    expect(host.textContent).not.toContain('XP.Xpert.ConnectorAuthorizationMode')
+    expect(host.textContent).not.toContain('XP.Xpert.ConnectorSharedAuthorization')
+    expect(connectButton?.textContent).toContain('XP.Xpert.ConnectorConnect')
+    expect(connectButton?.textContent).not.toContain('XP.Xpert.ConnectorConnectSharedAccount')
     fixture.destroy()
   })
 
   it('keeps OAuth authorization and polling attached to the selected binding', async () => {
     const { popup, navigate, focus } = createAuthorizationPopup()
     const openSpy = jest.spyOn(window, 'open').mockReturnValue(popup)
-    const pendingPersonalBinding = { ...personalBinding, status: 'pending' as const }
+    const pendingWorkspaceBinding = { ...workspaceBinding, status: 'pending' as const }
     const { component, connectorService, fixture } = await setup({
-      canManage: false,
-      bindings: [personalBinding],
+      bindings: [workspaceBinding],
       connectResponse: {
         status: 'pending',
-        connector: pendingPersonalBinding,
+        connector: pendingWorkspaceBinding,
         authorizationUrl: 'https://accounts.example.com/oauth/start',
         stateExpiresAt: '2026-01-01T00:00:00.000Z',
         pollIntervalSeconds: 5
       }
     })
     component.definitions.set([connectorDefinition])
-    component.bindings.set([personalBinding])
+    component.bindings.set([workspaceBinding])
 
-    await component.connect(personalBinding, connectorDefinition)
+    await component.connect(workspaceBinding, connectorDefinition)
 
-    expect(connectorService.connectBinding).toHaveBeenCalledWith('personal-binding', { authMethodId: 'oauth2' })
-    expect(component.pendingAuthorizationUrl(pendingPersonalBinding)).toBe('https://accounts.example.com/oauth/start')
+    expect(connectorService.connectBinding).toHaveBeenCalledWith('workspace-binding', { authMethodId: 'oauth2' })
+    expect(component.pendingAuthorizationUrl(pendingWorkspaceBinding)).toBe('https://accounts.example.com/oauth/start')
     expect(openSpy).toHaveBeenCalledWith('', '_blank')
     expect(navigate).toHaveBeenCalledWith('https://accounts.example.com/oauth/start')
     expect(focus).toHaveBeenCalled()
@@ -299,62 +389,327 @@ describe('XpertConnectorsComponent', () => {
     fixture.destroy()
   })
 
+  it('recovers pending authorization without opening a popup from polling', async () => {
+    const openSpy = jest.spyOn(window, 'open').mockReturnValue(null)
+    const pendingBinding = { ...workspaceBinding, status: 'pending' as const }
+    const { component, connectorService, fixture } = await setup({
+      bindings: [],
+      pollResponse: {
+        connector: pendingBinding,
+        authorizationUrl: 'https://accounts.example.com/oauth/start',
+        stateExpiresAt: '2026-01-01T00:00:00.000Z',
+        pollIntervalSeconds: 5
+      }
+    })
+    connectorService.listBindings.mockReturnValueOnce(of([pendingBinding]))
+
+    await component.load('workspace-1')
+
+    expect(connectorService.bindingAuthorizationStatus).toHaveBeenCalledWith('workspace-binding')
+    expect(component.pendingAuthorizationUrl(pendingBinding)).toBe('https://accounts.example.com/oauth/start')
+    expect(openSpy).not.toHaveBeenCalled()
+    fixture.destroy()
+  })
+
+  it("does not close another binding's OAuth popup when embedded authorization is cancelled", async () => {
+    const { popup, close } = createAuthorizationPopup()
+    jest.spyOn(window, 'open').mockReturnValue(popup)
+    const pendingWorkspaceBinding = { ...workspaceBinding, status: 'pending' as const }
+    const pendingEmbeddedBinding = { ...embeddedBinding, status: 'pending' as const }
+    const { component, connectorService, fixture } = await setup({
+      definitions: [connectorDefinition, embeddedDefinition],
+      bindings: [workspaceBinding, embeddedBinding],
+      connectResponse: {
+        status: 'pending',
+        connector: pendingWorkspaceBinding,
+        authorizationUrl: 'https://accounts.example.com/oauth/start',
+        stateExpiresAt: '2026-01-01T00:00:00.000Z',
+        pollIntervalSeconds: 5
+      }
+    })
+
+    await component.connect(workspaceBinding, connectorDefinition)
+    await component.cancelAuthorization(pendingEmbeddedBinding)
+
+    expect(connectorService.cancelBindingAuthorization).toHaveBeenCalledWith('wecom-binding')
+    expect(close).not.toHaveBeenCalled()
+    fixture.destroy()
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores the compact connector catalog and opens binding controls in a dialog', async () => {
+    const { fixture, component, connectorSearchQuery } = await setup({
+      definitions: [githubDefinition, embeddedDefinition],
+      bindings: [githubBinding, embeddedBinding]
+    })
+    fixture.detectChanges()
+
+    const host = fixture.nativeElement as HTMLElement
+    const refreshSpy = jest.spyOn(component, 'refresh').mockImplementation()
+    host.querySelector<HTMLButtonElement>('[data-connector-action="refresh"]')?.click()
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+    expect(host.querySelector('[data-connector-provider="wecom"]')).not.toBeNull()
+    connectorSearchQuery.set('github')
+    fixture.detectChanges()
+    expect(host.querySelector('[data-connector-provider="wecom"]')).toBeNull()
+    const card = host.querySelector<HTMLElement>('[data-connector-provider="github"]')
+    expect(card).not.toBeNull()
+
+    card?.querySelector<HTMLButtonElement>('[data-connector-action="open-details"]')?.click()
+    fixture.detectChanges()
+
+    expect(host.querySelector('[data-connector-dialog]')).not.toBeNull()
+    expect(host.querySelector('[data-connector-action="connect"]')).not.toBeNull()
+    expect(host.querySelector('[data-credential-field="token"]')).not.toBeNull()
+    fixture.destroy()
+  })
+
+  it('uses an auto-filling connector grid that follows the available width', async () => {
+    const { fixture } = await setup({ definitions: [connectorDefinition, githubDefinition] })
+    fixture.detectChanges()
+
+    const grid = (fixture.nativeElement as HTMLElement).querySelector<HTMLElement>('[data-connector-grid]')
+    expect(grid?.classList).toContain('grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))]')
+    fixture.destroy()
+  })
+
+  it('shows an icon-only disconnect action on an active connector card', async () => {
+    const { connectorService, fixture } = await setup({ bindings: [sharedBinding] })
+    fixture.detectChanges()
+
+    const host = fixture.nativeElement as HTMLElement
+    const disconnectButton = host.querySelector<HTMLButtonElement>(
+      '[data-connector-provider="example"] [data-connector-action="disconnect"]'
+    )
+    expect(disconnectButton).not.toBeNull()
+    expect(disconnectButton?.textContent?.trim()).toBe('')
+
+    disconnectButton?.click()
+    await fixture.whenStable()
+
+    expect(connectorService.disconnect).toHaveBeenCalledWith('workspace-1', 'shared-binding')
+    fixture.destroy()
+  })
+
+  it('does not expose binding removal in the pending QR dialog', async () => {
+    const pendingBinding = { ...embeddedBinding, status: 'pending' as const }
+    const { component, fixture } = await setup({
+      definitions: [embeddedDefinition],
+      bindings: [pendingBinding],
+      pollResponse: {
+        connector: pendingBinding,
+        authorizationUrl: 'https://accounts.example.com/wecom/device',
+        stateExpiresAt: '2026-01-01T00:00:00.000Z',
+        pollIntervalSeconds: 5
+      }
+    })
+    await component.load('workspace-1')
+    component.openConnectorDialog(embeddedDefinition)
+    fixture.detectChanges()
+
+    expect(fixture.nativeElement.querySelector('[data-connector-action="delete"]')).toBeNull()
+    expect(fixture.nativeElement.querySelector('[data-connector-action="cancel-authorization"]')).not.toBeNull()
+    expect(fixture.nativeElement.querySelector('[data-connector-action="copy-authorization-url"]')).not.toBeNull()
+    fixture.destroy()
+  })
+
+  it('copies and cancels the exact embedded binding authorization', async () => {
+    const pendingBinding = { ...embeddedBinding, status: 'pending' as const }
+    const { component, connectorService, clipboard, fixture } = await setup({
+      definitions: [embeddedDefinition],
+      bindings: [pendingBinding],
+      pollResponse: {
+        connector: pendingBinding,
+        authorizationUrl: 'https://accounts.example.com/wecom/device',
+        stateExpiresAt: '2026-01-01T00:00:00.000Z',
+        pollIntervalSeconds: 5
+      }
+    })
+    await component.load('workspace-1')
+    component.openConnectorDialog(embeddedDefinition)
+    fixture.detectChanges()
+    const presentation = embeddedDefinition.authMethods?.[0].authorizationPresentation
+    expect(presentation).toBeDefined()
+    connectorService.listBindings.mockReturnValueOnce(of([{ ...pendingBinding, status: 'disconnected' }]))
+
+    component.copyPendingAuthorizationUrl(pendingBinding, presentation!)
+    await component.cancelAuthorization(pendingBinding)
+
+    expect(clipboard.copy).toHaveBeenCalledWith('https://accounts.example.com/wecom/device')
+    expect(connectorService.cancelBindingAuthorization).toHaveBeenCalledWith('wecom-binding')
+    expect(component.pendingAuthorizationUrl(pendingBinding)).toBeFalsy()
+    expect(component.selectedProvider()).toBeNull()
+    fixture.destroy()
+  })
+
+  it('keeps the retry URL when scoped authorization cancellation fails', async () => {
+    const pendingBinding = { ...embeddedBinding, status: 'pending' as const }
+    const { component, connectorService, fixture, toastr } = await setup({
+      definitions: [embeddedDefinition],
+      bindings: [pendingBinding],
+      pollResponse: {
+        connector: pendingBinding,
+        authorizationUrl: 'https://accounts.example.com/wecom/device',
+        stateExpiresAt: '2026-01-01T00:00:00.000Z',
+        pollIntervalSeconds: 5
+      }
+    })
+    await component.load('workspace-1')
+    connectorService.cancelBindingAuthorization.mockReturnValueOnce(throwError(() => new Error('cancel failed')))
+
+    await component.cancelAuthorization(pendingBinding)
+
+    expect(component.pendingAuthorizationUrl(pendingBinding)).toBe('https://accounts.example.com/wecom/device')
+    expect(toastr.error).toHaveBeenCalledWith('cancel failed')
+    fixture.destroy()
+  })
+
+  it('keeps embedded authorization inside the restored dialog', async () => {
+    const openSpy = jest.spyOn(window, 'open')
+    const pendingBinding = { ...embeddedBinding, status: 'pending' as const }
+    const { component, fixture } = await setup({
+      definitions: [embeddedDefinition],
+      bindings: [embeddedBinding],
+      connectResponse: {
+        status: 'pending',
+        connector: pendingBinding,
+        authorizationUrl: 'https://accounts.example.com/wecom/device',
+        stateExpiresAt: '2026-01-01T00:00:00.000Z',
+        pollIntervalSeconds: 5
+      }
+    })
+    fixture.detectChanges()
+
+    const host = fixture.nativeElement as HTMLElement
+    host
+      .querySelector<HTMLButtonElement>('[data-connector-provider="wecom"] [data-connector-action="open-details"]')
+      ?.click()
+    await component.connect(embeddedBinding, embeddedDefinition)
+    fixture.detectChanges()
+
+    expect(openSpy).not.toHaveBeenCalled()
+    expect(host.querySelector('[data-connector-authorization-qr]')).not.toBeNull()
+    expect(host.querySelector('[data-connector-action="cancel-authorization"]')).not.toBeNull()
+    expect(host.querySelector('[data-connector-action="copy-authorization-url"]')).not.toBeNull()
+    fixture.destroy()
+  })
+
   it('keeps shared credential management restricted to workspace managers', async () => {
     const { component, connectorService, fixture } = await setup({ canManage: false, bindings: [sharedBinding] })
     component.definitions.set([connectorDefinition])
     component.bindings.set([sharedBinding])
+    component.openConnectorDialog(connectorDefinition)
     fixture.detectChanges()
 
     await component.connect(sharedBinding, connectorDefinition)
-    await component.deleteBinding(sharedBinding)
+    await component.disconnect(sharedBinding)
 
-    expect(component.canConnect(sharedBinding)).toBe(false)
     expect(connectorService.connectBinding).not.toHaveBeenCalled()
-    expect(connectorService.deleteBinding).not.toHaveBeenCalled()
+    expect(connectorService.disconnect).not.toHaveBeenCalled()
     const host = fixture.nativeElement as HTMLElement
-    expect(host.textContent).toContain('XP.Xpert.ConnectorSharedManagedByManager')
+    expect(host.textContent).not.toContain('XP.Xpert.ConnectorAuthorizationMode')
+    expect(host.textContent).not.toContain('XP.Xpert.ConnectorSharedAuthorization')
+    expect(host.textContent).toContain('XP.Xpert.ConnectorsReadonly')
     expect(host.querySelector('[data-connector-action="delete"]')).toBeNull()
     fixture.destroy()
   })
 
-  it('lets a workspace manager rotate an active shared credential without changing the binding mode', async () => {
-    jest.spyOn(window, 'open').mockReturnValue(null)
+  it('shows only disconnect for an active Workspace connector', async () => {
     const { component, connectorService, fixture } = await setup({ bindings: [sharedBinding] })
     component.definitions.set([connectorDefinition])
     component.bindings.set([sharedBinding])
+    component.openConnectorDialog(connectorDefinition)
+    fixture.detectChanges()
 
-    await component.connect(sharedBinding, connectorDefinition)
+    const host = fixture.nativeElement as HTMLElement
+    const disconnectButton = host.querySelector<HTMLButtonElement>('[data-connector-action="disconnect"]')
+    expect(disconnectButton).not.toBeNull()
+    expect(host.querySelector('[data-connector-action="connect"]')).toBeNull()
+    expect(host.querySelector('[data-connector-action="delete"]')).toBeNull()
 
-    expect(connectorService.connectBinding).toHaveBeenCalledWith('shared-binding', { authMethodId: 'oauth2' })
-    expect(connectorService.createBinding).not.toHaveBeenCalled()
+    disconnectButton?.click()
+    await fixture.whenStable()
+
+    expect(connectorService.disconnect).toHaveBeenCalledWith('workspace-1', 'shared-binding')
     fixture.destroy()
   })
 
-  it('uses provider credential forms with the generic binding connect endpoint', async () => {
+  it('keeps a disconnected Workspace connector available for reconnect without delete controls', async () => {
+    const { component, fixture } = await setup({ bindings: [workspaceBinding] })
+    component.definitions.set([connectorDefinition])
+    component.bindings.set([workspaceBinding])
+    component.openConnectorDialog(connectorDefinition)
+    fixture.detectChanges()
+
+    const host = fixture.nativeElement as HTMLElement
+    expect(host.querySelector('[data-connector-action="connect"]')).not.toBeNull()
+    expect(host.querySelector('[data-connector-action="delete"]')).toBeNull()
+    fixture.destroy()
+  })
+
+  it('connects directly from the card plus button when no credentials are required', async () => {
+    jest.spyOn(window, 'open').mockReturnValue(null)
+    const { component, connectorService, fixture } = await setup({ definitions: [connectorDefinition] })
+    fixture.detectChanges()
+
+    const host = fixture.nativeElement as HTMLElement
+    host
+      .querySelector<HTMLButtonElement>('[data-connector-provider="example"] [data-connector-action="quick-connect"]')
+      ?.click()
+    await fixture.whenStable()
+
+    expect(connectorService.connect).toHaveBeenCalledWith('workspace-1', 'example', { authMethodId: 'oauth2' })
+    expect(component.selectedProvider()).toBeNull()
+    expect(component.bindingFor(connectorDefinition)?.status).toBe('active')
+    fixture.destroy()
+  })
+
+  it('opens the dialog from the card plus button when required credentials are missing', async () => {
+    const { component, connectorService, fixture } = await setup({ definitions: [githubDefinition] })
+    fixture.detectChanges()
+
+    const host = fixture.nativeElement as HTMLElement
+    host
+      .querySelector<HTMLButtonElement>('[data-connector-provider="github"] [data-connector-action="quick-connect"]')
+      ?.click()
+    fixture.detectChanges()
+
+    expect(component.selectedProvider()).toBe('github')
+    expect(host.querySelector('[data-connector-dialog]')).not.toBeNull()
+    expect(connectorService.connect).not.toHaveBeenCalled()
+    fixture.destroy()
+  })
+
+  it('shows provider credential forms before the first connection and connects without enable', async () => {
     const openSpy = jest.spyOn(window, 'open')
     const { component, connectorService, fixture, toastr } = await setup({
       definitions: [githubDefinition],
-      bindings: [githubBinding],
+      bindings: [],
       connectResponse: {
         status: 'active',
         connector: { ...githubBinding, status: 'active' }
       }
     })
     component.definitions.set([githubDefinition])
-    component.bindings.set([githubBinding])
-    const form = component.formFor(githubBinding, githubDefinition)
+    component.bindings.set([])
+    component.openConnectorDialog(githubDefinition)
+    component.selectAuthMethod(null, githubDefinition, 'pat')
+    fixture.detectChanges()
+    const form = component.formFor(null, githubDefinition)
 
-    await component.connect(githubBinding, githubDefinition)
+    expect(fixture.nativeElement.querySelector('[data-credential-field="token"]')).not.toBeNull()
+
+    await component.connect(null, githubDefinition)
     expect(form.controls.token.touched).toBe(true)
-    expect(connectorService.connectBinding).not.toHaveBeenCalled()
+    expect(connectorService.connect).not.toHaveBeenCalled()
     expect(toastr.error).toHaveBeenCalledWith('XP.Xpert.ConnectorCredentialsRequired', 'XP.TOASTR.TITLE.ERROR', {
       Default: 'Complete the required authentication fields before connecting.'
     })
 
     form.controls.token.setValue('github_pat_test')
-    await component.connect(githubBinding, githubDefinition)
+    await component.connect(null, githubDefinition)
 
-    expect(connectorService.connectBinding).toHaveBeenCalledWith('github-binding', {
+    expect(connectorService.connect).toHaveBeenCalledWith('workspace-1', 'github', {
       authMethodId: 'pat',
       values: { token: 'github_pat_test' }
     })

--- a/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.ts
+++ b/apps/cloud/src/app/features/xpert/workspace/connectors/connectors.component.ts
@@ -1,11 +1,13 @@
-import { Component, DestroyRef, computed, effect, inject, signal } from '@angular/core'
+import { Clipboard } from '@angular/cdk/clipboard'
+import { Component, DestroyRef, HostListener, computed, effect, inject, signal } from '@angular/core'
 import { FormControl, FormRecord, ReactiveFormsModule, Validators } from '@angular/forms'
-import { TranslateModule } from '@ngx-translate/core'
-import { getConnectorAuthMethods, getConnectorAuthorizationModes } from '@xpert-ai/plugin-sdk/connector'
+import { TranslateModule, TranslateService } from '@ngx-translate/core'
+import { resolveI18nText } from '@xpert-ai/contracts'
+import { getConnectorAuthMethods } from '@xpert-ai/plugin-sdk/connector'
 import type {
   ConnectorAppCredentialField,
   ConnectorAuthMethodDefinition,
-  ConnectorAuthorizationMode,
+  ConnectorAuthorizationPresentation,
   ConnectorBinding,
   ConnectorCredentialFormDefinition,
   ConnectorInstance,
@@ -14,16 +16,17 @@ import type {
 import {
   XpI18nPipe,
   XpSpinComponent,
-  ZardBadgeComponent,
   ZardButtonComponent,
   ZardFormImports,
   ZardIconComponent,
   ZardInputDirective,
   ZardSelectImports
 } from '@xpert-ai/headless-ui'
-import { AlertCircle, Cable, LoaderCircle, RefreshCw, Trash2 } from 'lucide-angular'
+import { AlertCircle, Cable, Link2Off, LoaderCircle, RefreshCw } from 'lucide-angular'
 import { firstValueFrom } from 'rxjs'
 import { getErrorMessage, injectToastr, XpertConnectorService, XpertWorkspaceService } from 'apps/cloud/src/app/@core'
+import { IconComponent } from 'apps/cloud/src/app/@shared/avatar'
+import { QRCodeComponent } from 'apps/cloud/src/app/@shared/qrcode'
 import { XpertWorkspaceHomeComponent } from '../home/home.component'
 
 type ConnectorStatusLabel = {
@@ -39,7 +42,8 @@ type ConnectorStatusLabel = {
     TranslateModule,
     XpI18nPipe,
     XpSpinComponent,
-    ZardBadgeComponent,
+    IconComponent,
+    QRCodeComponent,
     ZardButtonComponent,
     ZardIconComponent,
     ZardInputDirective,
@@ -51,6 +55,8 @@ type ConnectorStatusLabel = {
 export class XpertConnectorsComponent {
   readonly #connectorService = inject(XpertConnectorService)
   readonly #workspaceService = inject(XpertWorkspaceService)
+  readonly #clipboard = inject(Clipboard)
+  readonly #translate = inject(TranslateService)
   readonly #toastr = injectToastr()
   readonly #destroyRef = inject(DestroyRef)
 
@@ -61,27 +67,52 @@ export class XpertConnectorsComponent {
 
   readonly definitions = signal<ConnectorStrategyDefinition[]>([])
   readonly bindings = signal<ConnectorBinding[]>([])
+  readonly searchQuery = this.homeComponent.connectorSearchQuery
+  readonly selectedProvider = signal<string | null>(null)
+  readonly filteredDefinitions = computed(() => {
+    const query = this.searchQuery().trim().toLocaleLowerCase()
+    if (!query) {
+      return this.definitions()
+    }
+
+    return this.definitions().filter((definition) => {
+      const searchableText = [
+        definition.provider,
+        this.searchableText(definition.label),
+        this.searchableText(this.descriptionFor(definition))
+      ]
+        .join(' ')
+        .toLocaleLowerCase()
+      return searchableText.includes(query)
+    })
+  })
+  readonly selectedDefinition = computed(() => {
+    const provider = this.selectedProvider()
+    return provider ? (this.definitions().find((definition) => definition.provider === provider) ?? null) : null
+  })
   readonly loading = signal(false)
   readonly errorMessage = signal<string | null>(null)
   readonly connectingBindingId = signal<string | null>(null)
-  readonly deletingBindingId = signal<string | null>(null)
-  readonly creatingProvider = signal<string | null>(null)
+  readonly disconnectingBindingId = signal<string | null>(null)
+  readonly cancellingBindingId = signal<string | null>(null)
   readonly pendingAuthorizationUrls = signal<Record<string, string>>({})
-  readonly selectedModes = signal<Record<string, ConnectorAuthorizationMode>>({})
   readonly reloadKey = signal(0)
   readonly skeletonCards = [0, 1, 2, 3]
   readonly connectorIcon = Cable
   readonly refreshIcon = RefreshCw
-  readonly deleteIcon = Trash2
+  readonly disconnectIcon = Link2Off
   readonly errorIcon = AlertCircle
   readonly loadingIcon = LoaderCircle
   readonly #connectorForms = new Map<string, FormRecord<FormControl<string>>>()
   readonly #authorizationPollTimers = new Map<string, ReturnType<typeof setTimeout>>()
-  #authorizationPopup: Window | null = null
+  readonly #authorizationPopups = new Map<string, Window>()
   #currentWorkspaceId: string | null = null
 
   constructor() {
-    this.#destroyRef.onDestroy(() => this.clearAuthorizationPolling())
+    this.#destroyRef.onDestroy(() => {
+      this.clearAuthorizationPolling()
+      this.closeAllAuthorizationPopups()
+    })
 
     effect(() => {
       const workspaceId = this.workspaceId()
@@ -89,8 +120,10 @@ export class XpertConnectorsComponent {
       if ((workspaceId ?? null) !== this.#currentWorkspaceId) {
         this.#currentWorkspaceId = workspaceId ?? null
         this.clearAuthorizationPolling()
+        this.closeAllAuthorizationPopups()
         this.pendingAuthorizationUrls.set({})
         this.#connectorForms.clear()
+        this.selectedProvider.set(null)
       }
       if (workspaceId) {
         void this.load(workspaceId)
@@ -113,7 +146,6 @@ export class XpertConnectorsComponent {
       this.definitions.set(definitions)
       this.bindings.set(bindings)
       this.prepareConnectorForms(definitions, bindings)
-      this.alignSelectedModes(definitions)
       await this.recoverPendingAuthorizations(workspaceId, bindings)
     } catch (error) {
       const message = getErrorMessage(error)
@@ -130,88 +162,44 @@ export class XpertConnectorsComponent {
     }
   }
 
+  openConnectorDialog(definition: ConnectorStrategyDefinition) {
+    this.selectedProvider.set(definition.provider)
+  }
+
+  closeConnectorDialog() {
+    this.selectedProvider.set(null)
+  }
+
+  @HostListener('document:keydown.escape')
+  closeConnectorDialogOnEscape() {
+    if (this.selectedProvider()) {
+      this.closeConnectorDialog()
+    }
+  }
+
+  quickConnect(definition: ConnectorStrategyDefinition) {
+    const binding = this.bindingFor(definition)
+    if (binding?.status === 'active') {
+      this.openConnectorDialog(definition)
+      return
+    }
+
+    const authMethod = this.selectedAuthMethod(binding, definition)
+    if (!authMethod || this.formFor(binding, definition).invalid) {
+      this.openConnectorDialog(definition)
+      return
+    }
+
+    void this.connect(binding, definition)
+  }
+
   bindingFor(definition: ConnectorStrategyDefinition) {
     return this.bindings().find((binding) => binding.provider === definition.provider) ?? null
   }
 
-  authorizationModesFor(definition: ConnectorStrategyDefinition) {
-    return getConnectorAuthorizationModes(definition)
-  }
-
-  selectedModeFor(definition: ConnectorStrategyDefinition): ConnectorAuthorizationMode {
-    const supportedModes = this.authorizationModesFor(definition)
-    const selected = this.selectedModes()[definition.provider]
-    return selected && supportedModes.includes(selected) ? selected : (supportedModes[0] ?? 'shared')
-  }
-
-  selectMode(definition: ConnectorStrategyDefinition, value: unknown) {
-    const mode = normalizeAuthorizationMode(value)
-    if (!mode || !this.authorizationModesFor(definition).includes(mode)) {
-      return
-    }
-    this.selectedModes.update((modes) => ({ ...modes, [definition.provider]: mode }))
-  }
-
-  async createBinding(definition: ConnectorStrategyDefinition) {
+  async connect(binding: ConnectorBinding | null, definition: ConnectorStrategyDefinition) {
     const workspaceId = this.workspaceId()
-    if (!workspaceId || !this.canManageWorkspace() || this.bindingFor(definition)) {
-      return
-    }
-
-    this.creatingProvider.set(definition.provider)
-    try {
-      await firstValueFrom(
-        this.#connectorService.createBinding({
-          scope: { type: 'workspace', workspaceId },
-          provider: definition.provider,
-          authorizationMode: this.selectedModeFor(definition)
-        })
-      )
-      await this.load(workspaceId)
-    } catch (error) {
-      this.#toastr.error(getErrorMessage(error))
-    } finally {
-      this.creatingProvider.set(null)
-    }
-  }
-
-  async deleteBinding(binding: ConnectorBinding) {
-    if (!this.canManageWorkspace()) {
-      return
-    }
-
-    this.deletingBindingId.set(binding.id)
-    try {
-      await firstValueFrom(this.#connectorService.deleteBinding(binding.id))
-      this.clearPendingAuthorization(binding.id)
-      this.bindings.update((bindings) => bindings.filter((item) => item.id !== binding.id))
-      this.#connectorForms.delete(binding.id)
-      this.#toastr.success('XP.Messages.UpdatedSuccessfully', { Default: 'Updated successfully' })
-    } catch (error) {
-      this.#toastr.error(getErrorMessage(error))
-    } finally {
-      this.deletingBindingId.set(null)
-    }
-  }
-
-  async consent(binding: ConnectorBinding) {
-    if (binding.authorizationMode !== 'personal') {
-      return
-    }
-    this.connectingBindingId.set(binding.id)
-    try {
-      const updated = await firstValueFrom(this.#connectorService.consentToBinding(binding.id))
-      this.upsertBinding(updated)
-      this.#toastr.success('XP.Messages.UpdatedSuccessfully', { Default: 'Updated successfully' })
-    } catch (error) {
-      this.#toastr.error(getErrorMessage(error))
-    } finally {
-      this.connectingBindingId.set(null)
-    }
-  }
-
-  async connect(binding: ConnectorBinding, definition: ConnectorStrategyDefinition) {
-    if (!this.canConnect(binding)) {
+    if (!workspaceId || !this.canManageWorkspace()) {
       return
     }
 
@@ -229,60 +217,126 @@ export class XpertConnectorsComponent {
       return
     }
 
-    const hasAuthorizationPopup = !!this.#authorizationPopup && !this.#authorizationPopup.closed
-    const reservedPopup = authMethod.type === 'oauth2' && !hasAuthorizationPopup ? this.openAuthorizationPopup() : null
-    this.connectingBindingId.set(binding.id)
+    const usesEmbeddedAuthorization = this.usesEmbeddedAuthorization(authMethod)
+    const connectionKey = binding?.id ?? definition.provider
+    const reservedPopup =
+      authMethod.type === 'oauth2' && !usesEmbeddedAuthorization ? this.openAuthorizationPopup(connectionKey) : null
+    this.connectingBindingId.set(connectionKey)
     try {
       const values = this.connectorValues(binding, definition, authMethod)
+      const input = {
+        authMethodId: authMethod.id,
+        ...(values ? { values } : {})
+      }
       const response = await firstValueFrom(
-        this.#connectorService.connectBinding(binding.id, {
-          authMethodId: authMethod.id,
-          ...(values ? { values } : {})
-        })
+        binding
+          ? this.#connectorService.connectBinding(binding.id, input)
+          : this.#connectorService.connect(workspaceId, definition.provider, input)
       )
-      this.upsertBindingState(binding, response.connector)
+      const connectedBinding = binding
+        ? this.bindingState(binding, response.connector)
+        : this.workspaceBinding(response.connector, workspaceId)
+      this.upsertBinding(connectedBinding)
+      this.moveAuthorizationPopup(connectionKey, connectedBinding.id, reservedPopup)
       if (response.status === 'active') {
-        this.closeReservedAuthorizationPopup(reservedPopup)
+        this.closeReservedAuthorizationPopup(connectedBinding.id, reservedPopup)
         await this.reloadCurrentWorkspace()
+        if (this.selectedProvider() === definition.provider) {
+          this.closeConnectorDialog()
+        }
         return
       }
 
       if (response.authorizationUrl) {
-        this.openAuthorizationUrl(response.authorizationUrl)
-        this.setPendingAuthorizationUrl(binding.id, response.authorizationUrl)
-        this.startAuthorizationPolling(binding.id, response.pollIntervalSeconds ?? 5)
+        this.setPendingAuthorizationUrl(connectedBinding.id, response.authorizationUrl)
+        this.startAuthorizationPolling(connectedBinding.id, response.pollIntervalSeconds ?? 5)
+        if (usesEmbeddedAuthorization) {
+          this.openConnectorDialog(definition)
+        } else {
+          this.openAuthorizationUrl(connectedBinding.id, response.authorizationUrl)
+        }
       }
     } catch (error) {
-      this.closeReservedAuthorizationPopup(reservedPopup)
+      this.closeReservedAuthorizationPopup(connectionKey, reservedPopup)
+      if (!binding) {
+        await this.reloadCurrentWorkspace()
+      }
       this.#toastr.error(getErrorMessage(error))
     } finally {
       this.connectingBindingId.set(null)
     }
   }
 
-  canConnect(binding: ConnectorBinding) {
-    return binding.authorizationMode === 'personal' || this.canManageWorkspace()
+  async cancelAuthorization(binding: ConnectorBinding) {
+    if (!this.canManageWorkspace() || binding.status !== 'pending') {
+      return
+    }
+
+    this.cancellingBindingId.set(binding.id)
+    try {
+      await firstValueFrom(this.#connectorService.cancelBindingAuthorization(binding.id))
+      this.clearPendingAuthorization(binding.id)
+      this.closeAuthorizationPopup(binding.id)
+      await this.reloadCurrentWorkspace()
+      if (this.selectedProvider() === binding.provider) {
+        this.closeConnectorDialog()
+      }
+      this.#toastr.success('XP.Xpert.ConnectorAuthorizationCancelled', {
+        Default: 'Authorization cancelled.'
+      })
+    } catch (error) {
+      this.#toastr.error(getErrorMessage(error))
+    } finally {
+      this.cancellingBindingId.set(null)
+    }
+  }
+
+  async disconnect(binding: ConnectorBinding) {
+    const workspaceId = this.workspaceId()
+    if (!workspaceId || !this.canManageWorkspace()) {
+      return
+    }
+
+    this.disconnectingBindingId.set(binding.id)
+    try {
+      await firstValueFrom(this.#connectorService.disconnect(workspaceId, binding.id))
+      this.clearPendingAuthorization(binding.id)
+      this.closeAuthorizationPopup(binding.id)
+      await this.reloadCurrentWorkspace()
+      if (this.selectedProvider() === binding.provider) {
+        this.closeConnectorDialog()
+      }
+      this.#toastr.success('XP.Messages.UpdatedSuccessfully', { Default: 'Updated successfully' })
+    } catch (error) {
+      this.#toastr.error(getErrorMessage(error))
+    } finally {
+      this.disconnectingBindingId.set(null)
+    }
   }
 
   authMethodsFor(definition: ConnectorStrategyDefinition): ConnectorAuthMethodDefinition[] {
     return getConnectorAuthMethods(definition)
   }
 
-  formFor(binding: ConnectorBinding, definition: ConnectorStrategyDefinition) {
-    let form = this.#connectorForms.get(binding.id)
+  formFor(binding: ConnectorBinding | null | undefined, definition: ConnectorStrategyDefinition) {
+    let form = this.#connectorForms.get(definition.provider)
     if (!form) {
       form = this.createConnectorForm(definition, binding)
-      this.#connectorForms.set(binding.id, form)
+      this.#connectorForms.set(definition.provider, form)
     }
     return form
   }
 
-  selectedAuthMethod(binding: ConnectorBinding, definition: ConnectorStrategyDefinition) {
+  selectedAuthMethod(binding: ConnectorBinding | null | undefined, definition: ConnectorStrategyDefinition) {
     const authMethodId = this.formFor(binding, definition).controls.authMethodId?.value
     return this.authMethodsFor(definition).find((method) => method.id === authMethodId) ?? null
   }
 
-  selectAuthMethod(binding: ConnectorBinding, definition: ConnectorStrategyDefinition, value: unknown) {
+  selectAuthMethod(
+    binding: ConnectorBinding | null | undefined,
+    definition: ConnectorStrategyDefinition,
+    value: unknown
+  ) {
     const authMethodId = normalizeSelection(value)
     if (!authMethodId) {
       return
@@ -307,7 +361,11 @@ export class XpertConnectorsComponent {
     return this.credentialFormFor(method)?.fields ?? []
   }
 
-  fieldControl(binding: ConnectorBinding, definition: ConnectorStrategyDefinition, field: ConnectorAppCredentialField) {
+  fieldControl(
+    binding: ConnectorBinding | null | undefined,
+    definition: ConnectorStrategyDefinition,
+    field: ConnectorAppCredentialField
+  ) {
     return this.formFor(binding, definition).controls[field.name]
   }
 
@@ -329,14 +387,18 @@ export class XpertConnectorsComponent {
     }
   }
 
-  modeLabel(mode: ConnectorAuthorizationMode) {
-    return mode === 'personal' ? 'XP.Xpert.ConnectorPersonalAuthorization' : 'XP.Xpert.ConnectorSharedAuthorization'
-  }
-
-  modeDescription(mode: ConnectorAuthorizationMode) {
-    return mode === 'personal'
-      ? 'XP.Xpert.ConnectorPersonalAuthorizationDescription'
-      : 'XP.Xpert.ConnectorSharedAuthorizationDescription'
+  statusDotClass(binding?: ConnectorBinding | null) {
+    switch (binding?.status) {
+      case 'active':
+        return 'bg-[var(--color-status-success-indicator-bg)]'
+      case 'pending':
+      case 'expired':
+        return 'bg-[var(--color-status-warning-indicator-bg)]'
+      case 'error':
+        return 'bg-[var(--color-status-error-indicator-bg)]'
+      default:
+        return 'bg-text-tertiary'
+    }
   }
 
   iconImageUrl(definition: ConnectorStrategyDefinition) {
@@ -352,16 +414,16 @@ export class XpertConnectorsComponent {
     return profile?.name || profile?.email || profile?.openId || binding.id
   }
 
-  isConnecting(binding: ConnectorBinding) {
-    return this.connectingBindingId() === binding.id
+  isConnecting(binding: ConnectorBinding | null | undefined, definition?: ConnectorStrategyDefinition) {
+    return this.connectingBindingId() === (binding?.id ?? definition?.provider)
   }
 
-  isCreating(definition: ConnectorStrategyDefinition) {
-    return this.creatingProvider() === definition.provider
+  isDisconnecting(binding: ConnectorBinding) {
+    return this.disconnectingBindingId() === binding.id
   }
 
-  isDeleting(binding: ConnectorBinding) {
-    return this.deletingBindingId() === binding.id
+  isCancelling(binding: ConnectorBinding) {
+    return this.cancellingBindingId() === binding.id
   }
 
   isPolling(binding?: ConnectorBinding | null) {
@@ -373,18 +435,58 @@ export class XpertConnectorsComponent {
   }
 
   openPendingAuthorizationUrl(binding: ConnectorBinding) {
+    const definition = this.definitionForBinding(binding)
+    if (definition && this.usesEmbeddedAuthorization(this.authMethodForBinding(definition, binding))) {
+      this.openConnectorDialog(definition)
+      return
+    }
+
     const authorizationUrl = this.pendingAuthorizationUrl(binding)
     if (authorizationUrl) {
-      this.openAuthorizationUrl(authorizationUrl)
+      this.openAuthorizationUrl(binding.id, authorizationUrl)
     }
   }
 
-  private openAuthorizationUrl(authorizationUrl: string) {
+  authMethodForBinding(definition: ConnectorStrategyDefinition, binding?: ConnectorBinding | null) {
+    return (
+      this.authMethodsFor(definition).find((method) => method.id === binding?.authMethodId) ??
+      (binding ? this.selectedAuthMethod(binding, definition) : (this.authMethodsFor(definition)[0] ?? null))
+    )
+  }
+
+  authorizationPresentationFor(authMethod?: ConnectorAuthMethodDefinition | null) {
+    return authMethod?.type === 'oauth2' ? (authMethod.authorizationPresentation ?? null) : null
+  }
+
+  usesEmbeddedAuthorization(authMethod?: ConnectorAuthMethodDefinition | null) {
+    return this.authorizationPresentationFor(authMethod)?.mode === 'embedded_qr'
+  }
+
+  copyPendingAuthorizationUrl(
+    binding: ConnectorBinding | null | undefined,
+    presentation: ConnectorAuthorizationPresentation
+  ) {
+    const authorizationUrl = this.pendingAuthorizationUrl(binding)
     if (!authorizationUrl) {
       return
     }
 
-    const popup = this.openAuthorizationPopup()
+    if (this.#clipboard.copy(authorizationUrl)) {
+      this.#toastr.success('XP.Messages.CopiedToClipboard', { Default: 'Copied to clipboard' })
+      return
+    }
+
+    this.#toastr.error(
+      resolveI18nText(presentation.copyLinkError, this.#translate.currentLang) ?? 'Could not copy authorization link.'
+    )
+  }
+
+  private openAuthorizationUrl(bindingId: string, authorizationUrl: string) {
+    if (!authorizationUrl) {
+      return
+    }
+
+    const popup = this.openAuthorizationPopup(bindingId)
     if (popup) {
       popup.location.href = authorizationUrl
       popup.focus()
@@ -398,17 +500,15 @@ export class XpertConnectorsComponent {
 
   private prepareConnectorForms(definitions: ConnectorStrategyDefinition[], bindings: ConnectorBinding[]) {
     this.#connectorForms.clear()
-    for (const binding of bindings) {
-      const definition = definitions.find((item) => item.provider === binding.provider)
-      if (definition) {
-        this.#connectorForms.set(binding.id, this.createConnectorForm(definition, binding))
-      }
+    for (const definition of definitions) {
+      const binding = bindings.find((item) => item.provider === definition.provider)
+      this.#connectorForms.set(definition.provider, this.createConnectorForm(definition, binding))
     }
   }
 
-  private createConnectorForm(definition: ConnectorStrategyDefinition, binding: ConnectorBinding) {
+  private createConnectorForm(definition: ConnectorStrategyDefinition, binding?: ConnectorBinding | null) {
     const methods = this.authMethodsFor(definition)
-    const selectedMethod = methods.find((method) => method.id === binding.authMethodId) ?? methods[0]
+    const selectedMethod = methods.find((method) => method.id === binding?.authMethodId) ?? methods[0]
     const form = new FormRecord<FormControl<string>>({
       authMethodId: new FormControl(selectedMethod?.id ?? '', {
         nonNullable: true,
@@ -442,7 +542,7 @@ export class XpertConnectorsComponent {
   }
 
   private connectorValues(
-    binding: ConnectorBinding,
+    binding: ConnectorBinding | null | undefined,
     definition: ConnectorStrategyDefinition,
     method: ConnectorAuthMethodDefinition
   ) {
@@ -456,27 +556,69 @@ export class XpertConnectorsComponent {
     return Object.keys(values).length ? values : undefined
   }
 
-  private openAuthorizationPopup() {
-    if (this.#authorizationPopup && !this.#authorizationPopup.closed) {
-      return this.#authorizationPopup
+  private searchableText(value: unknown): string {
+    if (typeof value === 'string') {
+      return value
+    }
+    if (value && typeof value === 'object') {
+      return Object.values(value)
+        .filter((item): item is string => typeof item === 'string')
+        .join(' ')
+    }
+    return ''
+  }
+
+  private definitionForBinding(binding: ConnectorBinding) {
+    return this.definitions().find((definition) => definition.provider === binding.provider) ?? null
+  }
+
+  private openAuthorizationPopup(bindingId: string) {
+    const currentPopup = this.#authorizationPopups.get(bindingId)
+    if (currentPopup && !currentPopup.closed) {
+      return currentPopup
+    }
+    if (currentPopup) {
+      this.#authorizationPopups.delete(bindingId)
     }
 
     const popup = window.open('', '_blank')
     if (popup) {
-      this.#authorizationPopup = popup
+      this.#authorizationPopups.set(bindingId, popup)
       popup.opener = null
     }
     return popup
   }
 
-  private closeReservedAuthorizationPopup(popup: Window | null) {
-    if (!popup || this.#authorizationPopup !== popup) {
+  private closeReservedAuthorizationPopup(bindingId: string, popup: Window | null) {
+    if (!popup || this.#authorizationPopups.get(bindingId) !== popup) {
       return
     }
     if (!popup.closed) {
       popup.close()
     }
-    this.#authorizationPopup = null
+    this.#authorizationPopups.delete(bindingId)
+  }
+
+  private moveAuthorizationPopup(fromKey: string, bindingId: string, popup: Window | null) {
+    if (!popup || fromKey === bindingId || this.#authorizationPopups.get(fromKey) !== popup) {
+      return
+    }
+    this.#authorizationPopups.delete(fromKey)
+    this.#authorizationPopups.set(bindingId, popup)
+  }
+
+  private closeAuthorizationPopup(bindingId: string) {
+    const popup = this.#authorizationPopups.get(bindingId)
+    if (popup && !popup.closed) {
+      popup.close()
+    }
+    this.#authorizationPopups.delete(bindingId)
+  }
+
+  private closeAllAuthorizationPopups() {
+    for (const bindingId of this.#authorizationPopups.keys()) {
+      this.closeAuthorizationPopup(bindingId)
+    }
   }
 
   private startAuthorizationPolling(bindingId: string, intervalSeconds: number) {
@@ -492,7 +634,7 @@ export class XpertConnectorsComponent {
 
   private async pollAuthorization(bindingId: string) {
     const binding = this.bindings().find((item) => item.id === bindingId)
-    if (!binding || (binding.authorizationMode === 'shared' && !this.canManageWorkspace())) {
+    if (!binding || !this.canManageWorkspace()) {
       this.clearPendingAuthorization(bindingId)
       return
     }
@@ -501,11 +643,7 @@ export class XpertConnectorsComponent {
       const response = await firstValueFrom(this.#connectorService.bindingAuthorizationStatus(bindingId))
       this.upsertBindingState(binding, response.connector)
       if (response.authorizationUrl) {
-        const currentAuthorizationUrl = this.pendingAuthorizationUrls()[bindingId]
         this.setPendingAuthorizationUrl(bindingId, response.authorizationUrl)
-        if (response.authorizationUrl !== currentAuthorizationUrl) {
-          this.openAuthorizationUrl(response.authorizationUrl)
-        }
       }
 
       if (response.connector.status === 'pending') {
@@ -514,7 +652,11 @@ export class XpertConnectorsComponent {
       }
 
       this.clearPendingAuthorization(bindingId)
+      this.closeAuthorizationPopup(bindingId)
       await this.reloadCurrentWorkspace()
+      if (this.selectedProvider() === binding.provider) {
+        this.closeConnectorDialog()
+      }
     } catch (error) {
       this.clearPendingAuthorization(bindingId)
       this.#toastr.error(getErrorMessage(error))
@@ -524,9 +666,7 @@ export class XpertConnectorsComponent {
   private async recoverPendingAuthorizations(workspaceId: string, bindings: ConnectorBinding[]) {
     const pendingBinding = bindings.find(
       (binding) =>
-        binding.status === 'pending' &&
-        (binding.authorizationMode === 'personal' || this.canManageWorkspace()) &&
-        !this.#authorizationPollTimers.has(binding.id)
+        binding.status === 'pending' && this.canManageWorkspace() && !this.#authorizationPollTimers.has(binding.id)
     )
     if (pendingBinding && this.workspaceId() === workspaceId) {
       await this.pollAuthorization(pendingBinding.id)
@@ -566,27 +706,29 @@ export class XpertConnectorsComponent {
     })
   }
 
-  private upsertBindingState(binding: ConnectorBinding, connector: ConnectorInstance) {
-    this.upsertBinding({
+  private bindingState(binding: ConnectorBinding, connector: ConnectorInstance): ConnectorBinding {
+    return {
       ...binding,
       ...connector,
       scopeType: binding.scopeType,
       scope: binding.scope,
       authorizationMode: binding.authorizationMode
-    })
+    }
   }
 
-  private alignSelectedModes(definitions: ConnectorStrategyDefinition[]) {
-    this.selectedModes.update((selectedModes) => {
-      const next = { ...selectedModes }
-      for (const definition of definitions) {
-        const supportedModes = this.authorizationModesFor(definition)
-        if (!next[definition.provider] || !supportedModes.includes(next[definition.provider])) {
-          next[definition.provider] = supportedModes[0] ?? 'shared'
-        }
-      }
-      return next
-    })
+  private workspaceBinding(connector: ConnectorInstance, workspaceId: string): ConnectorBinding {
+    return {
+      ...connector,
+      workspaceId,
+      projectId: null,
+      scopeType: 'workspace',
+      scope: { type: 'workspace', workspaceId },
+      authorizationMode: 'shared'
+    }
+  }
+
+  private upsertBindingState(binding: ConnectorBinding, connector: ConnectorInstance) {
+    this.upsertBinding(this.bindingState(binding, connector))
   }
 
   private async reloadCurrentWorkspace() {
@@ -625,9 +767,4 @@ function connectorStatusLabel(binding?: ConnectorBinding | null): ConnectorStatu
 function normalizeSelection(value: unknown) {
   const selected = Array.isArray(value) ? value[0] : value
   return typeof selected === 'string' || typeof selected === 'number' ? String(selected) : ''
-}
-
-function normalizeAuthorizationMode(value: unknown): ConnectorAuthorizationMode | null {
-  const normalized = normalizeSelection(value)
-  return normalized === 'personal' || normalized === 'shared' ? normalized : null
 }

--- a/apps/cloud/src/app/features/xpert/workspace/connectors/workspace-connectors.component.html
+++ b/apps/cloud/src/app/features/xpert/workspace/connectors/workspace-connectors.component.html
@@ -1,301 +1,539 @@
-<div class="relative px-12 py-4">
-  <div class="mb-4 flex items-center justify-between gap-3">
-    <div>
-      <h2 class="text-base font-medium text-text-primary">
-        {{ 'XP.Xpert.ConnectorCatalogTitle' | translate: { Default: 'Connector catalog' } }}
-      </h2>
-      <p class="mt-1 text-sm text-text-secondary">
-        {{
-          'XP.Xpert.WorkspaceConnectorCatalogDescription'
-            | translate
-              : {
-                  Default:
-                    'Workspace managers choose how each connector is authorized. Personal accounts remain private; shared credentials are available only to workspace members.'
+<div class="relative min-h-full bg-background-body px-6 py-5 xl:px-10">
+  <div class="w-full">
+    <div class="mb-3 flex justify-end">
+      <button
+        z-button
+        zType="ghost"
+        zSize="icon-sm"
+        type="button"
+        data-connector-action="refresh"
+        [zDisabled]="loading()"
+        [attr.aria-label]="'XP.ACTIONS.Refresh' | translate: { Default: 'Refresh' }"
+        (click)="refresh()"
+      >
+        <z-icon [zType]="refreshIcon" [class]="loading() ? 'animate-spin' : ''" />
+      </button>
+    </div>
+
+    @if (errorMessage(); as error) {
+      <div
+        class="mb-4 flex items-start gap-2 rounded-lg border border-danger-500/30 bg-danger-500/10 px-3 py-2 text-sm text-text-danger"
+      >
+        <z-icon [zType]="errorIcon" class="mt-0.5 size-4 shrink-0" />
+        <span>{{ error }}</span>
+      </div>
+    }
+
+    <section aria-label="Connector catalog">
+      @if (loading() && definitions().length === 0) {
+        <div class="grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3">
+          @for (card of skeletonCards; track card) {
+            <div class="h-[116px] animate-pulse rounded-lg border border-divider-regular bg-components-card-bg"></div>
+          }
+        </div>
+      } @else if (definitions().length === 0) {
+        <div class="flex min-h-56 flex-col items-center justify-center gap-2 text-center">
+          <z-icon [zType]="connectorIcon" class="size-8 text-text-tertiary" />
+          <p class="text-sm font-medium text-text-primary">
+            {{ 'XP.Xpert.NoConnectorsAvailable' | translate: { Default: 'No connectors are currently available.' } }}
+          </p>
+        </div>
+      } @else if (filteredDefinitions().length === 0) {
+        <div class="flex min-h-56 flex-col items-center justify-center gap-2 text-center">
+          <z-icon zType="search" class="size-8 text-text-tertiary" />
+          <p class="text-sm font-medium text-text-primary">
+            {{ 'XP.Xpert.NoMatchingConnectors' | translate: { Default: 'No matching connectors found.' } }}
+          </p>
+          <button z-button zType="ghost" zSize="sm" type="button" (click)="searchQuery.set('')">
+            {{ 'XP.ACTIONS.Clear' | translate: { Default: 'Clear search' } }}
+          </button>
+        </div>
+      } @else {
+        <div class="grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3" data-connector-grid>
+          @for (definition of filteredDefinitions(); track definition.provider) {
+            @let binding = bindingFor(definition);
+            @let status = statusLabelFor(binding);
+
+            <article
+              [class]="
+                binding
+                  ? 'group relative flex min-h-[116px] items-start gap-2 rounded-lg border border-divider-regular bg-background-default-subtle p-4 transition-colors'
+                  : 'group relative flex min-h-[116px] items-start gap-2 rounded-lg border border-divider-regular bg-components-card-bg p-4 transition-colors hover:bg-background-default-subtle'
+              "
+              [attr.data-connector-provider]="definition.provider"
+            >
+              <button
+                type="button"
+                class="flex min-w-0 flex-1 cursor-pointer items-start gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40"
+                data-connector-action="open-details"
+                [attr.aria-label]="definition.label | i18n"
+                (click)="openConnectorDialog(definition)"
+              >
+                <div
+                  class="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-divider-regular bg-components-card-bg"
+                >
+                  @if (definition.icon; as icon) {
+                    <xp-icon
+                      [icon]="icon"
+                      [size]="28"
+                      class="flex size-7 items-center justify-center text-2xl leading-none"
+                    />
+                  } @else {
+                    <z-icon [zType]="connectorIcon" class="size-5 text-text-secondary" />
+                  }
+                </div>
+
+                <div class="min-w-0 flex-1">
+                  <div class="flex min-w-0 items-center gap-2">
+                    <h2 class="truncate text-base font-semibold text-text-primary">{{ definition.label | i18n }}</h2>
+                    <span class="inline-flex shrink-0 items-center gap-1.5 text-sm text-text-secondary">
+                      <span class="size-1.5 rounded-full" [class]="statusDotClass(binding)"></span>
+                      {{ status.key | translate: { Default: status.defaultLabel } }}
+                    </span>
+                  </div>
+                  <p class="mt-1.5 line-clamp-2 text-sm leading-5 text-text-secondary">
+                    {{ descriptionFor(definition) | i18n }}
+                  </p>
+                </div>
+              </button>
+
+              @if (!binding) {
+                @if (canManageWorkspace()) {
+                  <button
+                    z-button
+                    zType="ghost"
+                    zSize="icon-sm"
+                    type="button"
+                    class="!size-10 shrink-0 cursor-pointer rounded-lg !bg-hover-bg text-text-secondary transition-[background-color,color,transform] hover:!bg-components-list-option-active-bg hover:text-text-primary active:scale-95 disabled:cursor-default"
+                    data-connector-action="quick-connect"
+                    [zDisabled]="loading() || isConnecting(binding, definition)"
+                    [attr.aria-label]="'XP.Xpert.ConnectConnector' | translate: { Default: 'Connect connector' }"
+                    (click)="quickConnect(definition)"
+                  >
+                    @if (isConnecting(binding, definition)) {
+                      <z-icon [zType]="loadingIcon" class="!size-5 animate-spin" />
+                    } @else {
+                      <z-icon zType="plus" class="!size-5" />
+                    }
+                  </button>
                 }
-        }}
-      </p>
-    </div>
-    <button z-button zType="outline" zSize="sm" type="button" (click)="refresh()">
-      <z-icon [zType]="refreshIcon"></z-icon>
-      {{ 'XP.ACTIONS.Refresh' | translate: { Default: 'Refresh' } }}
-    </button>
-  </div>
-
-  @if (errorMessage(); as error) {
-    <div
-      class="mb-4 flex items-start gap-2 rounded-lg border border-danger-500/30 bg-danger-500/10 px-3 py-2 text-sm text-text-danger"
-    >
-      <z-icon [zType]="errorIcon" class="mt-0.5 size-4 shrink-0"></z-icon>
-      <span>{{ error }}</span>
-    </div>
-  }
-
-  @if (loading() && definitions().length === 0) {
-    <div class="grid max-w-7xl grid-cols-1 gap-3 xl:grid-cols-2">
-      @for (card of skeletonCards; track card) {
-        <div class="h-44 animate-pulse rounded-lg border border-divider-regular bg-components-card-bg"></div>
+              } @else if (binding.status === 'pending' && pendingAuthorizationUrl(binding)) {
+                <button
+                  z-button
+                  zType="ghost"
+                  zSize="sm"
+                  type="button"
+                  class="!h-10 shrink-0 cursor-pointer gap-1.5 rounded-lg !bg-hover-bg px-3 text-text-primary transition-[background-color,color,transform] hover:!bg-components-list-option-active-bg active:scale-[0.98] disabled:cursor-default"
+                  data-connector-action="continue-authorization"
+                  [zDisabled]="loading() || !canManageWorkspace()"
+                  (click)="openPendingAuthorizationUrl(binding)"
+                >
+                  <z-icon zType="arrow-up-right" class="!size-5" />
+                  {{ 'XP.Xpert.ConnectorOpenAuthorization' | translate: { Default: 'Continue authorization' } }}
+                </button>
+              } @else if (binding.status === 'active' && canManageWorkspace()) {
+                <button
+                  z-button
+                  zType="ghost"
+                  zSize="icon-sm"
+                  type="button"
+                  class="!size-10 shrink-0 cursor-pointer rounded-lg !bg-hover-bg text-text-secondary transition-[background-color,color,transform] hover:!bg-components-list-option-active-bg hover:text-text-primary active:scale-95 disabled:cursor-default"
+                  data-connector-action="disconnect"
+                  [zDisabled]="loading() || isDisconnecting(binding)"
+                  [attr.aria-label]="'XP.Xpert.ConnectorDisconnect' | translate: { Default: 'Disconnect' }"
+                  (click)="disconnect(binding)"
+                >
+                  @if (isDisconnecting(binding)) {
+                    <z-icon [zType]="loadingIcon" class="!size-5 animate-spin" />
+                  } @else {
+                    <z-icon [zType]="disconnectIcon" class="!size-5" />
+                  }
+                </button>
+              } @else if (canManageWorkspace() && binding.status !== 'active') {
+                <button
+                  z-button
+                  zType="ghost"
+                  zSize="icon-sm"
+                  type="button"
+                  class="!size-10 shrink-0 cursor-pointer rounded-lg !bg-hover-bg text-text-secondary transition-[background-color,color,transform] hover:!bg-components-list-option-active-bg hover:text-text-primary active:scale-95 disabled:cursor-default"
+                  data-connector-action="quick-connect"
+                  [zDisabled]="loading() || isConnecting(binding)"
+                  [attr.aria-label]="'XP.Xpert.ConnectConnector' | translate: { Default: 'Connect connector' }"
+                  (click)="quickConnect(definition)"
+                >
+                  @if (isConnecting(binding)) {
+                    <z-icon [zType]="loadingIcon" class="!size-5 animate-spin" />
+                  } @else {
+                    <z-icon zType="plus" class="!size-5" />
+                  }
+                </button>
+              }
+            </article>
+          }
+        </div>
       }
-    </div>
-  } @else if (definitions().length) {
-    <div class="grid max-w-7xl grid-cols-1 gap-3 xl:grid-cols-2">
-      @for (definition of definitions(); track definition.provider) {
-        @let binding = bindingFor(definition);
-        @let status = statusLabelFor(binding);
-        @let authMethods = authMethodsFor(definition);
+    </section>
+  </div>
+</div>
 
-        <article
-          class="relative flex w-full items-start gap-3 rounded-xl border border-divider-regular bg-components-card-bg p-4"
-        >
+@if (selectedDefinition(); as definition) {
+  @let binding = bindingFor(definition);
+  @let status = statusLabelFor(binding);
+  @let authMethods = authMethodsFor(definition);
+  @let authMethod = selectedAuthMethod(binding, definition);
+  @let bindingAuthMethod = binding ? authMethodForBinding(definition, binding) : null;
+  @let credentialForm = credentialFormFor(authMethod);
+  @let authorizationPresentation = authorizationPresentationFor(bindingAuthMethod);
+  @let authorizationLink = pendingAuthorizationUrl(binding);
+
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-[var(--color-overlay-backdrop-strong)] p-4"
+    role="dialog"
+    aria-modal="true"
+    [attr.aria-label]="definition.label | i18n"
+    data-connector-dialog
+    (click)="closeConnectorDialog()"
+  >
+    <div
+      [class]="
+        authorizationPresentation && binding?.status === 'pending'
+          ? 'max-h-[min(860px,calc(100vh-32px))] w-full max-w-3xl overflow-auto rounded-lg border border-divider-regular bg-components-card-bg shadow-2xl'
+          : 'max-h-[min(760px,calc(100vh-32px))] w-full max-w-lg overflow-auto rounded-lg border border-divider-regular bg-components-card-bg shadow-2xl'
+      "
+      (click)="$event.stopPropagation()"
+    >
+      <header class="flex items-start justify-between gap-4 border-b border-divider-regular px-5 py-4">
+        <div class="flex min-w-0 items-center gap-3">
           <div
-            class="flex size-9 shrink-0 items-center justify-center rounded-lg border border-divider-regular bg-background-default-subtle"
+            class="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-divider-regular bg-background-default-subtle"
           >
-            @if (iconImageUrl(definition); as iconUrl) {
-              <img class="size-6 rounded-md object-contain" [src]="iconUrl" [alt]="definition.provider" />
+            @if (definition.icon; as icon) {
+              <xp-icon
+                [icon]="icon"
+                [size]="32"
+                class="flex size-8 items-center justify-center text-3xl leading-none"
+              />
             } @else {
-              <z-icon [zType]="connectorIcon" class="size-5 text-text-secondary"></z-icon>
+              <z-icon [zType]="connectorIcon" class="size-6 text-text-secondary" />
             }
           </div>
+          <div class="min-w-0">
+            <h2 class="truncate text-base font-semibold text-text-primary">{{ definition.label | i18n }}</h2>
+            <div class="mt-1 flex items-center gap-1.5 text-xs text-text-secondary">
+              <span class="size-1.5 rounded-full" [class]="statusDotClass(binding)"></span>
+              {{ status.key | translate: { Default: status.defaultLabel } }}
+            </div>
+          </div>
+        </div>
+        <button
+          z-button
+          zType="ghost"
+          zSize="icon-sm"
+          type="button"
+          class="size-8 shrink-0"
+          [attr.aria-label]="'XP.ACTIONS.Close' | translate: { Default: 'Close' }"
+          (click)="closeConnectorDialog()"
+        >
+          <z-icon zType="x" />
+        </button>
+      </header>
 
-          <div class="min-w-0 flex-1">
-            <div class="flex min-w-0 items-start justify-between gap-2">
-              <div class="min-w-0">
-                <h3 class="truncate font-medium text-text-primary">{{ definition.label | i18n }}</h3>
-                <p class="mt-1 line-clamp-2 text-sm text-text-secondary">{{ descriptionFor(definition) | i18n }}</p>
+      <div [class]="authorizationPresentation && binding?.status === 'pending' ? 'px-5 py-5' : 'space-y-5 px-5 py-5'">
+        @if (authorizationPresentation && binding?.status === 'pending' && authorizationLink) {
+          <div
+            class="rounded-lg bg-background-default-subtle px-4 py-6 sm:px-8 sm:py-10"
+            data-connector-authorization-qr
+          >
+            <div
+              class="mx-auto flex w-full max-w-md flex-col items-center rounded-lg border border-divider-regular bg-components-card-bg px-6 py-8 text-center shadow-sm sm:px-10"
+            >
+              <h3 class="text-xl font-semibold text-text-primary">{{ authorizationPresentation.title | i18n }}</h3>
+              <div class="mt-7 rounded-lg border border-divider-regular bg-components-card-bg p-3 shadow-sm">
+                <qrcode
+                  cssClass="flex items-center justify-center"
+                  elementType="img"
+                  [qrdata]="authorizationLink"
+                  [width]="280"
+                  [margin]="1"
+                  [ariaLabel]="authorizationPresentation.ariaLabel | i18n"
+                />
               </div>
-              <div class="flex shrink-0 flex-wrap justify-end gap-1.5">
-                @if (binding) {
-                  <z-badge zType="outline" zShape="pill">
-                    {{ modeLabel(binding.authorizationMode) | translate }}
-                  </z-badge>
-                }
-                <z-badge [zType]="statusBadgeType(binding)" zShape="pill">
+              <p class="mt-5 max-w-xs text-sm leading-6 text-text-secondary">
+                {{ authorizationPresentation.description | i18n }}
+              </p>
+              @if (isPolling(binding)) {
+                <span class="mt-3 inline-flex items-center gap-1.5 text-xs text-text-tertiary">
+                  <z-icon [zType]="loadingIcon" class="animate-spin" />
+                  {{
+                    'XP.Xpert.ConnectorAuthorizationPending'
+                      | translate: { Default: 'Waiting for authorization to complete.' }
+                  }}
+                </span>
+              }
+            </div>
+          </div>
+
+          @if (binding.lastError) {
+            <div class="mt-4 flex items-start gap-2 rounded-lg bg-danger-500/10 px-3 py-2.5 text-sm text-text-danger">
+              <z-icon [zType]="errorIcon" class="mt-0.5 size-4 shrink-0" />
+              <span>{{ binding.lastError }}</span>
+            </div>
+          }
+        } @else {
+          <p class="text-sm leading-6 text-text-secondary">{{ descriptionFor(definition) | i18n }}</p>
+
+          @if (binding) {
+            <div class="divide-y divide-divider-regular rounded-lg border border-divider-regular">
+              <div class="flex items-center justify-between gap-4 px-3 py-3 text-sm">
+                <span class="text-text-secondary">{{ 'XP.KEY_WORDS.Status' | translate: { Default: 'Status' } }}</span>
+                <span class="inline-flex items-center gap-1.5 font-medium text-text-primary">
+                  <span class="size-1.5 rounded-full" [class]="statusDotClass(binding)"></span>
                   {{ status.key | translate: { Default: status.defaultLabel } }}
-                </z-badge>
+                </span>
               </div>
+              @if (binding.profile) {
+                <div class="flex items-center justify-between gap-4 px-3 py-3 text-sm">
+                  <span class="text-text-secondary">
+                    {{ 'XP.Xpert.ConnectorConnectedAccount' | translate: { Default: 'Connected account' } }}
+                  </span>
+                  <span class="max-w-[65%] truncate font-medium text-text-primary">{{ profileLabel(binding) }}</span>
+                </div>
+              }
+              @if (binding.authMethodId) {
+                <div class="flex items-center justify-between gap-4 px-3 py-3 text-sm">
+                  <span class="text-text-secondary">
+                    {{ 'XP.Xpert.ConnectorAuthenticationMethod' | translate: { Default: 'Authentication method' } }}
+                  </span>
+                  <span class="max-w-[65%] truncate font-medium text-text-primary">{{ binding.authMethodId }}</span>
+                </div>
+              }
             </div>
 
-            @if (!binding) {
-              @if (canManageWorkspace()) {
-                <div class="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+            @if (binding.lastError) {
+              <div class="flex items-start gap-2 rounded-lg bg-danger-500/10 px-3 py-2.5 text-sm text-text-danger">
+                <z-icon [zType]="errorIcon" class="mt-0.5 size-4 shrink-0" />
+                <span>{{ binding.lastError }}</span>
+              </div>
+            }
+          }
+
+          @if (binding?.status === 'pending') {
+            <div class="flex flex-wrap items-center gap-2">
+              @if (authorizationLink) {
+                <button
+                  z-button
+                  type="button"
+                  zType="default"
+                  zSize="sm"
+                  (click)="openPendingAuthorizationUrl(binding)"
+                >
+                  <z-icon zType="arrow-up-right" />
+                  {{ 'XP.Xpert.ConnectorOpenAuthorization' | translate: { Default: 'Continue authorization' } }}
+                </button>
+              }
+              @if (isPolling(binding)) {
+                <span class="inline-flex items-center gap-1.5 text-xs text-text-tertiary">
+                  <z-icon [zType]="loadingIcon" class="animate-spin" />
+                  {{
+                    'XP.Xpert.ConnectorAuthorizationPending'
+                      | translate: { Default: 'Waiting for authorization to complete.' }
+                  }}
+                </span>
+              }
+            </div>
+          } @else if (canManageWorkspace() && binding?.status !== 'active') {
+            <form class="grid gap-4" [formGroup]="formFor(binding, definition)">
+              @if (authMethods.length > 1) {
+                <z-form-field>
+                  <z-form-label>
+                    {{ 'XP.Xpert.ConnectorAuthenticationMethod' | translate: { Default: 'Authentication method' } }}
+                  </z-form-label>
                   <z-select
-                    [zValue]="selectedModeFor(definition)"
-                    [zDisabled]="loading() || isCreating(definition)"
-                    (zSelectionChange)="selectMode(definition, $event)"
+                    class="w-full"
+                    formControlName="authMethodId"
+                    (zSelectionChange)="selectAuthMethod(binding, definition, $event)"
                   >
-                    @for (mode of authorizationModesFor(definition); track mode) {
-                      <z-select-item [zValue]="mode">{{ modeLabel(mode) | translate }}</z-select-item>
+                    @for (method of authMethods; track method.id) {
+                      <z-select-item [zValue]="method.id">{{ method.label | i18n }}</z-select-item>
                     }
                   </z-select>
-                  <button
-                    z-button
-                    zType="outline"
-                    zSize="sm"
-                    type="button"
-                    data-connector-action="create"
-                    [zDisabled]="loading() || isCreating(definition)"
-                    (click)="createBinding(definition)"
-                  >
-                    @if (isCreating(definition)) {
-                      <z-icon [zType]="loadingIcon" class="animate-spin"></z-icon>
-                    } @else {
-                      <z-icon zType="plus"></z-icon>
+                </z-form-field>
+              }
+
+              @for (field of credentialFieldsFor(authMethod); track field.name) {
+                <z-form-field>
+                  <z-form-label>
+                    {{ field.label | i18n }}
+                    @if (field.required) {
+                      <span aria-hidden="true"> *</span>
                     }
-                    {{ 'XP.Xpert.ConnectorEnable' | translate: { Default: 'Enable' } }}
-                  </button>
-                </div>
-                <p class="mt-2 text-xs text-text-tertiary">
-                  {{ modeDescription(selectedModeFor(definition)) | translate }}
-                </p>
-              } @else {
-                <p class="mt-3 text-xs text-text-tertiary">
-                  {{
-                    'XP.Xpert.ConnectorNotEnabledByManager'
-                      | translate: { Default: 'A workspace manager has not enabled this connector.' }
-                  }}
-                </p>
-              }
-            } @else {
-              @let authMethod = selectedAuthMethod(binding, definition);
-              @let credentialForm = credentialFormFor(authMethod);
-
-              <p class="mt-2 text-xs text-text-secondary">
-                {{ modeDescription(binding.authorizationMode) | translate }}
-              </p>
-
-              @if (binding.lastError) {
-                <p class="mt-2 text-xs text-text-warning">{{ binding.lastError }}</p>
+                  </z-form-label>
+                  <input
+                    z-input
+                    [attr.data-credential-field]="field.name"
+                    [type]="field.type === 'password' || field.secret ? 'password' : 'text'"
+                    [formControlName]="field.name"
+                    [placeholder]="field.placeholder ? (field.placeholder | i18n) : ''"
+                    [attr.autocomplete]="field.type === 'password' || field.secret ? 'new-password' : 'off'"
+                  />
+                  @if (field.description) {
+                    <z-form-message>{{ field.description | i18n }}</z-form-message>
+                  }
+                  @if (
+                    fieldControl(binding, definition, field)?.touched &&
+                    fieldControl(binding, definition, field)?.hasError('required')
+                  ) {
+                    <z-form-message>
+                      {{ 'XP.Xpert.ConnectorCredentialRequired' | translate: { Default: 'This field is required.' } }}
+                    </z-form-message>
+                  }
+                </z-form-field>
               }
 
-              @if (binding.profile) {
-                <p class="mt-2 text-xs text-text-secondary">
-                  {{ 'XP.Xpert.ConnectorConnectedAccount' | translate: { Default: 'Connected account:' } }}
-                  <span class="font-medium text-text-primary">{{ profileLabel(binding) }}</span>
-                </p>
+              @if (credentialForm?.help; as help) {
+                <a
+                  class="inline-flex w-fit items-center gap-1 text-xs text-text-secondary underline underline-offset-2"
+                  [href]="help.url"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {{ help.label | i18n }}
+                  <z-icon zType="arrow-up-right" class="size-3.5" />
+                </a>
               }
+            </form>
+          } @else if (!canManageWorkspace()) {
+            <div class="rounded-lg bg-background-default-subtle px-3 py-2.5 text-xs text-text-secondary">
+              {{ 'XP.Xpert.ConnectorsReadonly' | translate }}
+            </div>
+          }
+        }
+      </div>
 
-              @if (canConnect(binding) && binding.status !== 'pending') {
-                <form class="mt-3 grid gap-3" [formGroup]="formFor(binding, definition)">
-                  @if (authMethods.length > 1) {
-                    <z-form-field>
-                      <z-form-label>
-                        {{ 'XP.Xpert.ConnectorAuthenticationMethod' | translate: { Default: 'Authentication method' } }}
-                      </z-form-label>
-                      <z-select
-                        class="w-full"
-                        formControlName="authMethodId"
-                        (zSelectionChange)="selectAuthMethod(binding, definition, $event)"
-                      >
-                        @for (method of authMethods; track method.id) {
-                          <z-select-item [zValue]="method.id">{{ method.label | i18n }}</z-select-item>
-                        }
-                      </z-select>
-                    </z-form-field>
-                  }
-
-                  @for (field of credentialFieldsFor(authMethod); track field.name) {
-                    <z-form-field>
-                      <z-form-label>{{ field.label | i18n }}</z-form-label>
-                      <input
-                        z-input
-                        [attr.data-credential-field]="field.name"
-                        [type]="field.type === 'password' || field.secret ? 'password' : 'text'"
-                        [formControlName]="field.name"
-                        [placeholder]="field.placeholder ? (field.placeholder | i18n) : ''"
-                        [attr.autocomplete]="field.type === 'password' || field.secret ? 'new-password' : 'off'"
-                      />
-                      @if (field.description) {
-                        <z-form-message>{{ field.description | i18n }}</z-form-message>
-                      }
-                      @if (
-                        fieldControl(binding, definition, field)?.touched &&
-                        fieldControl(binding, definition, field)?.hasError('required')
-                      ) {
-                        <z-form-message>
-                          {{
-                            'XP.Xpert.ConnectorCredentialRequired' | translate: { Default: 'This field is required.' }
-                          }}
-                        </z-form-message>
-                      }
-                    </z-form-field>
-                  }
-
-                  @if (credentialForm?.help; as help) {
-                    <a
-                      class="w-fit text-xs text-text-secondary underline underline-offset-2"
-                      [href]="help.url"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {{ help.label | i18n }}
-                    </a>
-                  }
-                </form>
-
-                <div class="mt-3 flex flex-wrap items-center gap-2">
-                  @if (binding.authorizationMode === 'personal' && binding.status !== 'active') {
-                    <button
-                      z-button
-                      zType="outline"
-                      zSize="sm"
-                      type="button"
-                      data-connector-action="consent"
-                      [zDisabled]="loading() || isConnecting(binding)"
-                      (click)="consent(binding)"
-                    >
-                      {{ 'XP.Xpert.ConnectorUseExistingPersonalAccount' | translate }}
-                    </button>
-                  }
-                  <button
-                    z-button
-                    zType="outline"
-                    zSize="sm"
-                    type="button"
-                    data-connector-action="connect"
-                    [zDisabled]="loading() || isConnecting(binding)"
-                    (click)="connect(binding, definition)"
-                  >
-                    @if (isConnecting(binding)) {
-                      <z-icon [zType]="loadingIcon" class="animate-spin"></z-icon>
-                    } @else {
-                      <z-icon zType="plus"></z-icon>
-                    }
-                    {{
-                      (binding.authorizationMode === 'personal'
-                        ? binding.status === 'active'
-                          ? 'XP.Xpert.ConnectorReplaceMyAccount'
-                          : 'XP.Xpert.ConnectorConnectMyAccount'
-                        : binding.status === 'active'
-                          ? 'XP.Xpert.ConnectorRotateSharedCredential'
-                          : 'XP.Xpert.ConnectorConnectSharedAccount'
-                      ) | translate
-                    }}
-                  </button>
-                </div>
-              } @else if (binding.authorizationMode === 'shared' && !canManageWorkspace()) {
-                <p class="mt-3 text-xs text-text-tertiary">
-                  {{ 'XP.Xpert.ConnectorSharedManagedByManager' | translate }}
-                </p>
-              }
-
-              @if (binding.status === 'pending' && canConnect(binding)) {
-                <div class="mt-3 flex flex-wrap items-center gap-2">
-                  @if (pendingAuthorizationUrl(binding)) {
-                    <button
-                      z-button
-                      type="button"
-                      zType="secondary"
-                      zSize="sm"
-                      (click)="openPendingAuthorizationUrl(binding)"
-                    >
-                      <z-icon zType="arrow-up-right"></z-icon>
-                      {{ 'XP.Xpert.ConnectorOpenAuthorization' | translate: { Default: 'Continue authorization' } }}
-                    </button>
-                  }
-                  @if (isPolling(binding)) {
-                    <span class="inline-flex items-center gap-1 text-xs text-text-tertiary">
-                      <z-icon [zType]="loadingIcon" class="animate-spin"></z-icon>
-                      {{
-                        'XP.Xpert.ConnectorAuthorizationPending'
-                          | translate: { Default: 'Waiting for authorization to complete.' }
-                      }}
-                    </span>
-                  }
-                </div>
-              }
-            }
-          </div>
-
-          @if (binding && canManageWorkspace()) {
+      <footer
+        [class]="
+          authorizationPresentation && binding?.status === 'pending'
+            ? 'flex flex-wrap items-center justify-between gap-3 border-t border-divider-regular px-5 py-4'
+            : 'flex flex-wrap items-center justify-end gap-2 border-t border-divider-regular px-5 py-4'
+        "
+      >
+        @if (authorizationPresentation && binding?.status === 'pending') {
+          <span class="text-sm text-text-secondary">{{ authorizationPresentation.completionHint | i18n }}</span>
+          <div class="flex flex-wrap items-center justify-end gap-2">
             <button
               z-button
-              type="button"
               zType="ghost"
               zSize="sm"
-              class="shrink-0"
-              data-connector-action="delete"
-              [zDisabled]="loading() || isDeleting(binding)"
-              [attr.aria-label]="'XP.Xpert.ConnectorRemoveBinding' | translate"
-              (click)="deleteBinding(binding)"
+              type="button"
+              data-connector-action="cancel-authorization"
+              class="text-text-danger"
+              [zDisabled]="loading() || isCancelling(binding) || !canManageWorkspace()"
+              (click)="cancelAuthorization(binding)"
             >
-              @if (isDeleting(binding)) {
-                <z-icon [zType]="loadingIcon" class="animate-spin"></z-icon>
+              @if (isCancelling(binding)) {
+                <z-icon [zType]="loadingIcon" class="animate-spin" />
               } @else {
-                <z-icon [zType]="deleteIcon" class="text-text-destructive"></z-icon>
+                <z-icon [zType]="disconnectIcon" />
               }
+              {{ authorizationPresentation.cancelLabel | i18n }}
             </button>
-          }
+            <button
+              z-button
+              zType="outline"
+              zSize="sm"
+              type="button"
+              data-connector-action="copy-authorization-url"
+              [zDisabled]="!authorizationLink"
+              (click)="copyPendingAuthorizationUrl(binding, authorizationPresentation)"
+            >
+              <z-icon zType="copy" />
+              {{ authorizationPresentation.copyLinkLabel | i18n }}
+            </button>
+          </div>
+        } @else {
+          <button z-button zType="ghost" zSize="sm" type="button" (click)="closeConnectorDialog()">
+            {{ 'XP.ACTIONS.Cancel' | translate: { Default: 'Cancel' } }}
+          </button>
 
-          @if (loading()) {
-            <xp-spin class="absolute inset-0"></xp-spin>
+          @if (!binding) {
+            @if (canManageWorkspace()) {
+              <button
+                z-button
+                zType="default"
+                zSize="sm"
+                type="button"
+                data-connector-action="connect"
+                [zDisabled]="loading() || isConnecting(binding, definition)"
+                (click)="connect(binding, definition)"
+              >
+                @if (isConnecting(binding, definition)) {
+                  <z-icon [zType]="loadingIcon" class="animate-spin" />
+                } @else {
+                  <z-icon [zType]="connectorIcon" />
+                }
+                {{ 'XP.Xpert.ConnectorConnect' | translate: { Default: 'Connect' } }}
+              </button>
+            }
+          } @else {
+            @if (binding.status === 'pending' && canManageWorkspace()) {
+              <button
+                z-button
+                zType="outline"
+                zSize="sm"
+                type="button"
+                class="text-text-danger"
+                data-connector-action="cancel-authorization"
+                [zDisabled]="loading() || isCancelling(binding)"
+                (click)="cancelAuthorization(binding)"
+              >
+                @if (isCancelling(binding)) {
+                  <z-icon [zType]="loadingIcon" class="animate-spin" />
+                } @else {
+                  <z-icon [zType]="disconnectIcon" />
+                }
+                {{ 'XP.ACTIONS.Cancel' | translate: { Default: 'Cancel authorization' } }}
+              </button>
+            }
+
+            @if (binding.status === 'active' && canManageWorkspace()) {
+              <button
+                z-button
+                zType="outline"
+                zSize="sm"
+                type="button"
+                class="text-text-danger"
+                data-connector-action="disconnect"
+                [zDisabled]="loading() || isDisconnecting(binding)"
+                (click)="disconnect(binding)"
+              >
+                @if (isDisconnecting(binding)) {
+                  <z-icon [zType]="loadingIcon" class="animate-spin" />
+                } @else {
+                  <z-icon [zType]="disconnectIcon" />
+                }
+                {{ 'XP.Xpert.ConnectorDisconnect' | translate: { Default: 'Disconnect' } }}
+              </button>
+            } @else if (binding.status !== 'pending' && canManageWorkspace()) {
+              <button
+                z-button
+                zType="default"
+                zSize="sm"
+                type="button"
+                data-connector-action="connect"
+                [zDisabled]="loading() || isConnecting(binding)"
+                (click)="connect(binding, definition)"
+              >
+                @if (isConnecting(binding)) {
+                  <z-icon [zType]="loadingIcon" class="animate-spin" />
+                } @else {
+                  <z-icon [zType]="connectorIcon" />
+                }
+                {{ 'XP.Xpert.ConnectorConnect' | translate: { Default: 'Connect' } }}
+              </button>
+            }
           }
-        </article>
-      }
+        }
+      </footer>
     </div>
-  } @else {
-    <div
-      class="max-w-5xl rounded-lg border border-dashed border-divider-regular p-10 text-center text-sm text-text-secondary"
-    >
-      {{ 'XP.Xpert.NoConnectorsAvailable' | translate: { Default: 'No connectors are available.' } }}
-    </div>
-  }
-</div>
+  </div>
+}

--- a/apps/cloud/src/app/features/xpert/workspace/home/home.component.html
+++ b/apps/cloud/src/app/features/xpert/workspace/home/home.component.html
@@ -1,6 +1,6 @@
 @if (isMarketplaceWorkspaceRoute()) {
   <header class="sticky top-0 z-20 border-b border-border/70 bg-background/95 px-6 py-3 backdrop-blur-xl xl:px-10">
-    <div class="mx-auto flex w-full max-w-[1440px] flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <nav
         class="flex w-fit max-w-full items-center gap-1 overflow-x-auto"
         aria-label="{{ 'XP.Explore.NavigationLabel' | translate: { Default: 'Marketplace navigation' } }}"

--- a/packages/server-ai/src/connector/connector.controller.spec.ts
+++ b/packages/server-ai/src/connector/connector.controller.spec.ts
@@ -311,6 +311,16 @@ describe('ConnectorController', () => {
         await expect(controller.cancelAuthorization('workspace-1', 'connector-1')).resolves.toBeNull()
         expect(service.cancelAuthorization).toHaveBeenCalledWith('workspace-1', 'connector-1')
     })
+
+    it('delegates scoped binding authorization cancellation to the service', async () => {
+        const service: Pick<ConnectorService, 'cancelBindingAuthorization'> = {
+            cancelBindingAuthorization: jest.fn().mockResolvedValue(null)
+        }
+        const controller = new ConnectorController(service as ConnectorService)
+
+        await expect(controller.cancelBindingAuthorization('binding-1', { xpertId: 'xpert-1' })).resolves.toBeNull()
+        expect(service.cancelBindingAuthorization).toHaveBeenCalledWith('binding-1', 'xpert-1')
+    })
 })
 
 function htmlResponse() {

--- a/packages/server-ai/src/connector/connector.controller.ts
+++ b/packages/server-ai/src/connector/connector.controller.ts
@@ -189,6 +189,11 @@ export class ConnectorController {
         return this.service.authorizationStatusBinding(connectorId, xpertId)
     }
 
+    @Post('bindings/:connectorId/cancel-authorization')
+    cancelBindingAuthorization(@Param('connectorId') connectorId: string, @Body() body?: { xpertId?: string }) {
+        return this.service.cancelBindingAuthorization(connectorId, body?.xpertId)
+    }
+
     @Post('bindings/:connectorId/consent')
     consentBinding(@Param('connectorId') connectorId: string, @Body() body?: { xpertId?: string }) {
         return this.service.consentPersonalBinding(connectorId, body?.xpertId)
@@ -281,11 +286,7 @@ export class ConnectorController {
         )
     }
 
-    private bindOAuthBrowser(
-        result: ConnectorConnectResponse,
-        request: HttpRequestLike,
-        response?: Response
-    ) {
+    private bindOAuthBrowser(result: ConnectorConnectResponse, request: HttpRequestLike, response?: Response) {
         if (result.status !== 'pending' || !result.authorizationUrl || !response) {
             return
         }

--- a/packages/server-ai/src/connector/connector.service.spec.ts
+++ b/packages/server-ai/src/connector/connector.service.spec.ts
@@ -1112,6 +1112,27 @@ describe('ConnectorService', () => {
         expect(strategy.connect).not.toHaveBeenCalled()
     })
 
+    it('initializes a first Workspace connector before database persistence', async () => {
+        const save = connectors.save.bind(connectors)
+        jest.spyOn(connectors, 'save').mockImplementation(async (connector) => {
+            if (!connector.status) {
+                throw new Error('xpert_connector.status must not be null')
+            }
+            return save(connector)
+        })
+
+        await expect(
+            service.connect('workspace-1', 'example', {
+                redirectUri: 'https://xpert.test/callback'
+            })
+        ).resolves.toEqual(
+            expect.objectContaining({
+                status: 'pending',
+                connector: expect.objectContaining({ status: 'pending' })
+            })
+        )
+    })
+
     it('activates an API key connector and exposes only the plugin runtime projection', async () => {
         strategy.definition = {
             provider: 'github',
@@ -1798,6 +1819,186 @@ describe('ConnectorService', () => {
             BadRequestException
         )
         expect(personalGrants.items).toHaveLength(0)
+    })
+
+    it('cancels only the current users pending personal binding authorization', async () => {
+        strategy.definition = {
+            ...strategy.definition,
+            authorizationModes: ['personal', 'shared']
+        }
+        const binding = await service.createBinding({
+            scope: { type: 'workspace', workspaceId: 'workspace-1' },
+            provider: 'example',
+            authorizationMode: 'personal'
+        })
+        await service.connectBinding(binding.id, {
+            redirectUri: 'https://xpert.test/callback'
+        })
+        const state = (strategy.buildAuthorizationUrl as jest.Mock).mock.calls[0][0].state
+
+        await service.cancelBindingAuthorization(binding.id)
+
+        expect(personalAccounts.items).toEqual([
+            expect.objectContaining({ userId: 'user-1', provider: 'example', status: 'disconnected' })
+        ])
+        expect(sessions.items[0]).toEqual(expect.objectContaining({ consumedAt: expect.any(Date) }))
+        await expect(service.completeOAuthCallback({ state, code: 'stale-code' })).rejects.toBeInstanceOf(
+            BadRequestException
+        )
+    })
+
+    it('does not overwrite a personal credential that leaves pending before cancellation updates it', async () => {
+        strategy.definition = {
+            ...strategy.definition,
+            authorizationModes: ['personal', 'shared']
+        }
+        const binding = await service.createBinding({
+            scope: { type: 'workspace', workspaceId: 'workspace-1' },
+            provider: 'example',
+            authorizationMode: 'personal'
+        })
+        await service.connectBinding(binding.id, {
+            redirectUri: 'https://xpert.test/callback'
+        })
+        const account = personalAccounts.items[0]
+        jest.spyOn(personalAccounts, 'update').mockImplementationOnce(async () => {
+            Object.assign(account, {
+                status: 'active',
+                connectionAttemptId: null,
+                credentialCiphertext: 'completed-credential'
+            })
+            return { affected: 0 }
+        })
+
+        await expect(service.cancelBindingAuthorization(binding.id)).rejects.toBeInstanceOf(BadRequestException)
+
+        expect(account).toEqual(
+            expect.objectContaining({ status: 'active', credentialCiphertext: 'completed-credential' })
+        )
+        expect(sessions.items[0].consumedAt).toBeFalsy()
+    })
+
+    it('cancels pending shared authorization through the scoped Project binding', async () => {
+        strategy.definition = {
+            ...strategy.definition,
+            authorizationModes: ['personal', 'shared']
+        }
+        const binding = await service.createBinding({
+            scope: { type: 'project', projectId: 'project-1' },
+            provider: 'example',
+            authorizationMode: 'shared'
+        })
+        await service.connectBinding(binding.id, {
+            xpertId: 'xpert-1',
+            redirectUri: 'https://xpert.test/callback'
+        })
+
+        await service.cancelBindingAuthorization(binding.id, 'xpert-1')
+
+        expect(projectAccess.assertCanManage).toHaveBeenCalledWith('project-1')
+        expect(connectors.items.find((item) => item.id === binding.id)).toEqual(
+            expect.objectContaining({ status: 'disconnected', credentialCiphertext: null })
+        )
+        expect(sessions.items[0].consumedAt).toBeInstanceOf(Date)
+    })
+
+    it('cancels an orphaned pending shared binding when its authorization session is missing', async () => {
+        const binding = await service.createBinding({
+            scope: { type: 'workspace', workspaceId: 'workspace-1' },
+            provider: 'example',
+            authorizationMode: 'shared'
+        })
+        await service.connectBinding(binding.id, {
+            redirectUri: 'https://xpert.test/callback'
+        })
+        sessions.items.splice(0, sessions.items.length)
+
+        await expect(service.cancelBindingAuthorization(binding.id)).resolves.toBeNull()
+
+        expect(connectors.items.find((item) => item.id === binding.id)).toEqual(
+            expect.objectContaining({ status: 'disconnected', connectionAttemptId: null })
+        )
+    })
+
+    it('does not let a Project member cancel pending shared authorization', async () => {
+        strategy.definition = {
+            ...strategy.definition,
+            authorizationModes: ['personal', 'shared']
+        }
+        const binding = await service.createBinding({
+            scope: { type: 'project', projectId: 'project-1' },
+            provider: 'example',
+            authorizationMode: 'shared'
+        })
+        await service.connectBinding(binding.id, {
+            xpertId: 'xpert-1',
+            redirectUri: 'https://xpert.test/callback'
+        })
+        projectAccess.assertCanManage.mockRejectedValueOnce(new ForbiddenException())
+
+        await expect(service.cancelBindingAuthorization(binding.id, 'xpert-1')).rejects.toBeInstanceOf(
+            ForbiddenException
+        )
+
+        expect(connectors.items.find((item) => item.id === binding.id)).toEqual(
+            expect.objectContaining({ status: 'pending' })
+        )
+        expect(sessions.items[0].consumedAt).toBeFalsy()
+    })
+
+    it('does not let a user without Project access cancel pending personal authorization', async () => {
+        strategy.definition = {
+            ...strategy.definition,
+            authorizationModes: ['personal', 'shared']
+        }
+        const binding = await service.createBinding({
+            scope: { type: 'project', projectId: 'project-1' },
+            provider: 'example',
+            authorizationMode: 'personal'
+        })
+        await service.connectBinding(binding.id, {
+            xpertId: 'xpert-1',
+            redirectUri: 'https://xpert.test/callback'
+        })
+        projectAccess.assertCanUse.mockRejectedValueOnce(new ForbiddenException())
+
+        await expect(service.cancelBindingAuthorization(binding.id, 'xpert-1')).rejects.toBeInstanceOf(
+            ForbiddenException
+        )
+
+        expect(personalAccounts.items[0]).toEqual(expect.objectContaining({ status: 'pending' }))
+        expect(sessions.items[0].consumedAt).toBeFalsy()
+    })
+
+    it('does not cancel a personal authorization started from another binding', async () => {
+        strategy.definition = {
+            ...strategy.definition,
+            authorizationModes: ['personal', 'shared']
+        }
+        const workspaceBinding = await service.createBinding({
+            scope: { type: 'workspace', workspaceId: 'workspace-1' },
+            provider: 'example',
+            authorizationMode: 'personal'
+        })
+        const projectBinding = await service.createBinding({
+            scope: { type: 'project', projectId: 'project-1' },
+            provider: 'example',
+            authorizationMode: 'personal'
+        })
+        await service.connectBinding(projectBinding.id, {
+            xpertId: 'xpert-1',
+            redirectUri: 'https://xpert.test/callback'
+        })
+
+        await expect(service.cancelBindingAuthorization(workspaceBinding.id)).rejects.toBeInstanceOf(
+            BadRequestException
+        )
+        expect(personalAccounts.items[0]).toEqual(expect.objectContaining({ status: 'pending' }))
+        expect(sessions.items[0].consumedAt).toBeFalsy()
+
+        await expect(service.cancelBindingAuthorization(projectBinding.id, 'xpert-1')).resolves.toBeNull()
+        expect(personalAccounts.items[0]).toEqual(expect.objectContaining({ status: 'disconnected' }))
+        expect(sessions.items[0].consumedAt).toBeInstanceOf(Date)
     })
 
     it('denies Connector runtime access unless the binding was selected for this conversation', async () => {

--- a/packages/server-ai/src/connector/connector.service.ts
+++ b/packages/server-ai/src/connector/connector.service.ts
@@ -434,6 +434,7 @@ export class ConnectorService {
             projectId: null,
             provider,
             authorizationMode: 'shared',
+            status: existing?.status ?? 'disconnected',
             updatedById: userId,
             createdById: existing?.createdById ?? userId
         })
@@ -1436,14 +1437,69 @@ export class ConnectorService {
     async cancelAuthorization(workspaceId: string, connectorId: string) {
         await this.workspaceAccessService.assertCanManage(workspaceId)
         const connector = await this.requireConnector({ workspaceId, connectorId, authorizationMode: 'shared' })
-        if (connector.status !== 'pending') {
-            throw new BadRequestException('Connector authorization is not pending')
+        await this.cancelPendingAuthorization({ binding: connector, owner: connector, ownerKind: 'shared' })
+        return null
+    }
+
+    async cancelBindingAuthorization(connectorId: string, xpertId?: string) {
+        const binding = await this.requireBinding(connectorId)
+        const authorizationMode = connectorAuthorizationMode(binding)
+        let connection: BindingConnection
+        if (authorizationMode === 'shared') {
+            await this.assertBindingManage(binding)
+            connection = { binding, owner: binding, ownerKind: 'shared' }
+        } else {
+            await this.assertBindingUse(binding, xpertId)
+            const account = await this.findPersonalAccount(binding.provider, RequestContext.currentUserId())
+            if (!account) {
+                throw connectorAuthorizationNotPendingError()
+            }
+            connection = { binding, owner: account, ownerKind: 'personal' }
         }
 
-        Object.assign(connector, disconnectedCredentialState())
-        await this.connectorRepository.save(connector)
-        await this.consumeSupersededSessions(connector)
+        await this.cancelPendingAuthorization(connection)
         return null
+    }
+
+    private async cancelPendingAuthorization(connection: BindingConnection) {
+        const sessions = await this.sessionRepository.find({
+            where: {
+                tenantId: connection.binding.tenantId,
+                connectorId: connection.binding.id,
+                provider: connection.binding.provider,
+                authorizationMode: connectorAuthorizationMode(connection.binding),
+                ...(connection.ownerKind === 'personal'
+                    ? {
+                          personalAccountId: connection.owner.id,
+                          actorUserId: RequestContext.currentUserId()
+                      }
+                    : {})
+            }
+        })
+        const openSessions = sessions.filter((candidate) => !candidate.consumedAt)
+        const personalSession =
+            connection.ownerKind === 'personal'
+                ? openSessions.find((candidate) => this.isCurrentSession(candidate, connection.owner))
+                : null
+        if (connection.ownerKind === 'personal' && !personalSession) {
+            throw connectorAuthorizationNotPendingError()
+        }
+        const updated = await this.updatePendingCredentialOwner(
+            connection,
+            connection.owner.connectionAttemptId ?? undefined,
+            {
+                ...disconnectedCredentialState(),
+                updatedById: RequestContext.currentUserId()
+            }
+        )
+        if (!updated) {
+            throw connectorAuthorizationNotPendingError()
+        }
+        if (connection.ownerKind === 'shared') {
+            await Promise.all(openSessions.map((session) => this.consumeOAuthSession(session)))
+        } else if (personalSession) {
+            await this.consumeOAuthSession(personalSession)
+        }
     }
 
     createScopedRuntimeApi(scope: AgentMiddlewareRuntimeScope): ConnectorRuntimeApi {
@@ -2357,6 +2413,15 @@ function disconnectedCredentialState(): CredentialOwnerUpdate {
         disconnectedAt: new Date(),
         lastError: null
     }
+}
+
+function connectorAuthorizationNotPendingError() {
+    const defaultValue = 'Connector authorization is not pending'
+    return new BadRequestException(
+        t('server-ai:Error.ConnectorAuthorizationNotPending', {
+            defaultValue
+        }) || defaultValue
+    )
 }
 
 function isPersonalCredentialOwner(owner: CredentialOwner): owner is ConnectorPersonalAccount {

--- a/packages/server-ai/src/i18n/en-US.json
+++ b/packages/server-ai/src/i18n/en-US.json
@@ -496,6 +496,7 @@
         "ConnectorOAuthBrowserBindingInvalid": "This connector authorization was started in another browser session or has expired.",
         "ConnectorOAuthStartInvalid": "Connector '{{provider}}' did not start an OAuth authorization.",
         "ConnectorAuthorizationStartFailed": "Connector authorization could not be started.",
+        "ConnectorAuthorizationNotPending": "Connector authorization is not pending.",
         "ConnectorOAuthCallbackCredentialPayloadRejected": "Connector OAuth callback does not accept credential payloads.",
         "ConnectorOAuthCallbackCodeRequired": "Connector OAuth callback requires an authorization code.",
         "ConnectorOAuthStateInvalid": "Invalid connector OAuth state.",

--- a/packages/server-ai/src/i18n/en.json
+++ b/packages/server-ai/src/i18n/en.json
@@ -496,6 +496,7 @@
         "ConnectorOAuthBrowserBindingInvalid": "This connector authorization was started in another browser session or has expired.",
         "ConnectorOAuthStartInvalid": "Connector '{{provider}}' did not start an OAuth authorization.",
         "ConnectorAuthorizationStartFailed": "Connector authorization could not be started.",
+        "ConnectorAuthorizationNotPending": "Connector authorization is not pending.",
         "ConnectorOAuthCallbackCredentialPayloadRejected": "Connector OAuth callback does not accept credential payloads.",
         "ConnectorOAuthCallbackCodeRequired": "Connector OAuth callback requires an authorization code.",
         "ConnectorOAuthStateInvalid": "Invalid connector OAuth state.",

--- a/packages/server-ai/src/i18n/zh-Hans.json
+++ b/packages/server-ai/src/i18n/zh-Hans.json
@@ -496,6 +496,7 @@
         "ConnectorOAuthBrowserBindingInvalid": "此连接器授权由另一个浏览器会话发起，或已过期。",
         "ConnectorOAuthStartInvalid": "连接器“{{provider}}”未能启动 OAuth 授权。",
         "ConnectorAuthorizationStartFailed": "无法启动连接器授权。",
+        "ConnectorAuthorizationNotPending": "连接器当前没有待处理的授权。",
         "ConnectorOAuthCallbackCredentialPayloadRejected": "连接器 OAuth 回调不接受凭据内容。",
         "ConnectorOAuthCallbackCodeRequired": "连接器 OAuth 回调缺少授权码。",
         "ConnectorOAuthStateInvalid": "连接器 OAuth 状态无效。",


### PR DESCRIPTION
## Summary

- simplify Workspace connector management to connect/disconnect without enable or delete flows
- keep personal/team authorization mode selection in Project scope only
- restore compact responsive connector cards, direct plus-button connection, and dialog-based details
- cancel pending authorization safely without reopening external pages during polling
- add scoped backend cancellation handling and regression coverage

## Validation

- Workspace connector component: 22 tests passed
- Connector service: 60 tests passed
- Project connector dialog and connector controller focused tests passed during review
- TypeScript checks for cloud and server-ai passed during review
- git diff --check passed
- merge-tree against the latest origin/develop completed without conflicts

## Known follow-up

- Review identified an Escape-key interaction in the custom connector dialog when a nested select is open; it is not changed in this PR.