### PR TITLE
fix: register missing entities for standalone schema sync

### DIFF
--- a/packages/server-ai/src/core/entities/index.spec.ts
+++ b/packages/server-ai/src/core/entities/index.spec.ts
@@ -3,6 +3,10 @@ import { DataSource } from 'typeorm'
 import { XpertProjectInvitation, XpertProjectMembership } from './internal'
 import { ALL_AI_ENTITIES } from '.'
 import * as WikiEntities from '../../knowledgebase/wiki/entities'
+import * as DocumentLifecycleEntities from '../../knowledge-document/deletion'
+import * as GraphEntities from '../../graphrag/entities'
+import { MCP_PUBLICATION_ENTITIES, McpApiKey } from '../../mcp-publication/entities'
+import { ModelUsageDeliveryReceipt } from '../../copilot-usage/model-usage/model-usage-delivery-receipt.entity'
 
 class MetadataDataSource extends DataSource {
     buildMetadata() {
@@ -11,6 +15,43 @@ class MetadataDataSource extends DataSource {
 }
 
 describe('ALL_AI_ENTITIES', () => {
+    it.each([
+        ['GraphRAG', Object.values(GraphEntities)],
+        ['document lifecycle', Object.values(DocumentLifecycleEntities)],
+        ['MCP publication', MCP_PUBLICATION_ENTITIES],
+        ['model usage delivery', [ModelUsageDeliveryReceipt]]
+    ])('registers %s entities for standalone schema-sync', (_name, entities) => {
+        expect(ALL_AI_ENTITIES).toEqual(expect.arrayContaining(entities))
+    })
+
+    it('builds the missing deployment tables and MCP secret column without duplicate entities', async () => {
+        const dataSource = new MetadataDataSource({
+            type: 'postgres',
+            database: 'xpert',
+            entities: [...coreEntities, ...ALL_AI_ENTITIES]
+        })
+
+        await dataSource.buildMetadata()
+        expect(new Set(ALL_AI_ENTITIES).size).toBe(ALL_AI_ENTITIES.length)
+        expect(dataSource.entityMetadatas.map((metadata) => metadata.tableName)).toEqual(
+            expect.arrayContaining([
+                'knowledge_graph_entity_contribution',
+                'knowledge_graph_relation_contribution',
+                'knowledge_document_deletion_intent',
+                'knowledge_document_deletion_cleanup_receipt',
+                'knowledge_document_publication_attempt',
+                'knowledge_document_publication_attempt_source',
+                'model_usage_delivery_receipt',
+                'mcp_publication_access'
+            ])
+        )
+        expect(dataSource.getMetadata(McpApiKey).findColumnWithPropertyName('encryptedSecret')).toMatchObject({
+            type: 'text',
+            isNullable: true,
+            isSelect: false
+        })
+    })
+
     it('registers all Wiki entities for the standalone schema-sync command', () => {
         expect(ALL_AI_ENTITIES).toEqual(expect.arrayContaining(Object.values(WikiEntities)))
     })

--- a/packages/server-ai/src/core/entities/index.ts
+++ b/packages/server-ai/src/core/entities/index.ts
@@ -1,5 +1,14 @@
 import { KnowledgeIdentity } from '../../knowledgebase/identity/knowledge-identity.entity'
 import { KnowledgeIdentityObservation } from '../../knowledgebase/identity/knowledge-identity-observation.entity'
+import { ModelUsageDeliveryReceipt } from '../../copilot-usage/model-usage/model-usage-delivery-receipt.entity'
+import { KnowledgeGraphEntityContribution, KnowledgeGraphRelationContribution } from '../../graphrag/entities'
+import {
+    KnowledgeDocumentDeletionIntent,
+    KnowledgeDocumentDeletionCleanupReceipt,
+    KnowledgeDocumentPublicationAttempt,
+    KnowledgeDocumentPublicationAttemptSource
+} from '../../knowledge-document/deletion'
+import { MCP_PUBLICATION_ENTITIES } from '../../mcp-publication/entities'
 import {
     KnowledgeWikiJob,
     KnowledgeWikiModelInvocation,
@@ -107,6 +116,14 @@ import {
 } from './internal'
 
 export const ALL_AI_ENTITIES = [
+    ModelUsageDeliveryReceipt,
+    KnowledgeGraphEntityContribution,
+    KnowledgeGraphRelationContribution,
+    KnowledgeDocumentDeletionIntent,
+    KnowledgeDocumentDeletionCleanupReceipt,
+    KnowledgeDocumentPublicationAttempt,
+    KnowledgeDocumentPublicationAttemptSource,
+    ...MCP_PUBLICATION_ENTITIES,
     KnowledgeIdentity,
     KnowledgeIdentityObservation,
     KnowledgeWikiJob,


### PR DESCRIPTION
Standalone schema sync omitted GraphRAG contribution, document lifecycle, model usage delivery, and MCP publication entities. Deployments using external schema sync could start successfully while leaving eight new tables and the MCP API key encrypted-secret column absent.

Register these entities in ALL_AI_ENTITIES, reuse the complete MCP publication entity collection, and add regression coverage for registration, relation metadata, duplicate entries, and the MCP secret column.

Validation: 14 focused tests passed across entity metadata and the standalone schema-sync command; Prettier and git diff checks passed. The test deployment's existing schema gaps were repaired separately with additive SQL and verified. This PR contains only the entity registry and its tests.
