### PR TITLE
fix(cloud): localize blank Xpert save action

### DIFF
--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.html
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.html
@@ -957,7 +957,7 @@
             >
               <i class="ri-save-line mr-1"></i>
               {{
-                (completionMode === 'publish' ? 'XP.Xpert.CreateAndPublish' : 'Story.Common.Save')
+                (completionMode === 'publish' ? 'XP.Xpert.CreateAndPublish' : 'XP.ACTIONS.SAVE')
                   | translate: { Default: completionMode === 'publish' ? 'Create and publish' : 'Save' }
               }}
             </button>
@@ -1281,7 +1281,7 @@
             >
               <i class="ri-save-line mr-1"></i>
               {{
-                (completionMode === 'publish' ? 'XP.Xpert.CreateAndPublish' : 'Story.Common.Save')
+                (completionMode === 'publish' ? 'XP.Xpert.CreateAndPublish' : 'XP.ACTIONS.SAVE')
                   | translate: { Default: completionMode === 'publish' ? 'Create and publish' : 'Save' }
               }}
             </button>
@@ -1715,7 +1715,7 @@
             >
               <i class="ri-save-line mr-1"></i>
               {{
-                (completionMode === 'publish' ? 'XP.Xpert.CreateAndPublish' : 'Story.Common.Save')
+                (completionMode === 'publish' ? 'XP.Xpert.CreateAndPublish' : 'XP.ACTIONS.SAVE')
                   | translate: { Default: completionMode === 'publish' ? 'Create and publish' : 'Save' }
               }}
             </button>
@@ -1922,7 +1922,7 @@
             >
               <i class="ri-save-line mr-1"></i>
               {{
-                (completionMode === 'publish' ? 'XP.Xpert.CreateAndPublish' : 'Story.Common.Save')
+                (completionMode === 'publish' ? 'XP.Xpert.CreateAndPublish' : 'XP.ACTIONS.SAVE')
                   | translate: { Default: completionMode === 'publish' ? 'Create and publish' : 'Save' }
               }}
             </button>


### PR DESCRIPTION
## Summary
- replace the missing Story.Common.Save translation key in blank Xpert creation flows
- reuse the existing XP.ACTIONS.SAVE key for all supported locales

## Validation
- verified all five Cloud locale files define XP.ACTIONS.SAVE
- confirmed the invalid key is removed from the blank Xpert wizard
- git diff --check
- pre-commit formatting, hardcoded-color, and TypeORM column checks