### PR TITLE
fix: restore Connector runtime after Sep 1 regression

### DIFF
--- a/packages/plugin-sdk/src/lib/connector/runtime-capability.ts
+++ b/packages/plugin-sdk/src/lib/connector/runtime-capability.ts
@@ -13,12 +13,23 @@ export type ConnectorRuntimeScope = RuntimeIdentityScope & {
 
 export type SelectedRuntimeConnectorBinding = { bindingId: string; provider: string }
 
+export type ConfiguredRuntimeConnectorSelection = {
+  provider: string
+  /** Optional binding pinned by the graph. Provider-only selections resolve in the current runtime scope. */
+  bindingId?: string | null
+}
+
 export interface ConnectorRuntimeFactory {
   /** Snapshot the authorized identity and selected binding IDs for this runtime. */
   createScopedApi(scope: ConnectorRuntimeScope): ConnectorRuntimeApi
   /** Preflight selected bindings through the same identity, project and credential checks. */
   resolveSelectedRuntimeBindings(
     bindingIds: string[] | null | undefined,
+    scope: ConnectorRuntimeScope
+  ): Promise<SelectedRuntimeConnectorBinding[]>
+  /** Resolve connector bindings explicitly enabled by middleware nodes in the published graph. */
+  resolveConfiguredRuntimeBindings(
+    selections: ConfiguredRuntimeConnectorSelection[] | null | undefined,
     scope: ConnectorRuntimeScope
   ): Promise<SelectedRuntimeConnectorBinding[]>
 }

--- a/packages/server-ai/src/connector/connector.service.spec.ts
+++ b/packages/server-ai/src/connector/connector.service.spec.ts
@@ -2017,6 +2017,99 @@ describe('ConnectorService', () => {
         ).rejects.toBeInstanceOf(ForbiddenException)
     })
 
