### PR TITLE
feat(files): refine workspace library tree

### DIFF
--- a/.changeset/refined-resource-library.md
+++ b/.changeset/refined-resource-library.md
@@ -1,5 +1,0 @@
----
-'@xpert-ai/xpert-ui': patch
----
-
-Improve the Xpert workspace library file tree with type-specific icons, a refresh action, overflow file actions, and clearer hover behavior.

--- a/.changeset/refined-resource-library.md
+++ b/.changeset/refined-resource-library.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/xpert-ui': patch
+---
+
+Improve the Xpert workspace library file tree with type-specific icons, a refresh action, overflow file actions, and clearer hover behavior.

--- a/apps/cloud/src/app/@shared/files/tree/tree.component.html
+++ b/apps/cloud/src/app/@shared/files/tree/tree.component.html
@@ -15,43 +15,65 @@
     </div>
 
     <div class="flex shrink-0 items-start gap-2">
-      @if (canUpload()) {
+      @if (canUpload() || showRefresh()) {
         <div class="flex shrink-0 flex-col items-end gap-1">
           <div class="flex flex-wrap justify-end gap-2">
-            <button
-              z-button
-              zSize="sm"
-              zType="ghost"
-              type="button"
-              [class]="uploadActionClasses()"
-              [zTooltip]="'XP.Files.UploadFiles' | translate: { Default: 'Upload files' }"
-              zPosition="top"
-              [attr.aria-label]="'XP.Files.UploadFiles' | translate: { Default: 'Upload files' }"
-              [zDisabled]="uploadDisabled() || uploading()"
-              (click)="onUploadClick('file')"
-            >
-              <i class="ri-upload-2-line"></i>
-              <span class="sr-only">{{ 'XP.Files.UploadFiles' | translate: { Default: 'Upload files' } }}</span>
-            </button>
+            @if (showRefresh()) {
+              <button
+                z-button
+                zSize="sm"
+                zType="ghost"
+                type="button"
+                [class]="uploadActionClasses()"
+                [zTooltip]="'XP.WorkspaceFiles.RefreshTree' | translate: { Default: 'Refresh file tree' }"
+                zPosition="top"
+                [attr.aria-label]="'XP.WorkspaceFiles.RefreshTree' | translate: { Default: 'Refresh file tree' }"
+                [zDisabled]="loading() || uploading()"
+                (click)="onRefreshClick()"
+              >
+                <z-icon zType="refresh" [class.animate-spin]="loading()" aria-hidden="true" />
+                <span class="sr-only">
+                  {{ 'XP.WorkspaceFiles.RefreshTree' | translate: { Default: 'Refresh file tree' } }}
+                </span>
+              </button>
+            }
 
-            <button
-              z-button
-              zSize="sm"
-              zType="ghost"
-              type="button"
-              [class]="uploadActionClasses()"
-              [zTooltip]="'XP.Files.UploadFolder' | translate: { Default: 'Upload folder' }"
-              zPosition="top"
-              [attr.aria-label]="'XP.Files.UploadFolder' | translate: { Default: 'Upload folder' }"
-              [zDisabled]="uploadDisabled() || uploading()"
-              (click)="onUploadClick('folder')"
-            >
-              <i class="ri-folder-upload-line"></i>
-              <span class="sr-only">{{ 'XP.Files.UploadFolder' | translate: { Default: 'Upload folder' } }}</span>
-            </button>
+            @if (canUpload()) {
+              <button
+                z-button
+                zSize="sm"
+                zType="ghost"
+                type="button"
+                [class]="uploadActionClasses()"
+                [zTooltip]="'XP.Files.UploadFiles' | translate: { Default: 'Upload files' }"
+                zPosition="top"
+                [attr.aria-label]="'XP.Files.UploadFiles' | translate: { Default: 'Upload files' }"
+                [zDisabled]="uploadDisabled() || uploading()"
+                (click)="onUploadClick('file')"
+              >
+                <i class="ri-upload-2-line"></i>
+                <span class="sr-only">{{ 'XP.Files.UploadFiles' | translate: { Default: 'Upload files' } }}</span>
+              </button>
+
+              <button
+                z-button
+                zSize="sm"
+                zType="ghost"
+                type="button"
+                [class]="uploadActionClasses()"
+                [zTooltip]="'XP.Files.UploadFolder' | translate: { Default: 'Upload folder' }"
+                zPosition="top"
+                [attr.aria-label]="'XP.Files.UploadFolder' | translate: { Default: 'Upload folder' }"
+                [zDisabled]="uploadDisabled() || uploading()"
+                (click)="onUploadClick('folder')"
+              >
+                <i class="ri-folder-upload-line"></i>
+                <span class="sr-only">{{ 'XP.Files.UploadFolder' | translate: { Default: 'Upload folder' } }}</span>
+              </button>
+            }
           </div>
 
-          @if (uploadTargetHint()) {
+          @if (canUpload() && uploadTargetHint()) {
             <div class="max-w-[14rem] text-right text-xs text-text-tertiary">
               {{ uploadTargetHint() }}
             </div>
@@ -76,11 +98,11 @@
               @if (item.hasChildren) {
                 <button type="button" [class]="toggleClasses()" (click)="onDirectoryToggle($event, item)">
                   @if (isDirectoryLoading(item.fullPath || item.filePath)) {
-                    <i class="ri-loader-4-line animate-spin"></i>
+                    <z-icon zType="loader-circle" class="animate-spin" aria-hidden="true" />
                   } @else if (item.expanded) {
-                    <i class="ri-arrow-down-s-line"></i>
+                    <z-icon zType="chevron-down" aria-hidden="true" />
                   } @else {
-                    <i class="ri-arrow-right-s-line"></i>
+                    <z-icon zType="chevron-right" aria-hidden="true" />
                   }
                 </button>
               } @else {
@@ -91,17 +113,10 @@
                 type="button"
                 data-file-tree-item-content
                 [class]="itemContentClasses()"
-                [zTooltip]="item.fullPath || item.filePath"
-                zPosition="top"
                 [title]="item.fullPath || item.filePath"
                 (click)="onItemClick(item)"
               >
-                <i
-                  [class]="itemIconClasses()"
-                  [class.ri-folder-open-line]="item.hasChildren && item.expanded"
-                  [class.ri-folder-line]="item.hasChildren && !item.expanded"
-                  [class.ri-file-text-line]="!item.hasChildren"
-                ></i>
+                <z-icon [zType]="itemIconType(item)" [class]="itemIconClasses()" aria-hidden="true" />
                 <span [class]="itemLabelClasses(item)">
                   {{ item.filePath }}
                 </span>
@@ -109,41 +124,22 @@
 
               @if (showActions(item)) {
                 <div
-                  class="absolute right-1 ml-auto flex shrink-0 items-center gap-1 p-0.5 rounded-lg opacity-100 transition-opacity bg-components-panel-bg md:pointer-events-none md:opacity-0 md:group-hover:pointer-events-auto md:group-hover:opacity-100 md:group-focus-within:pointer-events-auto"
+                  class="absolute right-1 ml-auto flex shrink-0 items-center rounded-md opacity-100 transition-opacity md:pointer-events-none md:opacity-0 md:group-hover:pointer-events-auto md:group-hover:opacity-100 md:group-focus-within:pointer-events-auto"
                 >
-                  @if (canDownloadItem(item)) {
-                    <button
-                      type="button"
-                      [class]="itemActionClasses()"
-                      [disabled]="isDownloading(item.fullPath || item.filePath)"
-                      [attr.aria-label]="'XP.Files.Download' | translate: { Default: 'Download' }"
-                      (click)="onFileDownload($event, item)"
-                    >
-                      @if (isDownloading(item.fullPath || item.filePath)) {
-                        <i class="ri-loader-4-line animate-spin"></i>
-                      } @else {
-                        <i class="ri-download-2-line"></i>
-                      }
-                      <span>{{ 'XP.Files.Download' | translate: { Default: 'Download' } }}</span>
-                    </button>
-                  }
-
-                  @if (canDelete()) {
-                    <button
-                      type="button"
-                      [class]="cx(itemActionClasses(), 'hover:text-text-destructive')"
-                      [disabled]="isDeleting(item.fullPath || item.filePath)"
-                      [attr.aria-label]="'XP.Files.Delete' | translate: { Default: 'Delete' }"
-                      (click)="onFileDelete($event, item)"
-                    >
-                      @if (isDeleting(item.fullPath || item.filePath)) {
-                        <i class="ri-loader-4-line animate-spin"></i>
-                      } @else {
-                        <i class="ri-delete-bin-line"></i>
-                      }
-                      <span>{{ 'XP.Files.Delete' | translate: { Default: 'Delete' } }}</span>
-                    </button>
-                  }
+                  <button
+                    type="button"
+                    z-button
+                    zType="ghost"
+                    zSize="icon-xs"
+                    z-menu
+                    [zMenuTriggerFor]="itemMenu"
+                    [zMenuTriggerData]="{ item: item }"
+                    zPlacement="bottomRight"
+                    [attr.aria-label]="'XP.Files.MoreActions' | translate: { Default: 'More actions' }"
+                    [title]="'XP.Files.MoreActions' | translate: { Default: 'More actions' }"
+                  >
+                    <z-icon zType="more_horiz" aria-hidden="true" />
+                  </button>
                 </div>
               }
             </div>
@@ -171,3 +167,40 @@
     }
   </div>
 </section>
+
+<ng-template #itemMenu let-item="item">
+  <div z-menu-content class="min-w-32">
+    @if (canDownloadItem(item)) {
+      <button
+        type="button"
+        z-menu-item
+        [zDisabled]="isDownloading(item.fullPath || item.filePath)"
+        (click)="onFileDownload($event, item)"
+      >
+        @if (isDownloading(item.fullPath || item.filePath)) {
+          <z-icon zType="loader-circle" class="mr-2 animate-spin" aria-hidden="true" />
+        } @else {
+          <z-icon zType="file_download" class="mr-2" aria-hidden="true" />
+        }
+        <span>{{ 'XP.Files.Download' | translate: { Default: 'Download' } }}</span>
+      </button>
+    }
+
+    @if (canDelete()) {
+      <button
+        type="button"
+        z-menu-item
+        zType="destructive"
+        [zDisabled]="isDeleting(item.fullPath || item.filePath)"
+        (click)="onFileDelete($event, item)"
+      >
+        @if (isDeleting(item.fullPath || item.filePath)) {
+          <z-icon zType="loader-circle" class="mr-2 animate-spin" aria-hidden="true" />
+        } @else {
+          <z-icon zType="delete" class="mr-2" aria-hidden="true" />
+        }
+        <span>{{ 'XP.Files.Delete' | translate: { Default: 'Delete' } }}</span>
+      </button>
+    }
+  </div>
+</ng-template>

--- a/apps/cloud/src/app/@shared/files/tree/tree.component.spec.ts
+++ b/apps/cloud/src/app/@shared/files/tree/tree.component.spec.ts
@@ -12,6 +12,7 @@ jest.mock('@xpert-ai/headless-ui', () => {
   class ZardButtonComponent {
     @Input() zSize?: string
     @Input() zType?: string
+    @Input() zDisabled?: boolean
   }
 
   @Component({
@@ -20,6 +21,15 @@ jest.mock('@xpert-ai/headless-ui', () => {
     template: ''
   })
   class ZardLoaderComponent {
+    @Input() zSize?: string
+  }
+
+  @Component({
+    standalone: true,
+    selector: 'z-icon'
+  })
+  class ZardIconComponent {
+    @Input() zType?: string
     @Input() zSize?: string
   }
 
@@ -32,11 +42,38 @@ jest.mock('@xpert-ai/headless-ui', () => {
     @Input() zPosition?: string
   }
 
+  @Directive({
+    standalone: true,
+    selector: '[z-menu]'
+  })
+  class ZardMenuDirective {
+    @Input() zMenuTriggerFor?: unknown
+    @Input() zMenuTriggerData?: unknown
+    @Input() zPlacement?: string
+  }
+
+  @Directive({
+    standalone: true,
+    selector: '[z-menu-content]'
+  })
+  class ZardMenuContentDirective {}
+
+  @Directive({
+    standalone: true,
+    selector: '[z-menu-item]'
+  })
+  class ZardMenuItemDirective {
+    @Input() zDisabled?: boolean
+    @Input() zType?: string
+  }
+
   return {
     cx: (...classes: Array<string | null | undefined | false>) => classes.filter(Boolean).join(' '),
     mergeClasses: (...classes: Array<string | null | undefined | false>) => classes.filter(Boolean).join(' '),
     ZardButtonComponent,
+    ZardIconComponent,
     ZardLoaderComponent,
+    ZardMenuImports: [ZardMenuDirective, ZardMenuContentDirective, ZardMenuItemDirective],
     ZardTooltipImports: [ZardTooltipDirective]
   }
 })
@@ -78,6 +115,7 @@ describe('FileTreeComponent', () => {
     const rows = Array.from(fixture.nativeElement.querySelectorAll<HTMLElement>('[data-file-tree-item-content]'))
 
     expect(rows.map((row) => row.getAttribute('title'))).toEqual(['workspace/docs', 'workspace/README.md'])
+    expect(rows.every((row) => !row.hasAttribute('zTooltip'))).toBe(true)
   })
 
   it('hides download actions for folders unless directory downloads are enabled', () => {
@@ -118,18 +156,60 @@ describe('FileTreeComponent', () => {
     fixture.componentInstance.fileDownload.subscribe(downloadSpy)
     fixture.detectChanges()
 
-    const downloadButton = fixture.nativeElement.querySelector<HTMLButtonElement>(
-      'button[aria-label="XP.Files.Download"]'
-    )
-    downloadButton?.click()
+    const menuTrigger = fixture.nativeElement.querySelector<HTMLButtonElement>('button[z-menu]')
 
-    expect(downloadButton).not.toBeNull()
-    expect(downloadSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        filePath: 'docs',
-        fullPath: 'workspace/docs',
-        hasChildren: true
-      })
+    expect(menuTrigger).not.toBeNull()
+    expect(fixture.componentInstance.canDownloadItem(fixture.componentRef.instance.items()[0])).toBe(true)
+
+    const item = fixture.componentRef.instance.items()[0]
+    fixture.componentInstance.onFileDownload(new MouseEvent('click'), item)
+    expect(downloadSpy).toHaveBeenCalledWith(item)
+  })
+
+  it('uses one more-actions trigger for row download and delete operations', () => {
+    const fixture = TestBed.createComponent(FileTreeComponent)
+    fixture.componentRef.setInput('hasContext', true)
+    fixture.componentRef.setInput('canDownload', true)
+    fixture.componentRef.setInput('canDelete', true)
+    fixture.componentRef.setInput('items', [
+      {
+        filePath: 'README.md',
+        fullPath: 'workspace/README.md',
+        fileType: 'md',
+        hasChildren: false
+      }
+    ])
+    fixture.detectChanges()
+
+    expect(fixture.nativeElement.querySelector('button[z-menu]')).not.toBeNull()
+    expect(fixture.nativeElement.querySelector('button[aria-label="XP.Files.Download"]')).toBeNull()
+    expect(fixture.nativeElement.querySelector('button[aria-label="XP.Files.Delete"]')).toBeNull()
+  })
+
+  it('emits refresh requests when the refresh control is enabled', () => {
+    const fixture = TestBed.createComponent(FileTreeComponent)
+    const refreshSpy = jest.fn()
+    fixture.componentRef.setInput('showRefresh', true)
+    fixture.componentInstance.refreshRequest.subscribe(refreshSpy)
+    fixture.detectChanges()
+
+    fixture.componentInstance.onRefreshClick()
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps folders and common file extensions to platform icon names', () => {
+    const fixture = TestBed.createComponent(FileTreeComponent)
+    const component = fixture.componentInstance
+
+    expect(component.itemIconType({ filePath: 'docs', hasChildren: true, expanded: false } as FileTreeNode)).toBe(
+      'folder'
     )
+    expect(component.itemIconType({ filePath: 'docs', hasChildren: true, expanded: true } as FileTreeNode)).toBe(
+      'folder-open'
+    )
+    expect(component.itemIconType({ filePath: 'README.md', hasChildren: false } as FileTreeNode)).toBe('book-open-text')
+    expect(component.itemIconType({ filePath: 'table.xlsx', hasChildren: false } as FileTreeNode)).toBe('table_view')
+    expect(component.itemIconType({ filePath: 'unknown.bin', hasChildren: false } as FileTreeNode)).toBe('file')
   })
 })

--- a/apps/cloud/src/app/@shared/files/tree/tree.component.ts
+++ b/apps/cloud/src/app/@shared/files/tree/tree.component.ts
@@ -1,6 +1,14 @@
 import { CommonModule } from '@angular/common'
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core'
-import { cx, mergeClasses, ZardButtonComponent, ZardLoaderComponent, ZardTooltipImports } from '@xpert-ai/headless-ui'
+import {
+  cx,
+  mergeClasses,
+  ZardButtonComponent,
+  ZardIconComponent,
+  ZardLoaderComponent,
+  ZardMenuImports,
+  ZardTooltipImports
+} from '@xpert-ai/headless-ui'
 import { TranslateModule } from '@ngx-translate/core'
 import { FILE_TREE_SIZE_PRESETS, type FileTreeSizeVariants } from './tree.component.variants'
 import { FileTreeNode, flattenFileTree } from './tree.utils'
@@ -13,7 +21,15 @@ export type FileTreeSurface = 'card' | 'plain'
   selector: 'xp-file-tree',
   templateUrl: './tree.component.html',
   styleUrls: ['./tree.component.css'],
-  imports: [CommonModule, TranslateModule, ZardButtonComponent, ZardLoaderComponent, ...ZardTooltipImports],
+  imports: [
+    CommonModule,
+    TranslateModule,
+    ZardButtonComponent,
+    ZardIconComponent,
+    ZardLoaderComponent,
+    ...ZardMenuImports,
+    ...ZardTooltipImports
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[attr.data-size]': 'zSize()',
@@ -34,6 +50,7 @@ export class FileTreeComponent {
   readonly canDownload = input(false)
   readonly canDownloadDirectory = input(false)
   readonly canDelete = input(false)
+  readonly showRefresh = input(false)
   readonly canUpload = input(false)
   readonly uploadDisabled = input(false)
   readonly uploading = input(false)
@@ -69,12 +86,6 @@ export class FileTreeComponent {
     mergeClasses('flex min-w-0 flex-1 items-center text-left', this.sizePreset().contentGap)
   )
   readonly itemIconClasses = computed(() => mergeClasses('shrink-0 text-text-tertiary', this.sizePreset().itemText))
-  readonly itemActionClasses = computed(() =>
-    mergeClasses(
-      'inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60',
-      this.sizePreset().subtitleText
-    )
-  )
   readonly uploadActionClasses = computed(() =>
     mergeClasses(
       'inline-flex shrink-0 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60',
@@ -92,6 +103,7 @@ export class FileTreeComponent {
   readonly fileDownload = output<FileTreeNode>()
   readonly fileDelete = output<FileTreeNode>()
   readonly uploadRequest = output<FileTreeUploadKind>()
+  readonly refreshRequest = output<void>()
 
   isActiveItem(item: FileTreeNode) {
     return this.activePath() === (item.fullPath || item.filePath)
@@ -111,6 +123,48 @@ export class FileTreeComponent {
       this.sizePreset().itemText,
       this.isActiveItem(item) ? 'font-medium text-text-primary' : 'text-text-secondary group-hover:text-text-primary'
     )
+  }
+
+  itemIconType(item: FileTreeNode) {
+    if (item.hasChildren) {
+      return item.expanded ? 'folder-open' : 'folder'
+    }
+
+    const path = (item.fullPath || item.filePath || '').toLowerCase()
+    const extension = path.includes('.') ? path.slice(path.lastIndexOf('.') + 1) : path
+
+    if (['md', 'mdx'].includes(extension)) {
+      return 'book-open-text'
+    }
+    if (['js', 'jsx', 'ts', 'tsx', 'py', 'sh', 'html', 'css', 'xml', 'json', 'yml', 'yaml'].includes(extension)) {
+      return 'code'
+    }
+    if (['xls', 'xlsx', 'csv', 'ods'].includes(extension)) {
+      return 'table_view'
+    }
+    if (['doc', 'docx', 'odt', 'rtf', 'txt'].includes(extension)) {
+      return 'file-text'
+    }
+    if (extension === 'pdf') {
+      return 'document_scanner'
+    }
+    if (['ppt', 'pptx', 'odp'].includes(extension)) {
+      return 'layers'
+    }
+    if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'].includes(extension)) {
+      return 'square-library'
+    }
+    if (['mp3', 'wav', 'ogg', 'm4a', 'flac'].includes(extension)) {
+      return 'activity'
+    }
+    if (['mp4', 'webm', 'mov', 'avi', 'mkv'].includes(extension)) {
+      return 'monitor'
+    }
+    if (['zip', 'rar', '7z', 'tar', 'gz'].includes(extension)) {
+      return 'archive'
+    }
+
+    return 'file'
   }
 
   isDirectoryLoading(filePath: string | null | undefined) {
@@ -154,5 +208,9 @@ export class FileTreeComponent {
 
   onUploadClick(kind: FileTreeUploadKind) {
     this.uploadRequest.emit(kind)
+  }
+
+  onRefreshClick() {
+    this.refreshRequest.emit()
   }
 }

--- a/apps/cloud/src/app/@shared/files/workbench/workbench.component.html
+++ b/apps/cloud/src/app/@shared/files/workbench/workbench.component.html
@@ -60,6 +60,7 @@
     [canDownload]="canDownloadFiles()"
     [canDownloadDirectory]="canDownloadDirectories()"
     [canDelete]="canDeleteFiles()"
+    [showRefresh]="showTreeRefresh()"
     [downloadingPaths]="downloadingPaths()"
     [deletingPaths]="deletingPaths()"
     [emptyTitle]="'XP.Files.NoFilesFound' | translate: { Default: 'No files found yet.' }"
@@ -73,6 +74,7 @@
     (fileSelect)="openFile($event)"
     (directoryToggle)="toggleDirectory($event)"
     (uploadRequest)="requestUpload($event)"
+    (refreshRequest)="refreshFileTree()"
     (fileDownload)="downloadTreeFile($event)"
     (fileDelete)="deleteTreeFile($event)"
   />

--- a/apps/cloud/src/app/@shared/files/workbench/workbench.component.spec.ts
+++ b/apps/cloud/src/app/@shared/files/workbench/workbench.component.spec.ts
@@ -85,6 +85,7 @@ jest.mock('../tree/tree.component', () => {
     @Input() canDownload?: boolean
     @Input() canDownloadDirectory?: boolean
     @Input() canDelete?: boolean
+    @Input() showRefresh?: boolean
     @Input() downloadingPaths?: Set<string>
     @Input() deletingPaths?: Set<string>
     @Input() emptyTitle?: string
@@ -94,6 +95,7 @@ jest.mock('../tree/tree.component', () => {
     @Output() readonly fileSelect = new EventEmitter<FileTreeNode>()
     @Output() readonly directoryToggle = new EventEmitter<FileTreeNode>()
     @Output() readonly uploadRequest = new EventEmitter<'file' | 'folder'>()
+    @Output() readonly refreshRequest = new EventEmitter<void>()
     @Output() readonly fileDownload = new EventEmitter<FileTreeNode>()
     @Output() readonly fileDelete = new EventEmitter<FileTreeNode>()
   }

--- a/apps/cloud/src/app/@shared/files/workbench/workbench.component.ts
+++ b/apps/cloud/src/app/@shared/files/workbench/workbench.component.ts
@@ -138,6 +138,7 @@ export class FileWorkbenchComponent {
   readonly rootId = input<string | null | undefined>(null)
   readonly rootLabel = input<string | null | undefined>(null)
   readonly layout = input<FileWorkbenchLayout>('default')
+  readonly showTreeRefresh = input(false)
   readonly navigationTitle = input<string | null>(null)
   readonly treeTitle = input<string | null>(null)
   readonly searchPlaceholder = input<string | null>(null)
@@ -303,6 +304,15 @@ export class FileWorkbenchComponent {
 
   toggleFileTree() {
     this.fileTreeVisible.update((visible) => !visible)
+  }
+
+  async refreshFileTree() {
+    const rootId = this.rootId()
+    if (!rootId || this.treeLoading()) {
+      return
+    }
+
+    await this.refreshRootTree(rootId)
   }
 
   async guardDirtyBefore(action: () => Promise<void> | void) {

--- a/apps/cloud/src/app/features/xpert/workspace/files/files.component.html
+++ b/apps/cloud/src/app/features/xpert/workspace/files/files.component.html
@@ -3,6 +3,7 @@
     <xp-file-workbench
       class="workspace-files-page__workbench"
       layout="library"
+      [showTreeRefresh]="true"
       [rootId]="xpertId()"
       [navigationTitle]="'XP.WorkspaceFiles.Title' | translate: { Default: 'Resource library' }"
       [treeTitle]="'XP.WorkspaceFiles.WorkspaceFiles' | translate: { Default: 'Workspace files' }"

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -1270,6 +1270,19 @@
       "PasteMCPJson": "Paste an MCP JSON config to create a toolset.",
       "UrlOnlySSECompatibility": "URL-only configs are imported as SSE for legacy compatibility."
     },
+    "Files": {
+      "MoreActions": "More actions"
+    },
+    "WorkspaceFiles": {
+      "Title": "Resource library",
+      "Description": "Browse, manage, and edit resources in the Claw Xpert workspace.",
+      "RootLabel": "Claw Xpert workspace files",
+      "WorkspaceFiles": "Workspace files",
+      "SearchPlaceholder": "Search workspace files",
+      "ClearSearch": "Clear search",
+      "RefreshTree": "Refresh file tree",
+      "Unavailable": "Configure Claw Xpert first."
+    },
     "Chat": {
       "WorkbenchPresentation": {
         "SearchAssistants": "Search assistants",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -1252,6 +1252,9 @@
       "PasteMCPJson": "Paste an MCP JSON config to create a toolset.",
       "UrlOnlySSECompatibility": "URL-only configs are imported as SSE for legacy compatibility."
     },
+    "Files": {
+      "MoreActions": "More actions"
+    },
     "WorkspaceFiles": {
       "Title": "Resource library",
       "Description": "Browse, manage, and edit resources in the Claw Xpert workspace.",
@@ -1259,6 +1262,7 @@
       "WorkspaceFiles": "Workspace files",
       "SearchPlaceholder": "Search workspace files",
       "ClearSearch": "Clear search",
+      "RefreshTree": "Refresh file tree",
       "Unavailable": "Configure Claw Xpert first."
     },
     "WorkspaceKnowledge": {

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -403,7 +403,8 @@
       "LoadFolderFailed": "加载文件夹失败",
       "LoadFileFailed": "加载文件失败",
       "UploadFiles": "上传文件",
-      "UploadFolder": "上传文件夹"
+      "UploadFolder": "上传文件夹",
+      "MoreActions": "更多操作"
     },
     "KEY_WORDS": {
       "Ask": "提问",
@@ -1931,6 +1932,16 @@
       "AddSemanticModels": "添加语义模型",
       "New": "新建",
       "Files": "文件"
+    },
+    "WorkspaceFiles": {
+      "Title": "资料库",
+      "Description": "浏览、管理和编辑 Claw Xpert 工作区中的资源。",
+      "RootLabel": "Claw Xpert 工作区文件",
+      "WorkspaceFiles": "工作区文件",
+      "SearchPlaceholder": "搜索工作区文件",
+      "ClearSearch": "清除搜索",
+      "RefreshTree": "刷新文件树",
+      "Unavailable": "请先配置 Claw Xpert。"
     },
     "Knowledgebase": {
       "FilterForm": {

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -1642,7 +1642,8 @@
       "ReferenceSelection": "引用选中内容",
       "ReferenceUnavailable": "当前没有可引用的文本内容",
       "DownloadUnavailable": "该文件暂时无法下载。",
-      "DownloadFailed": "下载文件失败"
+      "DownloadFailed": "下载文件失败",
+      "MoreActions": "更多操作"
     },
     "Skills": {
       "Selected": "已选",
@@ -3216,12 +3217,13 @@
       }
     },
     "WorkspaceFiles": {
-      "Title": "资源库",
+      "Title": "资料库",
       "Description": "浏览、管理和编辑 Claw Xpert 工作区中的资源。",
       "RootLabel": "Claw Xpert 工作区文件",
       "WorkspaceFiles": "工作区文件",
       "SearchPlaceholder": "搜索工作区文件",
       "ClearSearch": "清除搜索",
+      "RefreshTree": "刷新文件树",
       "Unavailable": "请先配置 Claw Xpert。"
     },
     "WorkspaceKnowledge": {

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -1046,7 +1046,8 @@
       "LoadFolderFailed": "載入資料夾失敗",
       "LoadFileFailed": "載入文件失敗",
       "UploadFiles": "上傳文件",
-      "UploadFolder": "上傳資料夾"
+      "UploadFolder": "上傳資料夾",
+      "MoreActions": "更多操作"
     },
     "KEY_WORDS": {
       "Skills": "技能",
@@ -5040,6 +5041,16 @@
       "FoundDoorwayGreat": "看起來您已經找到了通往偉大虛無的大門",
       "SorryAboutThat": "很抱歉！請訪問我們的主頁以找到您需要的信息。",
       "TakeMeThere": "帶我去！"
+    },
+    "WorkspaceFiles": {
+      "Title": "資料庫",
+      "Description": "瀏覽、管理和編輯 Claw Xpert 工作區中的資源。",
+      "RootLabel": "Claw Xpert 工作區文件",
+      "WorkspaceFiles": "工作區文件",
+      "SearchPlaceholder": "搜尋工作區文件",
+      "ClearSearch": "清除搜尋",
+      "RefreshTree": "重新整理檔案樹",
+      "Unavailable": "請先配置 Claw Xpert。"
     },
     "Knowledgebase": {
       "GraphDocumentProgress": {


### PR DESCRIPTION
## Summary
- refine the Xpert workspace library file tree with a refresh action and type-specific icons
- move download and delete into a three-dot overflow menu while preserving upload actions
- align folder expand/collapse indicators and remove the duplicate file hover tooltip
- add a patch changeset for @xpert-ai/xpert-ui

## Validation
- pnpm exec prettier --check (changed files and changeset)
- pnpm exec changeset status --since origin/develop
- pnpm exec nx test cloud --runInBand --testFile=apps/cloud/src/app/@shared/files/tree/tree.component.spec.ts
- pnpm exec nx test cloud --runInBand --testFile=apps/cloud/src/app/@shared/files/workbench/workbench.component.spec.ts
- pnpm exec nx build cloud --configuration=development