### PR TITLE
fix: improve task summary content and upgrade ChatKit

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -27,7 +27,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "@xpert-ai/chatkit-angular": "~0.4.3",
-    "@xpert-ai/chatkit-ui": "~0.5.8",
+    "@xpert-ai/chatkit-ui": "~0.5.9",
     "@xpert-ai/chatkit-types": "~0.5.7",
     "@xpert-ai/chatkit-web-component": "~0.5.4",
     "@xpert-ai/chatkit-web-shared": "~0.4.4",

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.spec.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.spec.ts
@@ -827,7 +827,7 @@ describe('ClawXpertConversationDetailComponent', () => {
     await settle(fixture)
 
     expect(getRuntimeInput().layout).toEqual({
-      maxWidth: '960px'
+      maxWidth: '840px'
     })
   })
 

--- a/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.ts
+++ b/apps/cloud/src/app/features/chat/clawxpert/clawxpert-conversation-detail.component.ts
@@ -104,9 +104,10 @@ const CHATKIT_OVERLAY_CONTROLS_STYLE_ATTRIBUTE = 'data-chatkit-overlay-controls-
 const CLAWXPERT_CHATKIT_MIN_WIDTH_PX = 384
 const CLAWXPERT_CHATKIT_DEFAULT_WIDTH_PX = 460
 const CLAWXPERT_CHATKIT_MAX_WIDTH_PX = 960
+const CLAWXPERT_CHAT_COLUMN_MAX_WIDTH_PX = 840
 const CLAWXPERT_OVERLAY_VIEWPORT_GUTTER_PX = 8
 const CLAWXPERT_OVERLAY_MIN_TOP_PX = 16
-const CLAWXPERT_CHATKIT_MAX_WIDTH = `${CLAWXPERT_CHATKIT_MAX_WIDTH_PX}px`
+const CLAWXPERT_CHAT_COLUMN_MAX_WIDTH = `${CLAWXPERT_CHAT_COLUMN_MAX_WIDTH_PX}px`
 const WORKSPACE_LAYOUT_TRANSITION_CLASSES =
   'transition-[grid-template-columns,grid-template-rows,gap] duration-500 ease-out motion-reduce:transition-none'
 const CHAT_SHELL_TRANSITION_CLASSES =
