### PR TITLE
fix(knowledge): handle omitted workspace query data

### DIFF
--- a/packages/server-ai/src/knowledgebase/knowledgebase.controller.spec.ts
+++ b/packages/server-ai/src/knowledgebase/knowledgebase.controller.spec.ts
@@ -11,6 +11,37 @@ describe('KnowledgebaseController generic CRUD access', () => {
         jest.restoreAllMocks()
     })
 
+    it('lists workspace knowledgebases when pagination data is omitted', async () => {
+        jest.spyOn(RequestContext, 'currentUser').mockReturnValue({ id: 'user-1' } as ReturnType<
+            typeof RequestContext.currentUser
+        >)
+        const service = {
+            getSafeReadRelations: jest.fn((relations: unknown) => relations),
+            getAllByWorkspace: jest.fn().mockResolvedValue({
+                items: [{ id: 'knowledgebase-1', name: 'Knowledgebase 1' }],
+                total: 1
+            })
+        }
+        const controller = new KnowledgebaseController(
+            service as unknown as KnowledgebaseService,
+            {} as CommandBus,
+            {} as QueryBus
+        )
+
+        await expect(controller.getAllByWorkspace('workspace-1')).resolves.toEqual({
+            items: [expect.objectContaining({ id: 'knowledgebase-1', name: 'Knowledgebase 1' })],
+            total: 1
+        })
+
+        expect(service.getSafeReadRelations).toHaveBeenCalledWith(undefined)
+        expect(service.getAllByWorkspace).toHaveBeenCalledWith(
+            'workspace-1',
+            { relations: undefined },
+            undefined,
+            expect.objectContaining({ id: 'user-1' })
+        )
+    })
+
     it('routes count and pagination through the same owner/shared visibility filter as the main list', async () => {
         jest.spyOn(RequestContext, 'currentUserId').mockReturnValue('user-1')
         const service = {

--- a/packages/server-ai/src/knowledgebase/knowledgebase.controller.ts
+++ b/packages/server-ai/src/knowledgebase/knowledgebase.controller.ts
@@ -134,14 +134,15 @@ export class KnowledgebaseController extends CrudController<Knowledgebase> {
     @Get('by-workspace/:workspaceId')
     async getAllByWorkspace(
         @Param('workspaceId') workspaceId: string,
-        @Query('data', ParseJsonPipe) data: PaginationParams<Knowledgebase>,
+        @Query('data', ParseJsonPipe) data?: PaginationParams<Knowledgebase>,
         @Query('published') published?: boolean
     ) {
+        const { relations, ...rest } = data ?? {}
         const result = await this.service.getAllByWorkspace(
             workspaceId,
             {
-                ...data,
-                relations: this.service.getSafeReadRelations(data.relations)
+                ...rest,
+                relations: this.service.getSafeReadRelations(relations)
             },
             published,
             RequestContext.currentUser()

--- a/packages/server-ai/src/knowledgebase/knowledgebase.service.ts
+++ b/packages/server-ai/src/knowledgebase/knowledgebase.service.ts
@@ -283,7 +283,7 @@ export class KnowledgebaseService extends XpertWorkspaceBaseService<Knowledgebas
      */
     async getAllByWorkspace(
         workspaceId: string,
-        data: PaginationParams<Knowledgebase>,
+        data: Partial<PaginationParams<Knowledgebase>> | undefined,
         published: boolean,
         user: IUser
     ) {


### PR DESCRIPTION
## Summary

- allow the workspace knowledgebase endpoint to use its default query behavior when data is omitted
- keep relation filtering in place while normalizing optional pagination options
- add a controller regression test for the canvas request shape

## Test plan

- corepack pnpm exec nx test server-ai --testFile=packages/server-ai/src/knowledgebase/knowledgebase.controller.spec.ts --runInBand
- git diff --check origin/main...HEAD