### PR TITLE
feat(knowledge): align workspace knowledgebase configuration

### DIFF
--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/knowledgebase.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/knowledgebase.component.html
@@ -75,23 +75,20 @@
         <z-icon zType="center_focus_strong" />
         <span class="hidden lg:inline">{{ 'XP.Knowledgebase.Test' | translate: { Default: 'Test' } }}</span>
       </a>
-      <a
-        z-tab-link
-        [routerLink]="['./', 'configuration']"
-        queryParamsHandling="preserve"
-        [routerLinkActiveOptions]="{ exact: false }"
-        routerLinkActive=""
-        #configurationActive="routerLinkActive"
-        [active]="configurationActive.isActive"
-      >
-        <z-icon zType="tune" />
-        <span class="hidden lg:inline">{{
-          'XP.Knowledgebase.Configuration' | translate: { Default: 'Configuration' }
-        }}</span>
-      </a>
     </nav>
 
     <div class="flex shrink-0 items-center gap-1.5">
+      <button
+        type="button"
+        z-button
+        zType="outline"
+        [disabled]="loading()"
+        (click)="openConfiguration()"
+        [attr.aria-label]="'XP.KEY_WORDS.Settings' | translate: { Default: 'Settings' }"
+      >
+        <z-icon zType="tune" />
+        <span class="hidden xl:inline">{{ 'XP.KEY_WORDS.Settings' | translate: { Default: 'Settings' } }}</span>
+      </button>
       <button type="button" z-button zType="outline" (click)="back()">
         <z-icon zType="arrow-left" />
         <span class="hidden xl:inline">{{ 'XP.ACTIONS.Back' | translate: { Default: 'Back' } }}</span>

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/knowledgebase.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/knowledgebase.component.ts
@@ -19,6 +19,7 @@ import {
   ApiKeyBindingType,
   getErrorMessage,
   injectHelpWebsite,
+  IKnowledgebase,
   IXpert,
   KnowledgebaseService,
   KnowledgebaseTypeEnum,
@@ -27,6 +28,7 @@ import {
   ToastrService
 } from '../../../../@core'
 import { XpertDevelopApiKeyComponent } from '../../xpert/develop'
+import { XpertNewKnowledgeComponent } from '../new/new.component'
 import { ZardButtonComponent, ZardIconComponent, ZardSwitchComponent, ZardTabsImports } from '@xpert-ai/headless-ui'
 
 @Component({
@@ -210,6 +212,33 @@ export class KnowledgebaseComponent {
       })
       .closed.subscribe({
         next: () => {}
+      })
+  }
+
+  openConfiguration() {
+    const knowledgebase = this.knowledgebase()
+    if (!knowledgebase || this.loading()) {
+      return
+    }
+
+    this.#dialog
+      .open<IKnowledgebase>(XpertNewKnowledgeComponent, {
+        width: 'min(96vw, 72rem)',
+        height: 'min(90vh, 52rem)',
+        maxWidth: 'calc(100vw - 1.5rem)',
+        maxHeight: 'calc(100vh - 1.5rem)',
+        panelClass: 'xp-overlay-pane-card',
+        data: {
+          workspaceId: knowledgebase.workspaceId,
+          knowledgebase
+        }
+      })
+      .closed.subscribe({
+        next: (updated) => {
+          if (updated) {
+            this.refresh()
+          }
+        }
       })
   }
 }

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
@@ -389,36 +389,17 @@
                   <p>{{ i18nPrefix + '.Chunk.SeparatorsDescription' | translate }}</p>
                 </div>
                 <div class="kb-separator-control">
-                  <div class="kb-chip-control">
-                    @for (separator of separators(); track separator) {
-                      <span class="kb-separator-chip"
-                        >{{ separatorLabelKey(separator) | translate
-                        }}<button
-                          z-button
-                          zType="ghost"
-                          zSize="icon-xs"
-                          type="button"
-                          (click)="removeSeparator(separator)"
-                          [attr.aria-label]="i18nPrefix + '.Chunk.RemoveSeparator' | translate"
-                        >
-                          <i class="ri-close-line"></i></button
-                      ></span>
-                    }
-                    <z-select
-                      class="kb-separator-add"
-                      zSize="sm"
-                      [zPlaceholder]="i18nPrefix + '.Chunk.Add' | translate"
-                      [zLabel]="i18nPrefix + '.Chunk.AddSeparator' | translate"
-                      [(ngModel)]="separatorToAdd"
-                      (ngModelChange)="selectSeparator($event)"
-                    >
-                      @for (option of separatorOptions; track option.value) {
-                        <z-select-item [zValue]="option.value">{{
-                          i18nPrefix + '.' + option.labelKey | translate
-                        }}</z-select-item>
-                      }
-                    </z-select>
-                  </div>
+                  <z-tag-select
+                    class="kb-separator-select"
+                    mode="multiple"
+                    [options]="separatorTagOptions"
+                    [enableSuggestions]="true"
+                    [searchable]="false"
+                    [checkable]="true"
+                    [placeholder]="i18nPrefix + '.Chunk.AddSeparator' | translate"
+                    [value]="separators()"
+                    (valueChange)="updateSeparators($event)"
+                  />
                 </div>
               </div>
             </section>

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
@@ -1,80 +1,456 @@
-<div
-  class="flex justify-between items-center px-6 py-4 cursor-move"
-  cdkDrag
-  cdkDragRootElement=".cdk-overlay-pane"
-  cdkDragHandle
->
-  <div class="text-xl font-semibold text-text-primary">
-    {{ 'XP.Knowledgebase.CreateKnowledgebase' | translate: { Default: 'Create Knowledgebase' } }}
-  </div>
-
-  <button
-    type="button"
-    class="btn-close btn btn-secondary flex items-center justify-center w-6 h-6 cursor-pointer z-20"
-    (click)="close()"
-  >
+<div class="kb-create-dialog" cdkDrag cdkDragRootElement=".cdk-overlay-pane">
+  <button type="button" class="kb-close-button" aria-label="关闭" (click)="close()">
     <i class="ri-close-line"></i>
   </button>
-</div>
-<div class="px-6 pb-4">
-  <div class="text-sm text-text-secondary">
-    {{
-      'XP.Knowledgebase.CreateKnowledgebaseDesc'
-        | translate
-          : {
-              Default:
-                'There are no documents in an empty knowledge base yet. You can upload documents to this knowledge base at any time in the future.'
+
+  <div class="kb-settings-container">
+    <aside class="kb-create-sidebar" aria-label="知识库设置导航">
+      <div class="kb-sidebar-header" cdkDragHandle>
+        <div class="kb-create-title">{{ isEditMode() ? '知识库设置' : '新建知识库' }}</div>
+      </div>
+      @for (group of groupedSections(); track group.group) {
+        <div class="kb-sidebar-group">
+          <div class="kb-sidebar-group-title">{{ group.group }}</div>
+          <nav class="kb-sidebar-nav">
+            @for (section of group.items; track section.key) {
+              <button
+                type="button"
+                class="kb-sidebar-item"
+                [class.kb-sidebar-item-active]="activeSection() === section.key"
+                [class.kb-sidebar-item-preview]="section.status !== 'supported'"
+                (click)="selectSection(section.key)"
+              >
+                <i [class]="section.icon"></i>
+                <span>{{ section.label }}</span>
+                @if (section.status !== 'supported') {
+                  <span class="kb-sidebar-dot" [attr.title]="sectionStatusLabel(section.status)"></span>
+                }
+              </button>
             }
-    }}
+          </nav>
+        </div>
+      }
+    </aside>
+
+    <section class="kb-settings-content">
+      <main class="kb-create-content">
+        @switch (activeSection()) {
+          @case ('basic') {
+            <section class="kb-section">
+              <div class="kb-section-heading">
+                <h1>基本信息</h1>
+                <p>设置知识库的类型、索引策略和基本信息</p>
+              </div>
+
+              <div class="kb-field">
+                <label class="kb-label">知识库类型 <span class="kb-required">*</span></label>
+                <div class="kb-segmented-control">
+                  <button
+                    type="button"
+                    class="kb-segmented-option"
+                    [class.kb-segmented-option-active]="type() === KnowledgebaseTypeEnum.Standard"
+                    (click)="type.set(KnowledgebaseTypeEnum.Standard)"
+                  >
+                    文档
+                  </button>
+                  <button type="button" class="kb-segmented-option kb-segmented-option-disabled" disabled>
+                    问答
+                    <span class="kb-mini-badge">预览</span>
+                  </button>
+                </div>
+                <p class="kb-help-text">Xpert 当前支持标准文档知识库，问答知识库将在后续版本接入。</p>
+              </div>
+
+              <div class="kb-field">
+                <label class="kb-label">索引策略 <span class="kb-required">*</span></label>
+                <div class="kb-choice-grid">
+                  <button
+                    type="button"
+                    class="kb-choice-card"
+                    [class.kb-choice-card-selected]="indexStrategy() === 'rag'"
+                    (click)="indexStrategy.set('rag')"
+                  >
+                    <span class="kb-choice-check"><i class="ri-check-line"></i></span>
+                    <span class="kb-choice-card-title">RAG 检索</span>
+                    <span class="kb-choice-card-description"
+                      >对文档进行分块、向量化和检索，支持向量、图谱和混合模式。</span
+                    >
+                  </button>
+                  <button type="button" class="kb-choice-card kb-choice-card-disabled" disabled>
+                    <span class="kb-choice-empty"><i class="ri-checkbox-blank-line"></i></span>
+                    <span class="kb-choice-card-title">Wiki 知识库 <span class="kb-new-badge">NEW</span></span>
+                    <span class="kb-choice-card-description"
+                      >自动生成关联的 Wiki 页面，当前 Xpert 暂无对应索引浏览器。</span
+                    >
+                  </button>
+                </div>
+              </div>
+
+              <div class="kb-field">
+                <label class="kb-label">知识库名称 <span class="kb-required">*</span></label>
+                <input class="kb-input" [(ngModel)]="name" placeholder="请输入知识库名称" maxlength="80" />
+              </div>
+
+              <div class="kb-field">
+                <label class="kb-label">知识库描述</label>
+                <textarea
+                  class="kb-textarea"
+                  [(ngModel)]="description"
+                  placeholder="请输入知识库描述（可选）"
+                  maxlength="200"
+                ></textarea>
+                <div class="kb-counter">{{ description().length }}/200</div>
+              </div>
+            </section>
+          }
+
+          @case ('models') {
+            <section class="kb-section">
+              <div class="kb-section-heading">
+                <h1>模型配置</h1>
+                <p>为知识库选择合适的 AI 模型</p>
+              </div>
+
+              <div class="kb-weknora-form">
+                <div class="kb-model-row">
+                  <div class="kb-model-row-copy">
+                    <div class="kb-model-row-title">LLM 大语言模型 <span class="kb-required">*</span></div>
+                    <p>用于总结和摘要的大语言模型</p>
+                  </div>
+                  <copilot-model-select
+                    class="kb-model-row-select"
+                    hiddenLabel
+                    [modelType]="eAiModelTypeEnum.LLM"
+                    [(ngModel)]="chatModel"
+                  />
+                </div>
+
+                <div class="kb-divider"></div>
+
+                <div class="kb-model-row">
+                  <div class="kb-model-row-copy">
+                    <div class="kb-model-row-title">Embedding 嵌入模型 <span class="kb-required">*</span></div>
+                    <p>用于文本向量化的嵌入模型</p>
+                  </div>
+                  <copilot-model-select
+                    class="kb-model-row-select"
+                    hiddenLabel
+                    required
+                    [modelType]="eAiModelTypeEnum.TEXT_EMBEDDING"
+                    [(ngModel)]="copilotModel"
+                  />
+                </div>
+              </div>
+            </section>
+          }
+
+          @case ('parser') {
+            <section class="kb-section">
+              <div class="kb-section-heading">
+                <h1>解析引擎</h1>
+                <p>为不同文件类型选择文档解析引擎。未配置的文件类型将使用内置解析引擎。</p>
+              </div>
+
+              <div class="kb-parser-engine-list">
+                @for (row of parserEngineRows; track row.key) {
+                  <div class="kb-parser-engine-row">
+                    <div class="kb-parser-engine-copy">
+                      <div class="kb-parser-engine-title"><i [class]="row.icon"></i>{{ row.label }}</div>
+                      <div class="kb-extension-list">
+                        @for (extension of row.extensions; track extension) {
+                          <span class="kb-extension-chip">{{ extension }}</span>
+                        }
+                      </div>
+                    </div>
+                    <div class="kb-parser-engine-control">
+                      <select
+                        class="kb-native-select kb-parser-engine-select"
+                        [ngModel]="parserEngineSelections()[row.key]"
+                        (ngModelChange)="updateParserEngine(row.key, $event)"
+                      >
+                        @for (option of row.options; track option.value) {
+                          <option [value]="option.value">{{ option.label }}</option>
+                        }
+                      </select>
+                      @if (row.hasHeaderToggle) {
+                        <label class="kb-checkbox-row">
+                          <input type="checkbox" [(ngModel)]="excelHeaderRow" />
+                          <span>将首行作为列标题，并保留在每行上下文中</span>
+                        </label>
+                      }
+                    </div>
+                  </div>
+                }
+              </div>
+            </section>
+          }
+
+          @case ('chunk') {
+            <section class="kb-section">
+              <div class="kb-section-heading">
+                <h1>分块设置</h1>
+                <p>控制上传文档在嵌入前的切分方式。默认值适用于大多数场景，仅在检索质量异常时调整。</p>
+              </div>
+
+              <div class="kb-chunk-strategy-row">
+                <div class="kb-chunk-copy">
+                  <div class="kb-field-title">分块策略</div>
+                  <p>选择文档的分块方式。自动模式会分析每个文档的结构并选择最佳策略。</p>
+                </div>
+                <div class="kb-chunk-strategy-control">
+                  <select class="kb-native-select" [(ngModel)]="chunkStrategy">
+                    <option value="auto">自动</option>
+                    <option value="title">按标题切分</option>
+                    <option value="structure">结构感知</option>
+                    <option value="length">按长度切分</option>
+                  </select>
+                  <button type="button" class="kb-test-chunk-button" title="测试分块效果">
+                    <i class="ri-play-circle-line"></i><span>测试分块效果</span>
+                  </button>
+                </div>
+              </div>
+
+              @if (chunkStrategy() === 'auto') {
+                <div class="kb-chunk-auto-note">
+                  <strong>自动:</strong> 文档分析器根据内容结构自动在「按标题切分」「结构感知」「按长度切分」之间选择。
+                </div>
+              }
+
+              <div class="kb-chunk-setting-row">
+                <div class="kb-chunk-copy">
+                  <div class="kb-field-title">分块大小</div>
+                  <p>
+                    每个分块的最大字符数（100–4000）。默认 512<br />≈ 中文 300 tokens / 英文 100–130 tokens。FAQ 用
+                    200–400，叙述性长文档用 1000–2000。
+                  </p>
+                </div>
+                <div class="kb-range-control">
+                  <input
+                    class="kb-range"
+                    type="range"
+                    min="100"
+                    max="4000"
+                    step="1"
+                    [attr.style]="'--range-progress: ' + chunkSizePercent()"
+                    [(ngModel)]="chunkSize"
+                  />
+                  <div class="kb-range-ticks"><span>100</span><span>1000</span><span>2000</span><span>4000</span></div>
+                  <strong>{{ chunkSize() ?? 512 }} 字符</strong>
+                </div>
+              </div>
+
+              <div class="kb-chunk-setting-row">
+                <div class="kb-chunk-copy">
+                  <div class="kb-field-title">分块重叠</div>
+                  <p>
+                    相邻分块之间共享的字符数（0–500）。默认 80 ≈ 分块大小的 15%，符合当前研究推荐。FAQ/结构化数据用
+                    0，长篇叙述用 150–200。
+                  </p>
+                </div>
+                <div class="kb-range-control">
+                  <input
+                    class="kb-range"
+                    type="range"
+                    min="0"
+                    max="500"
+                    step="1"
+                    [attr.style]="'--range-progress: ' + chunkOverlapPercent()"
+                    [(ngModel)]="chunkOverlap"
+                  />
+                  <div class="kb-range-ticks"><span>0</span><span>250</span><span>500</span></div>
+                  <strong>{{ chunkOverlap() ?? 80 }} 字符</strong>
+                </div>
+              </div>
+
+              <div class="kb-chunk-setting-row kb-separator-row">
+                <div class="kb-chunk-copy">
+                  <div class="kb-field-title">分隔符</div>
+                  <p>切分时优先使用的字符或字符串。优先级高的分隔符先尝试；默认顺序优先段落 → 句子 → 标点。</p>
+                </div>
+                <div class="kb-separator-control">
+                  <div class="kb-chip-control">
+                    @for (separator of separators(); track separator) {
+                      <span class="kb-separator-chip"
+                        >{{ separatorLabel(separator)
+                        }}<button type="button" (click)="removeSeparator(separator)" aria-label="移除分隔符">
+                          ×
+                        </button></span
+                      >
+                    }
+                    <select
+                      class="kb-separator-add"
+                      aria-label="添加分隔符"
+                      (change)="addSeparator($any($event.target).value); $any($event.target).value = ''"
+                    >
+                      <option value="">添加</option>
+                      @for (option of separatorOptions; track option.value) {
+                        <option [value]="option.value">{{ option.label }}</option>
+                      }
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </section>
+          }
+
+          @case ('image') {
+            <section class="kb-section">
+              <div class="kb-section-heading">
+                <h1>图像处理</h1>
+                <p>配置图片理解策略，帮助知识库提取图片中的文字和语义。</p>
+              </div>
+              <div class="kb-panel kb-panel-post-create">
+                <div class="kb-field kb-field-inline">
+                  <div>
+                    <label class="kb-label">启用图片理解</label>
+                    <p class="kb-help-text">图片文档将在导入时调用视觉理解模型。</p>
+                  </div>
+                  <z-switch
+                    class="kb-primary-switch"
+                    [ngModel]="parserPreview().imageUnderstanding"
+                    (ngModelChange)="updateParserPreview('imageUnderstanding', $event)"
+                  />
+                </div>
+                <div class="kb-divider"></div>
+                <copilot-model-select
+                  class="block"
+                  [label]="'Vision 模型'"
+                  [modelType]="eAiModelTypeEnum.LLM"
+                  [features]="[eModelFeature.VISION]"
+                  [(ngModel)]="visionModel"
+                />
+                <p class="kb-inline-notice">
+                  <i class="ri-information-line"></i> 图片理解配置将在知识库创建后从文档导入设置中保存。
+                </p>
+              </div>
+            </section>
+          }
+
+          @case ('audio') {
+            <section class="kb-section">
+              <div class="kb-section-heading">
+                <h1>音频处理</h1>
+                <p>为音频文件选择语音识别引擎。</p>
+              </div>
+              <div class="kb-placeholder-card">
+                <div class="kb-placeholder-icon"><i class="ri-volume-up-line"></i></div>
+                <div>
+                  <div class="kb-panel-title">语音转文本（ASR）</div>
+                  <p class="kb-panel-description">
+                    Xpert 文档模型已支持 Audio 类型，但当前知识库创建接口还没有 ASR 引擎字段。
+                  </p>
+                </div>
+                <span class="kb-status-badge kb-status-preview">前端预览</span>
+              </div>
+              <div class="kb-field mt-5">
+                <label class="kb-label">解析引擎</label>
+                <select class="kb-native-select" disabled>
+                  <option>暂未接入</option>
+                </select>
+              </div>
+            </section>
+          }
+
+          @case ('advanced') {
+            <section class="kb-section">
+              <div class="kb-section-heading">
+                <h1>高级设置</h1>
+                <p>配置问题生成等高级功能</p>
+              </div>
+
+              <div class="kb-advanced-switch-row">
+                <div>
+                  <div class="kb-field-title">AI 问题生成</div>
+                  <p>解析文档时调用大模型为每个分块生成相关问题，提高检索召回率。启用后会增加文档解析耗时。</p>
+                </div>
+                <z-switch class="kb-primary-switch" [(ngModel)]="questionGenerationEnabled" />
+              </div>
+
+              @if (questionGenerationEnabled()) {
+                <div class="kb-advanced-emphasis">
+                  <div class="kb-advanced-field kb-advanced-count-row">
+                    <div>
+                      <div class="kb-field-title">生成问题数量</div>
+                      <p>每个文档分块生成的问题数量（1–10）</p>
+                    </div>
+                    <input
+                      class="kb-input kb-number-input"
+                      type="number"
+                      min="1"
+                      max="10"
+                      [(ngModel)]="questionCount"
+                    />
+                  </div>
+                  <div class="kb-advanced-field">
+                    <div class="kb-field-title">问题生成要求</div>
+                    <p>指定问题面向的人群、场景和表达方式，系统仍维持稳定输出格式</p>
+                    <textarea
+                      class="kb-textarea kb-advanced-textarea"
+                      maxlength="4000"
+                      [(ngModel)]="questionRequirements"
+                      placeholder="例如：生成客服用户常问的自然语言问题，避免考试题式表达..."
+                    ></textarea>
+                    <div class="kb-counter">{{ questionRequirements().length }}/4000</div>
+                  </div>
+                </div>
+              }
+
+              <div class="kb-advanced-field kb-table-metadata-field">
+                <div class="kb-field-title">表格元数据生成要求</div>
+                <p>为 CSV/Excel 摘要补充业务背景和字段语义，帮助后续检索理解表格内容</p>
+                <textarea
+                  class="kb-textarea kb-advanced-textarea"
+                  maxlength="4000"
+                  [(ngModel)]="tableMetadataRequirements"
+                  placeholder="例如：这是销售订单表，金额单位为元，status 字段值使用公司内部状态码..."
+                ></textarea>
+                <div class="kb-counter">{{ tableMetadataRequirements().length }}/4000</div>
+              </div>
+            </section>
+          }
+
+          @case ('storage') {
+            <section class="kb-section">
+              <div class="kb-section-heading">
+                <h1>存储引擎</h1>
+                <p>配置原始文件和处理结果的存储方式。</p>
+              </div>
+              <div class="kb-placeholder-card">
+                <div class="kb-placeholder-icon"><i class="ri-hard-drive-3-line"></i></div>
+                <div>
+                  <div class="kb-panel-title">平台默认存储</div>
+                  <p class="kb-panel-description">
+                    当前 Xpert 统一使用工作空间存储服务，知识库创建时不单独选择存储引擎。
+                  </p>
+                </div>
+                <span class="kb-status-badge kb-status-preview">暂不支持切换</span>
+              </div>
+            </section>
+          }
+        }
+      </main>
+
+      <footer class="kb-create-footer">
+        <button
+          type="button"
+          class="btn btn-secondary btn-large kb-footer-button"
+          [disabled]="loading()"
+          (click)="close()"
+        >
+          取消
+        </button>
+        <button
+          type="button"
+          class="btn btn-primary btn-large kb-footer-button kb-footer-primary"
+          [disabled]="loading()"
+          (click)="submit()"
+        >
+          @if (loading()) {
+            <i class="ri-loader-4-line kb-spin"></i>
+          }
+          {{ isEditMode() ? '保存配置' : '创建知识库' }}
+        </button>
+      </footer>
+    </section>
   </div>
-  <div class="my-4">
-    <div class="text-text-secondary font-semibold">
-      {{ 'XP.Knowledgebase.KnowledgebaseName' | translate: { Default: 'Knowledgebase Name' } }}
-      <span class="mx-1 text-text-destructive">*</span>
-    </div>
-    <div class="relative w-full">
-      <input class="xp-input w-full" [(ngModel)]="name" />
-    </div>
-  </div>
-
-  <copilot-model-select
-    class="block mb-4"
-    required
-    [label]="'XP.Knowledgebase.EmbeddingModel' | translate: { Default: 'Embedding Model' }"
-    [modelType]="eAiModelTypeEnum.TEXT_EMBEDDING"
-    [(ngModel)]="copilotModel"
-  />
-
-  <copilot-model-select
-    class="block mb-4"
-    [label]="'XP.Knowledgebase.ChatModel' | translate: { Default: 'Chat Model' }"
-    [modelType]="eAiModelTypeEnum.LLM"
-    [(ngModel)]="chatModel"
-  />
-
-  <copilot-model-select
-    class="block mb-4"
-    [label]="'XP.Knowledgebase.RerankModel' | translate: { Default: 'Rerank Model' }"
-    [modelType]="eAiModelTypeEnum.RERANK"
-    [(ngModel)]="rerankModel"
-  />
-</div>
-
-<div class="flex justify-end gap-2 p-6">
-  <button
-    type="button"
-    class="btn disabled:btn-disabled btn-secondary btn-large justify-center w-24"
-    [disabled]="loading()"
-    (click)="close()"
-  >
-    {{ 'XP.Xpert.Cancel' | translate: { Default: 'Cancel' } }}
-  </button>
-  <button
-    type="button"
-    class="btn disabled:btn-disabled btn-primary btn-large justify-center w-24"
-    [disabled]="invalid() || loading()"
-    (click)="create()"
-  >
-    {{ 'XP.Xpert.Create' | translate: { Default: 'Create' } }}
-  </button>
 </div>

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
@@ -1,5 +1,13 @@
 <div class="kb-create-dialog" cdkDrag cdkDragRootElement=".cdk-overlay-pane">
-  <button type="button" class="kb-close-button" [attr.aria-label]="i18nPrefix + '.Close' | translate" (click)="close()">
+  <button
+    z-button
+    zType="secondary"
+    zSize="icon-lg"
+    type="button"
+    class="kb-close-button"
+    [attr.aria-label]="i18nPrefix + '.Close' | translate"
+    (click)="close()"
+  >
     <i class="ri-close-line"></i>
   </button>
 
@@ -16,6 +24,9 @@
           <nav class="kb-sidebar-nav">
             @for (section of group.items; track section.key) {
               <button
+                z-button
+                zType="ghost"
+                zSize="lg"
                 type="button"
                 class="kb-sidebar-item"
                 [class.kb-sidebar-item-active]="activeSection() === section.key"
@@ -48,20 +59,15 @@
                 <label class="kb-label"
                   >{{ i18nPrefix + '.Basic.KnowledgebaseType' | translate }} <span class="kb-required">*</span></label
                 >
-                <div class="kb-segmented-control">
-                  <button
-                    type="button"
-                    class="kb-segmented-option"
-                    [class.kb-segmented-option-active]="type() === KnowledgebaseTypeEnum.Standard"
-                    (click)="type.set(KnowledgebaseTypeEnum.Standard)"
-                  >
+                <z-toggle-group class="kb-type-toggle" zType="outline" zSize="lg" [(ngModel)]="type">
+                  <z-toggle-group-item class="min-w-28" [value]="KnowledgebaseTypeEnum.Standard">
                     {{ i18nPrefix + '.Basic.Document' | translate }}
-                  </button>
-                  <button type="button" class="kb-segmented-option kb-segmented-option-disabled" disabled>
+                  </z-toggle-group-item>
+                  <z-toggle-group-item class="min-w-28" value="qa" disabled>
                     {{ i18nPrefix + '.Basic.QandA' | translate }}
                     <span class="kb-mini-badge">{{ i18nPrefix + '.Statuses.Preview' | translate }}</span>
-                  </button>
-                </div>
+                  </z-toggle-group-item>
+                </z-toggle-group>
                 <p class="kb-help-text">{{ i18nPrefix + '.Basic.KnowledgebaseTypeHelp' | translate }}</p>
               </div>
 
@@ -100,6 +106,8 @@
                   >{{ i18nPrefix + '.Basic.Name' | translate }} <span class="kb-required">*</span></label
                 >
                 <input
+                  z-input
+                  zSize="lg"
                   class="kb-input"
                   [(ngModel)]="name"
                   [placeholder]="i18nPrefix + '.Basic.NamePlaceholder' | translate"
@@ -110,6 +118,7 @@
               <div class="kb-field">
                 <label class="kb-label">{{ i18nPrefix + '.Basic.KnowledgebaseDescription' | translate }}</label>
                 <textarea
+                  z-input
                   class="kb-textarea"
                   [(ngModel)]="description"
                   [placeholder]="i18nPrefix + '.Basic.DescriptionPlaceholder' | translate"
@@ -202,14 +211,12 @@
                       <strong>{{ vectorTopK() }}</strong>
                     </div>
                     <p class="kb-help-text">{{ i18nPrefix + '.Vector.TopKDescription' | translate }}</p>
-                    <input
+                    <z-slider
                       class="kb-range"
-                      type="range"
-                      min="1"
-                      max="100"
-                      step="1"
+                      [min]="1"
+                      [max]="100"
+                      [step]="1"
                       [attr.aria-label]="i18nPrefix + '.Vector.TopK' | translate"
-                      [attr.style]="'--range-progress: ' + vectorTopKPercent()"
                       [(ngModel)]="vectorTopK"
                     />
                     <div class="kb-range-ticks"><span>1</span><span>50</span><span>100</span></div>
@@ -222,15 +229,13 @@
                       <strong>{{ vectorScore() | number: '1.2-2' }}</strong>
                     </div>
                     <p class="kb-help-text">{{ i18nPrefix + '.Vector.ScoreThresholdDescription' | translate }}</p>
-                    <input
+                    <z-slider
                       class="kb-range"
-                      type="range"
-                      min="0"
-                      max="1"
-                      step="0.01"
-                      [disabled]="!vectorScoreEnabled()"
+                      [min]="0"
+                      [max]="1"
+                      [step]="0.01"
+                      [disabledInput]="!vectorScoreEnabled()"
                       [attr.aria-label]="i18nPrefix + '.Vector.ScoreThreshold' | translate"
-                      [attr.style]="'--range-progress: ' + vectorScorePercent()"
                       [(ngModel)]="vectorScore"
                     />
                     <div class="kb-range-ticks"><span>0</span><span>0.5</span><span>1</span></div>
@@ -266,20 +271,22 @@
                       </div>
                     </div>
                     <div class="kb-parser-engine-control">
-                      <select
-                        class="kb-native-select kb-parser-engine-select"
+                      <z-select
+                        class="kb-parser-engine-select"
+                        zSize="lg"
                         [ngModel]="parserEngineSelections()[row.key]"
                         (ngModelChange)="updateParserEngine(row.key, $event)"
                       >
                         @for (option of row.options; track option.value) {
-                          <option [value]="option.value">{{ i18nPrefix + '.' + option.labelKey | translate }}</option>
+                          <z-select-item [zValue]="option.value">{{
+                            i18nPrefix + '.' + option.labelKey | translate
+                          }}</z-select-item>
                         }
-                      </select>
+                      </z-select>
                       @if (row.hasHeaderToggle) {
-                        <label class="kb-checkbox-row">
-                          <input type="checkbox" [(ngModel)]="excelHeaderRow" />
-                          <span>{{ i18nPrefix + '.Parser.ExcelHeaderRow' | translate }}</span>
-                        </label>
+                        <z-checkbox class="kb-checkbox-row" [(ngModel)]="excelHeaderRow">
+                          {{ i18nPrefix + '.Parser.ExcelHeaderRow' | translate }}
+                        </z-checkbox>
                       }
                     </div>
                   </div>
@@ -301,13 +308,22 @@
                   <p>{{ i18nPrefix + '.Chunk.StrategyDescription' | translate }}</p>
                 </div>
                 <div class="kb-chunk-strategy-control">
-                  <select class="kb-native-select" [(ngModel)]="chunkStrategy">
-                    <option value="auto">{{ i18nPrefix + '.Chunk.Strategies.Auto' | translate }}</option>
-                    <option value="title">{{ i18nPrefix + '.Chunk.Strategies.Title' | translate }}</option>
-                    <option value="structure">{{ i18nPrefix + '.Chunk.Strategies.Structure' | translate }}</option>
-                    <option value="length">{{ i18nPrefix + '.Chunk.Strategies.Length' | translate }}</option>
-                  </select>
+                  <z-select zSize="lg" [(ngModel)]="chunkStrategy">
+                    <z-select-item zValue="auto">{{ i18nPrefix + '.Chunk.Strategies.Auto' | translate }}</z-select-item>
+                    <z-select-item zValue="title">{{
+                      i18nPrefix + '.Chunk.Strategies.Title' | translate
+                    }}</z-select-item>
+                    <z-select-item zValue="structure">{{
+                      i18nPrefix + '.Chunk.Strategies.Structure' | translate
+                    }}</z-select-item>
+                    <z-select-item zValue="length">{{
+                      i18nPrefix + '.Chunk.Strategies.Length' | translate
+                    }}</z-select-item>
+                  </z-select>
                   <button
+                    z-button
+                    zType="ghost"
+                    zSize="sm"
                     type="button"
                     class="kb-test-chunk-button"
                     [attr.title]="i18nPrefix + '.Chunk.Test' | translate"
@@ -333,13 +349,12 @@
                   </p>
                 </div>
                 <div class="kb-range-control">
-                  <input
+                  <z-slider
                     class="kb-range"
-                    type="range"
-                    min="100"
-                    max="4000"
-                    step="1"
-                    [attr.style]="'--range-progress: ' + chunkSizePercent()"
+                    [min]="100"
+                    [max]="4000"
+                    [step]="1"
+                    [attr.aria-label]="i18nPrefix + '.Chunk.Size' | translate"
                     [(ngModel)]="chunkSize"
                   />
                   <div class="kb-range-ticks"><span>100</span><span>1000</span><span>2000</span><span>4000</span></div>
@@ -353,13 +368,12 @@
                   <p>{{ i18nPrefix + '.Chunk.OverlapDescription' | translate }}</p>
                 </div>
                 <div class="kb-range-control">
-                  <input
+                  <z-slider
                     class="kb-range"
-                    type="range"
-                    min="0"
-                    max="500"
-                    step="1"
-                    [attr.style]="'--range-progress: ' + chunkOverlapPercent()"
+                    [min]="0"
+                    [max]="500"
+                    [step]="1"
+                    [attr.aria-label]="i18nPrefix + '.Chunk.Overlap' | translate"
                     [(ngModel)]="chunkOverlap"
                   />
                   <div class="kb-range-ticks"><span>0</span><span>250</span><span>500</span></div>
@@ -380,24 +394,30 @@
                       <span class="kb-separator-chip"
                         >{{ separatorLabelKey(separator) | translate
                         }}<button
+                          z-button
+                          zType="ghost"
+                          zSize="icon-xs"
                           type="button"
                           (click)="removeSeparator(separator)"
                           [attr.aria-label]="i18nPrefix + '.Chunk.RemoveSeparator' | translate"
                         >
-                          ×
-                        </button></span
-                      >
+                          <i class="ri-close-line"></i></button
+                      ></span>
                     }
-                    <select
+                    <z-select
                       class="kb-separator-add"
-                      [attr.aria-label]="i18nPrefix + '.Chunk.AddSeparator' | translate"
-                      (change)="addSeparator($any($event.target).value); $any($event.target).value = ''"
+                      zSize="sm"
+                      [zPlaceholder]="i18nPrefix + '.Chunk.Add' | translate"
+                      [zLabel]="i18nPrefix + '.Chunk.AddSeparator' | translate"
+                      [(ngModel)]="separatorToAdd"
+                      (ngModelChange)="selectSeparator($event)"
                     >
-                      <option value="">{{ i18nPrefix + '.Chunk.Add' | translate }}</option>
                       @for (option of separatorOptions; track option.value) {
-                        <option [value]="option.value">{{ i18nPrefix + '.' + option.labelKey | translate }}</option>
+                        <z-select-item [zValue]="option.value">{{
+                          i18nPrefix + '.' + option.labelKey | translate
+                        }}</z-select-item>
                       }
-                    </select>
+                    </z-select>
                   </div>
                 </div>
               </div>
@@ -457,9 +477,11 @@
               </div>
               <div class="kb-field mt-5">
                 <label class="kb-label">{{ i18nPrefix + '.Audio.ParserEngine' | translate }}</label>
-                <select class="kb-native-select" disabled>
-                  <option>{{ i18nPrefix + '.Audio.NotConnected' | translate }}</option>
-                </select>
+                <z-select zDisabled [zValue]="'unavailable'">
+                  <z-select-item zValue="unavailable">{{
+                    i18nPrefix + '.Audio.NotConnected' | translate
+                  }}</z-select-item>
+                </z-select>
               </div>
             </section>
           }
