### PR TITLE
fix(i18n): add shared retry action translations

### DIFF
--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -1566,6 +1566,7 @@
       }
     },
     "ACTIONS": {
+      "Retry": "Retry",
       "NEW": "New",
       "CREATE": "Create",
       "CANCEL": "Cancel",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -1550,6 +1550,7 @@
       "RemoveUserFromOrg": "Remove user from organization"
     },
     "ACTIONS": {
+      "Retry": "Retry",
       "ADD": "Add",
       "Add": "Add",
       "CANCEL": "Cancel",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -3532,6 +3532,7 @@
       "PasswordChangedSuccessfully": "密码修改成功"
     },
     "ACTIONS": {
+      "Retry": "重试",
       "Start": "开始",
       "Send": "发送",
       "Back": "返回",


### PR DESCRIPTION
# PR

Add the missing `XP.ACTIONS.Retry` translations for Simplified Chinese, English, and US English. The model selector error state and other shared retry buttons now display “重试” or “Retry” instead of the untranslated key.

No new dependencies. This PR contains only three locale entries.

Validation: parsed all three JSON resources and confirmed the only data change from `develop` is the added key; `git diff --check` and the normal pre-commit hooks passed. Browser validation was not run.

# Checklist

- [x] Have you followed the contributing guidelines?
- [x] Have you explained what your changes do, and why they add value?
