### PR TITLE
fix: harden GraphRAG indexing and retrieval

### DIFF
--- a/packages/server-ai/src/graphrag/graphrag.service.spec.ts
+++ b/packages/server-ai/src/graphrag/graphrag.service.spec.ts
@@ -1,7 +1,7 @@
 import { Queue } from 'bull'
 import { QueryBus } from '@nestjs/cqrs'
 import { Repository } from 'typeorm'
-import { AiModelTypeEnum, KnowledgebaseTypeEnum } from '@xpert-ai/contracts'
+import { AiModelTypeEnum, KnowledgebaseTypeEnum, KnowledgeGraphIndexJobStatus } from '@xpert-ai/contracts'
 import { Knowledgebase } from '../knowledgebase/knowledgebase.entity'
 import { KnowledgebaseService } from '../knowledgebase'
 import { CopilotModelGetChatModelQuery } from '../copilot-model'
@@ -14,7 +14,12 @@ import {
     KnowledgeGraphMention,
     KnowledgeGraphRelation
 } from './entities'
-import { GraphragService, normalizeKnowledgeGraphName, normalizeKnowledgeGraphType } from './graphrag.service'
+import {
+    GraphragService,
+    normalizeKnowledgeGraphName,
+    normalizeKnowledgeGraphType,
+    validateKnowledgeGraphExtractionEvidence
+} from './graphrag.service'
 import { TKnowledgeGraphIndexQueueJob } from './types'
 
 function repositoryMock<T>() {
@@ -52,6 +57,68 @@ describe('GraphRAG service', () => {
     it('normalizes entity names and types with stable explicit keys', () => {
         expect(normalizeKnowledgeGraphName('  OpenAI   Platform  ')).toBe('openai platform')
         expect(normalizeKnowledgeGraphType('Product Area')).toBe('product_area')
+    })
+
+    it('requires extracted graph items to reference evidence from the current chunks', () => {
+        expect(() =>
+            validateKnowledgeGraphExtractionEvidence(
+                {
+                    entities: [],
+                    relations: []
+                },
+                new Set(['chunk-1'])
+            )
+        ).toThrow('valid source evidence')
+
+        expect(() =>
+            validateKnowledgeGraphExtractionEvidence(
+                {
+                    entities: [
+                        {
+                            name: 'User-Centered Design',
+                            type: 'concept'
+                        }
+                    ],
+                    relations: []
+                },
+                new Set(['chunk-1'])
+            )
+        ).toThrow('valid source evidence')
+
+        expect(() =>
+            validateKnowledgeGraphExtractionEvidence(
+                {
+                    entities: [],
+                    relations: [
+                        {
+                            sourceName: 'Designer',
+                            sourceType: 'role',
+                            targetName: 'Prototype',
+                            targetType: 'artifact',
+                            type: 'creates',
+                            evidence: [{ chunkId: 'missing-chunk' }]
+                        }
+                    ]
+                },
+                new Set(['chunk-1'])
+            )
+        ).toThrow('valid source evidence')
+
+        expect(() =>
+            validateKnowledgeGraphExtractionEvidence(
+                {
+                    entities: [
+                        {
+                            name: 'User-Centered Design',
+                            type: 'concept',
+                            evidence: [{ chunkId: 'chunk-1' }]
+                        }
+                    ],
+                    relations: []
+                },
+                new Set(['chunk-1'])
+            )
+        ).not.toThrow()
     })
 
     it('does not enqueue graph jobs when GraphRAG is disabled', async () => {
@@ -103,12 +170,30 @@ describe('GraphRAG service', () => {
         expect(queue.add).not.toHaveBeenCalled()
     })
 
-    it('uses the configured knowledgebase chat model for extraction before primary copilot', async () => {
+    it('uses the configured knowledgebase chat model and extracts chunks in default-sized batches', async () => {
         const structuredModel = {
-            invoke: jest.fn(async () => ({
-                entities: [],
-                relations: []
-            }))
+            invoke: jest
+                .fn()
+                .mockResolvedValueOnce({
+                    entities: [
+                        {
+                            name: 'Alice',
+                            type: 'person',
+                            evidence: [{ chunkId: 'chunk-1' }]
+                        }
+                    ],
+                    relations: []
+                })
+                .mockResolvedValueOnce({
+                    entities: [
+                        {
+                            name: 'Bob',
+                            type: 'person',
+                            evidence: [{ chunkId: 'chunk-5' }]
+                        }
+                    ],
+                    relations: []
+                })
         }
         const chatModel = {
             withStructuredOutput: jest.fn(() => structuredModel)
@@ -149,20 +234,17 @@ describe('GraphRAG service', () => {
 
         await (service as any).extractDocumentGraph(
             knowledgebase,
-            [
-                {
-                    id: 'chunk-1',
-                    documentId: 'doc-1',
-                    pageContent: 'Alice works with Bob.',
-                    metadata: {
-                        chunkId: 'chunk-1'
-                    }
+            Array.from({ length: 5 }, (_, index) => ({
+                id: `chunk-${index + 1}`,
+                documentId: 'doc-1',
+                pageContent: `Chunk ${index + 1} content.`,
+                metadata: {
+                    chunkId: `chunk-${index + 1}`
                 }
-            ],
+            })),
             {
                 enabled: true,
-                extractionBatchSize: 1,
-                extractionMaxCharacters: 500
+                extractionMaxCharacters: 5000
             }
         )
 
@@ -171,7 +253,130 @@ describe('GraphRAG service', () => {
         expect(queryBus.execute.mock.calls[0][0].copilot).toBeNull()
         expect(queryBus.execute.mock.calls[0][0].copilotModel).toBe(knowledgebase.chatModel)
         expect(chatModel.withStructuredOutput).toHaveBeenCalled()
-        expect(structuredModel.invoke).toHaveBeenCalled()
+        expect(structuredModel.invoke).toHaveBeenCalledTimes(2)
+        expect(jobRepository.update).toHaveBeenNthCalledWith(
+            1,
+            {
+                knowledgebaseId: knowledgebase.id,
+                documentId: 'doc-1',
+                status: KnowledgeGraphIndexJobStatus.RUNNING
+            },
+            { processedChunks: 4 }
+        )
+        expect(jobRepository.update).toHaveBeenNthCalledWith(
+            2,
+            {
+                knowledgebaseId: knowledgebase.id,
+                documentId: 'doc-1',
+                status: KnowledgeGraphIndexJobStatus.RUNNING
+            },
+            { processedChunks: 5 }
+        )
+    })
+
+    it('fails an index job when extracted graph items have no source evidence', async () => {
+        const entityVectorQuery = {
+            where: jest.fn(),
+            andWhere: jest.fn(),
+            orderBy: jest.fn(),
+            getMany: jest.fn(async () => [])
+        }
+        entityVectorQuery.where.mockReturnValue(entityVectorQuery)
+        entityVectorQuery.andWhere.mockReturnValue(entityVectorQuery)
+        entityVectorQuery.orderBy.mockReturnValue(entityVectorQuery)
+
+        const knowledgebase = Object.assign(new Knowledgebase(), enabledKnowledgebase(), {
+            chatModel: {
+                copilotId: 'chat-copilot',
+                modelType: AiModelTypeEnum.LLM,
+                model: 'qwen3.7-plus'
+            }
+        })
+        const graphJob = Object.assign(new KnowledgeGraphIndexJob(), {
+            id: 'job-1',
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            knowledgebaseId: 'kb-1',
+            documentId: 'doc-1',
+            revision: 4,
+            knowledgebase
+        })
+        const jobRepository = {
+            findOne: jest.fn(async () => graphJob),
+            update: jest.fn(async () => undefined),
+            count: jest.fn(async (options: { where: { status: KnowledgeGraphIndexJobStatus } }) =>
+                options.where.status === KnowledgeGraphIndexJobStatus.FAILED ? 1 : 0
+            )
+        }
+        const entityRepository = {
+            createQueryBuilder: jest.fn(() => entityVectorQuery)
+        }
+        const mentionRepository = {
+            find: jest.fn(async () => []),
+            delete: jest.fn(async () => undefined),
+            save: jest.fn()
+        }
+        const knowledgebaseRepository = {
+            update: jest.fn(async () => undefined)
+        }
+        const vectorStore = {
+            clear: jest.fn(async () => undefined)
+        }
+        const knowledgebaseService = {
+            findOne: jest.fn(async () => knowledgebase),
+            getGraphEntityVectorStore: jest.fn(async () => vectorStore)
+        }
+        const chunkService = {
+            findAll: jest.fn(async () => ({
+                items: [
+                    {
+                        id: 'chunk-row-1',
+                        documentId: 'doc-1',
+                        pageContent: 'User-centered design reduces operational cost.',
+                        metadata: { chunkId: 'chunk-1' }
+                    }
+                ]
+            }))
+        }
+        const structuredModel = {
+            invoke: jest.fn(async () => ({
+                entities: [{ name: 'User-Centered Design', type: 'concept' }],
+                relations: []
+            }))
+        }
+        const queryBus = {
+            execute: jest.fn(async () => ({
+                withStructuredOutput: jest.fn(() => structuredModel)
+            }))
+        }
+        const service = new GraphragService(
+            entityRepository as unknown as Repository<KnowledgeGraphEntity>,
+            repositoryMock<KnowledgeGraphRelation>(),
+            mentionRepository as unknown as Repository<KnowledgeGraphMention>,
+            repositoryMock<KnowledgeGraphCommunity>(),
+            jobRepository as unknown as Repository<KnowledgeGraphIndexJob>,
+            knowledgebaseRepository as unknown as Repository<Knowledgebase>,
+            knowledgebaseService as unknown as KnowledgebaseService,
+            {} as unknown as KnowledgeDocumentService,
+            chunkService as unknown as KnowledgeDocumentChunkService,
+            queryBus as unknown as QueryBus,
+            { add: jest.fn() } as unknown as Queue<TKnowledgeGraphIndexQueueJob>
+        )
+
+        await service.processIndexJob('job-1')
+
+        expect(jobRepository.update).toHaveBeenCalledWith(
+            'job-1',
+            expect.objectContaining({
+                status: KnowledgeGraphIndexJobStatus.FAILED,
+                error: expect.stringContaining('valid source evidence')
+            })
+        )
+        expect(jobRepository.update).not.toHaveBeenCalledWith(
+            'job-1',
+            expect.objectContaining({ status: KnowledgeGraphIndexJobStatus.SUCCESS })
+        )
+        expect(mentionRepository.save).not.toHaveBeenCalled()
     })
 
     it('creates manual graph entities and syncs active entity vectors', async () => {

--- a/packages/server-ai/src/graphrag/graphrag.service.ts
+++ b/packages/server-ai/src/graphrag/graphrag.service.ts
@@ -31,6 +31,7 @@ import { BadRequestException, Injectable, Logger, NotFoundException } from '@nes
 import { QueryBus } from '@nestjs/cqrs'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Queue } from 'bull'
+import { t } from 'i18next'
 import { compact, uniq } from 'lodash'
 import { Brackets, FindOptionsWhere, In, IsNull, Not, Raw, Repository, SelectQueryBuilder } from 'typeorm'
 import { z } from 'zod'
@@ -64,7 +65,7 @@ const DEFAULT_GRAPH_RAG_CONFIG: Required<GraphRagConfig> = {
     neighborHops: 1,
     communityTopK: 0,
     graphWeight: 0.35,
-    extractionBatchSize: 8,
+    extractionBatchSize: 4,
     extractionMaxCharacters: 12000
 }
 
@@ -119,8 +120,7 @@ const graphExtractionSchema = z.object({
                             confidence: z.number().min(0).max(1).optional().nullable()
                         })
                     )
-                    .optional()
-                    .nullable()
+                    .min(1)
             })
         )
         .default([]),
@@ -142,8 +142,7 @@ const graphExtractionSchema = z.object({
                             confidence: z.number().min(0).max(1).optional().nullable()
                         })
                     )
-                    .optional()
-                    .nullable()
+                    .min(1)
             })
         )
         .default([])
@@ -170,6 +169,20 @@ export function normalizeKnowledgeGraphName(value: string) {
 
 export function normalizeKnowledgeGraphType(value: string) {
     return value.trim().replace(/\s+/g, '_').toLowerCase()
+}
+
+export function validateKnowledgeGraphExtractionEvidence(
+    extraction: TKnowledgeGraphExtraction,
+    validChunkIds: ReadonlySet<string>
+) {
+    const graphItems = [...extraction.entities, ...extraction.relations]
+    const hasInvalidEvidence = graphItems.some(
+        (item) => !item.evidence?.length || item.evidence.some(({ chunkId }) => !validChunkIds.has(chunkId))
+    )
+    if (!graphItems.length || hasInvalidEvidence) {
+        const defaultValue = 'GraphRAG extraction did not return valid source evidence for every graph item.'
+        throw new Error(t('server-ai:Error.GraphExtractionEvidenceInvalid', { defaultValue }) || defaultValue)
+    }
 }
 
 function isGraphOrigin(value: unknown): value is KnowledgeGraphItemOrigin {
@@ -1219,7 +1232,8 @@ export class GraphragService {
                         'Extract a small knowledge graph from the provided chunks.',
                         'Use only explicit machine-readable fields in the output schema.',
                         'Every entity and relation must include a stable type. Do not infer missing types from names.',
-                        'Use chunkId values exactly as provided for evidence.'
+                        'Every entity and relation must include a non-empty evidence array.',
+                        'Every evidence item must use a chunkId exactly as provided in the input chunks.'
                     ].join('\n')
                 ),
                 new HumanMessage(`Knowledgebase: ${knowledgebase.name ?? knowledgebase.id}\n\n${input}`)
@@ -1237,6 +1251,14 @@ export class GraphragService {
                 }
             )
         }
+        validateKnowledgeGraphExtractionEvidence(
+            merged,
+            new Set(
+                chunks
+                    .map((chunk) => chunk.metadata?.chunkId ?? chunk.id)
+                    .filter((chunkId): chunkId is string => typeof chunkId === 'string' && chunkId.length > 0)
+            )
+        )
         return merged
     }
 

--- a/packages/server-ai/src/graphrag/queries/handlers/entity-search.handler.spec.ts
+++ b/packages/server-ai/src/graphrag/queries/handlers/entity-search.handler.spec.ts
@@ -60,11 +60,10 @@ describe('KnowledgeGraphEntitySearchHandler', () => {
             })
         )
 
-        expect(knowledgebaseService.getGraphEntityVectorStore).toHaveBeenCalledWith(
-            expect.objectContaining({ id: 'kb-1' }),
-            true,
-            { xpertId: 'xpert-1', threadId: 'thread-1' }
-        )
+        expect(knowledgebaseService.getGraphEntityVectorStore).toHaveBeenCalledWith('kb-1', true, {
+            xpertId: 'xpert-1',
+            threadId: 'thread-1'
+        })
         expect(vectorStore.similaritySearchWithScore).toHaveBeenCalledWith('pump-station supplier', 10, {
             kind: 'knowledge_graph_entity',
             knowledgebaseId: 'kb-1'

--- a/packages/server-ai/src/graphrag/queries/handlers/entity-search.handler.ts
+++ b/packages/server-ai/src/graphrag/queries/handlers/entity-search.handler.ts
@@ -23,7 +23,7 @@ export class KnowledgeGraphEntitySearchHandler implements IQueryHandler<Knowledg
         }
 
         const limit = Math.min(100, Math.max(1, Math.trunc(input.take ?? 12)))
-        const vectorStore = await this.knowledgebaseService.getGraphEntityVectorStore(knowledgebase, true, {
+        const vectorStore = await this.knowledgebaseService.getGraphEntityVectorStore(knowledgebase.id, true, {
             xpertId: input.xpertId,
             threadId: input.threadId
         })

--- a/packages/server-ai/src/graphrag/queries/handlers/search.handler.spec.ts
+++ b/packages/server-ai/src/graphrag/queries/handlers/search.handler.spec.ts
@@ -95,11 +95,10 @@ describe('KnowledgeGraphSearchHandler', () => {
             })
         )
 
-        expect(knowledgebaseService.getGraphEntityVectorStore).toHaveBeenCalledWith(
-            expect.objectContaining({ id: 'kb-1' }),
-            true,
-            { xpertId: 'xpert-1', threadId: 'thread-1' }
-        )
+        expect(knowledgebaseService.getGraphEntityVectorStore).toHaveBeenCalledWith('kb-1', true, {
+            xpertId: 'xpert-1',
+            threadId: 'thread-1'
+        })
         expect(vectorStore.similaritySearchWithScore.mock.calls.map((call) => call[1])).toEqual([4, 8])
         expect(graphFilterScopeService.filterSeedEntities).toHaveBeenCalledTimes(2)
         expect(result.docs).toEqual([

--- a/packages/server-ai/src/graphrag/queries/handlers/search.handler.ts
+++ b/packages/server-ai/src/graphrag/queries/handlers/search.handler.ts
@@ -196,7 +196,11 @@ export class KnowledgeGraphSearchHandler implements IQueryHandler<KnowledgeGraph
         let entityScores: Array<{ entityId: string; score: number }> = []
         let exhausted = false
         let continueScanning: boolean
-        const vectorStore = await this.knowledgebaseService.getGraphEntityVectorStore(knowledgebase, true, modelContext)
+        const vectorStore = await this.knowledgebaseService.getGraphEntityVectorStore(
+            knowledgebase.id,
+            true,
+            modelContext
+        )
 
         do {
             rounds += 1

--- a/packages/server-ai/src/i18n/en-US.json
+++ b/packages/server-ai/src/i18n/en-US.json
@@ -167,6 +167,7 @@
         "KBReqVisionModel": "Knowledgebase requires vision model to process images",
         "GraphSearchScopeRequired": "GraphRAG search requires tenant and organization scope.",
         "GraphSearchFailed": "GraphRAG search failed.",
+        "GraphExtractionEvidenceInvalid": "GraphRAG extraction did not return valid source evidence for every graph item.",
         "IntegrationNotFound": "Integration '{{id}}' not found",
         "InvalidDocumentProcessingMode": "Document processing mode must be full or rechunk.",
         "TransformSnapshotMissing": "No saved conversion result is available. Run the converter once before re-chunking.",

--- a/packages/server-ai/src/i18n/en.json
+++ b/packages/server-ai/src/i18n/en.json
@@ -167,6 +167,7 @@
         "KBReqVisionModel": "Knowledgebase requires vision model to process images",
         "GraphSearchScopeRequired": "GraphRAG search requires tenant and organization scope.",
         "GraphSearchFailed": "GraphRAG search failed.",
+        "GraphExtractionEvidenceInvalid": "GraphRAG extraction did not return valid source evidence for every graph item.",
         "IntegrationNotFound": "Integration '{{id}}' not found",
         "InvalidDocumentProcessingMode": "Document processing mode must be full or rechunk.",
         "TransformSnapshotMissing": "No saved conversion result is available. Run the converter once before re-chunking.",

--- a/packages/server-ai/src/i18n/zh-Hans.json
+++ b/packages/server-ai/src/i18n/zh-Hans.json
@@ -167,6 +167,7 @@
         "KBReqVisionModel": "知识库需要视觉模型来处理图像",
         "GraphSearchScopeRequired": "GraphRAG 检索需要租户和组织范围。",
         "GraphSearchFailed": "GraphRAG 检索失败。",
+        "GraphExtractionEvidenceInvalid": "GraphRAG 提取结果没有为每个图谱项返回有效的原文依据。",
         "IntegrationNotFound": "未找到系统集成‘{{id}}’",
         "InvalidDocumentProcessingMode": "文档处理模式必须是 full 或 rechunk。",
         "TransformSnapshotMissing": "没有可用的转换结果快照，请先完整执行一次转换器。",


### PR DESCRIPTION
# PR

## Summary

- Reload the knowledgebase when resolving GraphRAG entity vector stores so graph search uses the configured embedding model and provider relations.
- Require every extracted entity and relation to include valid source evidence, and fail indexing instead of reporting an empty graph as successful.
- Reduce the default extraction batch size from 8 to 4 and persist progress after each completed batch.

## Motivation

Graph search could receive a partial knowledgebase object without model relations, causing the configured embedding model to appear missing. Graph indexing could also complete successfully with no usable evidence, while a single large extraction batch left progress at zero until the model returned.

## Validation

- [x] GraphRAG Jest suites: 3 passed, 11 tests passed.
- [x] Server AI TypeScript check passed.
- [x] Targeted ESLint passed with 0 errors (7 existing warnings).
- [x] Translation JSON parsing and Git diff checks passed.

## Scope

- This PR does not add OCR for image-only PDF chunks.
- This PR does not add GraphRAG-specific model timeout and retry controls; provider request timeouts still fail the indexing job.

# Checklist

- [x] Have you followed the [contributing guidelines](https://github.com/xpert-ai/xpert/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

---