### PR TITLE
fix(xpert): respect draft preview model priority

### DIFF
--- a/apps/cloud/src/app/features/xpert/studio/panel/xpert-agent/agent.component.ts
+++ b/apps/cloud/src/app/features/xpert/studio/panel/xpert-agent/agent.component.ts
@@ -454,7 +454,7 @@ export class XpertStudioPanelAgentComponent {
     effect(() => {
       if (this.xpertAgent()) {
         this.prompt.set(this.xpertAgent().prompt)
-        this.copilotModel.set(this.xpertAgent().copilotModel)
+        this.copilotModel.set(this.node()?.copilotModelSource === 'team' ? undefined : this.xpertAgent().copilotModel)
       }
     })
   }
@@ -481,8 +481,19 @@ export class XpertStudioPanelAgentComponent {
     this.apiService.updateXpertAgent(this.key(), { prompt: event })
   }
 
-  updateCopilotModel(model: ICopilotModel) {
-    this.apiService.updateXpertAgent(this.key(), { copilotModel: model })
+  updateCopilotModel(model: ICopilotModel | null) {
+    this.apiService.updateNode(this.key(), (node) => {
+      const agentNode = node as Partial<TXpertTeamNode<'agent'>>
+      return {
+        ...agentNode,
+        copilotModelSource: model ? 'agent' : 'team',
+        entity: {
+          ...this.xpertAgent(),
+          copilotModel: model ?? undefined,
+          copilotModelId: undefined
+        }
+      }
+    })
   }
 
   updateAvatar(avatar: TAvatar) {

--- a/apps/cloud/src/app/features/xpert/studio/panel/xpert-agent/agent.component.ts
+++ b/apps/cloud/src/app/features/xpert/studio/panel/xpert-agent/agent.component.ts
@@ -454,7 +454,7 @@ export class XpertStudioPanelAgentComponent {
     effect(() => {
       if (this.xpertAgent()) {
         this.prompt.set(this.xpertAgent().prompt)
-        this.copilotModel.set(this.node()?.copilotModelSource === 'team' ? undefined : this.xpertAgent().copilotModel)
+        this.copilotModel.set(this.xpertAgent().copilotModel)
       }
     })
   }
@@ -482,17 +482,9 @@ export class XpertStudioPanelAgentComponent {
   }
 
   updateCopilotModel(model: ICopilotModel | null) {
-    this.apiService.updateNode(this.key(), (node) => {
-      const agentNode = node as Partial<TXpertTeamNode<'agent'>>
-      return {
-        ...agentNode,
-        copilotModelSource: model ? 'agent' : 'team',
-        entity: {
-          ...this.xpertAgent(),
-          copilotModel: model ?? undefined,
-          copilotModelId: undefined
-        }
-      }
+    this.apiService.updateXpertAgent(this.key(), {
+      copilotModel: model ?? undefined,
+      copilotModelId: undefined
     })
   }
 

--- a/apps/cloud/src/app/features/xpert/xpert/basic/basic.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/basic/basic.component.spec.ts
@@ -1,6 +1,7 @@
 import { DialogRef } from '@angular/cdk/dialog'
 import { TestBed } from '@angular/core/testing'
 import { signal } from '@angular/core'
+import { AiModelTypeEnum, TCopilotModel, TXpertTeamDraft } from '@xpert-ai/contracts'
 import { ToastrService, XpertAPIService, XpertTypeEnum } from 'apps/cloud/src/app/@core'
 
 jest.mock('../xpert.component', () => ({ XpertComponent: class XpertComponent {} }))
@@ -8,7 +9,62 @@ jest.mock('apps/cloud/src/app/@shared/copilot', () => ({ CopilotModelSelectCompo
 
 import { XpertComponent } from '../xpert.component'
 import { XpertService } from '../xpert.service'
-import { XpertBasicComponent } from './basic.component'
+import { syncInheritedPrimaryAgentModel, XpertBasicComponent } from './basic.component'
+
+const initialModel = {
+  copilotId: 'copilot-qwen',
+  modelType: AiModelTypeEnum.LLM,
+  model: 'qwen-initial'
+} satisfies TCopilotModel
+const nextTeamModel = {
+  copilotId: 'copilot-qwen',
+  modelType: AiModelTypeEnum.LLM,
+  model: 'qwen-next'
+} satisfies TCopilotModel
+const canvasModel = {
+  copilotId: 'copilot-moonshot',
+  modelType: AiModelTypeEnum.LLM,
+  model: 'moonshot-v1-32k'
+} satisfies TCopilotModel
+
+describe('syncInheritedPrimaryAgentModel', () => {
+  function createDraft(
+    copilotModelSource?: 'team' | 'agent',
+    nodeModel: TCopilotModel = initialModel
+  ): TXpertTeamDraft {
+    return {
+      team: {
+        copilotModel: initialModel,
+        agent: { key: 'Agent_primary', copilotModel: initialModel }
+      },
+      nodes: [
+        {
+          type: 'agent',
+          key: 'Agent_primary',
+          position: { x: 0, y: 0 },
+          ...(copilotModelSource ? { copilotModelSource } : {}),
+          entity: { key: 'Agent_primary', copilotModel: nodeModel }
+        }
+      ],
+      connections: []
+    }
+  }
+
+  it.each([['team' as const], [undefined]])('updates an inherited or legacy copied Agent model (%s)', (source) => {
+    const nodes = syncInheritedPrimaryAgentModel(createDraft(source), nextTeamModel)
+
+    expect(nodes?.[0]).toEqual(
+      expect.objectContaining({
+        copilotModelSource: 'team',
+        entity: expect.objectContaining({ copilotModel: nextTeamModel })
+      })
+    )
+  })
+
+  it('preserves an explicitly selected canvas Agent model', () => {
+    expect(syncInheritedPrimaryAgentModel(createDraft('agent', canvasModel), nextTeamModel)).toBeNull()
+  })
+})
 
 describe('XpertBasicComponent workspace data scope', () => {
   afterEach(() => {

--- a/apps/cloud/src/app/features/xpert/xpert/basic/basic.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/basic/basic.component.spec.ts
@@ -9,17 +9,12 @@ jest.mock('apps/cloud/src/app/@shared/copilot', () => ({ CopilotModelSelectCompo
 
 import { XpertComponent } from '../xpert.component'
 import { XpertService } from '../xpert.service'
-import { syncInheritedPrimaryAgentModel, XpertBasicComponent } from './basic.component'
+import { clearLegacyInheritedPrimaryAgentModel, XpertBasicComponent } from './basic.component'
 
 const initialModel = {
   copilotId: 'copilot-qwen',
   modelType: AiModelTypeEnum.LLM,
   model: 'qwen-initial'
-} satisfies TCopilotModel
-const nextTeamModel = {
-  copilotId: 'copilot-qwen',
-  modelType: AiModelTypeEnum.LLM,
-  model: 'qwen-next'
 } satisfies TCopilotModel
 const canvasModel = {
   copilotId: 'copilot-moonshot',
@@ -27,11 +22,8 @@ const canvasModel = {
   model: 'moonshot-v1-32k'
 } satisfies TCopilotModel
 
-describe('syncInheritedPrimaryAgentModel', () => {
-  function createDraft(
-    copilotModelSource?: 'team' | 'agent',
-    nodeModel: TCopilotModel = initialModel
-  ): TXpertTeamDraft {
+describe('clearLegacyInheritedPrimaryAgentModel', () => {
+  function createDraft(nodeModel?: TCopilotModel): TXpertTeamDraft {
     return {
       team: {
         copilotModel: initialModel,
@@ -42,27 +34,29 @@ describe('syncInheritedPrimaryAgentModel', () => {
           type: 'agent',
           key: 'Agent_primary',
           position: { x: 0, y: 0 },
-          ...(copilotModelSource ? { copilotModelSource } : {}),
-          entity: { key: 'Agent_primary', copilotModel: nodeModel }
+          entity: { key: 'Agent_primary', ...(nodeModel ? { copilotModel: nodeModel } : {}) }
         }
       ],
       connections: []
     }
   }
 
-  it.each([['team' as const], [undefined]])('updates an inherited or legacy copied Agent model (%s)', (source) => {
-    const nodes = syncInheritedPrimaryAgentModel(createDraft(source), nextTeamModel)
+  it('clears a legacy model copied from the team so the Agent inherits future changes', () => {
+    const nodes = clearLegacyInheritedPrimaryAgentModel(createDraft(initialModel))
 
     expect(nodes?.[0]).toEqual(
       expect.objectContaining({
-        copilotModelSource: 'team',
-        entity: expect.objectContaining({ copilotModel: nextTeamModel })
+        entity: expect.objectContaining({ copilotModel: undefined })
       })
     )
   })
 
+  it('does not rewrite an Agent that already inherits through an empty model', () => {
+    expect(clearLegacyInheritedPrimaryAgentModel(createDraft())).toBeNull()
+  })
+
   it('preserves an explicitly selected canvas Agent model', () => {
-    expect(syncInheritedPrimaryAgentModel(createDraft('agent', canvasModel), nextTeamModel)).toBeNull()
+    expect(clearLegacyInheritedPrimaryAgentModel(createDraft(canvasModel))).toBeNull()
   })
 })
 

--- a/apps/cloud/src/app/features/xpert/xpert/basic/basic.component.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/basic/basic.component.ts
@@ -220,7 +220,7 @@ export class XpertBasicComponent implements IsDirty {
     }
     if (this.type() === XpertTypeEnum.Agent) {
       const draft = this.draft()
-      const inheritedModelNodes = syncInheritedPrimaryAgentModel(draft, basicValue.copilotModel)
+      const inheritedModelNodes = clearLegacyInheritedPrimaryAgentModel(draft)
       this.xpertAPI
         .upadteDraft(this.xpertId(), {
           team: {
@@ -317,9 +317,8 @@ export class XpertBasicComponent implements IsDirty {
   }
 }
 
-export function syncInheritedPrimaryAgentModel(
-  draft: Partial<TXpertTeamDraft> | null | undefined,
-  nextModel: TCopilotModel | null | undefined
+export function clearLegacyInheritedPrimaryAgentModel(
+  draft: Partial<TXpertTeamDraft> | null | undefined
 ): TXpertTeamDraft['nodes'] | null {
   const primaryAgentKey = draft?.team?.agent?.key
   const primaryNode = draft?.nodes?.find(
@@ -330,11 +329,7 @@ export function syncInheritedPrimaryAgentModel(
   }
 
   const legacyTeamModel = draft.team.agent?.copilotModel ?? draft.team.copilotModel
-  const inheritsTeamModel =
-    primaryNode.copilotModelSource === 'team' ||
-    (primaryNode.copilotModelSource == null &&
-      (!primaryNode.entity.copilotModel || isEqual(primaryNode.entity.copilotModel, legacyTeamModel)))
-  if (!inheritsTeamModel) {
+  if (!primaryNode.entity.copilotModel || !isEqual(primaryNode.entity.copilotModel, legacyTeamModel)) {
     return null
   }
 
@@ -342,10 +337,9 @@ export function syncInheritedPrimaryAgentModel(
     node.key === primaryNode.key && node.type === 'agent'
       ? {
           ...node,
-          copilotModelSource: 'team',
           entity: {
             ...node.entity,
-            copilotModel: nextModel ?? undefined,
+            copilotModel: undefined,
             copilotModelId: undefined
           }
         }

--- a/apps/cloud/src/app/features/xpert/xpert/basic/basic.component.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/basic/basic.component.ts
@@ -28,6 +28,7 @@ import { CopilotModelSelectComponent } from 'apps/cloud/src/app/@shared/copilot'
 import { TagSelectComponent } from 'apps/cloud/src/app/@shared/tag'
 import { XpertComponent } from '../xpert.component'
 import { XpertService } from '../xpert.service'
+import { isEqual } from 'lodash-es'
 
 @Component({
   selector: 'xpert-basic',
@@ -84,7 +85,7 @@ export class XpertBasicComponent implements IsDirty {
   //   { initialValue: null }
   // )
 
-  readonly draft = computed(() => {
+  readonly draft = computed<Partial<TXpertTeamDraft> | null>(() => {
     if (this.xpert()) {
       return this.xpert().draft ?? { team: omitXpertRelations(this.xpert()) }
     }
@@ -218,14 +219,26 @@ export class XpertBasicComponent implements IsDirty {
       }
     }
     if (this.type() === XpertTypeEnum.Agent) {
+      const draft = this.draft()
+      const inheritedModelNodes = syncInheritedPrimaryAgentModel(draft, basicValue.copilotModel)
       this.xpertAPI
         .upadteDraft(this.xpertId(), {
           team: {
             ...omitXpertRelations(this.xpert()),
-            ...(this.draft()?.team ?? {}),
+            ...(draft?.team ?? {}),
             ...basicValue,
+            ...(draft?.team?.agent
+              ? {
+                  agent: {
+                    ...draft.team.agent,
+                    copilotModel: basicValue.copilotModel ?? undefined,
+                    copilotModelId: undefined
+                  }
+                }
+              : {}),
             options
-          }
+          },
+          ...(inheritedModelNodes ? { nodes: inheritedModelNodes } : {})
         } as TXpertTeamDraft)
         .subscribe({
           next: (value) => {
@@ -302,4 +315,40 @@ export class XpertBasicComponent implements IsDirty {
     }
     return `${copilotId}\u0000${model.modelType ?? AiModelTypeEnum.LLM}\u0000${modelName}`
   }
+}
+
+export function syncInheritedPrimaryAgentModel(
+  draft: Partial<TXpertTeamDraft> | null | undefined,
+  nextModel: TCopilotModel | null | undefined
+): TXpertTeamDraft['nodes'] | null {
+  const primaryAgentKey = draft?.team?.agent?.key
+  const primaryNode = draft?.nodes?.find(
+    (node) => node.type === 'agent' && (node.key === primaryAgentKey || node.entity.key === primaryAgentKey)
+  )
+  if (!draft?.nodes || !primaryNode || primaryNode.type !== 'agent') {
+    return null
+  }
+
+  const legacyTeamModel = draft.team.agent?.copilotModel ?? draft.team.copilotModel
+  const inheritsTeamModel =
+    primaryNode.copilotModelSource === 'team' ||
+    (primaryNode.copilotModelSource == null &&
+      (!primaryNode.entity.copilotModel || isEqual(primaryNode.entity.copilotModel, legacyTeamModel)))
+  if (!inheritsTeamModel) {
+    return null
+  }
+
+  return draft.nodes.map((node) =>
+    node.key === primaryNode.key && node.type === 'agent'
+      ? {
+          ...node,
+          copilotModelSource: 'team',
+          entity: {
+            ...node.entity,
+            copilotModel: nextModel ?? undefined,
+            copilotModelId: undefined
+          }
+        }
+      : node
+  )
 }

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.spec.ts
@@ -162,6 +162,7 @@ describe('blank draft util', () => {
 
     expect(draft.nodes).toHaveLength(1)
     expect(draft.nodes[0].key).toBe('Agent_primary')
+    expect(draft.nodes[0].copilotModelSource).toBe('team')
     expect(draft.connections).toHaveLength(0)
     expect(draft.team.agent.options?.middlewares).toBeUndefined()
   })

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.spec.ts
@@ -162,7 +162,7 @@ describe('blank draft util', () => {
 
     expect(draft.nodes).toHaveLength(1)
     expect(draft.nodes[0].key).toBe('Agent_primary')
-    expect(draft.nodes[0].copilotModelSource).toBe('team')
+    expect(draft.nodes[0].entity.copilotModel).toBeUndefined()
     expect(draft.connections).toHaveLength(0)
     expect(draft.team.agent.options?.middlewares).toBeUndefined()
   })

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.ts
@@ -217,6 +217,7 @@ export async function buildBlankXpertDraft(
   if (!primaryAgentNode || !primaryAgentKey) {
     throw new Error('Primary agent node not found for blank xpert draft initialization')
   }
+  primaryAgentNode.copilotModelSource = 'team'
 
   const {
     triggerNodes,

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.ts
@@ -217,7 +217,8 @@ export async function buildBlankXpertDraft(
   if (!primaryAgentNode || !primaryAgentKey) {
     throw new Error('Primary agent node not found for blank xpert draft initialization')
   }
-  primaryAgentNode.copilotModelSource = 'team'
+  primaryAgentNode.entity.copilotModel = undefined
+  primaryAgentNode.entity.copilotModelId = undefined
 
   const {
     triggerNodes,

--- a/packages/contracts/src/ai/xpert.model.ts
+++ b/packages/contracts/src/ai/xpert.model.ts
@@ -648,6 +648,8 @@ export type TXpertTeamNodeBase = {
   position: IRect
   size?: ISize
   hash?: string
+  /** Whether the Agent node model follows the draft team's primary model. */
+  copilotModelSource?: 'team' | 'agent'
   parentId?: string
   readonly?: boolean
 }

--- a/packages/contracts/src/ai/xpert.model.ts
+++ b/packages/contracts/src/ai/xpert.model.ts
@@ -648,8 +648,6 @@ export type TXpertTeamNodeBase = {
   position: IRect
   size?: ISize
   hash?: string
-  /** Whether the Agent node model follows the draft team's primary model. */
-  copilotModelSource?: 'team' | 'agent'
   parentId?: string
   readonly?: boolean
 }

--- a/packages/server-ai/src/xpert-agent/effective-copilot-model.spec.ts
+++ b/packages/server-ai/src/xpert-agent/effective-copilot-model.spec.ts
@@ -14,6 +14,13 @@ describe('resolveEffectiveCopilotModel', () => {
     }
     const team = { id: 'assistant-1', copilotModel: configured }
 
+    it('uses the Agent model first and falls back to the team model', () => {
+        expect(
+            resolveEffectiveCopilotModel(team as never, { key: 'primary', copilotModel: selected } as never, {})
+        ).toEqual(selected)
+        expect(resolveEffectiveCopilotModel(team as never, { key: 'primary' } as never, {})).toEqual(configured)
+    })
+
     it('overrides only the root Assistant Primary Agent', () => {
         expect(
             resolveEffectiveCopilotModel(team as never, { key: 'primary', copilotModel: configured } as never, {

--- a/packages/server-ai/src/xpert/commands/handlers/chat.handler.spec.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/chat.handler.spec.ts
@@ -208,7 +208,8 @@ describe('XpertChatHandler', () => {
 
     async function executeQueuedFollowUp(
         xpertType: XpertTypeEnum,
-        assistantModelSelectionService: { resolveSelection: jest.Mock }
+        assistantModelSelectionService: { resolveSelection: jest.Mock },
+        isDraft = false
     ) {
         xpertService.findOneForRuntime.mockResolvedValue({
             ...xpert,
@@ -238,7 +239,7 @@ describe('XpertChatHandler', () => {
                         input: { input: 'Continue later' }
                     }
                 },
-                { xpertId: 'xpert-1' } as XpertChatCommandOptions
+                { xpertId: 'xpert-1', isDraft } as XpertChatCommandOptions
             )
         )
 
@@ -292,6 +293,59 @@ describe('XpertChatHandler', () => {
             expect.objectContaining({ type: XpertTypeEnum.Agent }),
             { explicitModelId: undefined }
         )
+    })
+
+    it('keeps queued draft follow-ups on the draft graph model configuration', async () => {
+        const assistantModelSelectionService = {
+            resolveSelection: jest.fn().mockRejectedValue(new Error('must not resolve a published model override'))
+        }
+
+        await expect(executeQueuedFollowUp(XpertTypeEnum.Agent, assistantModelSelectionService, true)).resolves.toEqual(
+            []
+        )
+        expect(assistantModelSelectionService.resolveSelection).not.toHaveBeenCalled()
+    })
+
+    it('keeps draft sends on the draft graph model configuration', async () => {
+        const assistantModelSelectionService = {
+            resolveSelection: jest.fn().mockRejectedValue(new Error('must not resolve a published model override'))
+        }
+        handler = createHandlerWithModelSelection(assistantModelSelectionService)
+        mockSuccessfulSendCommands()
+
+        const stream = await handler.execute(
+            new XpertChatCommand(
+                {
+                    action: 'send',
+                    message: {
+                        clientMessageId: 'draft-run-1',
+                        input: { input: 'Preview the draft' }
+                    }
+                },
+                {
+                    xpertId: 'xpert-1',
+                    isDraft: true
+                } as XpertChatCommandOptions
+            )
+        )
+
+        await expect(lastValueFrom(stream.pipe(toArray()))).resolves.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    data: expect.objectContaining({ event: ChatMessageEventTypeEnum.ON_CONVERSATION_END })
+                })
+            ])
+        )
+        expect(assistantModelSelectionService.resolveSelection).not.toHaveBeenCalled()
+        const agentCommand = commandBus.execute.mock.calls
+            .map(([command]) => command)
+            .find((command) => command instanceof XpertAgentChatCommand) as XpertAgentChatCommand
+        expect(agentCommand.options).toEqual(
+            expect.objectContaining({
+                isDraft: true
+            })
+        )
+        expect(agentCommand.options.primaryCopilotModel).toBeUndefined()
     })
 
     it('does not require an Assistant primary model for queued knowledge pipeline follow-ups', async () => {

--- a/packages/server-ai/src/xpert/commands/handlers/chat.handler.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/chat.handler.ts
@@ -302,6 +302,7 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                 : null
             if (
                 request.mode === 'queue' &&
+                !options?.isDraft &&
                 this.assistantModelSelectionService &&
                 xpertId &&
                 supportsAssistantPrimaryModelSelection(followUpXpert)
@@ -813,7 +814,8 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                 xpert: latestXpert,
                 runtimeAgentKey,
                 input,
-                sourceExecution: sourceModelExecution
+                sourceExecution: sourceModelExecution,
+                isDraft: Boolean(options?.isDraft)
             })
             if (primaryModelSelection) {
                 applicationMetrics.recordAssistantModelSelection(primaryModelSelection.source)
@@ -965,7 +967,8 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
                 xpert: latestXpert,
                 runtimeAgentKey,
                 input,
-                sourceExecution: sourceModelExecution
+                sourceExecution: sourceModelExecution,
+                isDraft: Boolean(options?.isDraft)
             })
             if (primaryModelSelection) {
                 applicationMetrics.recordAssistantModelSelection(primaryModelSelection.source)
@@ -1473,16 +1476,19 @@ export class XpertChatHandler implements ICommandHandler<XpertChatCommand> {
         xpert,
         runtimeAgentKey,
         input,
-        sourceExecution
+        sourceExecution,
+        isDraft
     }: {
         request: TChatRequest
         xpert: Partial<IXpert>
         runtimeAgentKey: string
         input: TChatRequestHuman | null
         sourceExecution: IXpertAgentExecution | null
+        isDraft: boolean
     }): Promise<TAssistantPrimaryModelSelection | null> {
         const primaryAgentKey = xpert.agent?.key
         if (
+            isDraft ||
             !this.assistantModelSelectionService ||
             !supportsAssistantPrimaryModelSelection(xpert) ||
             !primaryAgentKey ||


### PR DESCRIPTION
## Summary

- Make draft preview runs use the draft graph model configuration instead of applying the published Assistant model override.
- Track whether the primary Agent model inherits the team model or was explicitly selected on the canvas.
- Sync Basic Information model changes to inheriting Agent nodes and migrate legacy drafts whose initial model was copied into the node.

## Expected behavior

- An explicitly selected canvas Agent model takes precedence during preview.
- When the canvas Agent inherits its model, preview uses the model from Basic Information.
- Published runtime model-selection logic is unchanged.

## Tests

- `corepack pnpm exec jest --config apps/cloud/jest.config.ts --runTestsByPath apps/cloud/src/app/features/xpert/xpert/basic/basic.component.spec.ts apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.spec.ts --runInBand`
- `corepack pnpm exec jest --config packages/server-ai/jest.config.ts --runTestsByPath packages/server-ai/src/xpert/commands/handlers/chat.handler.spec.ts packages/server-ai/src/xpert-agent/effective-copilot-model.spec.ts --runInBand`
- `corepack pnpm exec tsc -p apps/cloud/tsconfig.app.json --noEmit`

## Checklist

- [x] Have you followed the [contributing guidelines](https://github.com/xpert-ai/xpert/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?
