### PR TITLE
fix(studio): align parameter and retry controls

### DIFF
--- a/apps/cloud/src/app/@shared/workflow/retry/retry.component.html
+++ b/apps/cloud/src/app/@shared/workflow/retry/retry.component.html
@@ -9,8 +9,8 @@
 </div>
 
 @if (enabledRetry()) {
-  <div class="w-full flex justify-between items-center px-4">
-    <div class="grow text-sm">
+  <div class="mt-3 grid w-full min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,200px)_3.5rem] items-center gap-3 px-4">
+    <div class="min-w-0 truncate whitespace-nowrap text-sm">
       {{ 'XP.Xpert.StopAfterAttempt' | translate: { Default: 'Stop After Attempt' } }}
       <i
         class="ri-information-line opacity-20 hover:opacity-100"
@@ -20,7 +20,7 @@
     </div>
 
     <z-slider
-      class="w-[200px] grow"
+      class="min-w-0 w-full"
       [min]="1"
       [max]="10"
       [showValueLabel]="true"
@@ -29,7 +29,7 @@
     ></z-slider>
 
     <input
-      class="xp-input shrink-0 block ml-4 pl-3 w-16 h-8 text-[13px] text-gra-900"
+      class="xp-input !w-14 !max-w-14 block h-8 text-center text-[13px] text-gra-900"
       [min]="1"
       [max]="10"
       [step]="1"
@@ -39,8 +39,8 @@
     />
   </div>
 
-  <div class="w-full flex justify-between items-center px-4">
-    <div class="grow text-sm">
+  <div class="mt-2 grid w-full min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,200px)_3.5rem] items-center gap-3 px-4">
+    <div class="min-w-0 truncate whitespace-nowrap text-sm">
       {{ 'XP.Xpert.RetryInterval' | translate: { Default: 'Retry Interval' } }}
       <i
         class="ri-information-line opacity-20 hover:opacity-100"
@@ -50,7 +50,7 @@
     </div>
 
     <z-slider
-      class="w-[200px] grow"
+      class="min-w-0 w-full"
       [min]="1"
       [max]="10"
       [showValueLabel]="true"
@@ -59,7 +59,7 @@
     ></z-slider>
 
     <input
-      class="xp-input shrink-0 block ml-4 pl-3 w-16 h-8 text-[13px] text-gra-900"
+      class="xp-input !w-14 !max-w-14 block h-8 text-center text-[13px] text-gra-900"
       [min]="1"
       [max]="10"
       [step]="1"

--- a/apps/cloud/src/app/@shared/xpert/parameters-edit/parameters.component.html
+++ b/apps/cloud/src/app/@shared/xpert/parameters-edit/parameters.component.html
@@ -179,6 +179,12 @@
                         </g>
                       </svg>
                     }
+                    @case (eXpertParameterTypeEnum.OBJECT) {
+                      <i class="ri-braces-line flex h-4 w-4 items-center justify-center text-text-tertiary"></i>
+                    }
+                    @case (eXpertParameterTypeEnum.ARRAY) {
+                      <i class="ri-brackets-line flex h-4 w-4 items-center justify-center text-text-tertiary"></i>
+                    }
                   }
                   <input
                     placeholder="name"