@@ -487,19 +509,20 @@
 
                 <div class="kb-graph-mode-row">
                   <div class="kb-field-title">{{ i18nPrefix + '.Graph.RetrievalMode' | translate }}</div>
-                  <div class="kb-segmented-control">
+                  <z-segmented
+                    class="kb-graph-mode-control"
+                    [ngModel]="graphMode()"
+                    (ngModelChange)="setGraphMode($event)"
+                    [zAriaLabel]="i18nPrefix + '.Graph.RetrievalMode' | translate"
+                  >
                     @for (option of graphModeOptions; track option.value) {
-                      <button
-                        type="button"
-                        class="kb-segmented-option"
-                        [class.kb-segmented-option-active]="graphMode() === option.value"
-                        [disabled]="!graphEnabled() && option.value !== 'vector'"
-                        (click)="setGraphMode(option.value)"
-                      >
-                        {{ i18nPrefix + '.' + option.labelKey | translate }}
-                      </button>
+                      <z-segmented-item
+                        [value]="option.value"
+                        [label]="i18nPrefix + '.' + option.labelKey | translate"
+                        [zDisabled]="!graphEnabled() && option.value !== 'vector'"
+                      />
                     }
-                  </div>
+                  </z-segmented>
                   <p class="kb-help-text">{{ graphModeDescriptionKey() | translate }}</p>
                 </div>
 
@@ -518,15 +541,13 @@
                       <p class="kb-help-text">{{ i18nPrefix + '.Graph.EntityTopKDescription' | translate }}</p>
                     </div>
                     <div class="kb-graph-range-control">
-                      <input
+                      <z-slider
                         class="kb-range"
-                        type="range"
-                        min="1"
-                        max="50"
-                        step="1"
-                        [disabled]="!graphEnabled()"
+                        [min]="1"
+                        [max]="50"
+                        [step]="1"
+                        [disabledInput]="!graphEnabled()"
                         [attr.aria-label]="i18nPrefix + '.Graph.EntityTopK' | translate"
-                        [attr.style]="'--range-progress: ' + (graphEntityTopK() / 50) * 100 + '%'"
                         [ngModel]="graphEntityTopK()"
                         (ngModelChange)="graphEntityTopK.set(+$event)"
                       />
@@ -543,15 +564,13 @@
                       <p class="kb-help-text">{{ i18nPrefix + '.Graph.NeighborHopsDescription' | translate }}</p>
                     </div>
                     <div class="kb-graph-range-control">
-                      <input
+                      <z-slider
                         class="kb-range"
-                        type="range"
-                        min="1"
-                        max="2"
-                        step="1"
-                        [disabled]="!graphEnabled()"
+                        [min]="1"
+                        [max]="2"
+                        [step]="1"
+                        [disabledInput]="!graphEnabled()"
                         [attr.aria-label]="i18nPrefix + '.Graph.NeighborHops' | translate"
-                        [attr.style]="'--range-progress: ' + (graphNeighborHops() - 1) * 100 + '%'"
                         [ngModel]="graphNeighborHops()"
                         (ngModelChange)="graphNeighborHops.set(+$event)"
                       />
@@ -568,15 +587,13 @@
                       <p class="kb-help-text">{{ i18nPrefix + '.Graph.WeightDescription' | translate }}</p>
                     </div>
                     <div class="kb-graph-range-control">
-                      <input
+                      <z-slider
                         class="kb-range"
-                        type="range"
-                        min="0"
-                        max="1"
-                        step="0.05"
-                        [disabled]="!graphEnabled()"
+                        [min]="0"
+                        [max]="1"
+                        [step]="0.05"
+                        [disabledInput]="!graphEnabled()"
                         [attr.aria-label]="i18nPrefix + '.Graph.Weight' | translate"
-                        [attr.style]="'--range-progress: ' + graphWeight() * 100 + '%'"
                         [ngModel]="graphWeight()"
                         (ngModelChange)="graphWeight.set(+$event)"
                       />
@@ -616,6 +633,8 @@
                       <p>{{ i18nPrefix + '.Advanced.QuestionCountDescription' | translate }}</p>
                     </div>
                     <input
+                      z-input
+                      zSize="lg"
                       class="kb-input kb-number-input"
                       type="number"
                       min="1"
@@ -627,6 +646,7 @@
                     <div class="kb-field-title">{{ i18nPrefix + '.Advanced.QuestionRequirements' | translate }}</div>
                     <p>{{ i18nPrefix + '.Advanced.QuestionRequirementsDescription' | translate }}</p>
                     <textarea
+                      z-input
                       class="kb-textarea kb-advanced-textarea"
                       maxlength="4000"
                       [(ngModel)]="questionRequirements"
@@ -641,6 +661,7 @@
                 <div class="kb-field-title">{{ i18nPrefix + '.Advanced.TableMetadataRequirements' | translate }}</div>
                 <p>{{ i18nPrefix + '.Advanced.TableMetadataRequirementsDescription' | translate }}</p>
                 <textarea
+                  z-input
                   class="kb-textarea kb-advanced-textarea"
                   maxlength="4000"
                   [(ngModel)]="tableMetadataRequirements"
@@ -676,22 +697,27 @@
 
       <footer class="kb-create-footer">
         <button
+          z-button
+          zType="secondary"
+          zSize="lg"
           type="button"
-          class="btn btn-secondary btn-large kb-footer-button"
+          class="kb-footer-button"
           [disabled]="loading()"
           (click)="close()"
         >
           {{ i18nPrefix + '.Actions.Cancel' | translate }}
         </button>
         <button
+          z-button
+          zType="default"
+          zSize="lg"
           type="button"
-          class="btn btn-primary btn-large kb-footer-button kb-footer-primary"
+          class="kb-footer-button kb-footer-primary"
           [disabled]="loading()"
+          [zDisabled]="loading()"
+          [zLoading]="loading()"
           (click)="submit()"
         >
-          @if (loading()) {
-            <i class="ri-loader-4-line kb-spin"></i>
-          }
           {{ i18nPrefix + (isEditMode() ? '.Actions.Save' : '.Actions.Create') | translate }}
         </button>
       </footer>

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
@@ -1,16 +1,18 @@
 <div class="kb-create-dialog" cdkDrag cdkDragRootElement=".cdk-overlay-pane">
-  <button type="button" class="kb-close-button" aria-label="关闭" (click)="close()">
+  <button type="button" class="kb-close-button" [attr.aria-label]="i18nPrefix + '.Close' | translate" (click)="close()">
     <i class="ri-close-line"></i>
   </button>
 
   <div class="kb-settings-container">
-    <aside class="kb-create-sidebar" aria-label="知识库设置导航">
+    <aside class="kb-create-sidebar" [attr.aria-label]="i18nPrefix + '.NavigationLabel' | translate">
       <div class="kb-sidebar-header" cdkDragHandle>
