### PR TITLE
fix(plugin-sdk): increase default max tokens

### DIFF
--- a/.changeset/calm-limits-grow.md
+++ b/.changeset/calm-limits-grow.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-sdk': patch
+---
+
+Increase the default maximum output token limit to 2048.

--- a/packages/plugin-sdk/src/lib/ai-model/ai-model.spec.ts
+++ b/packages/plugin-sdk/src/lib/ai-model/ai-model.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '@xpert-ai/contracts'
 import { AIModel } from './ai-model'
 import { ModelProvider } from './abstract-provider'
+import { DefaultParameterName, PARAMETER_RULE_TEMPLATE } from './entities'
 
 class TestProvider extends ModelProvider {
   getAuthorization(): string {
@@ -70,5 +71,11 @@ describe('AIModel model profile', () => {
 
   it('returns null when the model schema is unavailable', () => {
     expect(new TestAIModel(null).getModelProfile('missing-model', {})).toBeNull()
+  })
+})
+
+describe('AIModel parameter rule templates', () => {
+  it('uses 2048 tokens as the default output limit', () => {
+    expect(PARAMETER_RULE_TEMPLATE[DefaultParameterName.MAX_TOKENS].default).toBe(2_048)
   })
 })

--- a/packages/plugin-sdk/src/lib/ai-model/entities/defaults.ts
+++ b/packages/plugin-sdk/src/lib/ai-model/entities/defaults.ts
@@ -98,7 +98,7 @@ export const PARAMETER_RULE_TEMPLATE: Record<DefaultParameterName, ParameterRule
             zh_Hans: "指定生成结果长度的上限。如果生成结果截断，可以调大该参数。",
         },
         required: false,
-        default: 64,
+        default: 2048,
         min: 1,
         max: 2048,
         precision: 0,


### PR DESCRIPTION
## Summary

- increase the shared `max_tokens` template default from 64 to 2048
- add a regression test for the default output limit
- add a patch changeset for `@xpert-ai/plugin-sdk`

## Testing

- `corepack pnpm nx test plugin-sdk --runInBand` (27 suites, 144 tests)
- `corepack pnpm exec jest --config packages/plugin-sdk/jest.config.ts packages/plugin-sdk/src/lib/ai-model/ai-model.spec.ts --runInBand`
- `corepack pnpm nx build plugin-sdk`
- `git diff --check`