--- a/apps/cloud/src/app/features/xpert/studio/panel/workflow/code/code.component.html
+++ b/apps/cloud/src/app/features/xpert/studio/panel/workflow/code/code.component.html
@@ -130,8 +130,8 @@
   </div>
 
   @if (enabledRetry()) {
-    <div class="w-full flex justify-between items-center px-4">
-      <div class="grow text-sm">
+    <div class="mt-3 grid w-full min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,200px)_3.5rem] items-center gap-3 px-4">
+      <div class="min-w-0 truncate whitespace-nowrap text-sm">
         {{ 'XP.Xpert.StopAfterAttempt' | translate: { Default: 'Stop After Attempt' } }}
         <i
           class="ri-information-line opacity-20 hover:opacity-100"
@@ -141,7 +141,7 @@
       </div>
 
       <z-slider
-        class="w-[200px] grow"
+        class="min-w-0 w-full"
         [min]="1"
         [max]="10"
         [showValueLabel]="true"
@@ -150,7 +150,7 @@
       ></z-slider>
 
       <input
-        class="xp-input shrink-0 block ml-4 pl-3 w-16 h-8 text-[13px] text-gra-900"
+        class="xp-input !w-14 !max-w-14 block h-8 text-center text-[13px] text-gra-900"
         [min]="1"
         [max]="10"
         [step]="1"
@@ -160,8 +160,8 @@
       />
     </div>
 
-    <div class="w-full flex justify-between items-center px-4">
-      <div class="grow text-sm">
+    <div class="mt-2 grid w-full min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,200px)_3.5rem] items-center gap-3 px-4">
+      <div class="min-w-0 truncate whitespace-nowrap text-sm">
         {{ 'XP.Xpert.RetryInterval' | translate: { Default: 'Retry Interval' } }}
         <i
           class="ri-information-line opacity-20 hover:opacity-100"
@@ -171,7 +171,7 @@
       </div>
 
       <z-slider
-        class="w-[200px] grow"
+        class="min-w-0 w-full"
         [min]="1"
         [max]="10"
         [showValueLabel]="true"
@@ -180,7 +180,7 @@
       ></z-slider>
 
       <input
-        class="xp-input shrink-0 block ml-4 pl-3 w-16 h-8 text-[13px] text-gra-900"
+        class="xp-input !w-14 !max-w-14 block h-8 text-center text-[13px] text-gra-900"
         [min]="1"
         [max]="10"
         [step]="1"

--- a/apps/cloud/src/app/features/xpert/studio/panel/xpert-agent/agent.component.html
+++ b/apps/cloud/src/app/features/xpert/studio/panel/xpert-agent/agent.component.html
@@ -446,8 +446,8 @@
       </div>
 
       @if (retryEnabled()) {
-        <div class="w-full flex justify-between items-center">
-          <div class="grow text-sm">
+        <div class="mt-3 grid w-full min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,200px)_3.5rem] items-center gap-3">
+          <div class="min-w-0 truncate whitespace-nowrap text-sm">
             {{ 'XP.Xpert.StopAfterAttempt' | translate: { Default: 'Stop After Attempt' } }}
             <i
               class="ri-information-line opacity-20 hover:opacity-100"
@@ -459,7 +459,7 @@
           </div>
 
           <z-slider
-            class="w-[200px]"
+            class="min-w-0 w-full"
             [min]="1"
             [max]="10"
             [showValueLabel]="true"
@@ -468,7 +468,7 @@
           ></z-slider>
 
           <input
-            class="xp-input shrink-0 block ml-4 pl-3 w-16 h-8 text-[13px] text-gra-900"
+            class="xp-input !w-14 !max-w-14 block h-8 text-center text-[13px] text-gra-900"
             [min]="1"
             [max]="10"
             [step]="1"


### PR DESCRIPTION
# Summary

- Show object and object-array type icons in Agent parameter rows.
- Use a stable label, slider, and compact number-input layout for retry controls.
- Add spacing between retry switches and their numeric configuration rows.
- Keep Agent, HTTP workflow, and Code workflow retry controls visually consistent.

# Motivation and context

Object and object-array parameters exposed icons in the add menu but omitted them after insertion. Retry number inputs also inherited the global full-width input style, which crowded the switch, label, and slider in narrow configuration panels.

# Dependencies

None.

# Validation

- [x] Targeted ESLint checks for all four changed Angular templates.
- [x] Angular development build and hot-reload compilation.
- [x] Git diff whitespace validation.

# Checklist

- [x] Have you followed the [contributing guidelines](https://github.com/xpert-ai/xpert/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?
