### PR TITLE
fix(models): align runtime parameters and preserve output limits

### DIFF
--- a/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.spec.ts
+++ b/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.spec.ts
@@ -292,6 +292,7 @@ describe('CopilotModelGetChatModelHandler', () => {
 
         await handler.execute(query)
 
+        expect(query.copilotModel.options).toEqual(getModelInstance.mock.calls[0][1].options)
         expect(getModelInstance.mock.calls[0][1].options).toEqual({
             temperature: 0.3,
             enable_thinking: true

--- a/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.ts
+++ b/packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.ts
@@ -99,6 +99,7 @@ export class CopilotModelGetChatModelHandler implements IQueryHandler<CopilotMod
             ...copilotModel,
             options: resolveModelParameterOptions(copilotModel.options, parameterRules)
         }
+        copilotModel.options = resolvedCopilotModel.options
         const resolveUsagePricingSnapshot = async (context: ModelUsagePricingContext) =>
             modelProvider
                 .getModelManager(copilotModel.modelType)

--- a/packages/server-ai/src/shared/agent/middleware-runtime/middleware-runtime.service.spec.ts
+++ b/packages/server-ai/src/shared/agent/middleware-runtime/middleware-runtime.service.spec.ts
@@ -73,6 +73,8 @@ import {
     ModelAccessChannelEnum,
     ModelAccessOwnershipScopeEnum,
     ModelAccessSourceEnum,
+    ParameterRule,
+    ParameterType,
     XpertAgentExecutionStatusEnum
 } from '@xpert-ai/contracts'
 import { dispatchCustomEvent } from '@langchain/core/callbacks/dispatch'
@@ -883,7 +885,10 @@ describe('AgentMiddlewareRuntimeService', () => {
         })
     })
 
-    function mockCreateModelClientDependencies(options?: { tokenRecordError?: Error }) {
+    function mockCreateModelClientDependencies(options?: {
+        tokenRecordError?: Error
+        parameterRules?: ParameterRule[]
+    }) {
         const modelInstance = {
             invoke: jest.fn()
         }
@@ -912,7 +917,8 @@ describe('AgentMiddlewareRuntimeService', () => {
 
             if (query instanceof AIModelGetProviderQuery) {
                 return {
-                    getModelInstance
+                    getModelInstance,
+                    getModelManager: () => ({ getParameterRules: () => options?.parameterRules ?? [] })
                 }
             }
 
@@ -941,7 +947,12 @@ describe('AgentMiddlewareRuntimeService', () => {
     }
 
     it('creates a model client and records token usage through the runtime facade', async () => {
-        const { getModelInstance, modelInstance } = mockCreateModelClientDependencies()
+        const { getModelInstance, modelInstance } = mockCreateModelClientDependencies({
+            parameterRules: [
+                { name: 'max_tokens', label: { en_US: 'Maximum tokens' }, type: ParameterType.INT, default: 4096 },
+                { name: 'temperature', label: { en_US: 'Temperature' }, type: ParameterType.FLOAT, default: 0.7 }
+            ]
+        })
         const usageCallback = jest.fn()
         const executionUsageCallback = jest.fn()
         const runtime = service.createScopedApi({ usageCallback: executionUsageCallback })
@@ -950,8 +961,9 @@ describe('AgentMiddlewareRuntimeService', () => {
             {
                 copilotId: 'copilot-1',
                 model: 'gpt-4o-mini',
-                modelType: 'LLM'
-            } as any,
+                modelType: AiModelTypeEnum.LLM,
+                options: { temperature: 0.3 }
+            } as ICopilotModel,
             {
                 usageCallback
             }
@@ -960,9 +972,10 @@ describe('AgentMiddlewareRuntimeService', () => {
         expect(client).toBe(modelInstance)
         expect(commandBus.execute).toHaveBeenCalledWith(expect.any(CopilotCheckLimitCommand))
         expect(getModelInstance).toHaveBeenCalledWith(
-            'LLM',
+            AiModelTypeEnum.LLM,
             expect.objectContaining({
                 model: 'gpt-4o-mini',
+                options: { temperature: 0.3, max_tokens: 4096 },
                 copilot: expect.objectContaining({
                     id: 'copilot-1'
                 })

--- a/packages/server-ai/src/shared/agent/middleware-runtime/model-runtime.service.ts
+++ b/packages/server-ai/src/shared/agent/middleware-runtime/model-runtime.service.ts
@@ -8,7 +8,8 @@ import {
     IModelAccessResolution,
     IXpertAgentExecution,
     ModelUsagePricingContext,
-    mapTranslationLanguage
+    mapTranslationLanguage,
+    resolveModelParameterOptions
 } from '@xpert-ai/contracts'
 import { omit } from '@xpert-ai/server-common'
 import { Injectable, Logger } from '@nestjs/common'
@@ -128,6 +129,11 @@ export class AgentMiddlewareModelRuntimeService {
 
         if (copilotModel.modelType === AiModelTypeEnum.LLM) {
             ensureCopilotModelContextSize(copilotModel, modelProvider, modelName, customModels)
+            const rules =
+                modelProvider
+                    .getModelManager(copilotModel.modelType)
+                    ?.getParameterRules(modelName, customModels[0]?.modelProperties) ?? []
+            copilotModel.options = resolveModelParameterOptions(copilotModel.options, rules)
         }
 
         return modelProvider.getModelInstance(

--- a/packages/server-ai/src/xpert/assistant-model-selection.util.spec.ts
+++ b/packages/server-ai/src/xpert/assistant-model-selection.util.spec.ts
@@ -68,4 +68,27 @@ describe('Assistant model selection utilities', () => {
             endpoints: [{ url: 'https://example.com' }]
         })
     })
+
+    it('retains numeric output limits without retaining credentials disguised as limits', () => {
+        const options = sanitizeAssistantModelSnapshot({
+            ...primary,
+            options: {
+                context_size: 32768,
+                max_tokens: 4096,
+                max_completion_tokens: 2048,
+                max_output_tokens: 1024,
+                maxTokens: 512,
+                access_token: 'secret',
+                nested: { max_tokens: { token: 'secret' }, refreshToken: 'secret' }
+            }
+        }).options
+        expect(options).toEqual({
+            context_size: 32768,
+            max_tokens: 4096,
+            max_completion_tokens: 2048,
+            max_output_tokens: 1024,
+            maxTokens: 512,
+            nested: {}
+        })
+    })
 })

--- a/packages/server-ai/src/xpert/assistant-model-selection.util.ts
+++ b/packages/server-ai/src/xpert/assistant-model-selection.util.ts
@@ -65,10 +65,20 @@ export function sanitizeAssistantModelSnapshot(model: TCopilotModel): ValidAssis
     }
 }
 
-function scrubSensitiveModelOptions(value: Record<string, unknown>): Record<string, unknown> {
+function scrubSensitiveModelOptions(value: object): Record<string, unknown> {
     return Object.fromEntries(
         Object.entries(value).flatMap(([key, item]) => {
-            if (/(api[-_]?key|token|secret|password|credential|authorization)/i.test(key)) {
+            const isOutputLimit =
+                /^(max_tokens|max_completion_tokens|max_output_tokens|max_tokens_to_sample|maxTokens|maxCompletionTokens|maxOutputTokens)$/.test(
+                    key
+                )
+            const isNumericLimit =
+                (typeof item === 'number' && Number.isFinite(item) && item >= 0) ||
+                (typeof item === 'string' && /^\d+$/.test(item))
+            if (
+                /(api[-_]?key|token|secret|password|credential|authorization)/i.test(key) &&
+                !(isOutputLimit && isNumericLimit)
+            ) {
                 return []
             }
             return [[key, scrubSensitiveModelOptionValue(item)]]
@@ -81,7 +91,7 @@ function scrubSensitiveModelOptionValue(value: unknown): unknown {
         return value.map((item) => scrubSensitiveModelOptionValue(item))
     }
     if (value && typeof value === 'object') {
-        return scrubSensitiveModelOptions(value as Record<string, unknown>)
+        return scrubSensitiveModelOptions(value)
     }
     return value
 }


### PR DESCRIPTION
Fix inconsistent model parameter resolution between normal chat calls and middleware model calls, and retain numeric output limits when saving sanitized model snapshots.

- Store resolved model options back on the configuration used for execution.
- Apply the existing provider parameter rules in the middleware model runtime.
- Preserve numeric max_tokens and supported equivalent fields while continuing to remove credentials.

The shared model selector, model-window provenance, compression policy and occupancy UI are outside this PR. The complete diff remains one commit and six backend files; this review did not change its code.

## Verification on 2026-09-09

70 tests in three backend suites passed at this PR head. The combined #996/#997/#998 checkout also passed 125 backend tests, eight Angular tests and backend/Angular/SDK type checks. The original commit used normal hooks. No browser or live-model verification was performed.

Independent companions: [actual model window #997](https://github.com/xpert-ai/xpert/pull/997), [compression failures #998](https://github.com/xpert-ai/xpert/pull/998), and [ChatKit context display/types #196](https://github.com/xpert-ai/chatkit-js/pull/196).

<details>
<summary>Commits and complete file manifest</summary>

```text
4880f2392 fix(models): Align resolved parameters and preserve output limits
```

```text
M	packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.spec.ts
M	packages/server-ai/src/copilot-model/queries/handlers/get-chat-model.handler.ts
M	packages/server-ai/src/shared/agent/middleware-runtime/middleware-runtime.service.spec.ts
M	packages/server-ai/src/shared/agent/middleware-runtime/model-runtime.service.ts
M	packages/server-ai/src/xpert/assistant-model-selection.util.spec.ts
M	packages/server-ai/src/xpert/assistant-model-selection.util.ts
```

</details>