@@ -878,7 +879,7 @@ export class ClawXpertConversationDetailComponent implements OnDestroy {
     initialThread: this.chatkitInitialThread,
     displayMode: this.chatkitDisplayMode,
     layout: {
-      maxWidth: CLAWXPERT_CHATKIT_MAX_WIDTH
+      maxWidth: CLAWXPERT_CHAT_COLUMN_MAX_WIDTH
     },
     taskSummary: {
       enabled: true

--- a/packages/server-ai/src/chat-conversation/task-summary.service.spec.ts
+++ b/packages/server-ai/src/chat-conversation/task-summary.service.spec.ts
@@ -22,6 +22,7 @@ describe('ChatTaskSummaryService', () => {
                         id: `output-${index + 1}`,
                         kind: 'document' as const,
                         title: `Output ${index + 1}`,
+                        resource: { type: 'artifact' as const, artifactId: `artifact-${index + 1}` },
                         updatedAt: `2026-07-13T0${index + 1}:00:00.000Z`
                     })),
                     sources: [
@@ -65,6 +66,7 @@ describe('ChatTaskSummaryService', () => {
                     items: [
                         {
                             id: 'root-agent',
+                            category: 'agent',
                             agentKey: 'Agent_primary',
                             title: 'Primary agent',
                             status: 'running',
@@ -73,6 +75,7 @@ describe('ChatTaskSummaryService', () => {
                         {
                             id: 'agent-1',
                             parentId: 'root-agent',
+                            category: 'agent',
                             agentKey: 'Agent_researcher',
                             title: 'Researcher',
                             status: 'error',
@@ -81,6 +84,7 @@ describe('ChatTaskSummaryService', () => {
                         {
                             id: 'agent-2',
                             parentId: 'root-agent',
+                            category: 'agent',
                             agentKey: 'Agent_researcher',
                             title: 'Researcher',
                             status: 'success',
@@ -89,10 +93,20 @@ describe('ChatTaskSummaryService', () => {
                         {
                             id: 'agent-3',
                             parentId: 'root-agent',
+                            category: 'agent',
                             agentKey: 'Agent_writer',
                             title: 'Writer',
                             status: 'success',
                             updatedAt: new Date('2026-07-13T03:30:00.000Z')
+                        },
+                        {
+                            id: 'workflow-1',
+                            parentId: 'root-agent',
+                            category: 'workflow',
+                            agentKey: 'Agent_writer',
+                            title: 'Workflow step',
+                            status: 'running',
+                            updatedAt: new Date('2026-07-13T05:30:00.000Z')
                         }
                     ],
                     total: 1
@@ -146,6 +160,7 @@ describe('ChatTaskSummaryService', () => {
             total: 2
         })
         expect(result.agents.items).not.toContainEqual(expect.objectContaining({ id: 'root-agent' }))
+        expect(result.agents.items).not.toContainEqual(expect.objectContaining({ id: 'workflow-1' }))
         expect(result.pending.items[0]).toMatchObject({
             id: 'follow-up:message-2',
             kind: 'follow_up',
@@ -158,12 +173,14 @@ describe('ChatTaskSummaryService', () => {
             id: `output-${index}`,
             kind: 'document' as const,
             title: `Output ${index}`,
+            resource: { type: 'artifact' as const, artifactId: `artifact-${index}` },
             updatedAt: `2026-07-13T01:${String(index).padStart(2, '0')}:00.000Z`
         }))
         outputs.push({
             id: 'output-1',
             kind: 'document',
             title: 'Newest output',
+            resource: { type: 'artifact', artifactId: 'artifact-1' },
             updatedAt: '2026-07-13T03:00:00.000Z'
         })
         const messageService = {
@@ -195,7 +212,7 @@ describe('ChatTaskSummaryService', () => {
         expect(page.items[0]).toMatchObject({ id: 'output-1', title: 'Newest output' })
     })
 
-    it('re-extracts outputs from messages with an incomplete persisted summary', async () => {
+    it('re-extracts outputs and sources from messages with an incomplete persisted summary', async () => {
         const messageService = {
             findAllInOrganizationOrTenant: jest
                 .fn()
@@ -218,6 +235,18 @@ describe('ChatTaskSummaryService', () => {
                                                 }
                                             ]
                                         }
+                                    }
+                                },
+                                {
+                                    type: 'component',
+                                    data: {
+                                        tool: 'web_search',
+                                        status: 'success',
+                                        output: [
+                                            'Title: Research report',
+                                            'URL: https://example.com/research-report',
+                                            'Published: 2026-07-13'
+                                        ].join('\n')
                                     }
                                 }
                             ],
@@ -251,8 +280,88 @@ describe('ChatTaskSummaryService', () => {
             ],
             total: 1
         })
+        expect(result.sources).toEqual({
+            items: [
+                expect.objectContaining({
+                    id: 'web:https://example.com/research-report',
+                    title: 'Research report',
+                    resource: { type: 'url', url: 'https://example.com/research-report' }
+                })
+            ],
+            total: 1
+        })
+    })
+
+    it('uses the request_user_input question for interrupted pending items', async () => {
+        const service = createEmptyService()
+        const interruptedConversation = conversation()
+        interruptedConversation.status = 'interrupted'
+        interruptedConversation.operation = {
+            tasks: [
+                {
+                    name: 'request_user_input',
+                    interrupts: [
+                        {
+                            value: {
+                                clientToolCalls: [
+                                    {
+                                        name: 'request_user_input',
+                                        args: {
+                                            questions: [
+                                                {
+                                                    id: 'implement_plan',
+                                                    header: '确认',
+                                                    question: '实施这个学习计划？',
+                                                    options: []
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        const result = await service.getSnapshot(interruptedConversation)
+
+        expect(result.pending).toEqual({
+            items: [
+                expect.objectContaining({
+                    kind: 'user_input',
+                    title: '实施这个学习计划？'
+                })
+            ],
+            total: 1
+        })
+    })
+
+    it('does not expose stale operation tasks after the conversation becomes idle', async () => {
+        const service = createEmptyService()
+        const idleConversation = conversation()
+        idleConversation.operation = {
+            tasks: [{ name: 'request_user_input', interrupts: [] }]
+        }
+
+        const result = await service.getSnapshot(idleConversation)
+
+        expect(result.pending).toEqual({ items: [], total: 0 })
     })
 })
+
+function createEmptyService() {
+    return new ChatTaskSummaryService(
+        {
+            findAllInOrganizationOrTenant: jest.fn(() => Promise.resolve({ items: [], total: 0 })),
+            save: jest.fn()
+        } as never,
+        { getByConversationId: jest.fn(() => Promise.resolve(null)) } as never,
+        { findAllInOrganizationOrTenant: jest.fn(() => Promise.resolve({ items: [], total: 0 })) } as never,
+        { find: jest.fn(() => Promise.resolve([])) } as never
+    )
+}
 
 function conversation(): ChatConversation {
     return {

--- a/packages/server-ai/src/chat-conversation/task-summary.service.ts
+++ b/packages/server-ai/src/chat-conversation/task-summary.service.ts
@@ -14,7 +14,7 @@ import { InjectRepository } from '@nestjs/typeorm'
 import { t } from 'i18next'
 import { IsNull, Repository } from 'typeorm'
 import { ChatMessageService } from '../chat-message/chat-message.service'
-import { extractChatMessageTaskSummary } from '../chat-message/task-summary'
+import { extractChatMessageTaskSummary, isCompletedOpenableTaskSummaryOutput } from '../chat-message/task-summary'
 import { XpertAgent } from '../xpert-agent/xpert-agent.entity'
 import { XpertAgentExecutionService } from '../xpert-agent-execution'
 import { ChatConversation } from './conversation.entity'
@@ -106,7 +106,17 @@ export class ChatTaskSummaryService {
             }),
             this.executionService.findAllInOrganizationOrTenant({
                 where: { threadId: conversation.threadId },
-                select: ['id', 'parentId', 'agentKey', 'title', 'status', 'elapsedTime', 'error', 'updatedAt'],
+                select: [
+                    'id',
+                    'parentId',
+                    'category',
+                    'agentKey',
+                    'title',
+                    'status',
+                    'elapsedTime',
+                    'error',
+                    'updatedAt'
+                ],
                 order: { updatedAt: 'DESC' }
             }),
             conversation.xpertId
@@ -120,25 +130,33 @@ export class ChatTaskSummaryService {
         const messages = messageResult.items
         const contributions = messages.flatMap((message) => {
             const persisted = message.taskSummary?.version === TASK_SUMMARY_VERSION ? message.taskSummary : undefined
+            const extracted = extractChatMessageTaskSummary(message)
             if (!persisted) {
-                const extracted = extractChatMessageTaskSummary(message)
-                return extracted.outputs?.length ? [extracted] : []
+                return extracted.outputs?.length || extracted.sources?.length ? [extracted] : []
             }
-            const extractedOutputs = extractChatMessageTaskSummary(message).outputs
             const existingOutputIds = new Set(persisted.outputs?.map((output) => output.id) ?? [])
-            const additionalOutputs = extractedOutputs?.filter((output) => !existingOutputIds.has(output.id)) ?? []
+            const additionalOutputs = extracted.outputs?.filter((output) => !existingOutputIds.has(output.id)) ?? []
+            const existingSourceIds = new Set(persisted.sources?.map((source) => source.id) ?? [])
+            const additionalSources = extracted.sources?.filter((source) => !existingSourceIds.has(source.id)) ?? []
             return [
                 {
                     ...persisted,
                     ...(additionalOutputs.length
                         ? { outputs: [...(persisted.outputs ?? []), ...additionalOutputs] }
+                        : {}),
+                    ...(additionalSources.length
+                        ? { sources: [...(persisted.sources ?? []), ...additionalSources] }
                         : {})
                 }
             ]
         })
         const plan = this.latestItem(contributions.flatMap((contribution) => contribution.plan ?? []))
         const todos = this.latestItem(contributions.flatMap((contribution) => contribution.todos ?? []))
-        const outputs = this.mergeLatest(contributions.flatMap((contribution) => contribution.outputs ?? []))
+        const outputs = this.mergeLatest(
+            contributions
+                .flatMap((contribution) => contribution.outputs ?? [])
+                .filter(isCompletedOpenableTaskSummaryOutput)
+        )
         const sources = this.mergeLatest(
             contributions
                 .flatMap((contribution) => contribution.sources ?? [])
@@ -153,7 +171,7 @@ export class ChatTaskSummaryService {
         )
         const agents = this.mergeAgents(
             executionResult.items
-                .filter((execution) => Boolean(execution.parentId))
+                .filter((execution) => execution.category === 'agent' && Boolean(execution.parentId))
                 .map((execution) => ({
                     id: execution.id,
                     parentId: execution.parentId,
@@ -224,17 +242,30 @@ export class ChatTaskSummaryService {
             createdAt?: Date
         }>
     ) {
-        const operationItems = (conversation.operation?.tasks ?? []).map((task, index) => ({
-            id: `operation:${task.name}:${index}`,
-            kind:
-                task.name === 'request_user_input' || task.info?.name === 'request_user_input'
-                    ? ('user_input' as const)
-                    : ('approval' as const),
-            title: task.info?.title?.trim() || task.info?.name?.trim() || task.name,
-            description: task.info?.description ? this.compact(task.info.description, 160) : undefined,
-            messageId: conversation.operation?.messageId,
-            createdAt: this.toIso(conversation.updatedAt)
-        }))
+        const operationItems = (conversation.status === 'interrupted' ? (conversation.operation?.tasks ?? []) : []).map(
+            (task, index) => {
+                const isUserInput = task.name === 'request_user_input' || task.info?.name === 'request_user_input'
+                const userInputCopy = isUserInput ? this.requestUserInputCopy(task) : null
+                return {
+                    id: `operation:${task.name}:${index}`,
+                    kind: isUserInput ? ('user_input' as const) : ('approval' as const),
+                    title:
+                        userInputCopy?.title ||
+                        task.info?.title?.trim() ||
+                        task.info?.name?.trim() ||
+                        (isUserInput
+                            ? t('server-ai:ChatTaskSummary.PendingUserInput', {
+                                  defaultValue: 'Waiting for your input'
+                              })
+                            : task.name),
+                    description:
+                        userInputCopy?.description ||
+                        (task.info?.description ? this.compact(task.info.description, 160) : undefined),
+                    messageId: conversation.operation?.messageId,
+                    createdAt: this.toIso(conversation.updatedAt)
+                }
+            }
+        )
         const followUps = messages.flatMap((message) =>
             message.id && message.followUpStatus === 'pending'
                 ? [
@@ -269,6 +300,42 @@ export class ChatTaskSummaryService {
                   ]
                 : []
         return [...operationItems, ...followUps, ...interrupted]
+    }
+
+    private requestUserInputCopy(task: NonNullable<NonNullable<ChatConversation['operation']>['tasks']>[number]) {
+        for (const interrupt of task.interrupts ?? []) {
+            if (!interrupt.value || typeof interrupt.value !== 'object' || Array.isArray(interrupt.value)) {
+                continue
+            }
+            const calls = (interrupt.value as { clientToolCalls?: unknown }).clientToolCalls
+            if (!Array.isArray(calls)) continue
+            for (const call of calls) {
+                if (!call || typeof call !== 'object' || Array.isArray(call)) continue
+                const candidate = call as { name?: unknown; args?: unknown }
+                if (candidate.name !== 'request_user_input') continue
+                if (!candidate.args || typeof candidate.args !== 'object' || Array.isArray(candidate.args)) continue
+                const questions = (candidate.args as { questions?: unknown }).questions
+                if (!Array.isArray(questions)) continue
+                const questionTexts = questions.flatMap((question) => {
+                    if (!question || typeof question !== 'object' || Array.isArray(question)) return []
+                    const candidateQuestion = question as { question?: unknown; header?: unknown }
+                    const questionText =
+                        typeof candidateQuestion.question === 'string' && candidateQuestion.question.trim()
+                            ? candidateQuestion.question.trim()
+                            : typeof candidateQuestion.header === 'string'
+                              ? candidateQuestion.header.trim()
+                              : ''
+                    return questionText ? [questionText] : []
+                })
+                if (!questionTexts.length) continue
+                return {
+                    title: this.compact(questionTexts[0], 160),
+                    description:
+                        questionTexts.length > 1 ? this.compact(questionTexts.slice(1).join(' · '), 160) : undefined
+                }
+            }
+        }
+        return null
     }
 
     private mergeLatest<T extends { id: string; updatedAt?: string }>(items: T[]) {

--- a/packages/server-ai/src/chat-message/task-summary.spec.ts
+++ b/packages/server-ai/src/chat-message/task-summary.spec.ts
@@ -60,6 +60,18 @@ describe('extractChatMessageTaskSummary', () => {
                                         title: 'Report',
                                         resource: { type: 'artifact', artifactId: 'artifact-1' }
                                     },
+                                    {
+                                        id: 'pending-output',
+                                        kind: 'document',
+                                        title: 'Pending report',
+                                        status: 'pending',
+                                        resource: { type: 'artifact', artifactId: 'artifact-pending' }
+                                    },
+                                    {
+                                        id: 'closed-output',
+                                        kind: 'document',
+                                        title: 'No resource'
+                                    },
                                     { id: 'unknown-1', kind: 'shell', title: 'Raw shell output', raw: 'secret' }
                                 ]
                             },
@@ -71,6 +83,11 @@ describe('extractChatMessageTaskSummary', () => {
                             artifactLink: {
                                 artifactId: 'artifact-3',
                                 title: 'Linked artifact'
+                            },
+                            file: {
+                                artifactId: 'artifact-pending',
+                                title: 'Pending artifact',
+                                status: 'running'
                             }
                         }
                     },
@@ -86,8 +103,7 @@ describe('extractChatMessageTaskSummary', () => {
             'artifact:artifact-2',
             'artifact:artifact-3',
             'image:https://example.com/result.png',
-            'url:https://example.com/site',
-            'mcp-app:app-1'
+            'url:https://example.com/site'
         ])
         expect(summary.outputs?.find((output) => output.id === 'output-1')?.resource).toEqual({
             type: 'artifact',
@@ -159,6 +175,61 @@ describe('extractChatMessageTaskSummary', () => {
         expect(JSON.stringify(summary)).not.toContain('token=secret')
     })
 
+    it('keeps only completed outputs and hides files from an incomplete parent artifact', () => {
+        const summary = extractChatMessageTaskSummary(
+            message({
+                content: [
+                    {
+                        type: 'component',
+                        data: {
+                            taskSummary: {
+                                version: 1,
+                                outputs: [
+                                    {
+                                        id: 'successful-report',
+                                        kind: 'document',
+                                        title: 'Successful report',
+                                        status: 'success',
+                                        resource: { type: 'artifact', artifactId: 'artifact-success' }
+                                    },
+                                    {
+                                        id: 'legacy-report',
+                                        kind: 'document',
+                                        title: 'Legacy report',
+                                        resource: { type: 'artifact', artifactId: 'artifact-legacy' }
+                                    },
+                                    {
+                                        id: 'processing-report',
+                                        kind: 'document',
+                                        title: 'Processing report',
+                                        status: 'processing',
+                                        resource: { type: 'artifact', artifactId: 'artifact-processing' }
+                                    }
+                                ]
+                            },
+                            artifact: {
+                                status: 'running',
+                                files: [
+                                    {
+                                        fileName: 'unfinished.pdf',
+                                        workspacePath: 'files/unfinished.pdf'
+                                    }
+                                ]
+                            },
+                            artifactLink: {
+                                artifactId: 'artifact-cancelled',
+                                title: 'Cancelled report',
+                                status: 'cancelled'
+                            }
+                        }
+                    }
+                ]
+            })
+        )
+
+        expect(summary.outputs?.map((output) => output.id)).toEqual(['successful-report', 'legacy-report'])
+    })
+
     it('extracts structured artifacts returned by tools through output text', () => {
         const summary = extractChatMessageTaskSummary(
             message({
@@ -210,7 +281,81 @@ describe('extractChatMessageTaskSummary', () => {
         expect(JSON.stringify(summary)).not.toContain('example.com/artifacts/share/secret')
     })
 
-    it('preserves element and file_element references and capability sources', () => {
+    it('projects successful sandbox files and web search results from program components', () => {
+        const summary = extractChatMessageTaskSummary(
+            message({
+                content: [
+                    {
+                        type: 'component',
+                        data: {
+                            tool: 'web_search',
+                            status: 'success',
+                            output: [
+                                'Title: Stanford AI Index 2026',
+                                'URL: https://hai.stanford.edu/ai-index/2026-ai-index-report',
+                                'Published: 2026-04-01',
+                                'Highlights: Research findings',
+                                '',
+                                'Title: N/A',
+                                'URL: https://example.com/research/report.pdf',
+                                'Published: 2026-03-01'
+                            ].join('\n')
+                        }
+                    },
+                    {
+                        type: 'component',
+                        data: {
+                            tool: 'sandbox_write_file',
+                            status: 'success',
+                            input: { file_path: 'reports/AI_Industry_Trends_Report_2026.md' },
+                            output: JSON.stringify({
+                                path: '/workspace/reports/AI_Industry_Trends_Report_2026.md',
+                                filesUpdate: null
+                            })
+                        }
+                    }
+                ]
+            })
+        )
+
+        expect(summary.outputs).toEqual([
+            {
+                id: 'workspace-file:reports/AI_Industry_Trends_Report_2026.md',
+                kind: 'document',
+                title: 'AI_Industry_Trends_Report_2026.md',
+                status: 'success',
+                resource: {
+                    type: 'workspace_file',
+                    workspacePath: 'reports/AI_Industry_Trends_Report_2026.md'
+                },
+                messageId: 'message-1',
+                updatedAt: '2026-07-13T01:00:00.000Z'
+            }
+        ])
+        expect(summary.sources).toEqual([
+            {
+                id: 'web:https://hai.stanford.edu/ai-index/2026-ai-index-report',
+                kind: 'web_page',
+                title: 'Stanford AI Index 2026',
+                description: 'https://hai.stanford.edu/ai-index/2026-ai-index-report',
+                resource: { type: 'url', url: 'https://hai.stanford.edu/ai-index/2026-ai-index-report' },
+                messageId: 'message-1',
+                updatedAt: '2026-07-13T01:00:00.000Z'
+            },
+            {
+                id: 'web:https://example.com/research/report.pdf',
+                kind: 'web_page',
+                title: 'example.com',
+                description: 'https://example.com/research/report.pdf',
+                resource: { type: 'url', url: 'https://example.com/research/report.pdf' },
+                messageId: 'message-1',
+                updatedAt: '2026-07-13T01:00:00.000Z'
+            }
+        ])
+        expect(JSON.stringify(summary)).not.toContain('/workspace/')
+    })
+
+    it('preserves reference sources without treating configured capabilities as sources', () => {
         const summary = extractChatMessageTaskSummary(
             message({
                 references: [
@@ -255,9 +400,7 @@ describe('extractChatMessageTaskSummary', () => {
         expect(summary.sources?.map((source) => source.id)).toEqual([
             'element-1',
             'file-element-1',
-            'attachment:file-1',
-            'skill:slides',
-            'plugin:github'
+            'attachment:file-1'
         ])
         expect(summary.sources?.[0]?.resource).toEqual({
             type: 'browser',

--- a/packages/server-ai/src/chat-message/task-summary.ts
+++ b/packages/server-ai/src/chat-message/task-summary.ts
@@ -14,6 +14,13 @@ const SUMMARY_VERSION = 1 as const
 const PLAN_EXCERPT_LENGTH = 160
 const PLAN_PATTERN = /<proposed_plan>\s*([\s\S]*?)\s*<\/proposed_plan>/i
 const MARKDOWN_LINK_PATTERN = /\[[^\]]*\]\((xpert:\/\/knowledgebase\/chunk\?[^)]+)\)/g
+const WEB_SEARCH_RESULT_PATTERN = /^Title:\s*(.+?)\r?\nURL:\s*(https?:\/\/\S+)\s*$/gim
+const SANDBOX_FILE_OUTPUT_TOOLS = new Set([
+    'sandbox_write_file',
+    'sandbox_append_file',
+    'sandbox_edit_file',
+    'sandbox_multi_edit_file'
+])
 
 type MessageContentPart = {
     id?: unknown
@@ -36,6 +43,7 @@ type ComponentData = {
     input?: unknown
     tool?: unknown
     output?: unknown
+    status?: unknown
     url?: unknown
 }
 
@@ -49,6 +57,7 @@ type ArtifactCandidate = {
     kind?: unknown
     title?: unknown
     description?: unknown
+    status?: unknown
     files?: unknown
     workspacePath?: unknown
     filePath?: unknown
@@ -125,6 +134,10 @@ type TodoCandidate = {
     status?: unknown
 }
 
+type SandboxFileInputCandidate = {
+    file_path?: unknown
+}
+
 type FileAssetCandidate = {
     id?: unknown
     fileAssetId?: unknown
@@ -133,20 +146,6 @@ type FileAssetCandidate = {
     originalName?: unknown
     name?: unknown
     fileName?: unknown
-}
-
-type RuntimeCapabilitiesMetadata = {
-    runtimeCapabilities?: unknown
-}
-
-type RuntimeCapabilitiesCandidate = {
-    skills?: unknown
-    plugins?: unknown
-}
-
-type CapabilityIdsCandidate = {
-    ids?: unknown
-    nodeKeys?: unknown
 }
 
 function isObjectValue(value: unknown): value is object {
@@ -280,10 +279,6 @@ function isSourceKind(value: unknown): value is ChatTaskSummarySourceKind {
     )
 }
 
-function isOutputStatus(value: unknown): value is ChatTaskSummaryOutput['status'] {
-    return value === 'pending' || value === 'running' || value === 'success' || value === 'error'
-}
-
 function normalizeResource(value: unknown): ChatTaskSummaryOutput['resource'] | undefined {
     if (!isObjectValue(value)) {
         return undefined
@@ -377,7 +372,16 @@ function normalizeOutput(value: unknown, messageId?: string, updatedAt?: string)
     const output = value as TaskSummaryOutputCandidate
     const id = readString(output.id)
     const title = readString(output.title)
-    if (!id || !title || !isOutputKind(output.kind)) {
+    const rawStatus = readString(output.status)?.toLowerCase()
+    const status = rawStatus === 'success' ? rawStatus : undefined
+    const resource = normalizeResource(output.resource)
+    if (
+        !id ||
+        !title ||
+        !isOutputKind(output.kind) ||
+        (rawStatus !== undefined && rawStatus !== 'success') ||
+        !isOpenableOutputResource(resource)
+    ) {
         return undefined
     }
     return {
@@ -385,11 +389,21 @@ function normalizeOutput(value: unknown, messageId?: string, updatedAt?: string)
         kind: output.kind,
         title: compactText(title, 160),
         description: readString(output.description),
-        status: isOutputStatus(output.status) ? output.status : undefined,
-        resource: normalizeResource(output.resource),
+        status,
+        resource,
         messageId: readString(output.messageId) ?? messageId,
         updatedAt: toIsoString(output.updatedAt) ?? updatedAt
     }
+}
+
+export function isCompletedOpenableTaskSummaryOutput(output: ChatTaskSummaryOutput) {
+    return (output.status === undefined || output.status === 'success') && isOpenableOutputResource(output.resource)
+}
+
+function isOpenableOutputResource(
+    resource: ChatTaskSummaryOutput['resource']
+): resource is NonNullable<ChatTaskSummaryOutput['resource']> {
+    return resource?.type === 'workspace_file' || resource?.type === 'artifact' || resource?.type === 'url'
 }
 
 function normalizeSource(value: unknown, messageId?: string, updatedAt?: string): ChatTaskSummarySource | undefined {
@@ -459,6 +473,9 @@ function artifactOutput(value: unknown, messageId?: string, updatedAt?: string):
         return undefined
     }
     const artifact = value as ArtifactCandidate
+    if (!isCompletedOutputStatus(artifact.status)) {
+        return undefined
+    }
     const artifactId = readString(artifact.artifactId) ?? readString(artifact.id)
     const workspacePath = readString(artifact.workspacePath) ?? readString(artifact.filePath)
     const fileId = readString(artifact.fileAssetId) ?? readString(artifact.storageFileId)
@@ -502,11 +519,19 @@ function artifactOutputs(value: unknown, messageId?: string, updatedAt?: string)
         return []
     }
     const artifact = value as ArtifactCandidate
+    if (!isCompletedOutputStatus(artifact.status)) {
+        return []
+    }
     const output = artifactOutput(value, messageId, updatedAt)
     const files = Array.isArray(artifact.files)
         ? artifact.files.flatMap((file) => artifactOutput(file, messageId, updatedAt) ?? [])
         : []
     return [...(output ? [output] : []), ...files]
+}
+
+function isCompletedOutputStatus(value: unknown) {
+    const status = readString(value)?.toLowerCase()
+    return status === undefined || status === 'success'
 }
 
 function parseStructuredOutput(value: unknown): Record<string, unknown> | undefined {
@@ -525,6 +550,11 @@ function parseStructuredOutput(value: unknown): Record<string, unknown> | undefi
 }
 
 function structuredToolOutputs(data: ComponentData, messageId?: string, updatedAt?: string) {
+    const sandboxOutput = sandboxFileOutput(data, messageId, updatedAt)
+    if (sandboxOutput) {
+        return [sandboxOutput]
+    }
+
     const payload = parseStructuredOutput(data.output)
     if (!payload) {
         return []
@@ -553,6 +583,47 @@ function structuredToolOutputs(data: ComponentData, messageId?: string, updatedA
         outputs.push(...artifactOutputs(payload.file, messageId, updatedAt))
     }
     return outputs
+}
+
+function sandboxFileOutput(
+    data: ComponentData,
+    messageId?: string,
+    updatedAt?: string
+): ChatTaskSummaryOutput | undefined {
+    const tool = readString(data.tool)
+    const status = readString(data.status)?.toLowerCase()
+    if (!tool || !SANDBOX_FILE_OUTPUT_TOOLS.has(tool) || status !== 'success' || !isObjectValue(data.input)) {
+        return undefined
+    }
+    const workspacePath = portableWorkspacePath((data.input as SandboxFileInputCandidate).file_path)
+    if (!workspacePath) {
+        return undefined
+    }
+    return {
+        id: `workspace-file:${workspacePath}`,
+        kind: artifactKind({ fileName: workspacePath }),
+        title: fileNameFromPath(workspacePath) ?? workspacePath,
+        status: 'success',
+        resource: { type: 'workspace_file', workspacePath },
+        ...(messageId ? { messageId } : {}),
+        ...(updatedAt ? { updatedAt } : {})
+    }
+}
+
+function portableWorkspacePath(value: unknown) {
+    const path = readString(value)
+        ?.replace(/\\/g, '/')
+        .replace(/^\.\/+/, '')
+        .replace(/\/{2,}/g, '/')
+    if (
+        !path ||
+        path.startsWith('/') ||
+        /^[a-z]:\//i.test(path) ||
+        path.split('/').some((segment) => segment === '..')
+    ) {
+        return undefined
+    }
+    return path
 }
 
 function artifactKind(artifact: ArtifactCandidate): ChatTaskSummaryOutputKind {
@@ -678,16 +749,6 @@ function partOutputs(part: MessageContentPart, messageId?: string, updatedAt?: s
     const data = part.data as ComponentData
     const explicit = readExplicitContribution(data, messageId, updatedAt)
     outputs.push(...(explicit?.outputs ?? []))
-    if (data.type === 'McpApp') {
-        outputs.push({
-            id: `mcp-app:${readString(part.id) ?? messageId ?? 'message'}`,
-            kind: 'mcp_app',
-            title: readString(data.title) ?? 'MCP App',
-            resource: messageId ? { type: 'message', messageId } : undefined,
-            ...(messageId ? { messageId } : {}),
-            ...(updatedAt ? { updatedAt } : {})
-        })
-    }
     outputs.push(...artifactOutputs(data.artifact, messageId, updatedAt))
     outputs.push(...artifactOutputs(data.artifactLink, messageId, updatedAt))
     outputs.push(...artifactOutputs(data.file, messageId, updatedAt))
@@ -769,42 +830,6 @@ function fileSource(value: unknown, messageId?: string, updatedAt?: string): Cha
     }
 }
 
-function capabilitySources(value: unknown, messageId?: string, updatedAt?: string) {
-    if (!isObjectValue(value)) {
-        return []
-    }
-    const metadata = value as RuntimeCapabilitiesMetadata
-    if (!isObjectValue(metadata.runtimeCapabilities)) {
-        return []
-    }
-    const capabilities = metadata.runtimeCapabilities as RuntimeCapabilitiesCandidate
-    const groups: Array<{ kind: ChatTaskSummarySourceKind; prefix: string; value: unknown }> = [
-        { kind: 'skill', prefix: 'skill', value: capabilities.skills },
-        { kind: 'plugin', prefix: 'plugin', value: capabilities.plugins }
-    ]
-    return groups.flatMap(({ kind, prefix, value: groupValue }) => {
-        if (!isObjectValue(groupValue)) {
-            return []
-        }
-        const group = groupValue as CapabilityIdsCandidate
-        const ids = Array.isArray(group.ids) ? group.ids : Array.isArray(group.nodeKeys) ? group.nodeKeys : []
-        return ids.flatMap((entry) => {
-            const id = readString(entry)
-            return id
-                ? [
-                      {
-                          id: `${prefix}:${id}`,
-                          kind,
-                          title: id,
-                          ...(messageId ? { messageId } : {}),
-                          ...(updatedAt ? { updatedAt } : {})
-                      } satisfies ChatTaskSummarySource
-                  ]
-                : []
-        })
-    })
-}
-
 function knowledgeSources(content: unknown, messageId?: string, updatedAt?: string) {
     const text = readMessageText(content)
     const sources: ChatTaskSummarySource[] = []
@@ -833,6 +858,52 @@ function knowledgeSources(content: unknown, messageId?: string, updatedAt?: stri
         }
     }
     return sources
+}
+
+function webSearchSources(part: MessageContentPart, messageId?: string, updatedAt?: string) {
+    if (part.type !== 'component' || !isObjectValue(part.data)) {
+        return []
+    }
+    const data = part.data as ComponentData
+    if (data.tool !== 'web_search' || readString(data.status)?.toLowerCase() !== 'success') {
+        return []
+    }
+    const output = readString(data.output)
+    if (!output) {
+        return []
+    }
+    const sources: ChatTaskSummarySource[] = []
+    for (const match of output.matchAll(WEB_SEARCH_RESULT_PATTERN)) {
+        const rawTitle = readString(match[1])
+        const url = httpUrl(match[2])
+        if (!url) {
+            continue
+        }
+        const title = rawTitle && rawTitle.toLowerCase() !== 'n/a' ? rawTitle : new URL(url).hostname
+        sources.push({
+            id: `web:${url}`,
+            kind: 'web_page',
+            title: compactText(title, 160),
+            description: url,
+            resource: { type: 'url', url },
+            ...(messageId ? { messageId } : {}),
+            ...(updatedAt ? { updatedAt } : {})
+        })
+    }
+    return sources
+}
+
+function httpUrl(value: unknown) {
+    const url = readString(value)
+    if (!url) {
+        return undefined
+    }
+    try {
+        const parsed = new URL(url)
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? url : undefined
+    } catch {
+        return undefined
+    }
 }
 
 function dedupeById<T extends { id: string }>(items: T[]) {
@@ -883,7 +954,7 @@ export function extractChatMessageTaskSummary(
         ...(message.references ?? []).map((reference) => referenceSource(reference, messageId, updatedAt)),
         ...(message.fileAssets ?? []).flatMap((file) => fileSource(file, messageId, updatedAt) ?? []),
         ...(message.attachments ?? []).flatMap((file) => fileSource(file, messageId, updatedAt) ?? []),
-        ...capabilitySources(message.thirdPartyMessage, messageId, updatedAt),
+        ...parts.flatMap((part) => webSearchSources(part, messageId, updatedAt)),
         ...knowledgeSources(message.content, messageId, updatedAt)
     ])
 

--- a/packages/server-ai/src/i18n/en-US.json
+++ b/packages/server-ai/src/i18n/en-US.json
@@ -655,6 +655,7 @@
     },
     "ChatTaskSummary": {
         "Agent": "Agent",
+        "PendingUserInput": "Waiting for your input",
         "PendingSteeringMessage": "Pending steering message",
         "PendingFollowUpMessage": "Pending follow-up message",
         "ConversationNeedsInput": "Conversation needs input"

--- a/packages/server-ai/src/i18n/en.json
+++ b/packages/server-ai/src/i18n/en.json
@@ -655,6 +655,7 @@
     },
     "ChatTaskSummary": {
         "Agent": "Agent",
+        "PendingUserInput": "Waiting for your input",
         "PendingSteeringMessage": "Pending steering message",
         "PendingFollowUpMessage": "Pending follow-up message",
         "ConversationNeedsInput": "Conversation needs input"

--- a/packages/server-ai/src/i18n/zh-Hans.json
+++ b/packages/server-ai/src/i18n/zh-Hans.json
@@ -655,6 +655,7 @@
     },
     "ChatTaskSummary": {
         "Agent": "智能体",
+        "PendingUserInput": "等待你的输入",
         "PendingSteeringMessage": "待处理的引导消息",
         "PendingFollowUpMessage": "待处理的追问消息",
         "ConversationNeedsInput": "会话需要输入"

--- a/packages/server-ai/src/sandbox/middlewares/sandbox-file.middleware.spec.ts
+++ b/packages/server-ai/src/sandbox/middlewares/sandbox-file.middleware.spec.ts
@@ -1,7 +1,17 @@
 import { WorkflowNodeTypeEnum } from '@xpert-ai/contracts'
 import { SandboxFileMiddleware } from './sandbox-file.middleware'
 
+jest.mock('@langchain/core/callbacks/dispatch', () => ({
+    dispatchCustomEvent: jest.fn().mockResolvedValue(undefined)
+}))
+
 jest.mock('@xpert-ai/contracts', () => ({
+    ChatMessageEventTypeEnum: {
+        ON_TOOL_MESSAGE: 'ON_TOOL_MESSAGE'
+    },
+    ChatMessageStepCategory: {
+        Program: 'Program'
+    },
     WorkflowNodeTypeEnum: {
         MIDDLEWARE: 'middleware'
     },
@@ -97,5 +107,49 @@ describe('SandboxFileMiddleware', () => {
             'sandbox_multi_edit_file',
             'sandbox_list_dir'
         ])
+    })
+
+    it('returns the caller workspace path instead of the provider absolute path after writing', async () => {
+        const middleware = new SandboxFileMiddleware()
+        const agentMiddleware = await Promise.resolve(
+            middleware.createMiddleware(
+                {},
+                {
+                    tenantId: 'tenant-1',
+                    userId: 'user-1',
+                    xpertFeatures: createXpertFeatures(),
+                    node: {
+                        id: 'middleware-1',
+                        key: 'middleware-1',
+                        type: WorkflowNodeTypeEnum.MIDDLEWARE,
+                        provider: 'sandbox-file'
+                    },
+                    runtime: {} as never,
+                    tools: new Map()
+                }
+            )
+        )
+        const writeTool = agentMiddleware.tools.find((tool) => tool.name === 'sandbox_write_file')
+        const backend = {
+            workingDirectory: '/workspace',
+            write: jest.fn().mockResolvedValue({
+                path: '/workspace/reports/report.md',
+                filesUpdate: null
+            })
+        }
+
+        const result = await writeTool?.invoke(
+            { file_path: 'reports/report.md', content: '# Report' },
+            {
+                configurable: { sandbox: { backend } },
+                metadata: { tool_call_id: 'tool-call-1' }
+            }
+        )
+
+        expect(backend.write).toHaveBeenCalledWith('/workspace/reports/report.md', '# Report')
+        expect(JSON.parse(result as string)).toEqual({
+            path: 'reports/report.md',
+            filesUpdate: null
+        })
     })
 })

--- a/packages/server-ai/src/sandbox/middlewares/sandbox-file.middleware.ts
+++ b/packages/server-ai/src/sandbox/middlewares/sandbox-file.middleware.ts
@@ -149,6 +149,12 @@ function resolveSandboxPath(config: any, fileOrDirPath?: string): string {
     return isAbsolute(fileOrDirPath) ? fileOrDirPath : resolve(workingDirectory, fileOrDirPath)
 }
 
+function stringifyPortableFileResult(result: unknown, filePath: string) {
+    const portableResult =
+        typeof result === 'object' && result !== null && !Array.isArray(result) ? { ...result, path: filePath } : result
+    return JSON.stringify(portableResult, null, 2)
+}
+
 @Injectable()
 @AgentMiddlewareStrategy(SANDBOX_FILE_MIDDLEWARE_NAME)
 export class SandboxFileMiddleware implements IAgentMiddlewareStrategy {
@@ -239,7 +245,7 @@ export class SandboxFileMiddleware implements IAgentMiddlewareStrategy {
                     { file_path },
                     async () => {
                         const result = await backend.edit(resolvedFilePath, old_string, new_string, replace_all)
-                        return JSON.stringify(result, null, 2)
+                        return stringifyPortableFileResult(result, file_path)
                     }
                 )
             },
@@ -263,7 +269,7 @@ export class SandboxFileMiddleware implements IAgentMiddlewareStrategy {
                     async () => {
                         const normalizedContent = Array.isArray(content) ? content.join('') : content
                         const result = await backend.write(resolvedFilePath, normalizedContent)
-                        return JSON.stringify(result, null, 2)
+                        return stringifyPortableFileResult(result, file_path)
                     }
                 )
             },
@@ -283,7 +289,7 @@ CRITICAL FORMAT REQUIREMENTS:
 
 CORRECT format:
 {
-  "file_path": "/path/to/file.js",
+  "file_path": "path/to/file.js",
   "content": "const x = 1;\\nconst y = 2;\\nconsole.log(x + y);"
 }
 
@@ -308,7 +314,7 @@ INCORRECT format (DO NOT USE):
                     async () => {
                         const normalizedContent = Array.isArray(content) ? content.join('') : content
                         const result = await backend.append(resolvedFilePath, normalizedContent)
-                        return JSON.stringify(result, null, 2)
+                        return stringifyPortableFileResult(result, file_path)
                     }
                 )
             },
@@ -342,7 +348,7 @@ CRITICAL FORMAT REQUIREMENTS:
                     { file_path },
                     async () => {
                         const result = await backend.multiEdit(resolvedFilePath, edits as EditOperation[])
-                        return JSON.stringify(result, null, 2)
+                        return stringifyPortableFileResult(result, file_path)
                     }
                 )
             },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,8 +632,8 @@ importers:
         specifier: ~0.5.7
         version: 0.5.7(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       '@xpert-ai/chatkit-ui':
-        specifier: ~0.5.8
-        version: 0.5.8(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(babel-plugin-macros@3.1.0)(openai@5.23.2(ws@8.21.0)(zod@3.25.67))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(signal-polyfill@0.2.2)(typescript@5.9.3)(vite@7.3.0(@types/node@22.20.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.59.0)(terser@5.46.0)(yaml@2.8.2))
+        specifier: ~0.5.9
+        version: 0.5.9(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(babel-plugin-macros@3.1.0)(openai@5.23.2(ws@8.21.0)(zod@3.25.67))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(signal-polyfill@0.2.2)(typescript@5.9.3)(vite@7.3.0(@types/node@22.20.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.59.0)(terser@5.46.0)(yaml@2.8.2))
       '@xpert-ai/chatkit-web-component':
         specifier: ~0.5.4
         version: 0.5.4(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
@@ -10268,8 +10268,8 @@ packages:
       '@a2ui/lit': ^0.8.1
       '@langchain/core': 0.3.72
 
-  '@xpert-ai/chatkit-ui@0.5.8':
-    resolution: {integrity: sha512-B2yRIw4FG7KtHB+Lfvr+poyRVvKoWh6qvm3fSNMYKhKnT07XZWbSgkhQ9txUYofExsmPZknMddnU53bjhIIrHw==}
+  '@xpert-ai/chatkit-ui@0.5.9':
+    resolution: {integrity: sha512-CEcIxR2scWLwKC9G6XNRhEnVuyBnPiZSjsOKZ3x0WCGyWmiGrC0fWaFdADq8i4CI01uxYe6yfUWmOQilAb4hpQ==}
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
@@ -34755,7 +34755,7 @@ snapshots:
       '@a2ui/lit': 0.8.3(signal-polyfill@0.2.2)
       '@langchain/core': 0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67))
 
-  '@xpert-ai/chatkit-ui@0.5.8(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(babel-plugin-macros@3.1.0)(openai@5.23.2(ws@8.21.0)(zod@3.25.67))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(signal-polyfill@0.2.2)(typescript@5.9.3)(vite@7.3.0(@types/node@22.20.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.59.0)(terser@5.46.0)(yaml@2.8.2))':
+  '@xpert-ai/chatkit-ui@0.5.9(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(babel-plugin-macros@3.1.0)(openai@5.23.2(ws@8.21.0)(zod@3.25.67))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(signal-polyfill@0.2.2)(typescript@5.9.3)(vite@7.3.0(@types/node@22.20.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.59.0)(terser@5.46.0)(yaml@2.8.2))':
     dependencies:
       '@fontsource-variable/geist': 5.2.9
       '@fontsource-variable/inter': 5.2.8


### PR DESCRIPTION
## Summary

- upgrade the Cloud app to @xpert-ai/chatkit-ui 0.5.9 and cap the embedded ClawXpert chat column at 840px
- keep Task Summary outputs completed and openable, derive sources from actual execution, and show the real request_user_input question
- return portable Sandbox file paths so generated workspace files can be projected as openable outputs

## Validation

- Cloud ClawXpert Jest: 85 passed
- Server-AI focused Jest: 16 passed
- Cloud and Server-AI TypeScript checks passed
- pnpm frozen lockfile check passed
- i18n JSON, hardcoded-color, TypeORM-column, and git diff checks passed