+    it('resolves provider-only graph Connector selections through the selected-binding checks', async () => {
+        const binding = await connectors.save(
+            connectors.create({
+                id: 'workspace-example-binding',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                scopeType: 'workspace',
+                workspaceId: 'workspace-1',
+                projectId: null,
+                provider: 'example',
+                authorizationMode: 'shared',
+                status: 'active',
+                credentialCiphertext: 'shared-credential'
+            })
+        )
+        const scope = {
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            userId: 'user-1',
+            workspaceId: 'workspace-1',
+            xpertId: 'xpert-1',
+            conversationId: 'conversation-configured',
+            executionId: 'execution-configured'
+        }
+
+        await expect(service.resolveConfiguredRuntimeBindings([{ provider: 'example' }], scope)).resolves.toEqual([
+            { bindingId: binding.id, provider: 'example' }
+        ])
+    })
+
+    it('delegates configured graph Connector selections to the existing selected-binding resolver', async () => {
+        const binding = await connectors.save(
+            connectors.create({
+                id: 'project-example-binding',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                scopeType: 'project',
+                workspaceId: null,
+                projectId: 'project-1',
+                provider: 'example',
+                authorizationMode: 'shared',
+                status: 'active',
+                credentialCiphertext: 'shared-credential'
+            })
+        )
+        const scope = {
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            userId: 'user-1',
+            workspaceId: 'workspace-1',
+            projectId: 'project-1',
+            xpertId: 'xpert-1',
+            conversationId: 'conversation-delegated',
+            executionId: 'execution-delegated'
+        }
+        const resolveSelected = jest
+            .spyOn(service, 'resolveSelectedRuntimeBindings')
+            .mockResolvedValue([{ bindingId: binding.id!, provider: binding.provider }])
+
+        await expect(
+            service.resolveConfiguredRuntimeBindings([{ provider: 'example', bindingId: binding.id }], scope)
+        ).resolves.toEqual([{ bindingId: binding.id, provider: 'example' }])
+        expect(resolveSelected).toHaveBeenCalledWith([binding.id], scope)
+    })
+
+    it('reuses the selected-binding active credential check for configured graph Connectors', async () => {
+        await connectors.save(
+            connectors.create({
+                id: 'inactive-example-binding',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                scopeType: 'workspace',
+                workspaceId: 'workspace-1',
+                projectId: null,
+                provider: 'example',
+                authorizationMode: 'shared',
+                status: 'disconnected',
+                credentialCiphertext: null
+            })
+        )
+        await expect(
+            service.resolveConfiguredRuntimeBindings([{ provider: 'example' }], {
+                tenantId: 'tenant-1',
+                organizationId: 'org-1',
+                userId: 'user-1',
+                workspaceId: 'workspace-1',
+                xpertId: 'xpert-1',
+                conversationId: 'conversation-inactive',
+                executionId: 'execution-inactive'
+            })
+        ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
     it('returns only Project bindings and sanitized auth forms in Project runtime options', async () => {
         strategy.definition = {
             ...strategy.definition,

--- a/packages/server-ai/src/connector/connector.service.ts
+++ b/packages/server-ai/src/connector/connector.service.ts
@@ -19,6 +19,7 @@ import {
     assertConnectorDefinition,
     ConnectorStrategyRegistry,
     ConnectorRuntimeFactoryCapability,
+    type ConfiguredRuntimeConnectorSelection,
     getConnectorAuthorizationModes,
     getConnectorAuthMethods
 } from '@xpert-ai/plugin-sdk'
@@ -1534,6 +1535,44 @@ export class ConnectorService implements ConnectorRuntimeFactory {
         return result
     }
 
+    async resolveConfiguredRuntimeBindings(
+        selections: ConfiguredRuntimeConnectorSelection[] | null | undefined,
+        scope: ConnectorRuntimeScope
+    ): Promise<SelectedRuntimeConnectorBinding[]> {
+        const configured = normalizeConfiguredRuntimeConnectorSelections(selections)
+        if (!configured.length) {
+            return []
+        }
+        this.assertRuntimeIdentityScope(scope)
+
+        const xpert = await this.assertXpertRunAccess(requiredConnectorText(scope.xpertId, 'runtime.xpertId'))
+        const bindingScope = scope.projectId
+            ? ({ type: 'project', projectId: requiredConnectorText(scope.projectId, 'runtime.projectId') } as const)
+            : ({
+                  type: 'workspace',
+                  workspaceId: requiredConnectorText(xpert.workspaceId, 'xpert.workspaceId')
+              } as const)
+
+        const availableBindings = await this.findBindings(bindingScope)
+        const bindingIds: string[] = []
+        for (const selection of configured) {
+            const binding = selection.bindingId
+                ? availableBindings.find((candidate) => candidate.id === selection.bindingId)
+                : availableBindings.find((candidate) => candidate.provider === selection.provider)
+            if (!binding || binding.provider !== selection.provider) {
+                throw new NotFoundException(
+                    t('server-ai:Error.ConnectorBindingNotFound', {
+                        defaultValue: `No '${selection.provider}' connector is configured for this runtime scope`
+                    })
+                )
+            }
+            bindingIds.push(binding.id)
+        }
+        // Reuse the selected-binding path for identity, scope, credential and
+        // active-connection checks instead of maintaining a second copy here.
+        return this.resolveSelectedRuntimeBindings(bindingIds, scope)
+    }
+
     async getRuntimeConnector(input: ConnectorRuntimeGetInput): Promise<ConnectorRuntimeCredential> {
         const runtime = await this.getRuntimeConnectorCredential(input)
         return this.projectLegacyRuntimeResponse(runtime)
@@ -2452,6 +2491,23 @@ function normalizeBindingIds(value?: string[] | null) {
     return Array.from(
         new Set((value ?? []).map((item) => (typeof item === 'string' ? item.trim() : '')).filter(Boolean))
     )
+}
+
+function normalizeConfiguredRuntimeConnectorSelections(
+    value?: ConfiguredRuntimeConnectorSelection[] | null
+): ConfiguredRuntimeConnectorSelection[] {
+    const providers = new Set<string>()
+    const result: ConfiguredRuntimeConnectorSelection[] = []
+    for (const item of value ?? []) {
+        const provider = typeof item?.provider === 'string' ? item.provider.trim() : ''
+        if (!provider || providers.has(provider)) {
+            continue
+        }
+        const bindingId = typeof item.bindingId === 'string' ? item.bindingId.trim() : ''
+        providers.add(provider)
+        result.push({ provider, ...(bindingId ? { bindingId } : {}) })
+    }
+    return result
 }
 
 function requiredConnectorText(value: unknown, field: string) {

--- a/packages/server-ai/src/shared/agent/middleware-runtime/middleware-runtime.service.ts
+++ b/packages/server-ai/src/shared/agent/middleware-runtime/middleware-runtime.service.ts
@@ -10,6 +10,7 @@ import {
     AgentMiddlewareModelProviderConnection,
     AgentMiddlewareRuntimeApi,
     AgentMiddlewareRuntimeScope,
+    type ConfiguredRuntimeConnectorSelection,
     AgentMiddlewareWrapWorkflowNodeExecutionParams,
     AgentMiddlewareWrapWorkflowNodeExecutionResult,
     ArtifactsRuntimeCapability,
@@ -87,6 +88,15 @@ export class AgentMiddlewareRuntimeService {
         return this.platformCapabilities
             .require(ConnectorRuntimeFactoryCapability)
             .resolveSelectedRuntimeBindings(scope.connectorBindingIds, scope)
+    }
+
+    resolveConfiguredConnectorRuntimeBindings(
+        selections: ConfiguredRuntimeConnectorSelection[] | null | undefined,
+        scope: AgentMiddlewareRuntimeScope
+    ) {
+        return this.platformCapabilities
+            .require(ConnectorRuntimeFactoryCapability)
+            .resolveConfiguredRuntimeBindings(selections, scope)
     }
 
     /** Build the middleware runtime API and capability registry for one invocation. */

--- a/packages/server-ai/src/shared/agent/middleware.ts
+++ b/packages/server-ai/src/shared/agent/middleware.ts
@@ -23,6 +23,7 @@ import { SKILLS_MIDDLEWARE_NAME } from '../../skill-package/types'
 import { isRuntimeCapabilitiesAllowlist } from './runtime-capabilities'
 
 const normalizeNodeKey = (key: string) => key?.split('/')?.[0]
+const CONNECTOR_MIDDLEWARE_NAME = 'ConnectorMiddleware'
 
 function isSkillsMiddlewareNode(node?: TXpertTeamNode | null) {
     const entity = node?.entity as unknown as IWFNMiddleware | undefined
@@ -105,7 +106,7 @@ export function getRuntimeEnabledMiddlewareNodes(
         }
 
         const provider = normalizeMiddlewareProvider(entity?.provider)
-        return hasSelectedSkills && provider === SKILLS_MIDDLEWARE_NAME
+        return provider === CONNECTOR_MIDDLEWARE_NAME || (hasSelectedSkills && provider === SKILLS_MIDDLEWARE_NAME)
     })
 
     assertSingleSkillsMiddlewareConnection(agent.key, runtimeEnabledMiddlewares)

--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
@@ -153,7 +153,9 @@ import { resolveEffectiveCopilotModel } from '../../effective-copilot-model'
 import { resolveToolRuntimeScope } from '../../../tool-runtime/workspace-scope'
 import {
     CONNECTOR_MIDDLEWARE_NAME,
-    connectorRuntimeMiddlewareProvider
+    connectorRuntimeMiddlewareProvider,
+    getConnectorMiddlewareProvider,
+    getConnectorMiddlewareSelection
 } from '../../../xpert-middleware/connector.middleware'
 
 const XPERT_TITLE_MIDDLEWARE_NODE_KEY = '__xpert_title_middleware__'
@@ -789,7 +791,7 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
         })
         const usageRecorder = createExecutionModelUsageRecorder(resolveExecutionId, persistExecutionUsage)
         const connectorBindingIds = getRuntimeConnectorBindingIds(options.runtimeCapabilities)
-        const middlewareRuntimeScope: AgentMiddlewareRuntimeScope = {
+        const middlewareRuntimeScopeBase: AgentMiddlewareRuntimeScope = {
             tenantId: runtimeXpert.tenantId,
             organizationId: runtimeOrganizationId,
             userId: runtimeUserId,
@@ -809,8 +811,31 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
             workspaceRoot: options.workspaceRoot,
             workspacePath: options.workspacePath
         }
-        const selectedRuntimeConnectorBindings =
-            await this.agentMiddlewareRuntimeService.resolveSelectedConnectorRuntimeBindings(middlewareRuntimeScope)
+        const explicitlySelectedRuntimeConnectorBindings =
+            await this.agentMiddlewareRuntimeService.resolveSelectedConnectorRuntimeBindings(middlewareRuntimeScopeBase)
+        const explicitlySelectedProviders = new Set(
+            explicitlySelectedRuntimeConnectorBindings.map((binding) => binding.provider)
+        )
+        const configuredConnectorSelections = visibleMiddlewareNodes
+            .map((node) => getConnectorMiddlewareSelection(node.entity as IWFNMiddleware))
+            .filter((selection): selection is NonNullable<typeof selection> => Boolean(selection))
+            .filter((selection) => !explicitlySelectedProviders.has(selection.provider))
+        const configuredRuntimeConnectorBindings =
+            await this.agentMiddlewareRuntimeService.resolveConfiguredConnectorRuntimeBindings(
+                configuredConnectorSelections,
+                middlewareRuntimeScopeBase
+            )
+        const selectedRuntimeConnectorBindings = [
+            ...explicitlySelectedRuntimeConnectorBindings,
+            ...configuredRuntimeConnectorBindings
+        ]
+        const middlewareRuntimeScope: AgentMiddlewareRuntimeScope = {
+            ...middlewareRuntimeScopeBase,
+            connectorBindingIds: selectedRuntimeConnectorBindings.map((binding) => binding.bindingId)
+        }
+        const selectedRuntimeConnectorProviders = new Set(
+            selectedRuntimeConnectorBindings.map((binding) => binding.provider)
+        )
         const middlewareRuntime = this.agentMiddlewareRuntimeService.createScopedApi(middlewareRuntimeScope)
         const middlewareContext: Omit<IAgentMiddlewareContext, 'node'> = {
             tenantId: runtimeXpert.tenantId,
@@ -907,7 +932,13 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
             const entity = node.entity as IWFNMiddleware
             const isGraphConnectorMiddleware =
                 normalizeMiddlewareProvider(entity.provider) === CONNECTOR_MIDDLEWARE_NAME
-            if (isRuntimeCapabilitiesAllowlist(options.runtimeCapabilities) && isGraphConnectorMiddleware) {
+            const isSelectedRuntimeConnectorProvider = selectedRuntimeConnectorProviders.has(
+                getConnectorMiddlewareProvider(entity) ?? ''
+            )
+            if (
+                isGraphConnectorMiddleware &&
+                (isRuntimeCapabilitiesAllowlist(options.runtimeCapabilities) || isSelectedRuntimeConnectorProvider)
+            ) {
                 return entries
             }
             const middleware = visibleAgentMiddlewares[index]

--- a/packages/server-ai/src/xpert-middleware/connector.middleware.ts
+++ b/packages/server-ai/src/xpert-middleware/connector.middleware.ts
@@ -1,4 +1,4 @@
-import { TAgentMiddlewareMeta } from '@xpert-ai/contracts'
+import { IWFNMiddleware, normalizeMiddlewareProvider, TAgentMiddlewareMeta } from '@xpert-ai/contracts'
 import {
     AgentMiddleware,
     AgentMiddlewareRegistry,
@@ -103,6 +103,22 @@ export class ConnectorMiddleware implements IAgentMiddlewareStrategy<ConnectorMi
 
 export function connectorRuntimeMiddlewareProvider(provider: string) {
     return `${CONNECTOR_RUNTIME_MIDDLEWARE_PREFIX}${provider}`
+}
+
+export function getConnectorMiddlewareProvider(node: Pick<IWFNMiddleware, 'provider' | 'options'>) {
+    return getConnectorMiddlewareSelection(node)?.provider ?? null
+}
+
+export function getConnectorMiddlewareSelection(node: Pick<IWFNMiddleware, 'provider' | 'options'>) {
+    if (normalizeMiddlewareProvider(node.provider) !== CONNECTOR_MIDDLEWARE_NAME) {
+        return null
+    }
+    const provider = normalizeConfigValue(node.options?.provider)
+    if (!provider) {
+        return null
+    }
+    const bindingId = normalizeConfigValue(node.options?.connectorId)
+    return { provider, ...(bindingId ? { bindingId } : {}) }
 }
 
 function normalizeConnectorMiddleware(middleware: AgentMiddleware): AgentMiddleware {


### PR DESCRIPTION
## Summary

- Fix the regression introduced by the September 1 project/flow Connector changes.
- Restore automatic runtime authorization for ConnectorMiddleware nodes in published Agent graphs.
- Resolve provider-only or graph-pinned Connector bindings in the current project/workspace scope.
- Reuse the existing selected-binding resolver for identity, tenant/organization, Xpert/project access, personal/shared credentials, and active-connection checks.
- Remove the duplicate configured-binding permission and connection validation path.

## User-visible behavior

When an Agent graph contains a ConnectorMiddleware node, runtime authorization is resolved automatically from the graph configuration. Users do not need to manually select a Connector in Preview/Composer for this flow. Preview/Composer manual Connector selection changes are intentionally not included in this PR.

## Regression fixed

On September 1, the project/flow Connector changes caused ConnectorMiddleware nodes in Agent graphs to fail to enter a valid Connector runtime. This PR restores the runtime path while keeping the existing access and credential protections as the single source of truth.

## Tests

- ConnectorService: 63 passed, including provider-only resolution, resolver delegation, and inactive-credential rejection tests.
- Existing Connector middleware and middleware-runtime coverage remains unchanged.

## Related

- xpert-plugins Connector provider changes: PR #616.