### PR TITLE
fix(knowledge): canonicalize managed file URLs

### DIFF
--- a/packages/server-ai/src/knowledge-document/document.service.spec.ts
+++ b/packages/server-ai/src/knowledge-document/document.service.spec.ts
@@ -4,18 +4,22 @@ jest.mock('@xpert-ai/plugin-sdk', () => ({
     TextSplitterRegistry: class TextSplitterRegistry {},
     mergeParentChildChunks: jest.fn((_pages, chunks) => chunks)
 }))
-jest.mock('../knowledgebase', () => ({
+jest.mock('../knowledgebase/knowledgebase.service', () => ({
     KnowledgebaseService: class KnowledgebaseService {}
 }))
-jest.mock('../shared', () => ({
-    KnowledgeWorkAreaResolver: class KnowledgeWorkAreaResolver {},
+jest.mock('../shared/volume/work-area', () => ({
+    KnowledgeWorkAreaResolver: class KnowledgeWorkAreaResolver {}
+}))
+jest.mock('../shared/volume/volume-subtree', () => ({
     VolumeSubtreeClient: class VolumeSubtreeClient {
         constructor(private readonly volume: { readFile: (...args: unknown[]) => Promise<unknown> }) {}
 
         readFile(...args: unknown[]) {
             return this.volume.readFile(...args)
         }
-    },
+    }
+}))
+jest.mock('../shared/commands/load-storage-file.command', () => ({
     LoadStorageFileCommand: class LoadStorageFileCommand {
         constructor(public readonly input: unknown) {}
     }
@@ -295,6 +299,28 @@ describe('KnowledgeDocumentService access boundaries', () => {
         await expect(
             service.prepareExternalDocumentInputs([{ fileUrl: 'http://127.0.0.1/internal' }])
         ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('replaces a client file URL with the canonical managed file URL', async () => {
+        const readFile = jest.fn().mockResolvedValue({
+            filePath: 'reports/summary.pdf',
+            fileUrl: 'https://files.example.test/reports/summary.pdf'
+        })
+        const service = createService([], {
+            knowledgeWorkAreaResolver: {
+                resolve: jest.fn(async () => ({ volume: { readFile } }))
+            }
+        })
+        const document = {
+            knowledgebaseId: 'kb-owner',
+            filePath: 'files/reports/summary.pdf',
+            fileUrl: 'http://127.0.0.1/internal'
+        }
+
+        await service.prepareExternalDocumentInputs([document])
+
+        expect(readFile).toHaveBeenCalledWith('files', 'reports/summary.pdf', { metadataOnly: true })
+        expect(document.fileUrl).toBe('https://files.example.test/reports/summary.pdf')
     })
 
     it('replaces a client file URL with the canonical owned StorageFile URL', async () => {

--- a/packages/server-ai/src/knowledge-document/document.service.ts
+++ b/packages/server-ai/src/knowledge-document/document.service.ts
@@ -457,6 +457,12 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
                 continue
             }
 
+            if (typeof document.filePath === 'string' && document.filePath.trim()) {
+                delete document.fileUrl
+                await this.canonicalizeExternalManagedFile(document, options?.resolveDocumentIds === true)
+                continue
+            }
+
             if (typeof document.fileUrl === 'string' && document.fileUrl.trim()) {
                 throw new BadRequestException(
                     'Remote fileUrl cannot be submitted directly. Upload the file first and use storageFileId.'


### PR DESCRIPTION
## Summary

- accept knowledgebase-managed uploads that contain both filePath and fileUrl
- discard the submitted URL and resolve canonical metadata through the scoped managed volume
- keep rejecting standalone remote URLs without an authorized StorageFile
- update the focused service test mocks to current direct import paths and add regression coverage

## Testing

- document.service.spec.ts: 43 passed
- server-ai production TypeScript check passed
- focused ESLint: 0 errors
- git diff --check passed