-        <div class="kb-create-title">{{ isEditMode() ? '知识库设置' : '新建知识库' }}</div>
+        <div class="kb-create-title">
+          {{ i18nPrefix + (isEditMode() ? '.EditTitle' : '.CreateTitle') | translate }}
+        </div>
       </div>
       @for (group of groupedSections(); track group.group) {
         <div class="kb-sidebar-group">
-          <div class="kb-sidebar-group-title">{{ group.group }}</div>
+          <div class="kb-sidebar-group-title">{{ i18nPrefix + '.Groups.' + group.group | translate }}</div>
           <nav class="kb-sidebar-nav">
             @for (section of group.items; track section.key) {
               <button
@@ -21,9 +23,9 @@
                 (click)="selectSection(section.key)"
               >
                 <i [class]="section.icon"></i>
-                <span>{{ section.label }}</span>
+                <span>{{ i18nPrefix + '.' + section.labelKey | translate }}</span>
                 @if (section.status !== 'supported') {
-                  <span class="kb-sidebar-dot" [attr.title]="sectionStatusLabel(section.status)"></span>
+                  <span class="kb-sidebar-dot" [attr.title]="sectionStatusKey(section.status) | translate"></span>
                 }
               </button>
             }
@@ -38,12 +40,14 @@
           @case ('basic') {
             <section class="kb-section">
               <div class="kb-section-heading">
-                <h1>基本信息</h1>
-                <p>设置知识库的类型、索引策略和基本信息</p>
+                <h1>{{ i18nPrefix + '.Sections.Basic' | translate }}</h1>
+                <p>{{ i18nPrefix + '.Basic.Description' | translate }}</p>
               </div>
 
               <div class="kb-field">
-                <label class="kb-label">知识库类型 <span class="kb-required">*</span></label>
+                <label class="kb-label"
+                  >{{ i18nPrefix + '.Basic.KnowledgebaseType' | translate }} <span class="kb-required">*</span></label
+                >
                 <div class="kb-segmented-control">
                   <button
                     type="button"
@@ -51,18 +55,20 @@
                     [class.kb-segmented-option-active]="type() === KnowledgebaseTypeEnum.Standard"
                     (click)="type.set(KnowledgebaseTypeEnum.Standard)"
                   >
-                    文档
+                    {{ i18nPrefix + '.Basic.Document' | translate }}
                   </button>
                   <button type="button" class="kb-segmented-option kb-segmented-option-disabled" disabled>
-                    问答
-                    <span class="kb-mini-badge">预览</span>
+                    {{ i18nPrefix + '.Basic.QandA' | translate }}
+                    <span class="kb-mini-badge">{{ i18nPrefix + '.Statuses.Preview' | translate }}</span>
                   </button>
                 </div>
-                <p class="kb-help-text">Xpert 当前支持标准文档知识库，问答知识库将在后续版本接入。</p>
+                <p class="kb-help-text">{{ i18nPrefix + '.Basic.KnowledgebaseTypeHelp' | translate }}</p>
               </div>
 
               <div class="kb-field">
-                <label class="kb-label">索引策略 <span class="kb-required">*</span></label>
+                <label class="kb-label"
+                  >{{ i18nPrefix + '.Basic.IndexStrategy' | translate }} <span class="kb-required">*</span></label
+                >
                 <div class="kb-choice-grid">
                   <button
                     type="button"
@@ -71,32 +77,42 @@
                     (click)="indexStrategy.set('rag')"
                   >
                     <span class="kb-choice-check"><i class="ri-check-line"></i></span>
-                    <span class="kb-choice-card-title">RAG 检索</span>
-                    <span class="kb-choice-card-description"
-                      >对文档进行分块、向量化和检索，支持向量、图谱和混合模式。</span
-                    >
+                    <span class="kb-choice-card-title">{{ i18nPrefix + '.Basic.RagSearch' | translate }}</span>
+                    <span class="kb-choice-card-description">{{
+                      i18nPrefix + '.Basic.RagSearchDescription' | translate
+                    }}</span>
                   </button>
                   <button type="button" class="kb-choice-card kb-choice-card-disabled" disabled>
                     <span class="kb-choice-empty"><i class="ri-checkbox-blank-line"></i></span>
-                    <span class="kb-choice-card-title">Wiki 知识库 <span class="kb-new-badge">NEW</span></span>
-                    <span class="kb-choice-card-description"
-                      >自动生成关联的 Wiki 页面，当前 Xpert 暂无对应索引浏览器。</span
+                    <span class="kb-choice-card-title"
+                      >{{ i18nPrefix + '.Basic.WikiKnowledgebase' | translate }}
+                      <span class="kb-new-badge">{{ i18nPrefix + '.Basic.New' | translate }}</span></span
                     >
+                    <span class="kb-choice-card-description">{{
+                      i18nPrefix + '.Basic.WikiDescription' | translate
+                    }}</span>
                   </button>
                 </div>
               </div>
 
               <div class="kb-field">
-                <label class="kb-label">知识库名称 <span class="kb-required">*</span></label>
-                <input class="kb-input" [(ngModel)]="name" placeholder="请输入知识库名称" maxlength="80" />
+                <label class="kb-label"
+                  >{{ i18nPrefix + '.Basic.Name' | translate }} <span class="kb-required">*</span></label
+                >
+                <input
+                  class="kb-input"
+                  [(ngModel)]="name"
+                  [placeholder]="i18nPrefix + '.Basic.NamePlaceholder' | translate"
+                  maxlength="80"
+                />
               </div>
 
               <div class="kb-field">
-                <label class="kb-label">知识库描述</label>
+                <label class="kb-label">{{ i18nPrefix + '.Basic.KnowledgebaseDescription' | translate }}</label>
                 <textarea
                   class="kb-textarea"
                   [(ngModel)]="description"
-                  placeholder="请输入知识库描述（可选）"
+                  [placeholder]="i18nPrefix + '.Basic.DescriptionPlaceholder' | translate"
                   maxlength="200"
                 ></textarea>
                 <div class="kb-counter">{{ description().length }}/200</div>
@@ -107,15 +123,17 @@
           @case ('models') {
             <section class="kb-section">
               <div class="kb-section-heading">
-                <h1>模型配置</h1>
-                <p>为知识库选择合适的 AI 模型</p>
+                <h1>{{ i18nPrefix + '.Sections.Models' | translate }}</h1>
+                <p>{{ i18nPrefix + '.Models.Description' | translate }}</p>
               </div>
 
               <div class="kb-weknora-form">
                 <div class="kb-model-row">
                   <div class="kb-model-row-copy">
-                    <div class="kb-model-row-title">LLM 大语言模型 <span class="kb-required">*</span></div>
-                    <p>用于总结和摘要的大语言模型</p>
+                    <div class="kb-model-row-title">
+                      {{ i18nPrefix + '.Models.LargeLanguageModel' | translate }} <span class="kb-required">*</span>
+                    </div>
+                    <p>{{ i18nPrefix + '.Models.LargeLanguageModelDescription' | translate }}</p>
                   </div>
                   <copilot-model-select
                     class="kb-model-row-select"
@@ -129,8 +147,10 @@
 
                 <div class="kb-model-row">
                   <div class="kb-model-row-copy">
-                    <div class="kb-model-row-title">Embedding 嵌入模型 <span class="kb-required">*</span></div>
-                    <p>用于文本向量化的嵌入模型</p>
+                    <div class="kb-model-row-title">
+                      {{ i18nPrefix + '.Models.EmbeddingModel' | translate }} <span class="kb-required">*</span>
+                    </div>
+                    <p>{{ i18nPrefix + '.Models.EmbeddingModelDescription' | translate }}</p>
                   </div>
                   <copilot-model-select
                     class="kb-model-row-select"
@@ -147,24 +167,24 @@
           @case ('vector') {
             <section class="kb-section">
               <div class="kb-section-heading">
-                <h1>向量检索</h1>
-                <p>配置查询向量、候选数量和相似度筛选策略。</p>
+                <h1>{{ i18nPrefix + '.Sections.Vector' | translate }}</h1>
+                <p>{{ i18nPrefix + '.Vector.Description' | translate }}</p>
               </div>
               <div class="kb-panel kb-vector-search-panel">
                 <div class="kb-vector-search-heading">
                   <div class="kb-vector-search-title">
                     <i class="ri-focus-2-line"></i>
-                    <span>向量搜索</span>
+                    <span>{{ i18nPrefix + '.Vector.Search' | translate }}</span>
                   </div>
-                  <p class="kb-panel-description">生成查询嵌入并搜索与其向量表示最相似的文本块。</p>
+                  <p class="kb-panel-description">{{ i18nPrefix + '.Vector.SearchDescription' | translate }}</p>
                 </div>
 
                 <div class="kb-divider"></div>
 
                 <div class="kb-vector-rerank-row">
                   <div>
-                    <div class="kb-field-title">重新排序模型</div>
-                    <p class="kb-help-text">使用重排模型对候选文本块重新排序，提升结果相关性。</p>
+                    <div class="kb-field-title">{{ i18nPrefix + '.Vector.RerankModel' | translate }}</div>
+                    <p class="kb-help-text">{{ i18nPrefix + '.Vector.RerankDescription' | translate }}</p>
                   </div>
                   <z-switch class="kb-primary-switch" [(ngModel)]="rerankEnabled" />
                 </div>
@@ -178,17 +198,17 @@
                 <div class="kb-vector-metric-grid">
                   <div class="kb-vector-metric-card">
                     <div class="kb-vector-metric-label">
-                      <span class="kb-field-title">前多少</span>
+                      <span class="kb-field-title">{{ i18nPrefix + '.Vector.TopK' | translate }}</span>
                       <strong>{{ vectorTopK() }}</strong>
                     </div>
-                    <p class="kb-help-text">返回候选文本块的数量（1–100）。</p>
+                    <p class="kb-help-text">{{ i18nPrefix + '.Vector.TopKDescription' | translate }}</p>
                     <input
                       class="kb-range"
                       type="range"
                       min="1"
                       max="100"
                       step="1"
-                      [attr.aria-label]="'前多少'"
+                      [attr.aria-label]="i18nPrefix + '.Vector.TopK' | translate"
                       [attr.style]="'--range-progress: ' + vectorTopKPercent()"
                       [(ngModel)]="vectorTopK"
                     />
@@ -197,11 +217,11 @@
 
                   <div class="kb-vector-metric-card">
                     <div class="kb-vector-metric-label">
-                      <span class="kb-field-title">相似度阈值</span>
+                      <span class="kb-field-title">{{ i18nPrefix + '.Vector.ScoreThreshold' | translate }}</span>
                       <z-switch class="kb-primary-switch" [(ngModel)]="vectorScoreEnabled" />
                       <strong>{{ vectorScore() | number: '1.2-2' }}</strong>
                     </div>
-                    <p class="kb-help-text">低于阈值的文本块会被过滤，关闭后不限制最低相似度。</p>
+                    <p class="kb-help-text">{{ i18nPrefix + '.Vector.ScoreThresholdDescription' | translate }}</p>
                     <input
                       class="kb-range"
                       type="range"
@@ -209,7 +229,7 @@
                       max="1"
                       step="0.01"
                       [disabled]="!vectorScoreEnabled()"
-                      [attr.aria-label]="'相似度阈值'"
+                      [attr.aria-label]="i18nPrefix + '.Vector.ScoreThreshold' | translate"
                       [attr.style]="'--range-progress: ' + vectorScorePercent()"
                       [(ngModel)]="vectorScore"
                     />
@@ -219,7 +239,7 @@
 
                 <div class="kb-inline-notice">
                   <i class="ri-information-line"></i>
-                  <span>向量存储由 Xpert 平台统一管理，此处只配置检索行为。</span>
+                  <span>{{ i18nPrefix + '.Vector.StorageNotice' | translate }}</span>
                 </div>
               </div>
             </section>
@@ -228,15 +248,17 @@
           @case ('parser') {
             <section class="kb-section">
               <div class="kb-section-heading">
-                <h1>解析引擎</h1>
-                <p>为不同文件类型选择文档解析引擎。未配置的文件类型将使用内置解析引擎。</p>
+                <h1>{{ i18nPrefix + '.Sections.Parser' | translate }}</h1>
+                <p>{{ i18nPrefix + '.Parser.Description' | translate }}</p>
               </div>
 
               <div class="kb-parser-engine-list">
                 @for (row of parserEngineRows; track row.key) {
                   <div class="kb-parser-engine-row">
                     <div class="kb-parser-engine-copy">
-                      <div class="kb-parser-engine-title"><i [class]="row.icon"></i>{{ row.label }}</div>
+                      <div class="kb-parser-engine-title">
+                        <i [class]="row.icon"></i>{{ i18nPrefix + '.' + row.labelKey | translate }}
+                      </div>
                       <div class="kb-extension-list">
                         @for (extension of row.extensions; track extension) {
                           <span class="kb-extension-chip">{{ extension }}</span>
@@ -250,13 +272,13 @@
                         (ngModelChange)="updateParserEngine(row.key, $event)"
                       >
                         @for (option of row.options; track option.value) {
-                          <option [value]="option.value">{{ option.label }}</option>
+                          <option [value]="option.value">{{ i18nPrefix + '.' + option.labelKey | translate }}</option>
                         }
                       </select>
                       @if (row.hasHeaderToggle) {
                         <label class="kb-checkbox-row">
                           <input type="checkbox" [(ngModel)]="excelHeaderRow" />
-                          <span>将首行作为列标题，并保留在每行上下文中</span>
+                          <span>{{ i18nPrefix + '.Parser.ExcelHeaderRow' | translate }}</span>
                         </label>
                       }
                     </div>
@@ -269,40 +291,45 @@
           @case ('chunk') {
             <section class="kb-section">
               <div class="kb-section-heading">
-                <h1>分块设置</h1>
-                <p>控制上传文档在嵌入前的切分方式。默认值适用于大多数场景，仅在检索质量异常时调整。</p>
+                <h1>{{ i18nPrefix + '.Sections.Chunk' | translate }}</h1>
+                <p>{{ i18nPrefix + '.Chunk.Description' | translate }}</p>
               </div>
 
               <div class="kb-chunk-strategy-row">
                 <div class="kb-chunk-copy">
-                  <div class="kb-field-title">分块策略</div>
-                  <p>选择文档的分块方式。自动模式会分析每个文档的结构并选择最佳策略。</p>
+                  <div class="kb-field-title">{{ i18nPrefix + '.Chunk.Strategy' | translate }}</div>
+                  <p>{{ i18nPrefix + '.Chunk.StrategyDescription' | translate }}</p>
                 </div>
                 <div class="kb-chunk-strategy-control">
                   <select class="kb-native-select" [(ngModel)]="chunkStrategy">
-                    <option value="auto">自动</option>
-                    <option value="title">按标题切分</option>
-                    <option value="structure">结构感知</option>
-                    <option value="length">按长度切分</option>
+                    <option value="auto">{{ i18nPrefix + '.Chunk.Strategies.Auto' | translate }}</option>
+                    <option value="title">{{ i18nPrefix + '.Chunk.Strategies.Title' | translate }}</option>
+                    <option value="structure">{{ i18nPrefix + '.Chunk.Strategies.Structure' | translate }}</option>
+                    <option value="length">{{ i18nPrefix + '.Chunk.Strategies.Length' | translate }}</option>
                   </select>
-                  <button type="button" class="kb-test-chunk-button" title="测试分块效果">
-                    <i class="ri-play-circle-line"></i><span>测试分块效果</span>
+                  <button
+                    type="button"
+                    class="kb-test-chunk-button"
+                    [attr.title]="i18nPrefix + '.Chunk.Test' | translate"
+                  >
+                    <i class="ri-play-circle-line"></i><span>{{ i18nPrefix + '.Chunk.Test' | translate }}</span>
                   </button>
                 </div>
               </div>
 
               @if (chunkStrategy() === 'auto') {
                 <div class="kb-chunk-auto-note">
-                  <strong>自动:</strong> 文档分析器根据内容结构自动在「按标题切分」「结构感知」「按长度切分」之间选择。
+                  <strong>{{ i18nPrefix + '.Chunk.AutoNoteLabel' | translate }}:</strong>
+                  {{ i18nPrefix + '.Chunk.AutoNote' | translate }}
                 </div>
               }
 
               <div class="kb-chunk-setting-row">
                 <div class="kb-chunk-copy">
-                  <div class="kb-field-title">分块大小</div>
+                  <div class="kb-field-title">{{ i18nPrefix + '.Chunk.Size' | translate }}</div>
                   <p>
-                    每个分块的最大字符数（100–4000）。默认 512<br />≈ 中文 300 tokens / 英文 100–130 tokens。FAQ 用
-                    200–400，叙述性长文档用 1000–2000。
+                    {{ i18nPrefix + '.Chunk.SizeDescription' | translate }}<br />
+                    {{ i18nPrefix + '.Chunk.SizeRecommendation' | translate }}
                   </p>
                 </div>
                 <div class="kb-range-control">
@@ -316,17 +343,14 @@
                     [(ngModel)]="chunkSize"
                   />
                   <div class="kb-range-ticks"><span>100</span><span>1000</span><span>2000</span><span>4000</span></div>
-                  <strong>{{ chunkSize() ?? 512 }} 字符</strong>
+                  <strong>{{ i18nPrefix + '.Chunk.CharacterCount' | translate: { count: chunkSize() ?? 512 } }}</strong>
                 </div>
               </div>
 
               <div class="kb-chunk-setting-row">
                 <div class="kb-chunk-copy">
-                  <div class="kb-field-title">分块重叠</div>
-                  <p>
-                    相邻分块之间共享的字符数（0–500）。默认 80 ≈ 分块大小的 15%，符合当前研究推荐。FAQ/结构化数据用
-                    0，长篇叙述用 150–200。
-                  </p>
+                  <div class="kb-field-title">{{ i18nPrefix + '.Chunk.Overlap' | translate }}</div>
+                  <p>{{ i18nPrefix + '.Chunk.OverlapDescription' | translate }}</p>
                 </div>
                 <div class="kb-range-control">
                   <input
@@ -339,33 +363,39 @@
                     [(ngModel)]="chunkOverlap"
                   />
                   <div class="kb-range-ticks"><span>0</span><span>250</span><span>500</span></div>
-                  <strong>{{ chunkOverlap() ?? 80 }} 字符</strong>
+                  <strong>{{
+                    i18nPrefix + '.Chunk.CharacterCount' | translate: { count: chunkOverlap() ?? 80 }
+                  }}</strong>
                 </div>
               </div>
 
               <div class="kb-chunk-setting-row kb-separator-row">
                 <div class="kb-chunk-copy">
-                  <div class="kb-field-title">分隔符</div>
-                  <p>切分时优先使用的字符或字符串。优先级高的分隔符先尝试；默认顺序优先段落 → 句子 → 标点。</p>
+                  <div class="kb-field-title">{{ i18nPrefix + '.Chunk.Separators' | translate }}</div>
+                  <p>{{ i18nPrefix + '.Chunk.SeparatorsDescription' | translate }}</p>
                 </div>
                 <div class="kb-separator-control">
                   <div class="kb-chip-control">
                     @for (separator of separators(); track separator) {
                       <span class="kb-separator-chip"
-                        >{{ separatorLabel(separator)
-                        }}<button type="button" (click)="removeSeparator(separator)" aria-label="移除分隔符">
+                        >{{ separatorLabelKey(separator) | translate
+                        }}<button
+                          type="button"
+                          (click)="removeSeparator(separator)"
+                          [attr.aria-label]="i18nPrefix + '.Chunk.RemoveSeparator' | translate"
+                        >
                           ×
                         </button></span
                       >
                     }
                     <select
                       class="kb-separator-add"
-                      aria-label="添加分隔符"
+                      [attr.aria-label]="i18nPrefix + '.Chunk.AddSeparator' | translate"
                       (change)="addSeparator($any($event.target).value); $any($event.target).value = ''"
                     >
-                      <option value="">添加</option>
+                      <option value="">{{ i18nPrefix + '.Chunk.Add' | translate }}</option>
                       @for (option of separatorOptions; track option.value) {
-                        <option [value]="option.value">{{ option.label }}</option>
+                        <option [value]="option.value">{{ i18nPrefix + '.' + option.labelKey | translate }}</option>
                       }
                     </select>
                   </div>
@@ -377,14 +407,14 @@
           @case ('image') {
             <section class="kb-section">
               <div class="kb-section-heading">
-                <h1>图像处理</h1>
-                <p>配置图片理解策略，帮助知识库提取图片中的文字和语义。</p>
+                <h1>{{ i18nPrefix + '.Sections.Image' | translate }}</h1>
+                <p>{{ i18nPrefix + '.Image.Description' | translate }}</p>
               </div>
               <div class="kb-panel kb-panel-post-create">
                 <div class="kb-field kb-field-inline">
                   <div>
-                    <label class="kb-label">启用图片理解</label>
-                    <p class="kb-help-text">图片文档将在导入时调用视觉理解模型。</p>
+                    <label class="kb-label">{{ i18nPrefix + '.Image.Enable' | translate }}</label>
+                    <p class="kb-help-text">{{ i18nPrefix + '.Image.EnableDescription' | translate }}</p>
                   </div>
                   <z-switch
                     class="kb-primary-switch"
@@ -395,13 +425,13 @@
                 <div class="kb-divider"></div>
                 <copilot-model-select
                   class="block"
-                  [label]="'Vision 模型'"
+                  [label]="i18nPrefix + '.Image.VisionModel' | translate"
                   [modelType]="eAiModelTypeEnum.LLM"
                   [features]="[eModelFeature.VISION]"
                   [(ngModel)]="visionModel"
                 />
                 <p class="kb-inline-notice">
-                  <i class="ri-information-line"></i> 图片理解配置将在知识库创建后从文档导入设置中保存。
+                  <i class="ri-information-line"></i> {{ i18nPrefix + '.Image.PostCreateNotice' | translate }}
                 </p>
               </div>
             </section>
@@ -410,23 +440,25 @@
           @case ('audio') {
             <section class="kb-section">
               <div class="kb-section-heading">
-                <h1>音频处理</h1>
-                <p>为音频文件选择语音识别引擎。</p>
+                <h1>{{ i18nPrefix + '.Sections.Audio' | translate }}</h1>
+                <p>{{ i18nPrefix + '.Audio.Description' | translate }}</p>
               </div>
               <div class="kb-placeholder-card">
                 <div class="kb-placeholder-icon"><i class="ri-volume-up-line"></i></div>
                 <div>
-                  <div class="kb-panel-title">语音转文本（ASR）</div>
+                  <div class="kb-panel-title">{{ i18nPrefix + '.Audio.SpeechToText' | translate }}</div>
                   <p class="kb-panel-description">
-                    Xpert 文档模型已支持 Audio 类型，但当前知识库创建接口还没有 ASR 引擎字段。
+                    {{ i18nPrefix + '.Audio.UnavailableDescription' | translate }}
                   </p>
                 </div>
-                <span class="kb-status-badge kb-status-preview">前端预览</span>
+                <span class="kb-status-badge kb-status-preview">{{
+                  i18nPrefix + '.Audio.FrontendPreview' | translate
+                }}</span>
               </div>
               <div class="kb-field mt-5">
-                <label class="kb-label">解析引擎</label>
+                <label class="kb-label">{{ i18nPrefix + '.Audio.ParserEngine' | translate }}</label>
                 <select class="kb-native-select" disabled>
-                  <option>暂未接入</option>
+                  <option>{{ i18nPrefix + '.Audio.NotConnected' | translate }}</option>
                 </select>
               </div>
             </section>
@@ -435,14 +467,14 @@
           @case ('graph') {
             <section class="kb-section">
               <div class="kb-section-heading">
-                <h1>知识图谱</h1>
-                <p>配置 GraphRAG，从文档中抽取实体和关系并参与知识检索。</p>
+                <h1>{{ i18nPrefix + '.Sections.Graph' | translate }}</h1>
+                <p>{{ i18nPrefix + '.Graph.Description' | translate }}</p>
               </div>
               <div class="kb-panel kb-graph-settings-panel">
                 <div class="kb-field-inline">
                   <div>
-                    <div class="kb-panel-title">启用 GraphRAG</div>
-                    <p class="kb-panel-description">解析文档时抽取实体、关系和证据，供图谱检索与混合检索使用。</p>
+                    <div class="kb-panel-title">{{ i18nPrefix + '.Graph.Enable' | translate }}</div>
+                    <p class="kb-panel-description">{{ i18nPrefix + '.Graph.EnableDescription' | translate }}</p>
                   </div>
                   <z-switch
                     class="kb-primary-switch"
@@ -454,7 +486,7 @@
                 <div class="kb-divider"></div>
 
                 <div class="kb-graph-mode-row">
-                  <div class="kb-field-title">检索模式</div>
+                  <div class="kb-field-title">{{ i18nPrefix + '.Graph.RetrievalMode' | translate }}</div>
                   <div class="kb-segmented-control">
                     @for (option of graphModeOptions; track option.value) {
                       <button
@@ -464,26 +496,26 @@
                         [disabled]="!graphEnabled() && option.value !== 'vector'"
                         (click)="setGraphMode(option.value)"
                       >
-                        {{ option.label }}
+                        {{ i18nPrefix + '.' + option.labelKey | translate }}
                       </button>
                     }
                   </div>
-                  <p class="kb-help-text">{{ graphModeDescription() }}</p>
+                  <p class="kb-help-text">{{ graphModeDescriptionKey() | translate }}</p>
                 </div>
 
                 <div class="kb-graph-settings-heading">
-                  <div class="kb-field-title">图谱检索参数</div>
-                  <p class="kb-help-text">与 Xpert 检索设置保持一致，关闭 GraphRAG 时保留当前配置。</p>
+                  <div class="kb-field-title">{{ i18nPrefix + '.Graph.Parameters' | translate }}</div>
+                  <p class="kb-help-text">{{ i18nPrefix + '.Graph.ParametersDescription' | translate }}</p>
                 </div>
 
                 <div class="kb-graph-setting-list" [class.kb-graph-setting-list-disabled]="!graphEnabled()">
                   <div class="kb-graph-setting-row">
                     <div class="kb-graph-setting-copy">
                       <div class="kb-graph-setting-label">
-                        <div class="kb-field-title">实体 Top K</div>
+                        <div class="kb-field-title">{{ i18nPrefix + '.Graph.EntityTopK' | translate }}</div>
                         <strong>{{ graphEntityTopK() }}</strong>
                       </div>
-                      <p class="kb-help-text">每次查询用于扩展图谱的候选实体数量。</p>
+                      <p class="kb-help-text">{{ i18nPrefix + '.Graph.EntityTopKDescription' | translate }}</p>
                     </div>
                     <div class="kb-graph-range-control">
                       <input
@@ -493,7 +525,7 @@
                         max="50"
                         step="1"
                         [disabled]="!graphEnabled()"
-                        [attr.aria-label]="'实体 Top K'"
+                        [attr.aria-label]="i18nPrefix + '.Graph.EntityTopK' | translate"
                         [attr.style]="'--range-progress: ' + (graphEntityTopK() / 50) * 100 + '%'"
                         [ngModel]="graphEntityTopK()"
                         (ngModelChange)="graphEntityTopK.set(+$event)"
@@ -505,10 +537,10 @@
                   <div class="kb-graph-setting-row">
                     <div class="kb-graph-setting-copy">
                       <div class="kb-graph-setting-label">
-                        <div class="kb-field-title">邻居跳数</div>
+                        <div class="kb-field-title">{{ i18nPrefix + '.Graph.NeighborHops' | translate }}</div>
                         <strong>{{ graphNeighborHops() }}</strong>
                       </div>
-                      <p class="kb-help-text">沿实体关系扩展的层数，最多支持两跳。</p>
+                      <p class="kb-help-text">{{ i18nPrefix + '.Graph.NeighborHopsDescription' | translate }}</p>
                     </div>
                     <div class="kb-graph-range-control">
                       <input
@@ -518,7 +550,7 @@
                         max="2"
                         step="1"
                         [disabled]="!graphEnabled()"
-                        [attr.aria-label]="'邻居跳数'"
+                        [attr.aria-label]="i18nPrefix + '.Graph.NeighborHops' | translate"
                         [attr.style]="'--range-progress: ' + (graphNeighborHops() - 1) * 100 + '%'"
                         [ngModel]="graphNeighborHops()"
                         (ngModelChange)="graphNeighborHops.set(+$event)"
@@ -530,10 +562,10 @@
                   <div class="kb-graph-setting-row">
                     <div class="kb-graph-setting-copy">
                       <div class="kb-graph-setting-label">
-                        <div class="kb-field-title">图谱权重</div>
+                        <div class="kb-field-title">{{ i18nPrefix + '.Graph.Weight' | translate }}</div>
                         <strong>{{ graphWeight() | number: '1.2-2' }}</strong>
                       </div>
-                      <p class="kb-help-text">混合检索时图谱结果在最终排序中的权重。</p>
+                      <p class="kb-help-text">{{ i18nPrefix + '.Graph.WeightDescription' | translate }}</p>
                     </div>
                     <div class="kb-graph-range-control">
                       <input
@@ -543,7 +575,7 @@
                         max="1"
                         step="0.05"
                         [disabled]="!graphEnabled()"
-                        [attr.aria-label]="'图谱权重'"
+                        [attr.aria-label]="i18nPrefix + '.Graph.Weight' | translate"
                         [attr.style]="'--range-progress: ' + graphWeight() * 100 + '%'"
                         [ngModel]="graphWeight()"
                         (ngModelChange)="graphWeight.set(+$event)"
@@ -555,7 +587,7 @@
 
                 <div class="kb-inline-notice">
                   <i class="ri-information-line"></i>
-                  <span>创建后可在知识库配置中重建图谱；已存在的文档需要重新解析才会生成图谱数据。</span>
+                  <span>{{ i18nPrefix + '.Graph.PostCreateNotice' | translate }}</span>
                 </div>
               </div>
             </section>
@@ -564,14 +596,14 @@
           @case ('advanced') {
             <section class="kb-section">
               <div class="kb-section-heading">
-                <h1>高级设置</h1>
-                <p>配置问题生成等高级功能</p>
+                <h1>{{ i18nPrefix + '.Sections.Advanced' | translate }}</h1>
+                <p>{{ i18nPrefix + '.Advanced.Description' | translate }}</p>
               </div>
 
               <div class="kb-advanced-switch-row">
                 <div>
-                  <div class="kb-field-title">AI 问题生成</div>
-                  <p>解析文档时调用大模型为每个分块生成相关问题，提高检索召回率。启用后会增加文档解析耗时。</p>
+                  <div class="kb-field-title">{{ i18nPrefix + '.Advanced.QuestionGeneration' | translate }}</div>
+                  <p>{{ i18nPrefix + '.Advanced.QuestionGenerationDescription' | translate }}</p>
                 </div>
                 <z-switch class="kb-primary-switch" [(ngModel)]="questionGenerationEnabled" />
               </div>
@@ -580,8 +612,8 @@
                 <div class="kb-advanced-emphasis">
                   <div class="kb-advanced-field kb-advanced-count-row">
                     <div>
-                      <div class="kb-field-title">生成问题数量</div>
-                      <p>每个文档分块生成的问题数量（1–10）</p>
+                      <div class="kb-field-title">{{ i18nPrefix + '.Advanced.QuestionCount' | translate }}</div>
+                      <p>{{ i18nPrefix + '.Advanced.QuestionCountDescription' | translate }}</p>
                     </div>
                     <input
                       class="kb-input kb-number-input"
@@ -592,13 +624,13 @@
                     />
                   </div>
                   <div class="kb-advanced-field">
-                    <div class="kb-field-title">问题生成要求</div>
-                    <p>指定问题面向的人群、场景和表达方式，系统仍维持稳定输出格式</p>
+                    <div class="kb-field-title">{{ i18nPrefix + '.Advanced.QuestionRequirements' | translate }}</div>
+                    <p>{{ i18nPrefix + '.Advanced.QuestionRequirementsDescription' | translate }}</p>
                     <textarea
                       class="kb-textarea kb-advanced-textarea"
                       maxlength="4000"
                       [(ngModel)]="questionRequirements"
-                      placeholder="例如：生成客服用户常问的自然语言问题，避免考试题式表达..."
+                      [placeholder]="i18nPrefix + '.Advanced.QuestionRequirementsPlaceholder' | translate"
                     ></textarea>
                     <div class="kb-counter">{{ questionRequirements().length }}/4000</div>
                   </div>
@@ -606,13 +638,13 @@
               }
 
               <div class="kb-advanced-field kb-table-metadata-field">
-                <div class="kb-field-title">表格元数据生成要求</div>
-                <p>为 CSV/Excel 摘要补充业务背景和字段语义，帮助后续检索理解表格内容</p>
+                <div class="kb-field-title">{{ i18nPrefix + '.Advanced.TableMetadataRequirements' | translate }}</div>
+                <p>{{ i18nPrefix + '.Advanced.TableMetadataRequirementsDescription' | translate }}</p>
                 <textarea
                   class="kb-textarea kb-advanced-textarea"
                   maxlength="4000"
                   [(ngModel)]="tableMetadataRequirements"
-                  placeholder="例如：这是销售订单表，金额单位为元，status 字段值使用公司内部状态码..."
+                  [placeholder]="i18nPrefix + '.Advanced.TableMetadataRequirementsPlaceholder' | translate"
                 ></textarea>
                 <div class="kb-counter">{{ tableMetadataRequirements().length }}/4000</div>
               </div>
@@ -622,18 +654,20 @@
           @case ('storage') {
             <section class="kb-section">
               <div class="kb-section-heading">
-                <h1>存储引擎</h1>
-                <p>配置原始文件和处理结果的存储方式。</p>
+                <h1>{{ i18nPrefix + '.Sections.Storage' | translate }}</h1>
+                <p>{{ i18nPrefix + '.Storage.Description' | translate }}</p>
               </div>
               <div class="kb-placeholder-card">
                 <div class="kb-placeholder-icon"><i class="ri-hard-drive-3-line"></i></div>
                 <div>
-                  <div class="kb-panel-title">平台默认存储</div>
+                  <div class="kb-panel-title">{{ i18nPrefix + '.Storage.PlatformDefault' | translate }}</div>
                   <p class="kb-panel-description">
-                    当前 Xpert 统一使用工作空间存储服务，知识库创建时不单独选择存储引擎。
+                    {{ i18nPrefix + '.Storage.PlatformDefaultDescription' | translate }}
                   </p>
                 </div>
-                <span class="kb-status-badge kb-status-preview">暂不支持切换</span>
+                <span class="kb-status-badge kb-status-preview">{{
+                  i18nPrefix + '.Storage.SwitchUnsupported' | translate
+                }}</span>
               </div>
             </section>
           }
@@ -647,7 +681,7 @@
           [disabled]="loading()"
           (click)="close()"
         >
-          取消
+          {{ i18nPrefix + '.Actions.Cancel' | translate }}
         </button>
         <button
           type="button"
@@ -658,7 +692,7 @@
           @if (loading()) {
             <i class="ri-loader-4-line kb-spin"></i>
           }
-          {{ isEditMode() ? '保存配置' : '创建知识库' }}
+          {{ i18nPrefix + (isEditMode() ? '.Actions.Save' : '.Actions.Create') | translate }}
         </button>
       </footer>
     </section>

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
@@ -144,6 +144,87 @@
             </section>
           }
 
+          @case ('vector') {
+            <section class="kb-section">
+              <div class="kb-section-heading">
+                <h1>向量检索</h1>
+                <p>配置查询向量、候选数量和相似度筛选策略。</p>
+              </div>
+              <div class="kb-panel kb-vector-search-panel">
+                <div class="kb-vector-search-heading">
+                  <div class="kb-vector-search-title">
+                    <i class="ri-focus-2-line"></i>
+                    <span>向量搜索</span>
+                  </div>
+                  <p class="kb-panel-description">生成查询嵌入并搜索与其向量表示最相似的文本块。</p>
+                </div>
+
+                <div class="kb-divider"></div>
+
+                <div class="kb-vector-rerank-row">
+                  <div>
+                    <div class="kb-field-title">重新排序模型</div>
+                    <p class="kb-help-text">使用重排模型对候选文本块重新排序，提升结果相关性。</p>
+                  </div>
+                  <z-switch class="kb-primary-switch" [(ngModel)]="rerankEnabled" />
+                </div>
+
+                @if (rerankEnabled()) {
+                  <div class="kb-vector-rerank-model">
+                    <copilot-model-select hiddenLabel [modelType]="eAiModelTypeEnum.RERANK" [(ngModel)]="rerankModel" />
+                  </div>
+                }
+
+                <div class="kb-vector-metric-grid">
+                  <div class="kb-vector-metric-card">
+                    <div class="kb-vector-metric-label">
+                      <span class="kb-field-title">前多少</span>
+                      <strong>{{ vectorTopK() }}</strong>
+                    </div>
+                    <p class="kb-help-text">返回候选文本块的数量（1–100）。</p>
+                    <input
+                      class="kb-range"
+                      type="range"
+                      min="1"
+                      max="100"
+                      step="1"
+                      [attr.aria-label]="'前多少'"
+                      [attr.style]="'--range-progress: ' + vectorTopKPercent()"
+                      [(ngModel)]="vectorTopK"
+                    />
+                    <div class="kb-range-ticks"><span>1</span><span>50</span><span>100</span></div>
+                  </div>
+
+                  <div class="kb-vector-metric-card">
+                    <div class="kb-vector-metric-label">
+                      <span class="kb-field-title">相似度阈值</span>
+                      <z-switch class="kb-primary-switch" [(ngModel)]="vectorScoreEnabled" />
+                      <strong>{{ vectorScore() | number: '1.2-2' }}</strong>
+                    </div>
+                    <p class="kb-help-text">低于阈值的文本块会被过滤，关闭后不限制最低相似度。</p>
+                    <input
+                      class="kb-range"
+                      type="range"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      [disabled]="!vectorScoreEnabled()"
+                      [attr.aria-label]="'相似度阈值'"
+                      [attr.style]="'--range-progress: ' + vectorScorePercent()"
+                      [(ngModel)]="vectorScore"
+                    />
+                    <div class="kb-range-ticks"><span>0</span><span>0.5</span><span>1</span></div>
+                  </div>
+                </div>
+
+                <div class="kb-inline-notice">
+                  <i class="ri-information-line"></i>
+                  <span>向量存储由 Xpert 平台统一管理，此处只配置检索行为。</span>
+                </div>
+              </div>
+            </section>
+          }
+
           @case ('parser') {
             <section class="kb-section">
               <div class="kb-section-heading">
@@ -347,6 +428,135 @@
                 <select class="kb-native-select" disabled>
                   <option>暂未接入</option>
                 </select>
+              </div>
+            </section>
+          }
+
+          @case ('graph') {
+            <section class="kb-section">
+              <div class="kb-section-heading">
+                <h1>知识图谱</h1>
+                <p>配置 GraphRAG，从文档中抽取实体和关系并参与知识检索。</p>
+              </div>
+              <div class="kb-panel kb-graph-settings-panel">
+                <div class="kb-field-inline">
+                  <div>
+                    <div class="kb-panel-title">启用 GraphRAG</div>
+                    <p class="kb-panel-description">解析文档时抽取实体、关系和证据，供图谱检索与混合检索使用。</p>
+                  </div>
+                  <z-switch
+                    class="kb-primary-switch"
+                    [ngModel]="graphEnabled()"
+                    (ngModelChange)="setGraphEnabled($event)"
+                  />
+                </div>
+
+                <div class="kb-divider"></div>
+
+                <div class="kb-graph-mode-row">
+                  <div class="kb-field-title">检索模式</div>
+                  <div class="kb-segmented-control">
+                    @for (option of graphModeOptions; track option.value) {
+                      <button
+                        type="button"
+                        class="kb-segmented-option"
+                        [class.kb-segmented-option-active]="graphMode() === option.value"
+                        [disabled]="!graphEnabled() && option.value !== 'vector'"
+                        (click)="setGraphMode(option.value)"
+                      >
+                        {{ option.label }}
+                      </button>
+                    }
+                  </div>
+                  <p class="kb-help-text">{{ graphModeDescription() }}</p>
+                </div>
+
+                <div class="kb-graph-settings-heading">
+                  <div class="kb-field-title">图谱检索参数</div>
+                  <p class="kb-help-text">与 Xpert 检索设置保持一致，关闭 GraphRAG 时保留当前配置。</p>
+                </div>
+
+                <div class="kb-graph-setting-list" [class.kb-graph-setting-list-disabled]="!graphEnabled()">
+                  <div class="kb-graph-setting-row">
+                    <div class="kb-graph-setting-copy">
+                      <div class="kb-graph-setting-label">
+                        <div class="kb-field-title">实体 Top K</div>
+                        <strong>{{ graphEntityTopK() }}</strong>
+                      </div>
+                      <p class="kb-help-text">每次查询用于扩展图谱的候选实体数量。</p>
+                    </div>
+                    <div class="kb-graph-range-control">
+                      <input
+                        class="kb-range"
+                        type="range"
+                        min="1"
+                        max="50"
+                        step="1"
+                        [disabled]="!graphEnabled()"
+                        [attr.aria-label]="'实体 Top K'"
+                        [attr.style]="'--range-progress: ' + (graphEntityTopK() / 50) * 100 + '%'"
+                        [ngModel]="graphEntityTopK()"
+                        (ngModelChange)="graphEntityTopK.set(+$event)"
+                      />
+                      <div class="kb-range-ticks"><span>1</span><span>25</span><span>50</span></div>
+                    </div>
+                  </div>
+
+                  <div class="kb-graph-setting-row">
+                    <div class="kb-graph-setting-copy">
+                      <div class="kb-graph-setting-label">
+                        <div class="kb-field-title">邻居跳数</div>
+                        <strong>{{ graphNeighborHops() }}</strong>
+                      </div>
+                      <p class="kb-help-text">沿实体关系扩展的层数，最多支持两跳。</p>
+                    </div>
+                    <div class="kb-graph-range-control">
+                      <input
+                        class="kb-range"
+                        type="range"
+                        min="1"
+                        max="2"
+                        step="1"
+                        [disabled]="!graphEnabled()"
+                        [attr.aria-label]="'邻居跳数'"
+                        [attr.style]="'--range-progress: ' + (graphNeighborHops() - 1) * 100 + '%'"
+                        [ngModel]="graphNeighborHops()"
+                        (ngModelChange)="graphNeighborHops.set(+$event)"
+                      />
+                      <div class="kb-range-ticks"><span>1</span><span>2</span></div>
+                    </div>
+                  </div>
+
+                  <div class="kb-graph-setting-row">
+                    <div class="kb-graph-setting-copy">
+                      <div class="kb-graph-setting-label">
+                        <div class="kb-field-title">图谱权重</div>
+                        <strong>{{ graphWeight() | number: '1.2-2' }}</strong>
+                      </div>
+                      <p class="kb-help-text">混合检索时图谱结果在最终排序中的权重。</p>
+                    </div>
+                    <div class="kb-graph-range-control">
+                      <input
+                        class="kb-range"
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.05"
+                        [disabled]="!graphEnabled()"
+                        [attr.aria-label]="'图谱权重'"
+                        [attr.style]="'--range-progress: ' + graphWeight() * 100 + '%'"
+                        [ngModel]="graphWeight()"
+                        (ngModelChange)="graphWeight.set(+$event)"
+                      />
+                      <div class="kb-range-ticks"><span>0</span><span>0.5</span><span>1</span></div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="kb-inline-notice">
+                  <i class="ri-information-line"></i>
+                  <span>创建后可在知识库配置中重建图谱；已存在的文档需要重新解析才会生成图谱数据。</span>
+                </div>
               </div>
             </section>
           }

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.html
@@ -531,7 +531,11 @@
                   <p class="kb-help-text">{{ i18nPrefix + '.Graph.ParametersDescription' | translate }}</p>
                 </div>
 
-                <div class="kb-graph-setting-list" [class.kb-graph-setting-list-disabled]="!graphEnabled()">
+                <fieldset
+                  class="kb-graph-setting-list"
+                  [class.kb-graph-setting-list-disabled]="!graphEnabled()"
+                  [disabled]="!graphEnabled()"
+                >
                   <div class="kb-graph-setting-row">
                     <div class="kb-graph-setting-copy">
                       <div class="kb-graph-setting-label">
@@ -549,7 +553,7 @@
                         [disabledInput]="!graphEnabled()"
                         [attr.aria-label]="i18nPrefix + '.Graph.EntityTopK' | translate"
                         [ngModel]="graphEntityTopK()"
-                        (ngModelChange)="graphEntityTopK.set(+$event)"
+                        (ngModelChange)="graphEnabled() && graphEntityTopK.set(+$event)"
                       />
                       <div class="kb-range-ticks"><span>1</span><span>25</span><span>50</span></div>
                     </div>
@@ -572,7 +576,7 @@
                         [disabledInput]="!graphEnabled()"
                         [attr.aria-label]="i18nPrefix + '.Graph.NeighborHops' | translate"
                         [ngModel]="graphNeighborHops()"
-                        (ngModelChange)="graphNeighborHops.set(+$event)"
+                        (ngModelChange)="graphEnabled() && graphNeighborHops.set(+$event)"
                       />
                       <div class="kb-range-ticks"><span>1</span><span>2</span></div>
                     </div>
@@ -595,12 +599,12 @@
                         [disabledInput]="!graphEnabled()"
                         [attr.aria-label]="i18nPrefix + '.Graph.Weight' | translate"
                         [ngModel]="graphWeight()"
-                        (ngModelChange)="graphWeight.set(+$event)"
+                        (ngModelChange)="graphEnabled() && graphWeight.set(+$event)"
                       />
                       <div class="kb-range-ticks"><span>0</span><span>0.5</span><span>1</span></div>
                     </div>
                   </div>
-                </div>
+                </fieldset>
 
                 <div class="kb-inline-notice">
                   <i class="ri-information-line"></i>

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.scss
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.scss
@@ -25,6 +25,10 @@
   @apply shrink-0 border-b border-divider-subtle px-3.5 pb-3 pt-4;
 }
 
+.kb-sidebar-header + .kb-sidebar-group {
+  @apply mt-3;
+}
+
 .kb-create-sidebar {
   @apply flex w-52 shrink-0 flex-col overflow-y-auto border-r border-divider-subtle bg-background-default-subtle;
 }
@@ -34,7 +38,7 @@
 }
 
 .kb-sidebar-group-title {
-  @apply px-3 pb-2 text-xs font-semibold tracking-wide text-text-tertiary;
+  @apply px-3 pb-2 text-sm font-semibold leading-5 text-text-tertiary;
 }
 
 .kb-sidebar-nav {
@@ -42,7 +46,7 @@
 }
 
 .kb-sidebar-item {
-  @apply flex h-10 w-full cursor-pointer items-center gap-3 rounded-lg px-3 text-left text-sm font-medium text-text-secondary transition hover:bg-components-card-bg hover:text-text-primary;
+  @apply flex h-10 w-full cursor-pointer items-center justify-start gap-3 rounded-lg px-3 text-left text-sm font-medium text-text-secondary transition hover:bg-components-card-bg hover:text-text-primary;
 }
 
 .kb-sidebar-item i {
@@ -109,51 +113,20 @@
   @apply mt-1 text-xs leading-5 text-text-tertiary;
 }
 
-.kb-input,
-.kb-textarea,
-.kb-native-select {
-  @apply w-full rounded-lg border border-divider-regular bg-components-input-bg-normal px-3 text-sm text-text-primary outline-none transition placeholder:text-text-quaternary focus:border-components-input-border-active focus:ring-1 focus:ring-components-input-border-active;
-}
-
-.kb-input,
-.kb-native-select {
-  @apply h-10;
+.kb-input {
+  @apply w-full;
 }
 
 .kb-textarea {
-  @apply min-h-28 resize-y py-2.5;
-}
-
-.kb-native-select {
-  @apply appearance-auto;
+  @apply min-h-28 w-full resize-y;
 }
 
 .kb-counter {
   @apply absolute bottom-2 right-2 text-xs text-text-quaternary;
 }
 
-.kb-segmented-control {
-  @apply inline-flex overflow-hidden rounded-lg border border-divider-regular;
-}
-
-.kb-segmented-option {
-  @apply flex h-10 min-w-28 cursor-pointer items-center justify-center gap-1.5 bg-components-card-bg px-5 text-sm font-medium text-text-secondary transition hover:bg-hover-bg;
-}
-
-.kb-segmented-option + .kb-segmented-option {
-  @apply border-l border-divider-regular;
-}
-
-.kb-segmented-option-active {
-  @apply bg-components-button-primary-bg text-components-button-primary-text hover:bg-components-button-primary-bg hover:text-components-button-primary-text;
-}
-
-.kb-segmented-option:disabled {
-  @apply cursor-not-allowed bg-components-panel-bg text-text-quaternary opacity-60;
-}
-
-.kb-segmented-option-disabled {
-  @apply cursor-not-allowed bg-components-panel-bg text-text-quaternary;
+.kb-type-toggle {
+  @apply overflow-hidden rounded-md;
 }
 
 .kb-choice-grid {
@@ -381,16 +354,11 @@
 }
 
 .kb-parser-engine-select {
-  @apply h-11 bg-components-input-bg-normal text-sm;
+  @apply w-full;
 }
 
 .kb-checkbox-row {
-  @apply flex cursor-pointer items-center gap-2 text-sm leading-5 text-text-secondary;
-}
-
-.kb-checkbox-row input {
-  @apply h-4 w-4;
-  accent-color: var(--sys-primary);
+  @apply text-sm leading-5 text-text-secondary;
 }
 
 .kb-chunk-strategy-row,
@@ -424,12 +392,8 @@
   @apply flex w-[min(100%,28rem)] shrink-0 flex-col items-end gap-4;
 }
 
-.kb-chunk-strategy-control .kb-native-select {
-  @apply h-11;
-}
-
 .kb-test-chunk-button {
-  @apply flex cursor-pointer items-center gap-2 text-sm font-semibold text-text-primary transition hover:opacity-70;
+  @apply cursor-pointer self-end text-sm font-semibold text-text-primary;
 }
 
 .kb-test-chunk-button i {
@@ -453,35 +417,7 @@
 }
 
 .kb-range {
-  @apply h-2 w-full cursor-pointer appearance-none rounded-full;
-  accent-color: var(--sys-primary);
-  background: linear-gradient(
-    to right,
-    var(--sys-primary) 0%,
-    var(--sys-primary) var(--range-progress, 0%),
-    var(--color-divider-regular) var(--range-progress, 0%),
-    var(--color-divider-regular) 100%
-  );
-}
-
-.kb-range::-webkit-slider-runnable-track {
-  @apply h-2 rounded-full bg-transparent;
-}
-
-.kb-range::-webkit-slider-thumb {
-  @apply mt-[-5px] h-5 w-5 appearance-none rounded-full border-2 border-components-button-primary-border bg-components-card-bg shadow-sm;
-}
-
-.kb-range::-moz-range-track {
-  @apply h-2 rounded-full bg-divider-deep;
-}
-
-.kb-range::-moz-range-progress {
-  @apply h-2 rounded-full bg-components-button-primary-bg;
-}
-
-.kb-range::-moz-range-thumb {
-  @apply h-5 w-5 rounded-full border-2 border-components-button-primary-border bg-components-card-bg shadow-sm;
+  @apply w-full;
 }
 
 .kb-primary-switch ::ng-deep button[data-state='checked'] {
@@ -509,7 +445,7 @@
 }
 
 .kb-separator-add {
-  @apply h-8 min-w-20 cursor-pointer rounded-md border-0 bg-transparent px-2 text-xs text-text-tertiary outline-none;
+  @apply min-w-28 max-w-48;
 }
 
 .kb-advanced-switch-row {
@@ -596,7 +532,7 @@
   @apply border-b border-divider-subtle pb-5;
 }
 
-.kb-graph-mode-row .kb-segmented-control {
+.kb-graph-mode-control {
   @apply mt-3;
 }
 
@@ -632,10 +568,6 @@
   @apply relative flex w-full min-w-0 flex-col items-stretch gap-1;
 }
 
-.kb-range:disabled {
-  @apply cursor-not-allowed;
-}
-
 .kb-create-footer {
   @apply flex shrink-0 justify-end gap-3 border-t border-divider-subtle bg-components-card-bg px-6 py-4;
 }
@@ -645,11 +577,7 @@
 }
 
 .kb-footer-primary {
-  @apply min-w-36 bg-components-button-primary-bg text-components-button-primary-text hover:opacity-80;
-}
-
-.kb-spin {
-  @apply mr-1 animate-spin;
+  @apply min-w-36;
 }
 
 @media (max-width: 720px) {

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.scss
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.scss
@@ -432,20 +432,12 @@
   @apply w-[min(100%,28rem)] shrink-0;
 }
 
-.kb-chip-control {
-  @apply flex min-h-20 flex-wrap items-start gap-2 rounded-lg border border-divider-regular bg-components-input-bg-normal p-2;
+.kb-separator-select {
+  @apply block min-h-20 w-full;
 }
 
-.kb-separator-chip {
-  @apply inline-flex items-center gap-2 rounded-md bg-components-button-secondary-bg px-2.5 py-1.5 text-sm text-text-secondary;
-}
-
-.kb-separator-chip button {
-  @apply cursor-pointer text-base leading-none text-text-tertiary transition hover:text-text-primary;
-}
-
-.kb-separator-add {
-  @apply min-w-28 max-w-48;
+.kb-separator-select ::ng-deep z-tag-select-input-trigger > div {
+  @apply min-h-20 content-start rounded-lg border-divider-regular bg-components-input-bg-normal;
 }
 
 .kb-advanced-switch-row {

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.scss
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.scss
@@ -264,6 +264,50 @@
   @apply mt-1 text-xs leading-5 text-text-tertiary;
 }
 
+.kb-vector-search-panel {
+  @apply bg-components-card-bg;
+}
+
+.kb-vector-search-heading {
+  @apply flex flex-col gap-1;
+}
+
+.kb-vector-search-title {
+  @apply flex items-center gap-2 text-lg font-semibold text-text-primary;
+}
+
+.kb-vector-search-title i {
+  @apply text-xl text-text-accent;
+}
+
+.kb-vector-rerank-row {
+  @apply flex items-start justify-between gap-6;
+}
+
+.kb-vector-rerank-model {
+  @apply mt-4;
+}
+
+.kb-vector-metric-grid {
+  @apply mt-5 grid grid-cols-1 gap-3 md:grid-cols-2;
+}
+
+.kb-vector-metric-card {
+  @apply flex min-w-0 flex-col gap-3 rounded-lg border border-divider-subtle bg-components-panel-bg p-4;
+}
+
+.kb-vector-metric-label {
+  @apply flex items-center gap-2;
+}
+
+.kb-vector-metric-label .kb-field-title {
+  @apply min-w-0 flex-1;
+}
+
+.kb-vector-metric-label > strong {
+  @apply shrink-0 text-base font-semibold text-text-primary;
+}
+
 .kb-status-post-create {
   @apply shrink-0 bg-background-default-subtle text-text-warning;
 }
@@ -544,6 +588,54 @@
   @apply text-text-primary;
 }
 
+.kb-graph-settings-panel {
+  @apply border-divider-subtle;
+}
+
+.kb-graph-mode-row {
+  @apply border-b border-divider-subtle pb-5;
+}
+
+.kb-graph-mode-row .kb-segmented-control {
+  @apply mt-3;
+}
+
+.kb-graph-settings-heading {
+  @apply mt-5 mb-3;
+}
+
+.kb-graph-setting-list {
+  @apply grid grid-cols-1 gap-3 md:grid-cols-3;
+}
+
+.kb-graph-setting-list-disabled {
+  @apply opacity-60;
+}
+
+.kb-graph-setting-row {
+  @apply flex min-w-0 flex-col justify-between gap-4 rounded-lg border border-divider-subtle bg-components-panel-bg p-4;
+}
+
+.kb-graph-setting-copy {
+  @apply min-w-0;
+}
+
+.kb-graph-setting-label {
+  @apply flex items-center justify-between gap-3;
+}
+
+.kb-graph-setting-label > strong {
+  @apply text-base font-semibold text-text-primary;
+}
+
+.kb-graph-range-control {
+  @apply relative flex w-full min-w-0 flex-col items-stretch gap-1;
+}
+
+.kb-range:disabled {
+  @apply cursor-not-allowed;
+}
+
 .kb-create-footer {
   @apply flex shrink-0 justify-end gap-3 border-t border-divider-subtle bg-components-card-bg px-6 py-4;
 }
@@ -596,7 +688,8 @@
   .kb-model-row,
   .kb-parser-engine-row,
   .kb-chunk-strategy-row,
-  .kb-chunk-setting-row {
+  .kb-chunk-setting-row,
+  .kb-graph-setting-row {
     @apply gap-5;
   }
 
@@ -604,6 +697,7 @@
   .kb-parser-engine-control,
   .kb-chunk-strategy-control,
   .kb-range-control,
+  .kb-graph-range-control,
   .kb-separator-control {
     @apply w-2/5;
   }
@@ -657,7 +751,9 @@
   .kb-model-row,
   .kb-parser-engine-row,
   .kb-chunk-strategy-row,
-  .kb-chunk-setting-row {
+  .kb-chunk-setting-row,
+  .kb-graph-setting-row,
+  .kb-vector-rerank-row {
     @apply flex-col gap-4;
   }
 
@@ -665,6 +761,7 @@
   .kb-parser-engine-control,
   .kb-chunk-strategy-control,
   .kb-range-control,
+  .kb-graph-range-control,
   .kb-separator-control {
     @apply w-full;
   }

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.scss
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.scss
@@ -544,8 +544,10 @@
   @apply grid grid-cols-1 gap-3 md:grid-cols-3;
 }
 
+.kb-graph-setting-list:disabled,
 .kb-graph-setting-list-disabled {
-  @apply opacity-60;
+  @apply m-0 min-w-0 border-0 p-0;
+  @apply pointer-events-none opacity-60;
 }
 
 .kb-graph-setting-row {

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.scss
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.scss
@@ -1,4 +1,691 @@
 @reference "../../../../../styles/tailwind-reference.css";
+@reference "../../../../../styles/theme/theme.tailwind.css";
+
 :host {
-  @apply flex flex-col relative rounded-2xl bg-components-card-bg;
+  @apply relative block h-full w-full overflow-hidden rounded-xl bg-components-card-bg text-text-primary;
+}
+
+.kb-create-dialog {
+  @apply relative flex h-full min-h-0 w-full flex-col overflow-hidden rounded-xl bg-components-card-bg;
+}
+
+.kb-settings-container {
+  @apply flex h-full min-h-0 w-full overflow-hidden;
+}
+
+.kb-create-title {
+  @apply text-xl font-semibold leading-7 text-text-primary;
+}
+
+.kb-close-button {
+  @apply absolute right-5 top-5 z-20 flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-components-button-secondary-bg text-xl text-text-secondary transition hover:bg-hover-bg hover:text-text-primary;
+}
+
+.kb-sidebar-header {
+  @apply shrink-0 border-b border-divider-subtle px-3.5 pb-3 pt-4;
+}
+
+.kb-create-sidebar {
+  @apply flex w-52 shrink-0 flex-col overflow-y-auto border-r border-divider-subtle bg-background-default-subtle;
+}
+
+.kb-sidebar-group + .kb-sidebar-group {
+  @apply mt-6;
+}
+
+.kb-sidebar-group-title {
+  @apply px-3 pb-2 text-xs font-semibold tracking-wide text-text-tertiary;
+}
+
+.kb-sidebar-nav {
+  @apply flex flex-col gap-1;
+}
+
+.kb-sidebar-item {
+  @apply flex h-10 w-full cursor-pointer items-center gap-3 rounded-lg px-3 text-left text-sm font-medium text-text-secondary transition hover:bg-components-card-bg hover:text-text-primary;
+}
+
+.kb-sidebar-item i {
+  @apply w-5 shrink-0 text-lg text-text-tertiary;
+}
+
+.kb-sidebar-item-active {
+  @apply bg-components-card-bg text-text-primary shadow-xs;
+}
+
+.kb-sidebar-item-active i {
+  @apply text-text-primary;
+}
+
+.kb-sidebar-item-preview {
+  @apply text-text-secondary;
+}
+
+.kb-sidebar-dot {
+  @apply ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-text-warning;
+}
+
+.kb-create-content {
+  @apply min-h-0 min-w-0 flex-1 overflow-y-auto bg-components-card-bg px-8 py-6;
+}
+
+.kb-settings-content {
+  @apply flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden;
+}
+
+.kb-section {
+  @apply mx-auto w-full max-w-4xl pb-8;
+}
+
+.kb-section-heading {
+  @apply mb-8;
+}
+
+.kb-section-heading h1 {
+  @apply text-2xl font-semibold leading-8 text-text-primary;
+}
+
+.kb-section-heading p {
+  @apply mt-1 text-sm leading-6 text-text-tertiary;
+}
+
+.kb-field {
+  @apply relative mb-6;
+}
+
+.kb-field:last-child {
+  @apply mb-0;
+}
+
+.kb-label {
+  @apply mb-2 block text-sm font-semibold leading-5 text-text-primary;
+}
+
+.kb-required {
+  @apply ml-0.5 text-text-destructive;
+}
+
+.kb-help-text {
+  @apply mt-1 text-xs leading-5 text-text-tertiary;
+}
+
+.kb-input,
+.kb-textarea,
+.kb-native-select {
+  @apply w-full rounded-lg border border-divider-regular bg-components-input-bg-normal px-3 text-sm text-text-primary outline-none transition placeholder:text-text-quaternary focus:border-components-input-border-active focus:ring-1 focus:ring-components-input-border-active;
+}
+
+.kb-input,
+.kb-native-select {
+  @apply h-10;
+}
+
+.kb-textarea {
+  @apply min-h-28 resize-y py-2.5;
+}
+
+.kb-native-select {
+  @apply appearance-auto;
+}
+
+.kb-counter {
+  @apply absolute bottom-2 right-2 text-xs text-text-quaternary;
+}
+
+.kb-segmented-control {
+  @apply inline-flex overflow-hidden rounded-lg border border-divider-regular;
+}
+
+.kb-segmented-option {
+  @apply flex h-10 min-w-28 cursor-pointer items-center justify-center gap-1.5 bg-components-card-bg px-5 text-sm font-medium text-text-secondary transition hover:bg-hover-bg;
+}
+
+.kb-segmented-option + .kb-segmented-option {
+  @apply border-l border-divider-regular;
+}
+
+.kb-segmented-option-active {
+  @apply bg-components-button-primary-bg text-components-button-primary-text hover:bg-components-button-primary-bg hover:text-components-button-primary-text;
+}
+
+.kb-segmented-option:disabled {
+  @apply cursor-not-allowed bg-components-panel-bg text-text-quaternary opacity-60;
+}
+
+.kb-segmented-option-disabled {
+  @apply cursor-not-allowed bg-components-panel-bg text-text-quaternary;
+}
+
+.kb-choice-grid {
+  @apply grid grid-cols-1 gap-4 md:grid-cols-2;
+}
+
+.kb-choice-card {
+  @apply relative flex min-h-36 cursor-pointer flex-col items-start rounded-xl border border-divider-regular bg-components-card-bg p-5 text-left transition hover:border-components-option-card-option-selected-border;
+}
+
+.kb-choice-card-selected {
+  @apply border-components-option-card-option-selected-border bg-background-default-subtle ring-1 ring-components-option-card-option-selected-border;
+}
+
+.kb-choice-card-disabled {
+  @apply cursor-not-allowed opacity-70 hover:border-divider-regular;
+}
+
+.kb-choice-check,
+.kb-choice-empty {
+  @apply mb-3 flex h-6 w-6 items-center justify-center rounded-md border border-divider-regular text-base text-text-quaternary;
+}
+
+.kb-choice-check {
+  @apply border-transparent bg-components-button-primary-bg text-components-button-primary-text;
+}
+
+.kb-choice-card-title {
+  @apply text-base font-semibold text-text-primary;
+}
+
+.kb-choice-card-description {
+  @apply mt-2 text-sm leading-5 text-text-tertiary;
+}
+
+.kb-new-badge,
+.kb-mini-badge,
+.kb-status-badge {
+  @apply inline-flex items-center rounded-md px-2 py-0.5 text-[10px] font-semibold leading-4;
+}
+
+.kb-new-badge {
+  @apply ml-1 bg-background-default-subtle text-text-primary;
+}
+
+.kb-mini-badge {
+  @apply bg-background-default-subtle text-text-warning;
+}
+
+.kb-field-inline {
+  @apply flex items-center justify-between gap-6;
+}
+
+.kb-model-grid,
+.kb-form-grid {
+  @apply grid grid-cols-1 gap-4 md:grid-cols-2;
+}
+
+.kb-weknora-form {
+  @apply w-full;
+}
+
+.kb-model-row {
+  @apply flex items-center justify-between gap-8 py-2;
+}
+
+.kb-model-row-copy {
+  @apply min-w-0 flex-1;
+}
+
+.kb-model-row-title {
+  @apply text-base font-semibold leading-6 text-text-primary;
+}
+
+.kb-model-row-copy p {
+  @apply mt-1 text-sm leading-6 text-text-tertiary;
+}
+
+.kb-model-row-select {
+  @apply w-[min(100%,30rem)] shrink-0;
+}
+
+.kb-model-row-select ::ng-deep .model-select-trigger {
+  @apply h-11 rounded-lg border-divider-regular bg-components-input-bg-normal px-3;
+}
+
+.kb-panel {
+  @apply rounded-xl border border-divider-subtle bg-components-panel-bg p-5;
+}
+
+.kb-panel + .kb-panel {
+  @apply mt-4;
+}
+
+.kb-panel-post-create {
+  @apply border-dashed;
+}
+
+.kb-panel-header {
+  @apply flex items-start justify-between gap-4;
+}
+
+.kb-panel-title {
+  @apply text-sm font-semibold leading-5 text-text-primary;
+}
+
+.kb-panel-description {
+  @apply mt-1 text-xs leading-5 text-text-tertiary;
+}
+
+.kb-status-post-create {
+  @apply shrink-0 bg-background-default-subtle text-text-warning;
+}
+
+.kb-status-preview {
+  @apply shrink-0 bg-components-input-bg-normal text-text-tertiary;
+}
+
+.kb-inline-notice {
+  @apply mt-3 flex items-start gap-2 rounded-lg border border-divider-subtle bg-components-card-bg px-3 py-2 text-xs leading-5 text-text-tertiary;
+}
+
+.kb-inline-notice i {
+  @apply mt-0.5 shrink-0 text-text-accent;
+}
+
+.kb-placeholder-card {
+  @apply flex items-center gap-4 rounded-xl border border-dashed border-divider-deep bg-components-panel-bg p-5;
+}
+
+.kb-placeholder-icon {
+  @apply flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-components-card-bg text-xl text-text-tertiary;
+}
+
+.kb-placeholder-card > div:nth-child(2) {
+  @apply min-w-0 flex-1;
+}
+
+.kb-divider {
+  @apply my-5 h-px w-full bg-divider-subtle;
+}
+
+.kb-parser-engine-list {
+  @apply w-full;
+}
+
+.kb-parser-engine-row {
+  @apply flex items-start justify-between gap-8 border-b border-divider-subtle py-5;
+}
+
+.kb-parser-engine-row:first-child {
+  @apply pt-0;
+}
+
+.kb-parser-engine-row:last-child {
+  @apply border-b-0 pb-0;
+}
+
+.kb-parser-engine-copy {
+  @apply min-w-0 flex-1;
+}
+
+.kb-parser-engine-title {
+  @apply flex items-center gap-3 text-base font-semibold leading-6 text-text-primary;
+}
+
+.kb-parser-engine-title i {
+  @apply text-2xl font-normal text-text-tertiary;
+}
+
+.kb-extension-list {
+  @apply mt-2 flex flex-wrap gap-2;
+}
+
+.kb-extension-chip {
+  @apply rounded-md bg-background-default-subtle px-2.5 py-1 text-xs font-medium text-text-tertiary;
+}
+
+.kb-parser-engine-control {
+  @apply flex w-[min(100%,28rem)] shrink-0 flex-col gap-3;
+}
+
+.kb-parser-engine-select {
+  @apply h-11 bg-components-input-bg-normal text-sm;
+}
+
+.kb-checkbox-row {
+  @apply flex cursor-pointer items-center gap-2 text-sm leading-5 text-text-secondary;
+}
+
+.kb-checkbox-row input {
+  @apply h-4 w-4;
+  accent-color: var(--sys-primary);
+}
+
+.kb-chunk-strategy-row,
+.kb-chunk-setting-row {
+  @apply flex items-start justify-between gap-10 border-b border-divider-subtle py-7;
+}
+
+.kb-chunk-strategy-row {
+  @apply pt-0;
+}
+
+.kb-separator-row {
+  @apply border-b-0 pb-0;
+}
+
+.kb-chunk-copy {
+  @apply min-w-0 flex-1;
+}
+
+.kb-field-title {
+  @apply text-lg font-semibold leading-7 text-text-primary;
+}
+
+.kb-chunk-copy p,
+.kb-advanced-switch-row p,
+.kb-advanced-field p {
+  @apply mt-1 text-sm leading-6 text-text-tertiary;
+}
+
+.kb-chunk-strategy-control {
+  @apply flex w-[min(100%,28rem)] shrink-0 flex-col items-end gap-4;
+}
+
+.kb-chunk-strategy-control .kb-native-select {
+  @apply h-11;
+}
+
+.kb-test-chunk-button {
+  @apply flex cursor-pointer items-center gap-2 text-sm font-semibold text-text-primary transition hover:opacity-70;
+}
+
+.kb-test-chunk-button i {
+  @apply text-xl;
+}
+
+.kb-chunk-auto-note {
+  @apply border-l-4 border-components-button-primary-border bg-components-panel-bg px-4 py-3 text-sm leading-6 text-text-secondary;
+}
+
+.kb-chunk-auto-note strong {
+  @apply font-semibold text-text-primary;
+}
+
+.kb-range-control {
+  @apply relative flex w-[min(100%,28rem)] shrink-0 flex-col items-end gap-1;
+}
+
+.kb-range-control > strong {
+  @apply text-lg font-semibold text-text-primary;
+}
+
+.kb-range {
+  @apply h-2 w-full cursor-pointer appearance-none rounded-full;
+  accent-color: var(--sys-primary);
+  background: linear-gradient(
+    to right,
+    var(--sys-primary) 0%,
+    var(--sys-primary) var(--range-progress, 0%),
+    var(--color-divider-regular) var(--range-progress, 0%),
+    var(--color-divider-regular) 100%
+  );
+}
+
+.kb-range::-webkit-slider-runnable-track {
+  @apply h-2 rounded-full bg-transparent;
+}
+
+.kb-range::-webkit-slider-thumb {
+  @apply mt-[-5px] h-5 w-5 appearance-none rounded-full border-2 border-components-button-primary-border bg-components-card-bg shadow-sm;
+}
+
+.kb-range::-moz-range-track {
+  @apply h-2 rounded-full bg-divider-deep;
+}
+
+.kb-range::-moz-range-progress {
+  @apply h-2 rounded-full bg-components-button-primary-bg;
+}
+
+.kb-range::-moz-range-thumb {
+  @apply h-5 w-5 rounded-full border-2 border-components-button-primary-border bg-components-card-bg shadow-sm;
+}
+
+.kb-primary-switch ::ng-deep button[data-state='checked'] {
+  background-color: var(--color-components-toggle-bg);
+}
+
+.kb-range-ticks {
+  @apply flex w-full justify-between text-xs text-text-secondary;
+}
+
+.kb-separator-control {
+  @apply w-[min(100%,28rem)] shrink-0;
+}
+
+.kb-chip-control {
+  @apply flex min-h-20 flex-wrap items-start gap-2 rounded-lg border border-divider-regular bg-components-input-bg-normal p-2;
+}
+
+.kb-separator-chip {
+  @apply inline-flex items-center gap-2 rounded-md bg-components-button-secondary-bg px-2.5 py-1.5 text-sm text-text-secondary;
+}
+
+.kb-separator-chip button {
+  @apply cursor-pointer text-base leading-none text-text-tertiary transition hover:text-text-primary;
+}
+
+.kb-separator-add {
+  @apply h-8 min-w-20 cursor-pointer rounded-md border-0 bg-transparent px-2 text-xs text-text-tertiary outline-none;
+}
+
+.kb-advanced-switch-row {
+  @apply flex items-start justify-between gap-8 border-b border-divider-subtle pb-7;
+}
+
+.kb-advanced-switch-row > div {
+  @apply min-w-0 flex-1;
+}
+
+.kb-advanced-emphasis {
+  @apply mt-6 border-l-4 border-components-button-primary-border pl-7;
+}
+
+.kb-advanced-field {
+  @apply relative;
+}
+
+.kb-advanced-field + .kb-advanced-field {
+  @apply mt-7 border-t border-divider-subtle pt-7;
+}
+
+.kb-advanced-count-row {
+  @apply flex items-start justify-between gap-8;
+}
+
+.kb-number-input {
+  @apply w-52 shrink-0;
+}
+
+.kb-advanced-textarea {
+  @apply mt-4 min-h-32;
+}
+
+.kb-table-metadata-field {
+  @apply mt-8;
+}
+
+.kb-source-grid {
+  @apply mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3;
+}
+
+.kb-parser-rules {
+  @apply mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2;
+}
+
+.kb-parser-rule {
+  @apply flex items-center justify-between gap-3 rounded-lg border border-divider-subtle bg-components-card-bg px-3 py-2;
+}
+
+.kb-parser-rule-name {
+  @apply flex min-w-0 items-center gap-2 text-sm font-medium text-text-secondary;
+}
+
+.kb-parser-rule-name i {
+  @apply text-lg text-text-tertiary;
+}
+
+.kb-parser-rule-select {
+  @apply h-8 w-32 shrink-0 bg-components-panel-bg text-xs;
+}
+
+.kb-source-card {
+  @apply flex h-20 cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border border-divider-regular bg-components-card-bg text-sm text-text-secondary transition hover:border-components-option-card-option-selected-border hover:text-text-primary;
+}
+
+.kb-source-card i {
+  @apply text-lg text-text-tertiary;
+}
+
+.kb-source-card-selected {
+  @apply border-components-option-card-option-selected-border bg-background-default-subtle text-text-primary ring-1 ring-components-option-card-option-selected-border;
+}
+
+.kb-source-card-selected i {
+  @apply text-text-primary;
+}
+
+.kb-create-footer {
+  @apply flex shrink-0 justify-end gap-3 border-t border-divider-subtle bg-components-card-bg px-6 py-4;
+}
+
+.kb-footer-button {
+  @apply min-w-28 justify-center;
+}
+
+.kb-footer-primary {
+  @apply min-w-36 bg-components-button-primary-bg text-components-button-primary-text hover:opacity-80;
+}
+
+.kb-spin {
+  @apply mr-1 animate-spin;
+}
+
+@media (max-width: 720px) {
+  :host {
+    @apply rounded-xl;
+  }
+
+  .kb-create-title {
+    @apply text-base;
+  }
+
+  .kb-create-sidebar {
+    @apply w-48;
+  }
+
+  .kb-sidebar-item {
+    @apply gap-2 px-2 text-xs;
+  }
+
+  .kb-sidebar-item i {
+    @apply w-4 text-base;
+  }
+
+  .kb-create-content {
+    @apply px-5 py-6;
+  }
+
+  .kb-section-heading {
+    @apply mb-6;
+  }
+
+  .kb-field-inline {
+    @apply items-start;
+  }
+
+  .kb-model-row,
+  .kb-parser-engine-row,
+  .kb-chunk-strategy-row,
+  .kb-chunk-setting-row {
+    @apply gap-5;
+  }
+
+  .kb-model-row-select,
+  .kb-parser-engine-control,
+  .kb-chunk-strategy-control,
+  .kb-range-control,
+  .kb-separator-control {
+    @apply w-2/5;
+  }
+}
+
+@media (max-width: 520px) {
+  .kb-settings-container {
+    @apply flex-col;
+  }
+
+  .kb-create-sidebar {
+    @apply flex w-full shrink-0 overflow-x-auto overflow-y-hidden border-b border-r-0 px-3 py-2;
+  }
+
+  .kb-sidebar-header {
+    @apply hidden;
+  }
+
+  .kb-sidebar-group {
+    @apply flex items-center gap-1;
+  }
+
+  .kb-sidebar-group + .kb-sidebar-group {
+    @apply mt-0;
+  }
+
+  .kb-sidebar-group-title {
+    @apply hidden;
+  }
+
+  .kb-sidebar-nav {
+    @apply flex-row;
+  }
+
+  .kb-sidebar-item {
+    @apply h-9 w-auto shrink-0 whitespace-nowrap rounded-md px-2;
+  }
+
+  .kb-sidebar-item span:not(.kb-sidebar-dot) {
+    @apply hidden;
+  }
+
+  .kb-create-content {
+    @apply px-4 py-5;
+  }
+
+  .kb-create-footer {
+    @apply px-4 py-3;
+  }
+
+  .kb-model-row,
+  .kb-parser-engine-row,
+  .kb-chunk-strategy-row,
+  .kb-chunk-setting-row {
+    @apply flex-col gap-4;
+  }
+
+  .kb-model-row-select,
+  .kb-parser-engine-control,
+  .kb-chunk-strategy-control,
+  .kb-range-control,
+  .kb-separator-control {
+    @apply w-full;
+  }
+
+  .kb-chunk-strategy-control {
+    @apply items-stretch;
+  }
+
+  .kb-range-control {
+    @apply items-stretch;
+  }
+
+  .kb-advanced-count-row {
+    @apply flex-col gap-3;
+  }
+
+  .kb-number-input {
+    @apply w-full;
+  }
+
+  .kb-footer-button {
+    @apply min-w-24;
+  }
 }

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
@@ -13,9 +13,9 @@ import {
   ZardSegmentedComponent,
   ZardSegmentedItemComponent,
   ZardSelectImports,
-  type ZardSelectValue,
   ZardSliderComponent,
   ZardSwitchComponent,
+  ZardTagSelectComponent,
   ZardToggleGroupComponent,
   ZardToggleGroupItemComponent,
   ZardTooltipImports
@@ -91,6 +91,7 @@ type KnowledgeDialogData = {
     ZardSegmentedItemComponent,
     ZardSliderComponent,
     ZardSwitchComponent,
+    ZardTagSelectComponent,
     ZardToggleGroupComponent,
     ZardToggleGroupItemComponent,
     ...ZardSelectImports,
@@ -247,7 +248,6 @@ export class XpertNewKnowledgeComponent {
   readonly incrementalSyncEnabled = model(this.#initialKnowledgebase?.incrementalSyncEnabled ?? false)
   readonly chunkStrategy = model<'auto' | 'title' | 'structure' | 'length'>('auto')
   readonly separators = signal<string[]>(['\\n\\n', '\\n', '。', '！', '？', '；', ';'])
-  readonly separatorToAdd = model<ZardSelectValue>('')
 
   readonly separatorOptions = [
     { value: '\\n\\n', labelKey: 'Chunk.SeparatorLabels.DoubleNewline' },
@@ -258,6 +258,11 @@ export class XpertNewKnowledgeComponent {
     { value: '；', labelKey: 'Chunk.SeparatorLabels.ChineseSemicolon' },
     { value: ';', labelKey: 'Chunk.SeparatorLabels.EnglishSemicolon' }
   ]
+
+  readonly separatorTagOptions = this.separatorOptions.map((option) => ({
+    value: option.value,
+    label: this.#translate.instant(`${this.i18nPrefix}.${option.labelKey}`)
+  }))
 
   // UI-only until the create DTO accepts WeKnora's advanced generation fields.
   readonly questionGenerationEnabled = model(true)
@@ -377,11 +382,14 @@ export class XpertNewKnowledgeComponent {
     this.delimiter.set(this.separators()[0] || '\n\n')
   }
 
-  selectSeparator(value: ZardSelectValue | ZardSelectValue[]) {
-    if (typeof value === 'string' && value) {
-      this.addSeparator(value)
+  updateSeparators(value: unknown) {
+    if (!Array.isArray(value)) {
+      return
     }
-    this.separatorToAdd.set('')
+
+    const nextSeparators = value.filter((separator): separator is string => typeof separator === 'string')
+    this.separators.set(nextSeparators)
+    this.delimiter.set(nextSeparators[0] || '\n\n')
   }
 
   removeSeparator(value: string) {

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
@@ -1,68 +1,381 @@
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog'
 import { DragDropModule } from '@angular/cdk/drag-drop'
 
+import { CommonModule } from '@angular/common'
 import { Component, computed, inject, model, signal } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { CopilotModelSelectComponent } from '@cloud/app/@shared/copilot'
 import { TranslateModule } from '@ngx-translate/core'
+import { ZardSwitchComponent, ZardTooltipImports } from '@xpert-ai/headless-ui'
 import {
   AiModelTypeEnum,
   getErrorMessage,
   ICopilotModel,
   IKnowledgebase,
   KnowledgebaseService,
-  ToastrService,
-  XpertAPIService,
-  XpertTypeEnum
+  KnowledgebaseTypeEnum,
+  ModelFeature,
+  ToastrService
 } from '../../../../@core'
 
+type SectionKey = 'basic' | 'models' | 'parser' | 'chunk' | 'image' | 'audio' | 'advanced' | 'storage'
+
+type SectionStatus = 'supported' | 'post-create' | 'preview'
+
+type CreateSection = {
+  key: SectionKey
+  group: '基础' | '索引与解析' | '存储与数据'
+  label: string
+  icon: string
+  status: SectionStatus
+}
+
+type ParserPreviewState = {
+  textSplitter: string
+  transformer: string
+  spreadsheetInterpretation: string
+  spreadsheetContextUnit: string
+  includeHiddenSheets: boolean
+  imageUnderstanding: boolean
+}
+
+type ParserEngineOption = {
+  value: string
+  label: string
+}
+
+type KnowledgeDialogData = {
+  workspaceId?: string
+  knowledgebase?: IKnowledgebase
+}
+
 @Component({
-  selector: 'xpert-new-knowledge',
+  selector: 'xp-new-knowledge',
   standalone: true,
-  imports: [TranslateModule, DragDropModule, FormsModule, CopilotModelSelectComponent],
+  imports: [
+    CommonModule,
+    TranslateModule,
+    DragDropModule,
+    FormsModule,
+    CopilotModelSelectComponent,
+    ZardSwitchComponent,
+    ...ZardTooltipImports
+  ],
   templateUrl: './new.component.html',
   styleUrl: './new.component.scss'
 })
 export class XpertNewKnowledgeComponent {
-  eXpertTypeEnum = XpertTypeEnum
-  eAiModelTypeEnum = AiModelTypeEnum
   readonly #dialogRef = inject(DialogRef<IKnowledgebase | undefined>)
-  readonly #dialogData = inject<{ workspaceId: string }>(DIALOG_DATA)
-  readonly xpertService = inject(XpertAPIService)
+  readonly #dialogData = inject<KnowledgeDialogData>(DIALOG_DATA)
+  readonly #initialKnowledgebase = this.#dialogData?.knowledgebase ?? null
   readonly #toastr = inject(ToastrService)
   readonly knowledgebaseService = inject(KnowledgebaseService)
 
-  readonly workspaceId = signal(this.#dialogData?.workspaceId)
-  readonly name = model<string>('')
-  readonly copilotModel = model<ICopilotModel>()
-  readonly chatModel = model<ICopilotModel>()
-  readonly rerankModel = model<ICopilotModel>()
+  readonly eAiModelTypeEnum = AiModelTypeEnum
+  readonly eModelFeature = ModelFeature
+  readonly KnowledgebaseTypeEnum = KnowledgebaseTypeEnum
+
+  readonly existingKnowledgebase = signal<IKnowledgebase | null>(this.#initialKnowledgebase)
+  readonly isEditMode = computed(() => !!this.existingKnowledgebase()?.id)
+  readonly workspaceId = signal(this.#dialogData?.workspaceId ?? this.#initialKnowledgebase?.workspaceId)
+  readonly activeSection = signal<SectionKey>('basic')
+
+  readonly sections: CreateSection[] = [
+    { key: 'basic', group: '基础', label: '基本信息', icon: 'ri-information-line', status: 'supported' },
+    { key: 'models', group: '基础', label: '模型配置', icon: 'ri-box-3-line', status: 'supported' },
+    { key: 'parser', group: '索引与解析', label: '解析引擎', icon: 'ri-file-search-line', status: 'supported' },
+    { key: 'chunk', group: '索引与解析', label: '分块设置', icon: 'ri-file-copy-2-line', status: 'supported' },
+    { key: 'image', group: '索引与解析', label: '图像处理', icon: 'ri-image-line', status: 'post-create' },
+    { key: 'audio', group: '索引与解析', label: '音频处理', icon: 'ri-volume-up-line', status: 'preview' },
+    { key: 'advanced', group: '索引与解析', label: '高级设置', icon: 'ri-settings-3-line', status: 'supported' },
+    { key: 'storage', group: '存储与数据', label: '存储引擎', icon: 'ri-hard-drive-3-line', status: 'preview' }
+  ]
+
+  readonly parserEngineRows: Array<{
+    key: string
+    label: string
+    extensions: string[]
+    icon: string
+    engine: string
+    options: ParserEngineOption[]
+    hasHeaderToggle?: boolean
+  }> = [
+    {
+      key: 'pdf',
+      label: 'PDF 文档',
+      extensions: ['.pdf'],
+      icon: 'ri-file-pdf-2-line',
+      engine: 'builtin',
+      options: [
+        { value: 'builtin', label: '内置（默认）' },
+        { value: 'markitdown', label: 'MarkItDown' },
+        { value: 'mineru', label: 'MinerU' }
+      ]
+    },
+    {
+      key: 'word',
+      label: 'Word 文档',
+      extensions: ['.docx', '.doc'],
+      icon: 'ri-file-word-2-line',
+      engine: 'builtin',
+      options: [
+        { value: 'builtin', label: '内置（默认）' },
+        { value: 'markitdown', label: 'MarkItDown' }
+      ]
+    },
+    {
+      key: 'presentation',
+      label: '演示文稿',
+      extensions: ['.pptx', '.ppt'],
+      icon: 'ri-file-ppt-2-line',
+      engine: 'markitdown',
+      options: [
+        { value: 'markitdown', label: 'MarkItDown（默认）' },
+        { value: 'builtin', label: '内置' }
+      ]
+    },
+    {
+      key: 'excel',
+      label: 'Excel 表格',
+      extensions: ['.xlsx', '.xls'],
+      icon: 'ri-file-excel-2-line',
+      engine: 'builtin',
+      options: [
+        { value: 'builtin', label: '内置（默认）' },
+        { value: 'markitdown', label: 'MarkItDown' }
+      ],
+      hasHeaderToggle: true
+    },
+    {
+      key: 'epub',
+      label: '电子书',
+      extensions: ['.epub'],
+      icon: 'ri-book-2-line',
+      engine: 'builtin',
+      options: [
+        { value: 'builtin', label: '内置（默认）' },
+        { value: 'markitdown', label: 'MarkItDown' }
+      ]
+    },
+    {
+      key: 'mhtml',
+      label: '网页归档',
+      extensions: ['.mhtml'],
+      icon: 'ri-file-code-line',
+      engine: 'builtin',
+      options: [
+        { value: 'builtin', label: '内置（默认）' },
+        { value: 'markitdown', label: 'MarkItDown' }
+      ]
+    },
+    {
+      key: 'csv',
+      label: 'CSV 文件',
+      extensions: ['.csv'],
+      icon: 'ri-file-excel-2-line',
+      engine: 'simple',
+      options: [
+        { value: 'simple', label: 'Simple（默认）' },
+        { value: 'builtin', label: '内置' }
+      ]
+    }
+  ]
+
+  readonly parserEngineSelections = signal<Record<string, string>>(
+    Object.fromEntries(this.parserEngineRows.map((row) => [row.key, row.engine]))
+  )
+
+  readonly name = model<string>(this.#initialKnowledgebase?.name ?? '')
+  readonly description = model<string>(this.#initialKnowledgebase?.description ?? '')
+  readonly type = model<KnowledgebaseTypeEnum>(this.#initialKnowledgebase?.type ?? KnowledgebaseTypeEnum.Standard)
+  readonly indexStrategy = model<'rag' | 'wiki'>('rag')
+  readonly excelHeaderRow = model(false)
+
+  readonly copilotModel = model<ICopilotModel | undefined>(this.#initialKnowledgebase?.copilotModel)
+  readonly chatModel = model<ICopilotModel | undefined>(this.#initialKnowledgebase?.chatModel ?? undefined)
+  readonly visionModel = model<ICopilotModel | undefined>(this.#initialKnowledgebase?.visionModel ?? undefined)
+
+  readonly embeddingBatchSize = model<number | null>(this.#initialKnowledgebase?.parserConfig?.embeddingBatchSize ?? 16)
+  readonly chunkSize = model<number | null>(this.#initialKnowledgebase?.parserConfig?.chunkSize ?? 512)
+  readonly chunkOverlap = model<number | null>(this.#initialKnowledgebase?.parserConfig?.chunkOverlap ?? 80)
+  readonly delimiter = model<string>(this.#initialKnowledgebase?.parserConfig?.delimiter ?? '\n\n')
+  readonly incrementalSyncEnabled = model(this.#initialKnowledgebase?.incrementalSyncEnabled ?? false)
+  readonly chunkStrategy = model<'auto' | 'title' | 'structure' | 'length'>('auto')
+  readonly separators = signal<string[]>(['\\n\\n', '\\n', '。', '！', '？', '；', ';'])
+  readonly chunkSizePercent = computed(() => `${(((this.chunkSize() ?? 512) - 100) / 3900) * 100}%`)
+  readonly chunkOverlapPercent = computed(() => `${((this.chunkOverlap() ?? 80) / 500) * 100}%`)
+
+  readonly separatorOptions = [
+    { value: '\\n\\n', label: '双换行 (\\n\\n)' },
+    { value: '\\n', label: '单换行 (\\n)' },
+    { value: '。', label: '中文句号 (。)' },
+    { value: '！', label: '感叹号 (！)' },
+    { value: '？', label: '问号 (？)' },
+    { value: '；', label: '中文分号 (；)' },
+    { value: ';', label: '英文分号 (;)' }
+  ]
+
+  // UI-only until the create DTO accepts WeKnora's advanced generation fields.
+  readonly questionGenerationEnabled = model(true)
+  readonly questionCount = model<number | null>(3)
+  readonly questionRequirements = model('')
+  readonly tableMetadataRequirements = model('')
+
+  // Document-level parser options are shown here for parity with WeKnora and
+  // will be applied from the document import flow until the KB create DTO grows.
+  readonly parserPreview = signal<ParserPreviewState>({
+    textSplitter: 'platform-default',
+    transformer: 'platform-default',
+    spreadsheetInterpretation: 'records',
+    spreadsheetContextUnit: 'row',
+    includeHiddenSheets: false,
+    imageUnderstanding: true
+  })
 
   readonly loading = signal(false)
+  readonly invalid = computed(() => !this.name().trim())
 
-  readonly invalid = computed(() => !this.copilotModel() || !this.name().trim())
+  readonly groupedSections = computed(() => {
+    const groups: CreateSection['group'][] = ['基础', '索引与解析', '存储与数据']
+    return groups.map((group) => ({ group, items: this.sections.filter((section) => section.group === group) }))
+  })
+
+  selectSection(section: SectionKey) {
+    this.activeSection.set(section)
+  }
+
+  sectionStatusLabel(status: SectionStatus) {
+    switch (status) {
+      case 'supported':
+        return '已支持'
+      case 'post-create':
+        return '创建后配置'
+      default:
+        return '预览'
+    }
+  }
+
+  updateParserPreview<K extends keyof ParserPreviewState>(key: K, value: ParserPreviewState[K]) {
+    this.parserPreview.update((current) => ({ ...current, [key]: value }))
+  }
+
+  updateParserEngine(key: string, value: string) {
+    this.parserEngineSelections.update((current) => ({ ...current, [key]: value }))
+  }
+
+  addSeparator(value: string) {
+    if (!value || this.separators().includes(value)) {
+      return
+    }
+    this.separators.update((current) => [...current, value])
+    this.delimiter.set(this.separators()[0] || '\n\n')
+  }
+
+  removeSeparator(value: string) {
+    this.separators.update((current) => current.filter((separator) => separator !== value))
+    this.delimiter.set(this.separators()[0] || '\n\n')
+  }
+
+  separatorLabel(value: string) {
+    return this.separatorOptions.find((option) => option.value === value)?.label ?? value
+  }
+
+  submit() {
+    if (this.isEditMode()) {
+      this.save()
+      return
+    }
+
+    this.create()
+  }
 
   create() {
-    this.knowledgebaseService
-      .create({
-        name: this.name(),
-        workspaceId: this.workspaceId(),
-        copilotModel: this.copilotModel(),
-        chatModel: this.chatModel(),
-        rerankModel: this.rerankModel()
-      })
-      .subscribe({
-        next: (knowledgebase) => {
-          this.#toastr.success('XP.Messages.CreatedSuccessfully', { Default: 'Created successfully!' })
-          this.close(knowledgebase)
-        },
-        error: (error) => {
-          this.#toastr.error(getErrorMessage(error))
-        }
-      })
+    if (!this.validate()) return
+
+    this.loading.set(true)
+
+    this.knowledgebaseService.create(this.buildPayload()).subscribe({
+      next: (knowledgebase) => {
+        this.#toastr.success('XP.Messages.CreatedSuccessfully', { Default: 'Knowledge base created successfully' })
+        this.loading.set(false)
+        this.close(knowledgebase)
+      },
+      error: (error) => {
+        this.loading.set(false)
+        this.#toastr.error(getErrorMessage(error))
+      }
+    })
+  }
+
+  save() {
+    if (!this.validate()) return
+
+    const knowledgebaseId = this.existingKnowledgebase()?.id
+    if (!knowledgebaseId) return
+
+    this.loading.set(true)
+    this.knowledgebaseService.update(knowledgebaseId, this.buildPayload()).subscribe({
+      next: (knowledgebase) => {
+        this.#toastr.success('XP.Messages.SavedSuccessfully', {
+          Default: 'Knowledge base settings saved successfully'
+        })
+        this.loading.set(false)
+        this.close(knowledgebase as IKnowledgebase)
+      },
+      error: (error) => {
+        this.loading.set(false)
+        this.#toastr.error(getErrorMessage(error))
+      }
+    })
+  }
+
+  private validate() {
+    if (this.loading()) {
+      return false
+    }
+
+    if (this.invalid()) {
+      this.activeSection.set('basic')
+      this.#toastr.error('请输入知识库名称')
+      return false
+    }
+
+    if (!this.copilotModel()) {
+      this.activeSection.set('models')
+      this.#toastr.error('请选择 Embedding 模型')
+      return false
+    }
+
+    return true
+  }
+
+  private buildPayload(): Partial<IKnowledgebase> {
+    const payload: Partial<IKnowledgebase> = {
+      name: this.name().trim(),
+      description: this.description().trim() || undefined,
+      copilotModel: this.copilotModel(),
+      chatModel: this.chatModel() ?? null,
+      visionModel: this.visionModel() ?? null,
+      parserConfig: {
+        embeddingBatchSize: this.embeddingBatchSize() ?? undefined,
+        chunkSize: this.chunkSize(),
+        chunkOverlap: this.chunkOverlap(),
+        delimiter: this.delimiter() || null
+      },
+      incrementalSyncEnabled: this.incrementalSyncEnabled()
+    }
+
+    if (!this.isEditMode()) {
+      payload.workspaceId = this.workspaceId()
+      payload.type = KnowledgebaseTypeEnum.Standard
+    }
+
+    return payload
   }
 
   close(value?: IKnowledgebase) {
-    this.#dialogRef.close(value)
+    if (!this.loading()) {
+      this.#dialogRef.close(value)
+    }
   }
 }

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
@@ -9,16 +9,29 @@ import { TranslateModule } from '@ngx-translate/core'
 import { ZardSwitchComponent, ZardTooltipImports } from '@xpert-ai/headless-ui'
 import {
   AiModelTypeEnum,
+  GraphRagConfig,
+  GraphRagRetrievalMode,
   getErrorMessage,
   ICopilotModel,
   IKnowledgebase,
   KnowledgebaseService,
   KnowledgebaseTypeEnum,
   ModelFeature,
-  ToastrService
+  ToastrService,
+  TKBRetrievalSettings
 } from '../../../../@core'
 
-type SectionKey = 'basic' | 'models' | 'parser' | 'chunk' | 'image' | 'audio' | 'advanced' | 'storage'
+type SectionKey =
+  | 'basic'
+  | 'models'
+  | 'vector'
+  | 'parser'
+  | 'chunk'
+  | 'image'
+  | 'audio'
+  | 'graph'
+  | 'advanced'
+  | 'storage'
 
 type SectionStatus = 'supported' | 'post-create' | 'preview'
 
@@ -83,10 +96,12 @@ export class XpertNewKnowledgeComponent {
   readonly sections: CreateSection[] = [
     { key: 'basic', group: '基础', label: '基本信息', icon: 'ri-information-line', status: 'supported' },
     { key: 'models', group: '基础', label: '模型配置', icon: 'ri-box-3-line', status: 'supported' },
+    { key: 'vector', group: '基础', label: '向量检索', icon: 'ri-focus-2-line', status: 'supported' },
     { key: 'parser', group: '索引与解析', label: '解析引擎', icon: 'ri-file-search-line', status: 'supported' },
     { key: 'chunk', group: '索引与解析', label: '分块设置', icon: 'ri-file-copy-2-line', status: 'supported' },
     { key: 'image', group: '索引与解析', label: '图像处理', icon: 'ri-image-line', status: 'post-create' },
     { key: 'audio', group: '索引与解析', label: '音频处理', icon: 'ri-volume-up-line', status: 'preview' },
+    { key: 'graph', group: '索引与解析', label: '知识图谱', icon: 'ri-node-tree', status: 'supported' },
     { key: 'advanced', group: '索引与解析', label: '高级设置', icon: 'ri-settings-3-line', status: 'supported' },
     { key: 'storage', group: '存储与数据', label: '存储引擎', icon: 'ri-hard-drive-3-line', status: 'preview' }
   ]
@@ -221,6 +236,51 @@ export class XpertNewKnowledgeComponent {
   readonly questionRequirements = model('')
   readonly tableMetadataRequirements = model('')
 
+  readonly vectorTopK = model(this.#initialKnowledgebase?.recall?.topK ?? 10)
+  readonly vectorScore = model(this.#initialKnowledgebase?.recall?.score ?? 0.5)
+  readonly vectorScoreEnabled = model(
+    this.#initialKnowledgebase ? this.#initialKnowledgebase.recall?.score != null : true
+  )
+  readonly rerankEnabled = model(
+    !!(this.#initialKnowledgebase?.rerankModel || this.#initialKnowledgebase?.rerankModelId)
+  )
+  readonly rerankModel = model<ICopilotModel | null>(this.#initialKnowledgebase?.rerankModel ?? null)
+  readonly vectorTopKPercent = computed(() => `${(((this.vectorTopK() - 1) / 99) * 100).toFixed(2)}%`)
+  readonly vectorScorePercent = computed(() => `${(this.vectorScore() * 100).toFixed(2)}%`)
+
+  readonly retrieval = computed<Partial<IKnowledgebase & TKBRetrievalSettings>>(() => ({
+    recall: {
+      topK: this.vectorTopK(),
+      score: this.vectorScoreEnabled() ? this.vectorScore() : null
+    },
+    rerankModel: this.rerankEnabled() ? this.rerankModel() : null,
+    rerankModelId: this.rerankEnabled() ? this.rerankModel()?.id : null
+  }))
+
+  readonly graphEnabled = model(this.#initialKnowledgebase?.graphRag?.enabled ?? false)
+  readonly graphMode = model<GraphRagRetrievalMode>(this.#initialKnowledgebase?.graphRag?.mode ?? 'vector')
+  readonly graphEntityTopK = model(this.#initialKnowledgebase?.graphRag?.entityTopK ?? 8)
+  readonly graphNeighborHops = model(this.#initialKnowledgebase?.graphRag?.neighborHops ?? 1)
+  readonly graphWeight = model(this.#initialKnowledgebase?.graphRag?.graphWeight ?? 0.35)
+
+  readonly graphRag = computed<GraphRagConfig>(() => ({
+    enabled: this.graphEnabled(),
+    mode: this.graphMode(),
+    entityTopK: this.graphEntityTopK(),
+    neighborHops: this.graphNeighborHops(),
+    graphWeight: this.graphWeight()
+  }))
+
+  readonly graphModeOptions: Array<{
+    value: GraphRagRetrievalMode
+    label: string
+    description: string
+  }> = [
+    { value: 'vector', label: '向量', description: '使用文本向量进行语义检索。' },
+    { value: 'graph', label: '图谱', description: '优先召回实体关系及其关联文档片段。' },
+    { value: 'hybrid', label: '混合', description: '融合向量检索与图谱召回，按权重合并结果。' }
+  ]
+
   // Document-level parser options are shown here for parity with WeKnora and
   // will be applied from the document import flow until the KB create DTO grows.
   readonly parserPreview = signal<ParserPreviewState>({
@@ -261,6 +321,24 @@ export class XpertNewKnowledgeComponent {
 
   updateParserEngine(key: string, value: string) {
     this.parserEngineSelections.update((current) => ({ ...current, [key]: value }))
+  }
+
+  setGraphEnabled(value: boolean) {
+    this.graphEnabled.set(value)
+    if (!value) {
+      this.graphMode.set('vector')
+    }
+  }
+
+  setGraphMode(value: GraphRagRetrievalMode) {
+    this.graphMode.set(value)
+    if (value !== 'vector') {
+      this.graphEnabled.set(true)
+    }
+  }
+
+  graphModeDescription() {
+    return this.graphModeOptions.find((option) => option.value === this.graphMode())?.description ?? ''
   }
 
   addSeparator(value: string) {
@@ -356,6 +434,12 @@ export class XpertNewKnowledgeComponent {
       copilotModel: this.copilotModel(),
       chatModel: this.chatModel() ?? null,
       visionModel: this.visionModel() ?? null,
+      recall: this.retrieval().recall,
+      rerankModel: this.rerankEnabled() ? this.rerankModel() : null,
+      rerankModelId: this.rerankEnabled()
+        ? (this.rerankModel()?.id ?? this.#initialKnowledgebase?.rerankModelId)
+        : null,
+      graphRag: this.graphRag(),
       parserConfig: {
         embeddingBatchSize: this.embeddingBatchSize() ?? undefined,
         chunkSize: this.chunkSize(),

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
@@ -5,7 +5,7 @@ import { CommonModule } from '@angular/common'
 import { Component, computed, inject, model, signal } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { CopilotModelSelectComponent } from '@cloud/app/@shared/copilot'
-import { TranslateModule } from '@ngx-translate/core'
+import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { ZardSwitchComponent, ZardTooltipImports } from '@xpert-ai/headless-ui'
 import {
   AiModelTypeEnum,
@@ -37,8 +37,8 @@ type SectionStatus = 'supported' | 'post-create' | 'preview'
 
 type CreateSection = {
   key: SectionKey
-  group: '基础' | '索引与解析' | '存储与数据'
-  label: string
+  group: 'Basic' | 'Indexing' | 'Storage'
+  labelKey: string
   icon: string
   status: SectionStatus
 }
@@ -54,7 +54,7 @@ type ParserPreviewState = {
 
 type ParserEngineOption = {
   value: string
-  label: string
+  labelKey: string
 }
 
 type KnowledgeDialogData = {
@@ -82,11 +82,13 @@ export class XpertNewKnowledgeComponent {
   readonly #dialogData = inject<KnowledgeDialogData>(DIALOG_DATA)
   readonly #initialKnowledgebase = this.#dialogData?.knowledgebase ?? null
   readonly #toastr = inject(ToastrService)
+  readonly #translate = inject(TranslateService)
   readonly knowledgebaseService = inject(KnowledgebaseService)
 
   readonly eAiModelTypeEnum = AiModelTypeEnum
   readonly eModelFeature = ModelFeature
   readonly KnowledgebaseTypeEnum = KnowledgebaseTypeEnum
+  readonly i18nPrefix = 'XP.Knowledgebase.WorkspaceConfiguration'
 
   readonly existingKnowledgebase = signal<IKnowledgebase | null>(this.#initialKnowledgebase)
   readonly isEditMode = computed(() => !!this.existingKnowledgebase()?.id)
@@ -94,21 +96,27 @@ export class XpertNewKnowledgeComponent {
   readonly activeSection = signal<SectionKey>('basic')
 
   readonly sections: CreateSection[] = [
-    { key: 'basic', group: '基础', label: '基本信息', icon: 'ri-information-line', status: 'supported' },
-    { key: 'models', group: '基础', label: '模型配置', icon: 'ri-box-3-line', status: 'supported' },
-    { key: 'vector', group: '基础', label: '向量检索', icon: 'ri-focus-2-line', status: 'supported' },
-    { key: 'parser', group: '索引与解析', label: '解析引擎', icon: 'ri-file-search-line', status: 'supported' },
-    { key: 'chunk', group: '索引与解析', label: '分块设置', icon: 'ri-file-copy-2-line', status: 'supported' },
-    { key: 'image', group: '索引与解析', label: '图像处理', icon: 'ri-image-line', status: 'post-create' },
-    { key: 'audio', group: '索引与解析', label: '音频处理', icon: 'ri-volume-up-line', status: 'preview' },
-    { key: 'graph', group: '索引与解析', label: '知识图谱', icon: 'ri-node-tree', status: 'supported' },
-    { key: 'advanced', group: '索引与解析', label: '高级设置', icon: 'ri-settings-3-line', status: 'supported' },
-    { key: 'storage', group: '存储与数据', label: '存储引擎', icon: 'ri-hard-drive-3-line', status: 'preview' }
+    { key: 'basic', group: 'Basic', labelKey: 'Sections.Basic', icon: 'ri-information-line', status: 'supported' },
+    { key: 'models', group: 'Basic', labelKey: 'Sections.Models', icon: 'ri-box-3-line', status: 'supported' },
+    { key: 'vector', group: 'Basic', labelKey: 'Sections.Vector', icon: 'ri-focus-2-line', status: 'supported' },
+    { key: 'parser', group: 'Indexing', labelKey: 'Sections.Parser', icon: 'ri-file-search-line', status: 'supported' },
+    { key: 'chunk', group: 'Indexing', labelKey: 'Sections.Chunk', icon: 'ri-file-copy-2-line', status: 'supported' },
+    { key: 'image', group: 'Indexing', labelKey: 'Sections.Image', icon: 'ri-image-line', status: 'post-create' },
+    { key: 'audio', group: 'Indexing', labelKey: 'Sections.Audio', icon: 'ri-volume-up-line', status: 'preview' },
+    { key: 'graph', group: 'Indexing', labelKey: 'Sections.Graph', icon: 'ri-node-tree', status: 'supported' },
+    {
+      key: 'advanced',
+      group: 'Indexing',
+      labelKey: 'Sections.Advanced',
+      icon: 'ri-settings-3-line',
+      status: 'supported'
+    },
+    { key: 'storage', group: 'Storage', labelKey: 'Sections.Storage', icon: 'ri-hard-drive-3-line', status: 'preview' }
   ]
 
   readonly parserEngineRows: Array<{
     key: string
-    label: string
+    labelKey: string
     extensions: string[]
     icon: string
     engine: string
@@ -117,81 +125,81 @@ export class XpertNewKnowledgeComponent {
   }> = [
     {
       key: 'pdf',
-      label: 'PDF 文档',
+      labelKey: 'Parser.FileTypes.Pdf',
       extensions: ['.pdf'],
       icon: 'ri-file-pdf-2-line',
       engine: 'builtin',
       options: [
-        { value: 'builtin', label: '内置（默认）' },
-        { value: 'markitdown', label: 'MarkItDown' },
-        { value: 'mineru', label: 'MinerU' }
+        { value: 'builtin', labelKey: 'Parser.Engines.BuiltinDefault' },
+        { value: 'markitdown', labelKey: 'Parser.Engines.MarkItDown' },
+        { value: 'mineru', labelKey: 'Parser.Engines.MinerU' }
       ]
     },
     {
       key: 'word',
-      label: 'Word 文档',
+      labelKey: 'Parser.FileTypes.Word',
       extensions: ['.docx', '.doc'],
       icon: 'ri-file-word-2-line',
       engine: 'builtin',
       options: [
-        { value: 'builtin', label: '内置（默认）' },
-        { value: 'markitdown', label: 'MarkItDown' }
+        { value: 'builtin', labelKey: 'Parser.Engines.BuiltinDefault' },
+        { value: 'markitdown', labelKey: 'Parser.Engines.MarkItDown' }
       ]
     },
     {
       key: 'presentation',
-      label: '演示文稿',
+      labelKey: 'Parser.FileTypes.Presentation',
       extensions: ['.pptx', '.ppt'],
       icon: 'ri-file-ppt-2-line',
       engine: 'markitdown',
       options: [
-        { value: 'markitdown', label: 'MarkItDown（默认）' },
-        { value: 'builtin', label: '内置' }
+        { value: 'markitdown', labelKey: 'Parser.Engines.MarkItDownDefault' },
+        { value: 'builtin', labelKey: 'Parser.Engines.Builtin' }
       ]
     },
     {
       key: 'excel',
-      label: 'Excel 表格',
+      labelKey: 'Parser.FileTypes.Excel',
       extensions: ['.xlsx', '.xls'],
       icon: 'ri-file-excel-2-line',
       engine: 'builtin',
       options: [
-        { value: 'builtin', label: '内置（默认）' },
-        { value: 'markitdown', label: 'MarkItDown' }
+        { value: 'builtin', labelKey: 'Parser.Engines.BuiltinDefault' },
+        { value: 'markitdown', labelKey: 'Parser.Engines.MarkItDown' }
       ],
       hasHeaderToggle: true
     },
     {
       key: 'epub',
-      label: '电子书',
+      labelKey: 'Parser.FileTypes.Ebook',
       extensions: ['.epub'],
       icon: 'ri-book-2-line',
       engine: 'builtin',
       options: [
-        { value: 'builtin', label: '内置（默认）' },
-        { value: 'markitdown', label: 'MarkItDown' }
+        { value: 'builtin', labelKey: 'Parser.Engines.BuiltinDefault' },
+        { value: 'markitdown', labelKey: 'Parser.Engines.MarkItDown' }
       ]
     },
     {
       key: 'mhtml',
-      label: '网页归档',
+      labelKey: 'Parser.FileTypes.WebArchive',
       extensions: ['.mhtml'],
       icon: 'ri-file-code-line',
       engine: 'builtin',
       options: [
-        { value: 'builtin', label: '内置（默认）' },
-        { value: 'markitdown', label: 'MarkItDown' }
+        { value: 'builtin', labelKey: 'Parser.Engines.BuiltinDefault' },
+        { value: 'markitdown', labelKey: 'Parser.Engines.MarkItDown' }
       ]
     },
     {
       key: 'csv',
-      label: 'CSV 文件',
+      labelKey: 'Parser.FileTypes.Csv',
       extensions: ['.csv'],
       icon: 'ri-file-excel-2-line',
       engine: 'simple',
       options: [
-        { value: 'simple', label: 'Simple（默认）' },
-        { value: 'builtin', label: '内置' }
+        { value: 'simple', labelKey: 'Parser.Engines.SimpleDefault' },
+        { value: 'builtin', labelKey: 'Parser.Engines.Builtin' }
       ]
     }
   ]
@@ -221,13 +229,13 @@ export class XpertNewKnowledgeComponent {
   readonly chunkOverlapPercent = computed(() => `${((this.chunkOverlap() ?? 80) / 500) * 100}%`)
 
   readonly separatorOptions = [
-    { value: '\\n\\n', label: '双换行 (\\n\\n)' },
-    { value: '\\n', label: '单换行 (\\n)' },
-    { value: '。', label: '中文句号 (。)' },
-    { value: '！', label: '感叹号 (！)' },
-    { value: '？', label: '问号 (？)' },
-    { value: '；', label: '中文分号 (；)' },
-    { value: ';', label: '英文分号 (;)' }
+    { value: '\\n\\n', labelKey: 'Chunk.SeparatorLabels.DoubleNewline' },
+    { value: '\\n', labelKey: 'Chunk.SeparatorLabels.SingleNewline' },
+    { value: '。', labelKey: 'Chunk.SeparatorLabels.ChinesePeriod' },
+    { value: '！', labelKey: 'Chunk.SeparatorLabels.Exclamation' },
+    { value: '？', labelKey: 'Chunk.SeparatorLabels.Question' },
+    { value: '；', labelKey: 'Chunk.SeparatorLabels.ChineseSemicolon' },
+    { value: ';', labelKey: 'Chunk.SeparatorLabels.EnglishSemicolon' }
   ]
 
   // UI-only until the create DTO accepts WeKnora's advanced generation fields.
@@ -273,12 +281,12 @@ export class XpertNewKnowledgeComponent {
 
   readonly graphModeOptions: Array<{
     value: GraphRagRetrievalMode
-    label: string
-    description: string
+    labelKey: string
+    descriptionKey: string
   }> = [
-    { value: 'vector', label: '向量', description: '使用文本向量进行语义检索。' },
-    { value: 'graph', label: '图谱', description: '优先召回实体关系及其关联文档片段。' },
-    { value: 'hybrid', label: '混合', description: '融合向量检索与图谱召回，按权重合并结果。' }
+    { value: 'vector', labelKey: 'Graph.Modes.Vector', descriptionKey: 'Graph.Modes.VectorDescription' },
+    { value: 'graph', labelKey: 'Graph.Modes.Graph', descriptionKey: 'Graph.Modes.GraphDescription' },
+    { value: 'hybrid', labelKey: 'Graph.Modes.Hybrid', descriptionKey: 'Graph.Modes.HybridDescription' }
   ]
 
   // Document-level parser options are shown here for parity with WeKnora and
@@ -296,7 +304,7 @@ export class XpertNewKnowledgeComponent {
   readonly invalid = computed(() => !this.name().trim())
 
   readonly groupedSections = computed(() => {
-    const groups: CreateSection['group'][] = ['基础', '索引与解析', '存储与数据']
+    const groups: CreateSection['group'][] = ['Basic', 'Indexing', 'Storage']
     return groups.map((group) => ({ group, items: this.sections.filter((section) => section.group === group) }))
   })
 
@@ -304,14 +312,14 @@ export class XpertNewKnowledgeComponent {
     this.activeSection.set(section)
   }
 
-  sectionStatusLabel(status: SectionStatus) {
+  sectionStatusKey(status: SectionStatus) {
     switch (status) {
       case 'supported':
-        return '已支持'
+        return `${this.i18nPrefix}.Statuses.Supported`
       case 'post-create':
-        return '创建后配置'
+        return `${this.i18nPrefix}.Statuses.PostCreate`
       default:
-        return '预览'
+        return `${this.i18nPrefix}.Statuses.Preview`
     }
   }
 
@@ -337,8 +345,9 @@ export class XpertNewKnowledgeComponent {
     }
   }
 
-  graphModeDescription() {
-    return this.graphModeOptions.find((option) => option.value === this.graphMode())?.description ?? ''
+  graphModeDescriptionKey() {
+    const key = this.graphModeOptions.find((option) => option.value === this.graphMode())?.descriptionKey
+    return key ? `${this.i18nPrefix}.${key}` : ''
   }
 
   addSeparator(value: string) {
@@ -354,8 +363,9 @@ export class XpertNewKnowledgeComponent {
     this.delimiter.set(this.separators()[0] || '\n\n')
   }
 
-  separatorLabel(value: string) {
-    return this.separatorOptions.find((option) => option.value === value)?.label ?? value
+  separatorLabelKey(value: string) {
+    const key = this.separatorOptions.find((option) => option.value === value)?.labelKey
+    return key ? `${this.i18nPrefix}.${key}` : value
   }
 
   submit() {
@@ -414,13 +424,13 @@ export class XpertNewKnowledgeComponent {
 
     if (this.invalid()) {
       this.activeSection.set('basic')
-      this.#toastr.error('请输入知识库名称')
+      this.#toastr.error(this.#translate.instant(`${this.i18nPrefix}.Validation.NameRequired`))
       return false
     }
 
     if (!this.copilotModel()) {
       this.activeSection.set('models')
-      this.#toastr.error('请选择 Embedding 模型')
+      this.#toastr.error(this.#translate.instant(`${this.i18nPrefix}.Validation.EmbeddingModelRequired`))
       return false
     }
 

--- a/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/new.component.ts
@@ -6,7 +6,20 @@ import { Component, computed, inject, model, signal } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { CopilotModelSelectComponent } from '@cloud/app/@shared/copilot'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
-import { ZardSwitchComponent, ZardTooltipImports } from '@xpert-ai/headless-ui'
+import {
+  ZardButtonComponent,
+  ZardCheckboxComponent,
+  ZardInputDirective,
+  ZardSegmentedComponent,
+  ZardSegmentedItemComponent,
+  ZardSelectImports,
+  type ZardSelectValue,
+  ZardSliderComponent,
+  ZardSwitchComponent,
+  ZardToggleGroupComponent,
+  ZardToggleGroupItemComponent,
+  ZardTooltipImports
+} from '@xpert-ai/headless-ui'
 import {
   AiModelTypeEnum,
   GraphRagConfig,
@@ -71,7 +84,16 @@ type KnowledgeDialogData = {
     DragDropModule,
     FormsModule,
     CopilotModelSelectComponent,
+    ZardButtonComponent,
+    ZardCheckboxComponent,
+    ZardInputDirective,
+    ZardSegmentedComponent,
+    ZardSegmentedItemComponent,
+    ZardSliderComponent,
     ZardSwitchComponent,
+    ZardToggleGroupComponent,
+    ZardToggleGroupItemComponent,
+    ...ZardSelectImports,
     ...ZardTooltipImports
   ],
   templateUrl: './new.component.html',
@@ -225,8 +247,7 @@ export class XpertNewKnowledgeComponent {
   readonly incrementalSyncEnabled = model(this.#initialKnowledgebase?.incrementalSyncEnabled ?? false)
   readonly chunkStrategy = model<'auto' | 'title' | 'structure' | 'length'>('auto')
   readonly separators = signal<string[]>(['\\n\\n', '\\n', '。', '！', '？', '；', ';'])
-  readonly chunkSizePercent = computed(() => `${(((this.chunkSize() ?? 512) - 100) / 3900) * 100}%`)
-  readonly chunkOverlapPercent = computed(() => `${((this.chunkOverlap() ?? 80) / 500) * 100}%`)
+  readonly separatorToAdd = model<ZardSelectValue>('')
 
   readonly separatorOptions = [
     { value: '\\n\\n', labelKey: 'Chunk.SeparatorLabels.DoubleNewline' },
@@ -253,8 +274,6 @@ export class XpertNewKnowledgeComponent {
     !!(this.#initialKnowledgebase?.rerankModel || this.#initialKnowledgebase?.rerankModelId)
   )
   readonly rerankModel = model<ICopilotModel | null>(this.#initialKnowledgebase?.rerankModel ?? null)
-  readonly vectorTopKPercent = computed(() => `${(((this.vectorTopK() - 1) / 99) * 100).toFixed(2)}%`)
-  readonly vectorScorePercent = computed(() => `${(this.vectorScore() * 100).toFixed(2)}%`)
 
   readonly retrieval = computed<Partial<IKnowledgebase & TKBRetrievalSettings>>(() => ({
     recall: {
@@ -356,6 +375,13 @@ export class XpertNewKnowledgeComponent {
     }
     this.separators.update((current) => [...current, value])
     this.delimiter.set(this.separators()[0] || '\n\n')
+  }
+
+  selectSeparator(value: ZardSelectValue | ZardSelectValue[]) {
+    if (typeof value === 'string' && value) {
+      this.addSeparator(value)
+    }
+    this.separatorToAdd.set('')
   }
 
   removeSeparator(value: string) {

--- a/apps/cloud/src/app/features/xpert/workspace/knowledges/knowledges-page.component.ts
+++ b/apps/cloud/src/app/features/xpert/workspace/knowledges/knowledges-page.component.ts
@@ -154,6 +154,11 @@ export class XpertWorkspaceKnowledgesPageComponent {
 
     this.#dialog
       .open<IKnowledgebase>(XpertNewKnowledgeComponent, {
+        width: 'min(96vw, 72rem)',
+        height: 'min(90vh, 52rem)',
+        maxWidth: 'calc(100vw - 1.5rem)',
+        maxHeight: 'calc(100vh - 1.5rem)',
+        panelClass: 'xp-overlay-pane-card',
         data: { workspaceId }
       })
       .closed.subscribe((knowledgebase) => {
@@ -166,11 +171,27 @@ export class XpertWorkspaceKnowledgesPageComponent {
   }
 
   openKnowledgebaseSettings() {
-    const id = this.activeKnowledgebaseId()
-    if (id && this.canWriteActiveKnowledgebase()) {
-      void this.#router.navigate(['/xpert/knowledges', id, 'configuration'], {
-        queryParams: { returnTo: this.workspaceReturnTo() }
-      })
+    const knowledgebase = this.activeKnowledgebase()
+    if (knowledgebase && this.canWriteActiveKnowledgebase()) {
+      this.#dialog
+        .open<IKnowledgebase>(XpertNewKnowledgeComponent, {
+          width: 'min(96vw, 72rem)',
+          height: 'min(90vh, 52rem)',
+          maxWidth: 'calc(100vw - 1.5rem)',
+          maxHeight: 'calc(100vh - 1.5rem)',
+          panelClass: 'xp-overlay-pane-card',
+          data: {
+            workspaceId: this.workspaceId(),
+            knowledgebase
+          }
+        })
+        .closed.subscribe({
+          next: (updated) => {
+            if (updated) {
+              this.refresh()
+            }
+          }
+        })
     }
   }
 

--- a/apps/cloud/src/app/features/xpert/workspace/knowledges/knowledges.component.ts
+++ b/apps/cloud/src/app/features/xpert/workspace/knowledges/knowledges.component.ts
@@ -109,6 +109,11 @@ export class XpertWorkspaceKnowledgesComponent {
 
     this.#dialog
       .open<IKnowledgebase>(XpertNewKnowledgeComponent, {
+        width: 'min(96vw, 72rem)',
+        height: 'min(90vh, 52rem)',
+        maxWidth: 'calc(100vw - 1.5rem)',
+        maxHeight: 'calc(100vh - 1.5rem)',
+        panelClass: 'xp-overlay-pane-card',
         data: {
           workspaceId: this.workspaceId()
         }
@@ -129,9 +134,25 @@ export class XpertWorkspaceKnowledgesComponent {
       return
     }
 
-    this.#router.navigate(['/xpert/knowledges', item.id, 'configuration'], {
-      queryParams: { returnTo: this.workspaceReturnTo() }
-    })
+    this.#dialog
+      .open<IKnowledgebase>(XpertNewKnowledgeComponent, {
+        width: 'min(96vw, 72rem)',
+        height: 'min(90vh, 52rem)',
+        maxWidth: 'calc(100vw - 1.5rem)',
+        maxHeight: 'calc(100vh - 1.5rem)',
+        panelClass: 'xp-overlay-pane-card',
+        data: {
+          workspaceId: this.workspaceId(),
+          knowledgebase: item
+        }
+      })
+      .closed.subscribe({
+        next: (updated) => {
+          if (updated) {
+            this.refresh()
+          }
+        }
+      })
   }
 
   remove(item: IKnowledgebase) {

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -4482,6 +4482,191 @@
       "NoMatchingMembersHint": "Try another search keyword."
     },
     "Knowledgebase": {
+      "WorkspaceConfiguration": {
+        "Close": "Close",
+        "NavigationLabel": "Knowledge base settings navigation",
+        "EditTitle": "Knowledge base settings",
+        "CreateTitle": "New knowledge base",
+        "Groups": {
+          "Basic": "Basics",
+          "Indexing": "Indexing and parsing",
+          "Storage": "Storage and data"
+        },
+        "Sections": {
+          "Basic": "Basic information",
+          "Models": "Model configuration",
+          "Vector": "Vector retrieval",
+          "Parser": "Parser engines",
+          "Chunk": "Chunk settings",
+          "Image": "Image processing",
+          "Audio": "Audio processing",
+          "Graph": "Knowledge graph",
+          "Advanced": "Advanced settings",
+          "Storage": "Storage engine"
+        },
+        "Statuses": {
+          "Supported": "Supported",
+          "PostCreate": "Configure after creation",
+          "Preview": "Preview"
+        },
+        "Basic": {
+          "Description": "Set the knowledge base type, indexing strategy, and basic information.",
+          "KnowledgebaseType": "Knowledge base type",
+          "Document": "Document",
+          "QandA": "Q&A",
+          "KnowledgebaseTypeHelp": "Xpert currently supports standard document knowledge bases. Q&A knowledge bases will be available in a future release.",
+          "IndexStrategy": "Indexing strategy",
+          "RagSearch": "RAG retrieval",
+          "RagSearchDescription": "Chunk, vectorize, and retrieve documents with vector, graph, and hybrid modes.",
+          "WikiKnowledgebase": "Wiki knowledge base",
+          "New": "NEW",
+          "WikiDescription": "Automatically generate connected Wiki pages. Xpert does not currently provide a corresponding index browser.",
+          "Name": "Knowledge base name",
+          "NamePlaceholder": "Enter a knowledge base name",
+          "KnowledgebaseDescription": "Knowledge base description",
+          "DescriptionPlaceholder": "Enter a knowledge base description (optional)"
+        },
+        "Models": {
+          "Description": "Select suitable AI models for the knowledge base.",
+          "LargeLanguageModel": "LLM",
+          "LargeLanguageModelDescription": "The large language model used for summaries and abstracts.",
+          "EmbeddingModel": "Embedding model",
+          "EmbeddingModelDescription": "The embedding model used to vectorize text."
+        },
+        "Vector": {
+          "Description": "Configure query vectors, candidate count, and similarity filtering.",
+          "Search": "Vector search",
+          "SearchDescription": "Generate a query embedding and find text chunks with the most similar vector representations.",
+          "RerankModel": "Rerank model",
+          "RerankDescription": "Rerank candidate text chunks to improve result relevance.",
+          "TopK": "Top K",
+          "TopKDescription": "Number of candidate text chunks to return (1-100).",
+          "ScoreThreshold": "Similarity threshold",
+          "ScoreThresholdDescription": "Text chunks below the threshold are filtered out. Turn this off to remove the minimum similarity requirement.",
+          "StorageNotice": "Vector storage is managed by Xpert. Only retrieval behavior is configured here."
+        },
+        "Parser": {
+          "Description": "Choose a document parser for each file type. File types without a selection use the built-in parser.",
+          "FileTypes": {
+            "Pdf": "PDF document",
+            "Word": "Word document",
+            "Presentation": "Presentation",
+            "Excel": "Excel spreadsheet",
+            "Ebook": "E-book",
+            "WebArchive": "Web archive",
+            "Csv": "CSV file"
+          },
+          "Engines": {
+            "BuiltinDefault": "Built-in (default)",
+            "MarkItDown": "MarkItDown",
+            "MinerU": "MinerU",
+            "MarkItDownDefault": "MarkItDown (default)",
+            "Builtin": "Built-in",
+            "SimpleDefault": "Simple (default)"
+          },
+          "ExcelHeaderRow": "Use the first row as column headers and retain it in each row's context."
+        },
+        "Chunk": {
+          "Description": "Control how uploaded documents are split before embedding. The defaults work for most cases; adjust them only when retrieval quality requires it.",
+          "Strategy": "Chunking strategy",
+          "StrategyDescription": "Choose how documents are chunked. Automatic mode analyzes each document's structure and selects the best strategy.",
+          "Strategies": {
+            "Auto": "Automatic",
+            "Title": "Split by heading",
+            "Structure": "Structure-aware",
+            "Length": "Split by length"
+          },
+          "Test": "Test chunking",
+          "AutoNoteLabel": "Automatic",
+          "AutoNote": "The parser selects split by heading, structure-aware, or split by length based on the document structure.",
+          "Size": "Chunk size",
+          "SizeDescription": "Maximum characters per chunk (100-4000). Default: 512.",
+          "SizeRecommendation": "About 300 Chinese tokens or 100-130 English tokens. Use 200-400 for FAQs and 1000-2000 for long-form text.",
+          "Overlap": "Chunk overlap",
+          "OverlapDescription": "Characters shared by adjacent chunks (0-500). Default: 80, about 15% of the chunk size. Use 0 for FAQs or structured data and 150-200 for long-form text.",
+          "CharacterCount": "{{count}} characters",
+          "Separators": "Separators",
+          "SeparatorsDescription": "Characters or strings preferred when splitting. Higher-priority separators are tried first; the default order is paragraph, sentence, then punctuation.",
+          "RemoveSeparator": "Remove separator",
+          "AddSeparator": "Add separator",
+          "Add": "Add",
+          "SeparatorLabels": {
+            "DoubleNewline": "Double newline (\\n\\n)",
+            "SingleNewline": "Single newline (\\n)",
+            "ChinesePeriod": "Chinese period (。)",
+            "Exclamation": "Exclamation mark (!)",
+            "Question": "Question mark (?)",
+            "ChineseSemicolon": "Chinese semicolon (；)",
+            "EnglishSemicolon": "English semicolon (;)"
+          }
+        },
+        "Image": {
+          "Description": "Configure image understanding to extract text and meaning from images.",
+          "Enable": "Enable image understanding",
+          "EnableDescription": "Image documents use the vision model during import.",
+          "VisionModel": "Vision model",
+          "PostCreateNotice": "Image understanding settings are saved from document import settings after the knowledge base is created."
+        },
+        "Audio": {
+          "Description": "Choose a speech recognition engine for audio files.",
+          "SpeechToText": "Speech to text (ASR)",
+          "UnavailableDescription": "Xpert document models support the Audio type, but the knowledge base creation API does not yet expose an ASR engine field.",
+          "FrontendPreview": "UI preview",
+          "ParserEngine": "Parser engine",
+          "NotConnected": "Not available yet"
+        },
+        "Graph": {
+          "Description": "Configure GraphRAG to extract entities and relationships from documents and use them in retrieval.",
+          "Enable": "Enable GraphRAG",
+          "EnableDescription": "Extract entities, relationships, and evidence during parsing for graph and hybrid retrieval.",
+          "RetrievalMode": "Retrieval mode",
+          "Parameters": "Graph retrieval parameters",
+          "ParametersDescription": "Aligned with Xpert retrieval settings. Current values are retained when GraphRAG is disabled.",
+          "EntityTopK": "Entity Top K",
+          "EntityTopKDescription": "Number of candidate entities used to expand the graph for each query.",
+          "NeighborHops": "Neighbor hops",
+          "NeighborHopsDescription": "Number of relationship levels to traverse, up to two hops.",
+          "Weight": "Graph weight",
+          "WeightDescription": "Weight of graph results in the final ranking for hybrid retrieval.",
+          "PostCreateNotice": "The graph can be rebuilt from knowledge base settings after creation. Existing documents must be parsed again to generate graph data.",
+          "Modes": {
+            "Vector": "Vector",
+            "VectorDescription": "Use text vectors for semantic retrieval.",
+            "Graph": "Graph",
+            "GraphDescription": "Prioritize entity relationships and their related document chunks.",
+            "Hybrid": "Hybrid",
+            "HybridDescription": "Combine vector and graph results using the configured weight."
+          }
+        },
+        "Advanced": {
+          "Description": "Configure question generation and other advanced features.",
+          "QuestionGeneration": "AI question generation",
+          "QuestionGenerationDescription": "Use a large language model to generate related questions for each chunk and improve recall. Enabling this increases parsing time.",
+          "QuestionCount": "Questions to generate",
+          "QuestionCountDescription": "Number of questions generated for each document chunk (1-10).",
+          "QuestionRequirements": "Question generation requirements",
+          "QuestionRequirementsDescription": "Specify the audience, scenario, and wording while the system maintains a stable output format.",
+          "QuestionRequirementsPlaceholder": "For example: Generate natural-language questions commonly asked by support customers and avoid exam-style wording...",
+          "TableMetadataRequirements": "Table metadata generation requirements",
+          "TableMetadataRequirementsDescription": "Add business context and field semantics to CSV/Excel summaries so retrieval can better understand the table.",
+          "TableMetadataRequirementsPlaceholder": "For example: This is a sales order table, amounts are in CNY, and the status field uses internal company codes..."
+        },
+        "Storage": {
+          "Description": "Configure storage for original files and processing results.",
+          "PlatformDefault": "Platform default storage",
+          "PlatformDefaultDescription": "Xpert currently uses the workspace storage service. A separate storage engine is not selected when creating a knowledge base.",
+          "SwitchUnsupported": "Switching is not supported"
+        },
+        "Actions": {
+          "Cancel": "Cancel",
+          "Save": "Save settings",
+          "Create": "Create knowledge base"
+        },
+        "Validation": {
+          "NameRequired": "Enter a knowledge base name",
+          "EmbeddingModelRequired": "Select an embedding model"
+        }
+      },
       "WorkbenchTitle": "Knowledge base",
       "WorkbenchDescription": "Share, organize, and manage knowledge.",
       "PersonalKnowledge": "Personal knowledge bases",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -6448,6 +6448,191 @@
       "TakeMeThere": "带我去！"
     },
     "Knowledgebase": {
+      "WorkspaceConfiguration": {
+        "Close": "关闭",
+        "NavigationLabel": "知识库设置导航",
+        "EditTitle": "知识库设置",
+        "CreateTitle": "新建知识库",
+        "Groups": {
+          "Basic": "基础",
+          "Indexing": "索引与解析",
+          "Storage": "存储与数据"
+        },
+        "Sections": {
+          "Basic": "基本信息",
+          "Models": "模型配置",
+          "Vector": "向量检索",
+          "Parser": "解析引擎",
+          "Chunk": "分块设置",
+          "Image": "图像处理",
+          "Audio": "音频处理",
+          "Graph": "知识图谱",
+          "Advanced": "高级设置",
+          "Storage": "存储引擎"
+        },
+        "Statuses": {
+          "Supported": "已支持",
+          "PostCreate": "创建后配置",
+          "Preview": "预览"
+        },
+        "Basic": {
+          "Description": "设置知识库的类型、索引策略和基本信息。",
+          "KnowledgebaseType": "知识库类型",
+          "Document": "文档",
+          "QandA": "问答",
+          "KnowledgebaseTypeHelp": "Xpert 当前支持标准文档知识库，问答知识库将在后续版本接入。",
+          "IndexStrategy": "索引策略",
+          "RagSearch": "RAG 检索",
+          "RagSearchDescription": "对文档进行分块、向量化和检索，支持向量、图谱和混合模式。",
+          "WikiKnowledgebase": "Wiki 知识库",
+          "New": "NEW",
+          "WikiDescription": "自动生成关联的 Wiki 页面，当前 Xpert 暂无对应索引浏览器。",
+          "Name": "知识库名称",
+          "NamePlaceholder": "请输入知识库名称",
+          "KnowledgebaseDescription": "知识库描述",
+          "DescriptionPlaceholder": "请输入知识库描述（可选）"
+        },
+        "Models": {
+          "Description": "为知识库选择合适的 AI 模型。",
+          "LargeLanguageModel": "LLM 大语言模型",
+          "LargeLanguageModelDescription": "用于总结和摘要的大语言模型。",
+          "EmbeddingModel": "Embedding 嵌入模型",
+          "EmbeddingModelDescription": "用于文本向量化的嵌入模型。"
+        },
+        "Vector": {
+          "Description": "配置查询向量、候选数量和相似度筛选策略。",
+          "Search": "向量搜索",
+          "SearchDescription": "生成查询嵌入并搜索与其向量表示最相似的文本块。",
+          "RerankModel": "重新排序模型",
+          "RerankDescription": "使用重排模型对候选文本块重新排序，提升结果相关性。",
+          "TopK": "前多少",
+          "TopKDescription": "返回候选文本块的数量（1–100）。",
+          "ScoreThreshold": "相似度阈值",
+          "ScoreThresholdDescription": "低于阈值的文本块会被过滤，关闭后不限制最低相似度。",
+          "StorageNotice": "向量存储由 Xpert 平台统一管理，此处只配置检索行为。"
+        },
+        "Parser": {
+          "Description": "为不同文件类型选择文档解析引擎。未配置的文件类型将使用内置解析引擎。",
+          "FileTypes": {
+            "Pdf": "PDF 文档",
+            "Word": "Word 文档",
+            "Presentation": "演示文稿",
+            "Excel": "Excel 表格",
+            "Ebook": "电子书",
+            "WebArchive": "网页归档",
+            "Csv": "CSV 文件"
+          },
+          "Engines": {
+            "BuiltinDefault": "内置（默认）",
+            "MarkItDown": "MarkItDown",
+            "MinerU": "MinerU",
+            "MarkItDownDefault": "MarkItDown（默认）",
+            "Builtin": "内置",
+            "SimpleDefault": "Simple（默认）"
+          },
+          "ExcelHeaderRow": "将首行作为列标题，并保留在每行上下文中。"
+        },
+        "Chunk": {
+          "Description": "控制上传文档在嵌入前的切分方式。默认值适用于大多数场景，仅在检索质量异常时调整。",
+          "Strategy": "分块策略",
+          "StrategyDescription": "选择文档的分块方式。自动模式会分析每个文档的结构并选择最佳策略。",
+          "Strategies": {
+            "Auto": "自动",
+            "Title": "按标题切分",
+            "Structure": "结构感知",
+            "Length": "按长度切分"
+          },
+          "Test": "测试分块效果",
+          "AutoNoteLabel": "自动",
+          "AutoNote": "文档分析器根据内容结构自动在“按标题切分”“结构感知”“按长度切分”之间选择。",
+          "Size": "分块大小",
+          "SizeDescription": "每个分块的最大字符数（100–4000）。默认 512。",
+          "SizeRecommendation": "约中文 300 tokens / 英文 100–130 tokens。FAQ 用 200–400，叙述性长文档用 1000–2000。",
+          "Overlap": "分块重叠",
+          "OverlapDescription": "相邻分块之间共享的字符数（0–500）。默认 80，约为分块大小的 15%。FAQ/结构化数据用 0，长篇叙述用 150–200。",
+          "CharacterCount": "{{count}} 字符",
+          "Separators": "分隔符",
+          "SeparatorsDescription": "切分时优先使用的字符或字符串。优先级高的分隔符先尝试；默认顺序优先段落、句子、标点。",
+          "RemoveSeparator": "移除分隔符",
+          "AddSeparator": "添加分隔符",
+          "Add": "添加",
+          "SeparatorLabels": {
+            "DoubleNewline": "双换行 (\\n\\n)",
+            "SingleNewline": "单换行 (\\n)",
+            "ChinesePeriod": "中文句号 (。)",
+            "Exclamation": "感叹号 (!)",
+            "Question": "问号 (?)",
+            "ChineseSemicolon": "中文分号 (；)",
+            "EnglishSemicolon": "英文分号 (;)"
+          }
+        },
+        "Image": {
+          "Description": "配置图片理解策略，帮助知识库提取图片中的文字和语义。",
+          "Enable": "启用图片理解",
+          "EnableDescription": "图片文档将在导入时调用视觉理解模型。",
+          "VisionModel": "Vision 模型",
+          "PostCreateNotice": "图片理解配置将在知识库创建后从文档导入设置中保存。"
+        },
+        "Audio": {
+          "Description": "为音频文件选择语音识别引擎。",
+          "SpeechToText": "语音转文本（ASR）",
+          "UnavailableDescription": "Xpert 文档模型已支持 Audio 类型，但当前知识库创建接口还没有 ASR 引擎字段。",
+          "FrontendPreview": "前端预览",
+          "ParserEngine": "解析引擎",
+          "NotConnected": "暂未接入"
+        },
+        "Graph": {
+          "Description": "配置 GraphRAG，从文档中抽取实体和关系并参与知识检索。",
+          "Enable": "启用 GraphRAG",
+          "EnableDescription": "解析文档时抽取实体、关系和证据，供图谱检索与混合检索使用。",
+          "RetrievalMode": "检索模式",
+          "Parameters": "图谱检索参数",
+          "ParametersDescription": "与 Xpert 检索设置保持一致，关闭 GraphRAG 时保留当前配置。",
+          "EntityTopK": "实体 Top K",
+          "EntityTopKDescription": "每次查询用于扩展图谱的候选实体数量。",
+          "NeighborHops": "邻居跳数",
+          "NeighborHopsDescription": "沿实体关系扩展的层数，最多支持两跳。",
+          "Weight": "图谱权重",
+          "WeightDescription": "混合检索时图谱结果在最终排序中的权重。",
+          "PostCreateNotice": "创建后可在知识库配置中重建图谱；已存在的文档需要重新解析才会生成图谱数据。",
+          "Modes": {
+            "Vector": "向量",
+            "VectorDescription": "使用文本向量进行语义检索。",
+            "Graph": "图谱",
+            "GraphDescription": "优先召回实体关系及其关联文档片段。",
+            "Hybrid": "混合",
+            "HybridDescription": "融合向量检索与图谱召回，按权重合并结果。"
+          }
+        },
+        "Advanced": {
+          "Description": "配置问题生成等高级功能。",
+          "QuestionGeneration": "AI 问题生成",
+          "QuestionGenerationDescription": "解析文档时调用大模型为每个分块生成相关问题，提高检索召回率。启用后会增加文档解析耗时。",
+          "QuestionCount": "生成问题数量",
+          "QuestionCountDescription": "每个文档分块生成的问题数量（1–10）。",
+          "QuestionRequirements": "问题生成要求",
+          "QuestionRequirementsDescription": "指定问题面向的人群、场景和表达方式，系统仍维持稳定输出格式。",
+          "QuestionRequirementsPlaceholder": "例如：生成客服用户常问的自然语言问题，避免考试题式表达...",
+          "TableMetadataRequirements": "表格元数据生成要求",
+          "TableMetadataRequirementsDescription": "为 CSV/Excel 摘要补充业务背景和字段语义，帮助后续检索理解表格内容。",
+          "TableMetadataRequirementsPlaceholder": "例如：这是销售订单表，金额单位为元，status 字段值使用公司内部状态码..."
+        },
+        "Storage": {
+          "Description": "配置原始文件和处理结果的存储方式。",
+          "PlatformDefault": "平台默认存储",
+          "PlatformDefaultDescription": "当前 Xpert 统一使用工作空间存储服务，知识库创建时不单独选择存储引擎。",
+          "SwitchUnsupported": "暂不支持切换"
+        },
+        "Actions": {
+          "Cancel": "取消",
+          "Save": "保存配置",
+          "Create": "创建知识库"
+        },
+        "Validation": {
+          "NameRequired": "请输入知识库名称",
+          "EmbeddingModelRequired": "请选择 Embedding 模型"
+        }
+      },
       "WorkbenchTitle": "知识库",
       "WorkbenchDescription": "团队知识共享、协作与管理",
       "PersonalKnowledge": "个人知识库",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -5007,6 +5007,191 @@
       "TakeMeThere": "帶我去！"
     },
     "Knowledgebase": {
+      "WorkspaceConfiguration": {
+        "Close": "關閉",
+        "NavigationLabel": "知識庫設置導航",
+        "EditTitle": "知識庫設置",
+        "CreateTitle": "新建知識庫",
+        "Groups": {
+          "Basic": "基礎",
+          "Indexing": "索引與解析",
+          "Storage": "儲存與資料"
+        },
+        "Sections": {
+          "Basic": "基本資訊",
+          "Models": "模型配置",
+          "Vector": "向量檢索",
+          "Parser": "解析引擎",
+          "Chunk": "分塊設置",
+          "Image": "圖像處理",
+          "Audio": "音訊處理",
+          "Graph": "知識圖譜",
+          "Advanced": "進階設置",
+          "Storage": "儲存引擎"
+        },
+        "Statuses": {
+          "Supported": "已支援",
+          "PostCreate": "建立後配置",
+          "Preview": "預覽"
+        },
+        "Basic": {
+          "Description": "設置知識庫的類型、索引策略和基本資訊。",
+          "KnowledgebaseType": "知識庫類型",
+          "Document": "文件",
+          "QandA": "問答",
+          "KnowledgebaseTypeHelp": "Xpert 目前支援標準文件知識庫，問答知識庫將在後續版本接入。",
+          "IndexStrategy": "索引策略",
+          "RagSearch": "RAG 檢索",
+          "RagSearchDescription": "對文件進行分塊、向量化和檢索，支援向量、圖譜和混合模式。",
+          "WikiKnowledgebase": "Wiki 知識庫",
+          "New": "NEW",
+          "WikiDescription": "自動產生關聯的 Wiki 頁面，目前 Xpert 暫無對應索引瀏覽器。",
+          "Name": "知識庫名稱",
+          "NamePlaceholder": "請輸入知識庫名稱",
+          "KnowledgebaseDescription": "知識庫描述",
+          "DescriptionPlaceholder": "請輸入知識庫描述（可選）"
+        },
+        "Models": {
+          "Description": "為知識庫選擇合適的 AI 模型。",
+          "LargeLanguageModel": "LLM 大語言模型",
+          "LargeLanguageModelDescription": "用於總結和摘要的大語言模型。",
+          "EmbeddingModel": "Embedding 嵌入模型",
+          "EmbeddingModelDescription": "用於文字向量化的嵌入模型。"
+        },
+        "Vector": {
+          "Description": "配置查詢向量、候選數量和相似度篩選策略。",
+          "Search": "向量搜尋",
+          "SearchDescription": "產生查詢嵌入並搜尋與其向量表示最相似的文字區塊。",
+          "RerankModel": "重新排序模型",
+          "RerankDescription": "使用重排模型對候選文字區塊重新排序，提升結果相關性。",
+          "TopK": "前多少",
+          "TopKDescription": "傳回候選文字區塊的數量（1–100）。",
+          "ScoreThreshold": "相似度閾值",
+          "ScoreThresholdDescription": "低於閾值的文字區塊會被過濾，關閉後不限制最低相似度。",
+          "StorageNotice": "向量儲存由 Xpert 平台統一管理，此處只配置檢索行為。"
+        },
+        "Parser": {
+          "Description": "為不同檔案類型選擇文件解析引擎。未配置的檔案類型將使用內置解析引擎。",
+          "FileTypes": {
+            "Pdf": "PDF 文件",
+            "Word": "Word 文件",
+            "Presentation": "簡報",
+            "Excel": "Excel 表格",
+            "Ebook": "電子書",
+            "WebArchive": "網頁封存",
+            "Csv": "CSV 檔案"
+          },
+          "Engines": {
+            "BuiltinDefault": "內置（預設）",
+            "MarkItDown": "MarkItDown",
+            "MinerU": "MinerU",
+            "MarkItDownDefault": "MarkItDown（預設）",
+            "Builtin": "內置",
+            "SimpleDefault": "Simple（預設）"
+          },
+          "ExcelHeaderRow": "將首列作為欄位標題，並保留在每列上下文中。"
+        },
+        "Chunk": {
+          "Description": "控制上傳文件在嵌入前的切分方式。預設值適用於大多數場景，僅在檢索品質異常時調整。",
+          "Strategy": "分塊策略",
+          "StrategyDescription": "選擇文件的分塊方式。自動模式會分析每個文件的結構並選擇最佳策略。",
+          "Strategies": {
+            "Auto": "自動",
+            "Title": "按標題切分",
+            "Structure": "結構感知",
+            "Length": "按長度切分"
+          },
+          "Test": "測試分塊效果",
+          "AutoNoteLabel": "自動",
+          "AutoNote": "文件分析器根據內容結構自動在「按標題切分」「結構感知」「按長度切分」之間選擇。",
+          "Size": "分塊大小",
+          "SizeDescription": "每個分塊的最大字元數（100–4000）。預設 512。",
+          "SizeRecommendation": "約中文 300 tokens / 英文 100–130 tokens。FAQ 用 200–400，敘述性長文件用 1000–2000。",
+          "Overlap": "分塊重疊",
+          "OverlapDescription": "相鄰分塊之間共享的字元數（0–500）。預設 80，約為分塊大小的 15%。FAQ/結構化資料用 0，長篇敘述用 150–200。",
+          "CharacterCount": "{{count}} 字元",
+          "Separators": "分隔符",
+          "SeparatorsDescription": "切分時優先使用的字元或字串。優先級高的分隔符先嘗試；預設順序優先段落、句子、標點。",
+          "RemoveSeparator": "移除分隔符",
+          "AddSeparator": "新增分隔符",
+          "Add": "新增",
+          "SeparatorLabels": {
+            "DoubleNewline": "雙換行 (\\n\\n)",
+            "SingleNewline": "單換行 (\\n)",
+            "ChinesePeriod": "中文句號 (。)",
+            "Exclamation": "驚嘆號 (!)",
+            "Question": "問號 (?)",
+            "ChineseSemicolon": "中文分號 (；)",
+            "EnglishSemicolon": "英文分號 (;)"
+          }
+        },
+        "Image": {
+          "Description": "配置圖片理解策略，幫助知識庫擷取圖片中的文字和語義。",
+          "Enable": "啟用圖片理解",
+          "EnableDescription": "圖片文件將在匯入時調用視覺理解模型。",
+          "VisionModel": "Vision 模型",
+          "PostCreateNotice": "圖片理解配置將在知識庫建立後從文件匯入設置中儲存。"
+        },
+        "Audio": {
+          "Description": "為音訊檔案選擇語音識別引擎。",
+          "SpeechToText": "語音轉文字（ASR）",
+          "UnavailableDescription": "Xpert 文件模型已支援 Audio 類型，但目前知識庫建立介面還沒有 ASR 引擎欄位。",
+          "FrontendPreview": "前端預覽",
+          "ParserEngine": "解析引擎",
+          "NotConnected": "暫未接入"
+        },
+        "Graph": {
+          "Description": "配置 GraphRAG，從文件中抽取實體和關係並參與知識檢索。",
+          "Enable": "啟用 GraphRAG",
+          "EnableDescription": "解析文件時抽取實體、關係和證據，供圖譜檢索與混合檢索使用。",
+          "RetrievalMode": "檢索模式",
+          "Parameters": "圖譜檢索參數",
+          "ParametersDescription": "與 Xpert 檢索設置保持一致，關閉 GraphRAG 時保留目前配置。",
+          "EntityTopK": "實體 Top K",
+          "EntityTopKDescription": "每次查詢用於擴展圖譜的候選實體數量。",
+          "NeighborHops": "鄰居跳數",
+          "NeighborHopsDescription": "沿實體關係擴展的層數，最多支援兩跳。",
+          "Weight": "圖譜權重",
+          "WeightDescription": "混合檢索時圖譜結果在最終排序中的權重。",
+          "PostCreateNotice": "建立後可在知識庫配置中重建圖譜；已存在的文件需要重新解析才會產生圖譜資料。",
+          "Modes": {
+            "Vector": "向量",
+            "VectorDescription": "使用文字向量進行語義檢索。",
+            "Graph": "圖譜",
+            "GraphDescription": "優先召回實體關係及其關聯文件片段。",
+            "Hybrid": "混合",
+            "HybridDescription": "融合向量檢索與圖譜召回，按權重合併結果。"
+          }
+        },
+        "Advanced": {
+          "Description": "配置問題產生等進階功能。",
+          "QuestionGeneration": "AI 問題產生",
+          "QuestionGenerationDescription": "解析文件時調用大模型為每個分塊產生相關問題，提高檢索召回率。啟用後會增加文件解析耗時。",
+          "QuestionCount": "產生問題數量",
+          "QuestionCountDescription": "每個文件分塊產生的問題數量（1–10）。",
+          "QuestionRequirements": "問題產生要求",
+          "QuestionRequirementsDescription": "指定問題面向的人群、場景和表達方式，系統仍維持穩定輸出格式。",
+          "QuestionRequirementsPlaceholder": "例如：產生客服使用者常問的自然語言問題，避免考試題式表達...",
+          "TableMetadataRequirements": "表格中繼資料產生要求",
+          "TableMetadataRequirementsDescription": "為 CSV/Excel 摘要補充業務背景和欄位語義，幫助後續檢索理解表格內容。",
+          "TableMetadataRequirementsPlaceholder": "例如：這是銷售訂單表，金額單位為元，status 欄位值使用公司內部狀態碼..."
+        },
+        "Storage": {
+          "Description": "配置原始檔案和處理結果的儲存方式。",
+          "PlatformDefault": "平台預設儲存",
+          "PlatformDefaultDescription": "目前 Xpert 統一使用工作空間儲存服務，知識庫建立時不單獨選擇儲存引擎。",
+          "SwitchUnsupported": "暫不支援切換"
+        },
+        "Actions": {
+          "Cancel": "取消",
+          "Save": "儲存配置",
+          "Create": "建立知識庫"
+        },
+        "Validation": {
+          "NameRequired": "請輸入知識庫名稱",
+          "EmbeddingModelRequired": "請選擇 Embedding 模型"
+        }
+      },
       "Knowledgebase": "知識庫",
       "KnowledgebaseSettings": "知識庫設置",
       "KnowledgebaseSettingsDescription": "在這裏，您可以修改此知識庫的屬性和檢索設置。",

--- a/packages/ui/src/lib/components/tag-select/option-list.component.html
+++ b/packages/ui/src/lib/components/tag-select/option-list.component.html
@@ -4,13 +4,19 @@
       <div
         #optionElement
         role="option"
-        [attr.aria-selected]="activeIndex() === index"
+        [attr.aria-selected]="checkable() ? isSelected(option) : activeIndex() === index"
         [class]="optionClasses(index, !!option.disabled)"
         (mousedown)="onMouseDown($event)"
         (mouseenter)="onMouseEnter(index)"
         (click)="onOptionClick(option)"
       >
-        <span class="truncate">{{ option.label }}</span>
+        @if (checkable()) {
+          <z-checkbox class="pointer-events-none w-full" [ngModel]="isSelected(option)">
+            <span class="truncate">{{ option.label }}</span>
+          </z-checkbox>
+        } @else {
+          <span class="truncate">{{ option.label }}</span>
+        }
       </div>
     }
   } @else {

--- a/packages/ui/src/lib/components/tag-select/option-list.component.ts
+++ b/packages/ui/src/lib/components/tag-select/option-list.component.ts
@@ -1,12 +1,15 @@
 import { ChangeDetectionStrategy, Component, ElementRef, effect, input, output, viewChildren } from '@angular/core'
+import { FormsModule } from '@angular/forms'
 
 import { commandEmptyVariants, commandItemVariants, commandListVariants } from '../command/command.variants'
+import { ZardCheckboxComponent } from '../checkbox'
 import { mergeClasses } from '../../utils/merge-classes'
 
 import type { ZardTagSelectOption } from './tag-select.types'
 
 @Component({
   selector: 'z-tag-select-option-list',
+  imports: [FormsModule, ZardCheckboxComponent],
   templateUrl: './option-list.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   exportAs: 'zTagSelectOptionList'
@@ -17,6 +20,8 @@ export class ZardTagSelectOptionListComponent {
   readonly options = input<readonly ZardTagSelectOption<unknown>[]>([])
   readonly activeIndex = input(-1)
   readonly emptyText = input('No results found.')
+  readonly checkable = input(false)
+  readonly selectedValues = input<readonly unknown[]>([])
 
   readonly optionSelected = output<ZardTagSelectOption<unknown>>()
   readonly activeIndexChange = output<number>()
@@ -60,5 +65,9 @@ export class ZardTagSelectOptionListComponent {
     }
 
     this.optionSelected.emit(option)
+  }
+
+  protected isSelected(option: ZardTagSelectOption<unknown>): boolean {
+    return this.selectedValues().some((value) => Object.is(value, option.value))
   }
 }

--- a/packages/ui/src/lib/components/tag-select/tag-select.component.html
+++ b/packages/ui/src/lib/components/tag-select/tag-select.component.html
@@ -23,6 +23,8 @@
   <z-popover class="w-full p-0">
     <z-tag-select-option-list
       [options]="visibleOptions()"
+      [checkable]="checkable()"
+      [selectedValues]="currentValues()"
       [activeIndex]="activeIndex()"
       (optionSelected)="onOptionSelected($event)"
       (activeIndexChange)="onActiveIndexChange($event)"

--- a/packages/ui/src/lib/components/tag-select/tag-select.component.spec.ts
+++ b/packages/ui/src/lib/components/tag-select/tag-select.component.spec.ts
@@ -82,6 +82,28 @@ class MultipleObjectHostComponent {
   template: `
     <z-tag-select
       [formControl]="control"
+      mode="multiple"
+      [checkable]="true"
+      [enableSuggestions]="true"
+      [searchable]="false"
+      [options]="options"
+    />
+  `,
+})
+class CheckableMultipleHostComponent {
+  readonly control = new FormControl<string[]>(['alpha-id'], { nonNullable: true });
+  readonly options = [
+    { value: 'alpha-id', label: 'Alpha' },
+    { value: 'beta-id', label: 'Beta' },
+  ];
+}
+
+@Component({
+  standalone: true,
+  imports: [ReactiveFormsModule, ZardTagSelectComponent],
+  template: `
+    <z-tag-select
+      [formControl]="control"
       mode="tags"
       [allowCreate]="true"
       [enableSuggestions]="true"
@@ -294,6 +316,34 @@ describe('ZardTagSelectComponent', () => {
     const overlayText = overlayContainer.getContainerElement().textContent as string;
     expect(overlayText).not.toContain('Alice');
     expect(overlayText).toContain('Bob');
+  });
+
+  it('allows a checkable option to be unchecked and selected again', async () => {
+    const fixture = TestBed.configureTestingModule({
+      imports: [CheckableMultipleHostComponent],
+    }).createComponent(CheckableMultipleHostComponent);
+    const overlayContainer = TestBed.inject(OverlayContainer);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    input.focus();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const selectAlpha = () => {
+      const option = overlayContainer.getContainerElement().querySelector('[role="option"]') as HTMLElement;
+      option.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+      option.click();
+      fixture.detectChanges();
+    };
+
+    selectAlpha();
+    expect(fixture.componentInstance.control.value).toEqual([]);
+
+    selectAlpha();
+    expect(fixture.componentInstance.control.value).toEqual(['alpha-id']);
   });
 
   it('creates object values from input when createValueFromInput is provided', async () => {

--- a/packages/ui/src/lib/components/tag-select/tag-select.component.ts
+++ b/packages/ui/src/lib/components/tag-select/tag-select.component.ts
@@ -100,6 +100,7 @@ export class ZardTagSelectComponent implements ControlValueAccessor {
   readonly compareWith = input<ZardTagSelectCompareWith<unknown> | null>(null)
   readonly displayWith = input<ZardTagSelectDisplayWith<unknown> | null>(null)
   readonly createValueFromInput = input<ZardTagSelectCreateValueFromInput<unknown> | null>(null)
+  readonly checkable = input(false, { transform: booleanAttribute })
   readonly zDisabled = input(false, { transform: booleanAttribute })
 
   readonly valueChange = output<unknown[]>()
@@ -142,11 +143,15 @@ export class ZardTagSelectComponent implements ControlValueAccessor {
     }))
   )
   protected readonly normalizedSearch = computed(() => normalizeTagSelectToken(this.inputValue()))
-  protected readonly availableOptions = computed(() =>
-    this.options().filter(
+  protected readonly availableOptions = computed(() => {
+    if (this.checkable()) {
+      return this.options()
+    }
+
+    return this.options().filter(
       (option) => !hasTagSelectValue(this.currentValues(), option.value, this.compareWith(), this.mode() === 'tags')
     )
-  )
+  })
   protected readonly visibleOptions = computed(() => {
     if (!this.enableSuggestions()) {
       return []
@@ -396,7 +401,12 @@ export class ZardTagSelectComponent implements ControlValueAccessor {
   }
 
   private selectOption(option: ZardTagSelectOption<unknown>): void {
-    const nextValues = addTagSelectValue(this.currentValues(), option.value, this.compareWith(), this.mode() === 'tags')
+    const currentValues = this.currentValues()
+    const isSelected = hasTagSelectValue(currentValues, option.value, this.compareWith(), this.mode() === 'tags')
+    const nextValues =
+      this.checkable() && this.mode() === 'multiple' && isSelected
+        ? removeTagSelectValue(currentValues, option.value, this.compareWith(), false)
+        : addTagSelectValue(currentValues, option.value, this.compareWith(), this.mode() === 'tags')
     this.emitValues(nextValues)
     this.setInputValue('')
     this.activeIndex.set(-1)


### PR DESCRIPTION
## Summary
- redesign the workspace knowledgebase create/edit dialog
- add vector retrieval and GraphRAG settings backed by existing Xpert fields
- open the shared configuration dialog from knowledgebase settings entries
- localize the configuration UI, validation feedback, and accessibility labels for English, Simplified Chinese, and Traditional Chinese
- use Zard controls throughout the setup dialog
- disable GraphRAG parameters while GraphRAG is turned off
- add a checkable separator selector that supports unchecking and selecting an option again

## Validation
- pnpm nx test ui --runInBand --testPathPattern=tag-select.component.spec.ts
- pnpm run theme:check-hardcoded-colors
- pnpm run check:typeorm-columns