### PR TITLE
fix(chat): report the active model context window

### DIFF
--- a/.changeset/active-model-context-window.md
+++ b/.changeset/active-model-context-window.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/contracts': patch
+---
+
+Expose the active execution model and context-window size in usage events and execution metadata so clients can calculate context occupancy after model fallback.

--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -28,7 +28,7 @@
     "@xterm/xterm": "^5.5.0",
     "@xpert-ai/chatkit-angular": "~0.4.3",
     "@xpert-ai/chatkit-ui": "~0.5.10",
-    "@xpert-ai/chatkit-types": "~0.5.7",
+    "@xpert-ai/chatkit-types": "~0.5.8",
     "@xpert-ai/chatkit-web-component": "~0.5.4",
     "@xpert-ai/chatkit-web-shared": "~0.4.4",
     "@xpert-ai/store": "3.9.1",

--- a/apps/cloud/src/app/@shared/chat/context/thread-context-usage.spec.ts
+++ b/apps/cloud/src/app/@shared/chat/context/thread-context-usage.spec.ts
@@ -23,6 +23,13 @@ describe('thread-context-usage helpers', () => {
     expect(isThreadContextUsageEvent({ type: 'sandbox' })).toBe(false)
   })
 
+  it('retains effective model information and rejects invalid windows', () => {
+    const resolved = { ...event, effectiveModel: { model: 'small', contextWindow: 32768 } }
+    expect(isThreadContextUsageEvent(resolved)).toBe(true)
+    expect(upsertThreadContextUsage({}, resolved)['agent-1'].effectiveModel?.contextWindow).toBe(32768)
+    expect(isThreadContextUsageEvent({ ...event, effectiveModel: { contextWindow: Infinity } })).toBe(false)
+  })
+
   it('stores the latest usage by agent key', () => {
     expect(upsertThreadContextUsage({}, event)).toEqual({
       'agent-1': event

--- a/apps/cloud/src/app/@shared/chat/context/thread-context-usage.ts
+++ b/apps/cloud/src/app/@shared/chat/context/thread-context-usage.ts
@@ -1,18 +1,31 @@
-import { CHAT_EVENT_TYPE_THREAD_CONTEXT_USAGE, TThreadContextUsageEvent } from '../../../@core'
+import { CHAT_EVENT_TYPE_THREAD_CONTEXT_USAGE, TAgentThreadContextUsageEvent } from '@xpert-ai/contracts'
 
-export function isThreadContextUsageEvent(value: unknown): value is TThreadContextUsageEvent {
+export function isThreadContextUsageEvent(value: unknown): value is TAgentThreadContextUsageEvent {
   return (
     !!value &&
     typeof value === 'object' &&
-    (value as TThreadContextUsageEvent).type === CHAT_EVENT_TYPE_THREAD_CONTEXT_USAGE &&
-    typeof (value as TThreadContextUsageEvent).agentKey === 'string'
+    'type' in value &&
+    value.type === CHAT_EVENT_TYPE_THREAD_CONTEXT_USAGE &&
+    'agentKey' in value &&
+    typeof value.agentKey === 'string' &&
+    (!('effectiveModel' in value) ||
+      value.effectiveModel === undefined ||
+      (!!value.effectiveModel &&
+        typeof value.effectiveModel === 'object' &&
+        'contextWindow' in value.effectiveModel &&
+        typeof value.effectiveModel.contextWindow === 'number' &&
+        Number.isFinite(value.effectiveModel.contextWindow) &&
+        value.effectiveModel.contextWindow > 0 &&
+        (!('model' in value.effectiveModel) ||
+          value.effectiveModel.model === undefined ||
+          typeof value.effectiveModel.model === 'string')))
   )
 }
 
 export function upsertThreadContextUsage(
-  state: Record<string, TThreadContextUsageEvent>,
-  event: TThreadContextUsageEvent
-): Record<string, TThreadContextUsageEvent> {
+  state: Record<string, TAgentThreadContextUsageEvent>,
+  event: TAgentThreadContextUsageEvent
+): Record<string, TAgentThreadContextUsageEvent> {
   return {
     ...(state ?? {}),
     [event.agentKey]: event

--- a/apps/cloud/src/app/xpert/chat-input/chat-input.component.ts
+++ b/apps/cloud/src/app/xpert/chat-input/chat-input.component.ts
@@ -203,6 +203,8 @@ export class ChatInputComponent {
   })
   readonly contextWindowSize = computed(() => {
     const value =
+      this.contextUsage()?.effectiveModel?.contextWindow ??
+      this.primaryAgent()?.copilotModel?.options?.context_size ??
       this.conversation()?.xpert?.copilotModel?.options?.context_size ??
       this.xpert()?.copilotModel?.options?.context_size
     const size = toPositiveNumber(value)

--- a/apps/cloud/src/app/xpert/chat.service.ts
+++ b/apps/cloud/src/app/xpert/chat.service.ts
@@ -26,7 +26,7 @@ import {
   TChatOptions,
   TChatRequest,
   TXpertChatResumeDecision,
-  TThreadContextUsageEvent,
+  TAgentThreadContextUsageEvent,
   TInterruptCommand,
   TMessageAppendContext,
   TMessageContent,
@@ -113,7 +113,7 @@ export abstract class ChatService {
 
   readonly answering = signal<boolean>(false)
   readonly pendingFollowUps = signal<PendingFollowUp[]>([])
-  readonly contextUsageByAgentKey = signal<Record<string, TThreadContextUsageEvent>>({})
+  readonly contextUsageByAgentKey = signal<Record<string, TAgentThreadContextUsageEvent>>({})
   protected chatSubscription: Subscription = null
   private joinedRunSubscription: Subscription = null
   private joinedRunKey: string | null = null
@@ -769,7 +769,7 @@ export abstract class ChatService {
     }
   }
 
-  setContextUsage(event: TThreadContextUsageEvent) {
+  setContextUsage(event: TAgentThreadContextUsageEvent) {
     this.contextUsageByAgentKey.update((state) => upsertThreadContextUsage(state, event))
   }
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@octokit/types": "13.10.0",
     "@types/json-schema": "^7.0.15",
-    "@xpert-ai/chatkit-types": "~0.5.5",
+    "@xpert-ai/chatkit-types": "~0.5.8",
     "zod-to-json-schema": "^3.25.2"
   }
 }

--- a/packages/contracts/src/ai/ai.model.ts
+++ b/packages/contracts/src/ai/ai.model.ts
@@ -1,4 +1,5 @@
-import type { TFollowUpConsumedEvent, TMessageContentComplex, TThreadContextUsageEvent } from '@xpert-ai/chatkit-types'
+import type { TAgentThreadContextUsageEvent } from './chat-event.model'
+import type { TFollowUpConsumedEvent, TMessageContentComplex } from '@xpert-ai/chatkit-types'
 import type { IChatConversation } from './chat.model'
 import type { IChatMessage } from './chat-message.model'
 import type { IXpertAgentExecution } from './xpert-agent-execution.model'
@@ -193,7 +194,7 @@ export type TChatStreamErrorPayload = {
 export type TChatStreamChatEventData =
   | NonNullable<IChatMessage['events']>[number]
   | TFollowUpConsumedEvent
-  | TThreadContextUsageEvent
+  | TAgentThreadContextUsageEvent
   | TThreadGoalUpdatedEvent
   | TThreadGoalClearedEvent
 

--- a/packages/contracts/src/ai/chat-event.model.ts
+++ b/packages/contracts/src/ai/chat-event.model.ts
@@ -73,7 +73,5 @@ function toIsoString(value?: string | Date) {
   return new Date().toISOString()
 }
 
-/** Optional resolved model information; older event consumers remain compatible. */
-export type TAgentThreadContextUsageEvent = TThreadContextUsageEvent & {
-  effectiveModel?: { model?: string; contextWindow: number }
-}
+/** Compatible public alias for the shared context usage event. */
+export type TAgentThreadContextUsageEvent = TThreadContextUsageEvent

--- a/packages/contracts/src/ai/chat-event.model.ts
+++ b/packages/contracts/src/ai/chat-event.model.ts
@@ -1,4 +1,5 @@
 import type {
+  TThreadContextUsageEvent,
   TChatEventMessage,
   TFollowUpConsumedEvent,
   TThreadGoalClearedEvent,
@@ -70,4 +71,9 @@ function toIsoString(value?: string | Date) {
     }
   }
   return new Date().toISOString()
+}
+
+/** Optional resolved model information; older event consumers remain compatible. */
+export type TAgentThreadContextUsageEvent = TThreadContextUsageEvent & {
+  effectiveModel?: { model?: string; contextWindow: number }
 }

--- a/packages/contracts/src/ai/xpert-agent-execution.model.ts
+++ b/packages/contracts/src/ai/xpert-agent-execution.model.ts
@@ -128,6 +128,10 @@ export type TAgentExecutionMetadata = {
   primaryModelId?: string
   primaryModelSource?: import('./assistant-model.model').TAssistantPrimaryModelSelectionSource
   /** Sanitized model snapshot used to keep resume and retry deterministic. */
+  effectiveModelSnapshot?: Pick<
+    import('./copilot-model.model').TCopilotModel,
+    'copilotId' | 'modelType' | 'model' | 'options'
+  >
   primaryModelSnapshot?: Pick<
     import('./copilot-model.model').TCopilotModel,
     'copilotId' | 'modelType' | 'model' | 'options'

--- a/packages/plugins/draft/package.json
+++ b/packages/plugins/draft/package.json
@@ -22,7 +22,7 @@
     "@nestjs/common": "*",
     "@nestjs/config": "*",
     "@nestjs/core": "*",
-    "@xpert-ai/chatkit-types": "~0.5.5",
+    "@xpert-ai/chatkit-types": "~0.5.8",
     "@xpert-ai/plugin-sdk": "workspace:*"
   }
 }

--- a/packages/server-ai/package.json
+++ b/packages/server-ai/package.json
@@ -41,7 +41,7 @@
         "@opentelemetry/sdk-trace-base": "^2.7.1",
         "@opentelemetry/sdk-trace-node": "^2.7.1",
         "@sap_oss/odata-library": "2.4.0",
-        "@xpert-ai/chatkit-types": "0.5.5",
+        "@xpert-ai/chatkit-types": "0.5.8",
         "@xpert-ai/contracts": "workspace:*",
         "@xpert-ai/plugin-sdk": "workspace:*",
         "@xpert-ai/server-auth": "workspace:*",

--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
@@ -25,6 +25,7 @@ import {
     StateGraph
 } from '@langchain/langgraph'
 import {
+    AiModelTypeEnum,
     agentLabel,
     agentUniqueName,
     allChannels,
@@ -149,6 +150,7 @@ import {
     createInvalidToolCallErrorMessage,
     createInvalidToolCallRepairContext
 } from './invalid-tool-call-diagnostics'
+import { createModelExecutionSnapshot, withModelExecutionSnapshot } from '../../model-execution-snapshot'
 import { resolveEffectiveCopilotModel } from '../../effective-copilot-model'
 import { resolveToolRuntimeScope } from '../../../tool-runtime/workspace-scope'
 import {
@@ -296,10 +298,31 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
                     })
                 )
             }
+            const snapshot = createModelExecutionSnapshot({
+                ...effectiveCopilotModel,
+                copilotId: effectiveCopilotModel.copilotId ?? copilot.id,
+                modelType: AiModelTypeEnum.LLM,
+                model: effectiveCopilotModel.model || copilot.copilotModel?.model
+            })
             execution.metadata = {
                 ...(execution.metadata ?? {}),
+                ...(snapshot
+                    ? {
+                          effectiveModelSnapshot: snapshot,
+                          ...(execution.metadata?.primaryModelSnapshot &&
+                          options.primaryAgentKey === agent.key &&
+                          options.xpertId === team.id
+                              ? { primaryModelSnapshot: snapshot }
+                              : {})
+                      }
+                    : {}),
                 provider: copilot.modelProvider?.providerName,
                 model: effectiveCopilotModel.model || copilot.copilotModel?.model
+            }
+            if (execution.id && snapshot) {
+                await this.commandBus.execute(
+                    new XpertAgentExecutionUpsertCommand({ id: execution.id, metadata: execution.metadata })
+                )
             }
         }
 
@@ -1025,10 +1048,15 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
             ...userAfterModelHooks,
             ...(!hiddenAgent
                 ? [
-                      createThreadContextUsageEventHook(agent, thread_id, async () => {
-                          const executionId = resolveExecutionId()
-                          return executionId ? await this.executionService.findOne(executionId) : null
-                      })
+                      createThreadContextUsageEventHook(
+                          agent,
+                          thread_id,
+                          async () => {
+                              const executionId = resolveExecutionId()
+                              return executionId ? await this.executionService.findOne(executionId) : null
+                          },
+                          () => execution.metadata?.effectiveModelSnapshot
+                      )
                   ]
                 : [])
         ]
@@ -1235,7 +1263,29 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
         // Execute agent
         const callModel = async (state: typeof SubgraphStateAnnotation.State, config?: RunnableConfig) => {
             const { structuredChatModel, jsonSchema } = withStructured(chatModel, agent, withTools)
-            let withFallbackModel: Runnable = withModelMessagePreparation(structuredChatModel, chatModel)
+            const withCandidateSnapshot = (model: Runnable, candidate: typeof effectiveCopilotModel) =>
+                withModelExecutionSnapshot(
+                    model,
+                    {
+                        ...candidate,
+                        copilotId: candidate?.copilotId ?? candidate?.copilot?.id ?? team.copilotModel?.copilotId,
+                        modelType: AiModelTypeEnum.LLM
+                    },
+                    async (snapshot) => {
+                        if (JSON.stringify(snapshot) === JSON.stringify(execution.metadata?.effectiveModelSnapshot))
+                            return
+                        execution.metadata = { ...execution.metadata, effectiveModelSnapshot: snapshot }
+                        const id = resolveExecutionId()
+                        if (id)
+                            await this.commandBus.execute(
+                                new XpertAgentExecutionUpsertCommand({ id, metadata: execution.metadata })
+                            )
+                    }
+                )
+            let withFallbackModel: Runnable = withCandidateSnapshot(
+                withModelMessagePreparation(structuredChatModel, chatModel),
+                effectiveCopilotModel
+            )
             if (agent.options?.retry?.enabled) {
                 withFallbackModel = withFallbackModel.withRetry({
                     stopAfterAttempt: agent.options.retry.stopAfterAttempt ?? 2
@@ -1263,7 +1313,10 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
                 )
                 const { structuredChatModel: fallbackChatModel } = withStructured(_fallbackChatModel, agent, withTools)
                 withFallbackModel = withFallbackModel.withFallbacks([
-                    withModelMessagePreparation(fallbackChatModel, _fallbackChatModel)
+                    withCandidateSnapshot(
+                        withModelMessagePreparation(fallbackChatModel, _fallbackChatModel),
+                        agent.options.fallback.copilotModel
+                    )
                 ])
             }
 

--- a/packages/server-ai/src/xpert-agent/hooks/context-usage.hook.spec.ts
+++ b/packages/server-ai/src/xpert-agent/hooks/context-usage.hook.spec.ts
@@ -1,0 +1,44 @@
+import { AIMessage } from '@langchain/core/messages'
+import { dispatchCustomEvent } from '@langchain/core/callbacks/dispatch'
+import { createThreadContextUsageEventHook, createThreadContextUsageEvent } from './context-usage.hook'
+
+it('reports the context window from the effective execution snapshot', () => {
+    const event = createThreadContextUsageEvent({
+        threadId: 'thread',
+        agentKey: 'agent',
+        message: new AIMessage({
+            content: 'done',
+            usage_metadata: { input_tokens: 120, output_tokens: 30, total_tokens: 150 }
+        }),
+        execution: { metadata: { effectiveModelSnapshot: { model: 'small', options: { context_size: 32768 } } } }
+    })
+    expect(event?.effectiveModel).toEqual({ model: 'small', contextWindow: 32768 })
+    expect(event?.usage.contextTokens).toBe(120)
+})
+
+jest.mock('@langchain/core/callbacks/dispatch', () => ({ dispatchCustomEvent: jest.fn() }))
+
+it('uses the active snapshot when the execution loader has not saved new metadata yet', async () => {
+    const snapshot = { model: 'selected', options: { context_size: 32768 } }
+    const loader = jest.fn(async () => ({ id: 'execution', metadata: {}, totalPrice: 0.5 }))
+    const { hook } = createThreadContextUsageEventHook({ key: 'Agent' }, 'thread', loader, () => snapshot)
+    await hook(
+        {
+            messages: [
+                new AIMessage({
+                    content: 'done',
+                    usage_metadata: { input_tokens: 120, output_tokens: 30, total_tokens: 150 }
+                })
+            ]
+        },
+        {}
+    )
+    expect(loader).toHaveBeenCalled()
+    expect(dispatchCustomEvent).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+            effectiveModel: { model: 'selected', contextWindow: 32768 },
+            usage: expect.objectContaining({ totalPrice: 0.5 })
+        })
+    )
+})

--- a/packages/server-ai/src/xpert-agent/hooks/context-usage.hook.ts
+++ b/packages/server-ai/src/xpert-agent/hooks/context-usage.hook.ts
@@ -5,7 +5,8 @@ import {
     ChatMessageEventTypeEnum,
     IXpertAgent,
     IXpertAgentExecution,
-    TThreadContextUsageEvent,
+    TAgentThreadContextUsageEvent,
+    TAgentExecutionMetadata,
     TTokenUsage
 } from '@xpert-ai/contracts'
 import { AfterModelHandler } from '@xpert-ai/plugin-sdk'
@@ -16,7 +17,8 @@ type TExecutionLoader = () => Promise<Partial<IXpertAgentExecution> | null>
 export function createThreadContextUsageEventHook(
     agent: IXpertAgent,
     thread_id: string,
-    loadExecution: TExecutionLoader
+    loadExecution: TExecutionLoader,
+    loadEffectiveModel?: () => TAgentExecutionMetadata['effectiveModelSnapshot']
 ) {
     const agentKey = agent.key
     return {
@@ -32,7 +34,13 @@ export function createThreadContextUsageEventHook(
                 runId: execution.id,
                 agentKey,
                 message: lastMessage,
-                execution,
+                execution: {
+                    ...execution,
+                    metadata: {
+                        ...execution.metadata,
+                        ...(loadEffectiveModel ? { effectiveModelSnapshot: loadEffectiveModel() } : {})
+                    }
+                },
                 updatedAt: new Date()
             })
 
@@ -73,7 +81,7 @@ export function createThreadContextUsageEvent(params: {
     execution?: Partial<IXpertAgentExecution> | null
     message: unknown
     updatedAt?: string | Date
-}): TThreadContextUsageEvent | null {
+}): TAgentThreadContextUsageEvent | null {
     const tokenUsage = getAIMessageTokenUsage(params.message)
     if (!tokenUsage) {
         return null
@@ -81,7 +89,12 @@ export function createThreadContextUsageEvent(params: {
 
     const totalTokens = toFiniteNumber(tokenUsage.totalTokens || tokenUsage.promptTokens + tokenUsage.completionTokens)
 
+    const snapshot = params.execution?.metadata?.effectiveModelSnapshot
+    const contextWindow = snapshot?.options?.context_size
     return {
+        ...(typeof contextWindow === 'number' && Number.isFinite(contextWindow) && contextWindow > 0
+            ? { effectiveModel: { model: snapshot.model, contextWindow } }
+            : {}),
         type: CHAT_EVENT_TYPE_THREAD_CONTEXT_USAGE,
         threadId: params.threadId,
         runId: params.runId ?? null,

--- a/packages/server-ai/src/xpert-agent/model-execution-snapshot.spec.ts
+++ b/packages/server-ai/src/xpert-agent/model-execution-snapshot.spec.ts
@@ -1,0 +1,55 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages'
+import { RunnableLambda } from '@langchain/core/runnables'
+import { AiModelTypeEnum, TCopilotModel } from '@xpert-ai/contracts'
+import { createModelExecutionSnapshot, withModelExecutionSnapshot } from './model-execution-snapshot'
+
+describe('model execution snapshots', () => {
+    const primary: TCopilotModel = {
+        copilotId: 'copilot',
+        modelType: AiModelTypeEnum.LLM,
+        model: 'primary',
+        options: { context_size: 32768, context_size_source: 'provider', api_key: 'secret' }
+    }
+
+    it('freezes the context window without changing configuration or retaining credentials', () => {
+        const snapshot = createModelExecutionSnapshot(primary)
+        expect(snapshot?.options).toEqual({ context_size: 32768, context_size_source: 'snapshot' })
+        expect(primary.options?.context_size_source).toBe('provider')
+        expect(primary.options?.api_key).toBe('secret')
+    })
+
+    it('records the actual fallback window before the provider replies', async () => {
+        const snapshots: Array<NonNullable<ReturnType<typeof createModelExecutionSnapshot>>> = []
+        const record = async (snapshot: (typeof snapshots)[number]) => {
+            snapshots.push(snapshot)
+        }
+        const failing = RunnableLambda.from(async () => {
+            expect(snapshots[snapshots.length - 1]?.model).toBe('primary')
+            throw new Error('primary unavailable')
+        })
+        const fallback = RunnableLambda.from(async () => {
+            expect(snapshots[snapshots.length - 1]?.model).toBe('fallback')
+            return new AIMessage('done')
+        })
+        const model = withModelExecutionSnapshot(failing, primary, record).withFallbacks([
+            withModelExecutionSnapshot(
+                fallback,
+                { ...primary, model: 'fallback', options: { context_size: 131072 } },
+                record
+            )
+        ])
+        await expect(model.invoke([new HumanMessage('hello')])).resolves.toMatchObject({ content: 'done' })
+        expect(snapshots.map((snapshot) => snapshot.options?.context_size)).toEqual([32768, 131072])
+    })
+
+    it('does not invent a snapshot for an incomplete model configuration', async () => {
+        const record = jest.fn(async () => {})
+        const model = withModelExecutionSnapshot(
+            RunnableLambda.from(async () => new AIMessage('done')),
+            { model: 'missing-copilot' },
+            record
+        )
+        await expect(model.invoke([])).resolves.toMatchObject({ content: 'done' })
+        expect(record).not.toHaveBeenCalled()
+    })
+})

--- a/packages/server-ai/src/xpert-agent/model-execution-snapshot.ts
+++ b/packages/server-ai/src/xpert-agent/model-execution-snapshot.ts
@@ -1,0 +1,26 @@
+// Invariants: record the invoked candidate inside retry/fallback. Snapshot tracking
+// must work independently of context-compression request validation.
+import { BaseMessage } from '@langchain/core/messages'
+import { Runnable, RunnableLambda } from '@langchain/core/runnables'
+import type { TCopilotModel } from '@xpert-ai/contracts'
+import { sanitizeAssistantCopilotModel, sanitizeAssistantModelSnapshot } from '../xpert/assistant-model-selection.util'
+
+export function createModelExecutionSnapshot(model: TCopilotModel) {
+    const normalized = sanitizeAssistantCopilotModel({
+        ...model,
+        options: { ...model.options, context_size_source: 'snapshot' }
+    })
+    return normalized ? sanitizeAssistantModelSnapshot(normalized) : null
+}
+
+export function withModelExecutionSnapshot(
+    model: Runnable,
+    candidate: TCopilotModel,
+    recordSnapshot: (snapshot: NonNullable<ReturnType<typeof createModelExecutionSnapshot>>) => Promise<void>
+): Runnable {
+    return RunnableLambda.from(async (messages: BaseMessage[], config) => {
+        const snapshot = createModelExecutionSnapshot(candidate)
+        if (snapshot) await recordSnapshot(snapshot)
+        return model.invoke(messages, config)
+    })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -629,8 +629,8 @@ importers:
         specifier: ~0.4.3
         version: 0.4.3(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@angular/core@21.1.4(@angular/compiler@21.1.4)(rxjs@7.8.2)(zone.js@0.16.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       '@xpert-ai/chatkit-types':
-        specifier: ~0.5.7
-        version: 0.5.7(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
+        specifier: ~0.5.8
+        version: 0.5.8(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       '@xpert-ai/chatkit-ui':
         specifier: ~0.5.10
         version: 0.5.10(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(babel-plugin-macros@3.1.0)(openai@5.23.2(ws@8.21.0)(zod@3.25.67))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(signal-polyfill@0.2.2)(typescript@5.9.3)(vite@7.3.0(@types/node@22.20.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.59.0)(terser@5.46.0)(yaml@2.8.2))
@@ -864,8 +864,8 @@ importers:
         specifier: ^7.0.15
         version: 7.0.15
       '@xpert-ai/chatkit-types':
-        specifier: ~0.5.5
-        version: 0.5.5(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
+        specifier: ~0.5.8
+        version: 0.5.8(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       zod-to-json-schema:
         specifier: ^3.25.2
         version: 3.25.2(zod@3.25.67)
@@ -941,8 +941,8 @@ importers:
         specifier: '*'
         version: 11.1.13(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/microservices@11.1.13)(@nestjs/platform-express@11.1.13)(@nestjs/websockets@11.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@xpert-ai/chatkit-types':
-        specifier: ~0.5.5
-        version: 0.5.5(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
+        specifier: ~0.5.8
+        version: 0.5.8(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       '@xpert-ai/contracts':
         specifier: workspace:*
         version: link:../../contracts/dist
@@ -1368,8 +1368,8 @@ importers:
         specifier: 2.4.0
         version: 2.4.0
       '@xpert-ai/chatkit-types':
-        specifier: 0.5.5
-        version: 0.5.5(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
+        specifier: 0.5.8
+        version: 0.5.8(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       '@xpert-ai/contracts':
         specifier: workspace:*
         version: link:../contracts/dist
@@ -10262,14 +10262,8 @@ packages:
     peerDependencies:
       '@angular/core': '>=17 <22'
 
-  '@xpert-ai/chatkit-types@0.5.5':
-    resolution: {integrity: sha512-ByqMQfMRoBvPRua09yKXXEe75/wlpS6jBZyaMXmFZWSsJ/cBcD81uYW/zQdYRGGBIgFo3b+UQFboMwU6ZDv2lA==}
-    peerDependencies:
-      '@a2ui/lit': ^0.8.1
-      '@langchain/core': 0.3.72
-
-  '@xpert-ai/chatkit-types@0.5.7':
-    resolution: {integrity: sha512-knkS6MJvWt1lR8xzjCuTNXb5VdEfGbPINkJ40wZZ1Xguws4xbktlQehndYvAoxkWs6glM4bPD3PJQ2VkdpchFQ==}
+  '@xpert-ai/chatkit-types@0.5.8':
+    resolution: {integrity: sha512-FbN8Etftuq33TDYOwFIzjB8A1Xa2JYa+6ubkGq+k4ZTP9YfaLENCaqHjSgCsscm5dDQnR3powAD2yas9G7Mqqw==}
     peerDependencies:
       '@a2ui/lit': ^0.8.1
       '@langchain/core': 0.3.72
@@ -34744,19 +34738,14 @@ snapshots:
   '@xpert-ai/chatkit-angular@0.4.3(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@angular/core@21.1.4(@angular/compiler@21.1.4)(rxjs@7.8.2)(zone.js@0.16.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))':
     dependencies:
       '@angular/core': 21.1.4(@angular/compiler@21.1.4)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@xpert-ai/chatkit-types': 0.5.7(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
+      '@xpert-ai/chatkit-types': 0.5.8(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       '@xpert-ai/chatkit-web-component': 0.5.4(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@a2ui/lit'
       - '@langchain/core'
 
-  '@xpert-ai/chatkit-types@0.5.5(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))':
-    dependencies:
-      '@a2ui/lit': 0.8.3(signal-polyfill@0.2.2)
-      '@langchain/core': 0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67))
-
-  '@xpert-ai/chatkit-types@0.5.7(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))':
+  '@xpert-ai/chatkit-types@0.5.8(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))':
     dependencies:
       '@a2ui/lit': 0.8.3(signal-polyfill@0.2.2)
       '@langchain/core': 0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67))
@@ -34775,7 +34764,7 @@ snapshots:
       '@radix-ui/react-tooltip': 1.2.10(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tailwindcss/vite': 4.3.2(vite@7.3.0(@types/node@22.20.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.59.0)(terser@5.46.0)(yaml@2.8.2))
       '@xpert-ai/a2ui-react': 0.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(signal-polyfill@0.2.2)(tailwindcss@4.3.2)
-      '@xpert-ai/chatkit-types': 0.5.7(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
+      '@xpert-ai/chatkit-types': 0.5.8(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       '@xpert-ai/chatkit-web-shared': 0.4.4(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       '@xpert-ai/xpert-sdk': 0.1.0
       class-variance-authority: 0.7.1
@@ -34826,7 +34815,7 @@ snapshots:
 
   '@xpert-ai/chatkit-web-component@0.5.4(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))':
     dependencies:
-      '@xpert-ai/chatkit-types': 0.5.7(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
+      '@xpert-ai/chatkit-types': 0.5.8(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
       '@xpert-ai/chatkit-web-shared': 0.4.4(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
     transitivePeerDependencies:
       - '@a2ui/lit'
@@ -34835,7 +34824,7 @@ snapshots:
   '@xpert-ai/chatkit-web-shared@0.4.4(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))':
     dependencies:
       '@microsoft/fetch-event-source': 2.0.1
-      '@xpert-ai/chatkit-types': 0.5.7(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
+      '@xpert-ai/chatkit-types': 0.5.8(@a2ui/lit@0.8.3(signal-polyfill@0.2.2))(@langchain/core@0.3.72(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.21.0)(zod@3.25.67)))
     transitivePeerDependencies:
       - '@a2ui/lit'
       - '@langchain/core'


### PR DESCRIPTION
Withdrawn from the context-compression bug-fix series.

This PR adds tracking of the actually invoked model and its context window, including configured fallback models. A mismatched window denominator was not established as the cause of the reported 32K replay symptoms, so this broader change is excluded from the reported-bug-only scope. Its runtime, metadata, event and Angular changes have been removed from the local git/xpert test checkout.

The reported compression failures, repeated attempts, lost acknowledgement constraints and failure status are handled in [#998](https://github.com/xpert-ai/xpert/pull/998). That PR also retains the explicitly requested published chatkit-types dependency update and does not depend on this PR.

The branch is retained for reference; this PR is closed without merging.
