### PR TITLE
fix: restore graph connector runtime access

### DIFF
--- a/.changeset/restore-graph-connector-runtime.md
+++ b/.changeset/restore-graph-connector-runtime.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-sdk': patch
+---
+
+Allow host-enabled graph Connector providers in scoped runtime credentials while preserving explicit binding checks. Existing Connector APIs remain compatible.

--- a/packages/plugin-sdk/src/lib/agent/middleware/runtime.ts
+++ b/packages/plugin-sdk/src/lib/agent/middleware/runtime.ts
@@ -18,7 +18,7 @@ import {
 import { Subscriber } from 'rxjs'
 import { AIGCModelClient, AsyncAIGCModelClient, IRerank, TLLMUsage } from '../../ai-model/types'
 import type { RuntimeCapabilityRegistry } from '../../core'
-import type { RuntimeIdentityScope } from '../../runtime/runtime-scope'
+import type { ConnectorRuntimeScope } from '../../connector/runtime-capability'
 import type { WorkspaceFileCatalog } from '../../runtime/capabilities/workspace-files'
 
 export * from './runtime-capability'
@@ -119,7 +119,7 @@ export type AgentMiddlewareModelProviderConnection = {
   reportUsage(report: ModelUsageReport, modelAccess?: IModelAccessResolution): Promise<ModelUsageReportResult>
 }
 
-export type AgentMiddlewareRuntimeScope = RuntimeIdentityScope & {
+export type AgentMiddlewareRuntimeScope = ConnectorRuntimeScope & {
   providerScopeId?: string | null
   /** Authoritative Volume catalog for runtime workspace files. */
   catalog?: WorkspaceFileCatalog | null
@@ -127,8 +127,6 @@ export type AgentMiddlewareRuntimeScope = RuntimeIdentityScope & {
   scopeId?: string | null
   /** Legacy xperts catalog compatibility flag; new runtimes use user-xperts instead. */
   isolateByUser?: boolean | null
-  /** Connector bindings selected for this conversation. An empty list denies connector resolution. */
-  connectorBindingIds?: string[] | null
   usageCallback?: (usage: TLLMUsage) => void | Promise<void>
   workspaceRoot?: string | null
   workspacePath?: string | null

--- a/packages/plugin-sdk/src/lib/connector/runtime-capability.ts
+++ b/packages/plugin-sdk/src/lib/connector/runtime-capability.ts
@@ -6,15 +6,18 @@ export const ConnectorRuntimeCapability = createRuntimeCapability<ConnectorRunti
   description: 'Resolve connector credentials for agent middleware.'
 })
 
+/** No binding or provider grants means no connector access. */
 export type ConnectorRuntimeScope = RuntimeIdentityScope & {
-  /** Host-selected binding IDs. Missing or empty means no connector access. */
+  /** Host-selected bindings, including IDs pinned by enabled graph Connector nodes. */
   connectorBindingIds?: string[] | null
+  /** Providers configured by enabled graph Connector nodes without a pinned ID. */
+  connectorProviders?: string[] | null
 }
 
 export type SelectedRuntimeConnectorBinding = { bindingId: string; provider: string }
 
 export interface ConnectorRuntimeFactory {
-  /** Snapshot the authorized identity and selected binding IDs for this runtime. */
+  /** Snapshot the authorized identity and connector grants for this runtime. */
   createScopedApi(scope: ConnectorRuntimeScope): ConnectorRuntimeApi
   /** Preflight selected bindings through the same identity, project and credential checks. */
   resolveSelectedRuntimeBindings(
@@ -25,5 +28,5 @@ export interface ConnectorRuntimeFactory {
 
 export const ConnectorRuntimeFactoryCapability = createRuntimeCapability<ConnectorRuntimeFactory>(
   'platform.connector.factory',
-  { description: 'Create a connector API restricted to host-selected bindings and the authorized execution identity.' }
+  { description: 'Create a connector API restricted to host-granted connectors and the authorized execution identity.' }
 )

--- a/packages/server-ai/src/connector/connector.service.spec.ts
+++ b/packages/server-ai/src/connector/connector.service.spec.ts
@@ -1,9 +1,9 @@
-import { BadRequestException, ForbiddenException } from '@nestjs/common'
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common'
 import { PARAMTYPES_METADATA, SELF_DECLARED_DEPS_METADATA } from '@nestjs/common/constants'
 import { ModuleRef } from '@nestjs/core'
 import { RequestContext, encryptSecret } from '@xpert-ai/server-core'
 import { environment } from '@xpert-ai/server-config'
-import type { ConnectorStrategyRuntime } from '@xpert-ai/plugin-sdk'
+import type { ConnectorAuthorizationMode, ConnectorScope, ConnectorStrategyRuntime } from '@xpert-ai/plugin-sdk'
 import { FindOperator, type FindOptionsWhere } from 'typeorm'
 import { PublishedXpertAccessService } from '../xpert/published-xpert-access.service'
 import { XpertProjectAccessService } from '../xpert-project/services/project-access.service'
@@ -2015,6 +2015,144 @@ describe('ConnectorService', () => {
                 }
             )
         ).rejects.toBeInstanceOf(ForbiddenException)
+    })
+
+    describe('graph Connector provider resolution', () => {
+        const runtimeScope = () => ({
+            tenantId: 'tenant-1',
+            organizationId: 'org-1',
+            userId: 'user-1',
+            workspaceId: 'workspace-1',
+            xpertId: 'xpert-1',
+            conversationId: 'conversation-1',
+            executionId: 'execution-1',
+            connectorProviders: ['example'],
+            connectorBindingIds: [] as string[]
+        })
+
+        async function connectTestBinding(
+            scope: ConnectorScope = { type: 'workspace', workspaceId: 'workspace-1' },
+            authorizationMode: ConnectorAuthorizationMode = 'shared'
+        ) {
+            strategy.definition = { ...strategy.definition, authorizationModes: ['shared', 'personal'] }
+            const binding = await service.createBinding({
+                scope,
+                provider: 'example',
+                authorizationMode
+            })
+            await service.connectBinding(binding.id, { redirectUri: 'https://xpert.test/callback', xpertId: 'xpert-1' })
+            const state = (strategy.buildAuthorizationUrl as jest.Mock).mock.calls[0][0].state
+            await service.completeOAuthCallback({ state, code: 'code' })
+            return binding
+        }
+
+        it('restores the legacy provider-only getConnector call for a host-enabled graph node', async () => {
+            const binding = await connectTestBinding()
+            await expect(
+                service
+                    .createScopedApi(runtimeScope())
+                    .getConnector({ workspaceId: 'workspace-1', provider: 'example' })
+            ).resolves.toEqual(expect.objectContaining({ connectorId: binding.id, accessToken: 'uat_secret' }))
+            expect(runtimeAudits.items).toEqual([
+                expect.objectContaining({ connectorId: binding.id, actorUserId: 'user-1', outcome: 'resolved' })
+            ])
+        })
+
+        it('does not grant provider lookup to an absent or disabled graph node', async () => {
+            await connectTestBinding()
+            const scope = { ...runtimeScope(), connectorProviders: [] }
+            await expect(service.getRuntimeConnectorForScope({ provider: 'example' }, scope)).rejects.toBeInstanceOf(
+                ForbiddenException
+            )
+        })
+
+        it('keeps pinned IDs exact and never falls back to the allowed provider', async () => {
+            const binding = await connectTestBinding()
+            const scope = { ...runtimeScope(), connectorBindingIds: [binding.id, 'missing-binding'] }
+            await expect(
+                service.getRuntimeConnectorForScope({ provider: 'example', connectorId: binding.id }, scope)
+            ).resolves.toEqual(expect.objectContaining({ connectorId: binding.id }))
+            await expect(
+                service.getRuntimeConnectorForScope({ provider: 'example', connectorId: 'unselected-binding' }, scope)
+            ).rejects.toBeInstanceOf(ForbiddenException)
+            await expect(
+                service.getRuntimeConnectorForScope({ provider: 'example', connectorId: 'missing-binding' }, scope)
+            ).rejects.toBeInstanceOf(NotFoundException)
+        })
+
+        it('uses the authorized Xpert workspace instead of a caller-supplied workspace', async () => {
+            const binding = await connectTestBinding()
+            await expect(
+                service.getRuntimeConnectorForScope(
+                    { provider: 'example', workspaceId: 'other-workspace' },
+                    { ...runtimeScope(), workspaceId: 'other-workspace' }
+                )
+            ).resolves.toEqual(expect.objectContaining({ connectorId: binding.id, workspaceId: 'workspace-1' }))
+        })
+
+        it('never falls back to a Workspace connector during a Project run', async () => {
+            await connectTestBinding()
+            await expect(
+                service.getRuntimeConnectorForScope(
+                    { provider: 'example' },
+                    { ...runtimeScope(), projectId: 'project-1' }
+                )
+            ).rejects.toBeInstanceOf(NotFoundException)
+        })
+
+        it.each(['shared', 'personal'] as const)('resolves Project providers with %s authorization', async (mode) => {
+            const binding = await connectTestBinding({ type: 'project', projectId: 'project-1' }, mode)
+            const scope = { ...runtimeScope(), projectId: 'project-1' }
+            await expect(service.getRuntimeConnectorForScope({ provider: 'example' }, scope)).resolves.toEqual(
+                expect.objectContaining({ bindingId: binding.id, projectId: 'project-1', authorizationMode: mode })
+            )
+            projectAccess.assertCanUseXpert.mockRejectedValueOnce(new ForbiddenException())
+            await expect(service.getRuntimeConnectorForScope({ provider: 'example' }, scope)).rejects.toBeInstanceOf(
+                ForbiddenException
+            )
+            if (mode === 'personal') {
+                currentUserId = 'user-2'
+                await expect(
+                    service.getRuntimeConnectorForScope({ provider: 'example' }, { ...scope, userId: 'user-2' })
+                ).rejects.toThrow()
+                personalGrants.items.splice(0)
+                currentUserId = 'user-1'
+                await expect(service.getRuntimeConnectorForScope({ provider: 'example' }, scope)).rejects.toThrow()
+            }
+        })
+
+        it('denies shared Workspace credentials to a non-member even with a graph provider grant', async () => {
+            await connectTestBinding()
+            currentUserId = 'user-2'
+            await expect(
+                service.getRuntimeConnectorForScope({ provider: 'example' }, { ...runtimeScope(), userId: 'user-2' })
+            ).rejects.toBeInstanceOf(ForbiddenException)
+        })
+
+        it.each(['user', 'organization', 'xpert', 'inactive'])('retains the %s access check', async (denied) => {
+            const binding = await connectTestBinding()
+            const scope = runtimeScope()
+            if (denied === 'user') currentUserId = 'user-2'
+            if (denied === 'organization') scope.organizationId = 'other-org'
+            if (denied === 'xpert')
+                publishedXpertAccess.getAccessiblePublishedXpert.mockRejectedValue(new ForbiddenException())
+            if (denied === 'inactive') connectors.items.find((item) => item.id === binding.id)!.status = 'disconnected'
+            await expect(service.getRuntimeConnectorForScope({ provider: 'example' }, scope)).rejects.toThrow()
+        })
+
+        it('snapshots provider grants when the scoped API is created', async () => {
+            await connectTestBinding()
+            const scope = runtimeScope()
+            const api = service.createScopedApi(scope)
+            scope.connectorProviders.length = 0
+            await expect(api.getConnector({ provider: 'example' })).resolves.toEqual(
+                expect.objectContaining({ accessToken: 'uat_secret' })
+            )
+            const deniedScope = { ...runtimeScope(), connectorProviders: [] as string[] }
+            const deniedApi = service.createScopedApi(deniedScope)
+            deniedScope.connectorProviders.push('example')
+            await expect(deniedApi.getConnector({ provider: 'example' })).rejects.toBeInstanceOf(ForbiddenException)
+        })
     })
 
     it('returns only Project bindings and sanitized auth forms in Project runtime options', async () => {

--- a/packages/server-ai/src/connector/connector.service.ts
+++ b/packages/server-ai/src/connector/connector.service.ts
@@ -1503,7 +1503,11 @@ export class ConnectorService implements ConnectorRuntimeFactory {
     }
 
     createScopedApi(scope: ConnectorRuntimeScope): ConnectorRuntimeApi {
-        scope = { ...scope, connectorBindingIds: [...(scope.connectorBindingIds ?? [])] }
+        scope = {
+            ...scope,
+            connectorBindingIds: [...(scope.connectorBindingIds ?? [])],
+            connectorProviders: [...(scope.connectorProviders ?? [])]
+        }
         return {
             getConnector: (input) => this.getRuntimeConnectorForScope(input, scope),
             getConnectorCredential: (input) => this.getRuntimeConnectorCredentialForScope(input, scope)
@@ -1596,11 +1600,20 @@ export class ConnectorService implements ConnectorRuntimeFactory {
     ): Promise<ConnectorRuntimeCredentialV2> {
         const bindingIds = normalizeBindingIds(scope.connectorBindingIds)
         const requestedBindingId = input.bindingId ?? input.connectorId
-        if (!requestedBindingId || !bindingIds.includes(requestedBindingId)) {
+        // Legacy graph nodes pass only a provider. The host must explicitly
+        // enable that provider; a supplied ID always keeps the exact-ID path.
+        const authorized =
+            requestedBindingId != null
+                ? bindingIds.includes(requestedBindingId)
+                : Boolean(input.provider && scope.connectorProviders?.includes(input.provider))
+        if (!authorized) {
             throw new ForbiddenException(connectorAccessDeniedMessage())
         }
         this.assertRuntimeIdentityScope(scope)
-        const binding = await this.requireBinding(requestedBindingId, scope.tenantId ?? undefined)
+        const binding =
+            requestedBindingId != null
+                ? await this.requireBinding(requestedBindingId, scope.tenantId ?? undefined)
+                : await this.requireRuntimeProviderBinding(requiredConnectorText(input.provider, 'provider'), scope)
         let connection: BindingConnection | null = null
         try {
             if (input.provider && input.provider !== binding.provider) {
@@ -1624,6 +1637,24 @@ export class ConnectorService implements ConnectorRuntimeFactory {
             )
             throw error
         }
+    }
+
+    private async requireRuntimeProviderBinding(provider: string, scope: ConnectorRuntimeScope) {
+        const xpert = await this.assertXpertRunAccess(requiredConnectorText(scope.xpertId, 'runtime.xpertId'))
+        if (!scope.projectId) {
+            return this.requireConnector({
+                workspaceId: requiredConnectorText(xpert.workspaceId, 'xpert.workspaceId'),
+                provider
+            })
+        }
+        const bindings = await this.findBindings({ type: 'project', projectId: scope.projectId })
+        const binding = bindings.find((candidate) => candidate.provider === provider)
+        if (!binding) {
+            throw new NotFoundException(
+                t('server-ai:Error.ConnectorBindingNotFound', { defaultValue: 'Connector binding was not found' })
+            )
+        }
+        return binding
     }
 
     private async resolveRuntimeCredential(connection: BindingConnection): Promise<ConnectorRuntimeCredentialV2> {

--- a/packages/server-ai/src/shared/agent/connector-runtime.spec.ts
+++ b/packages/server-ai/src/shared/agent/connector-runtime.spec.ts
@@ -1,0 +1,72 @@
+import { ForbiddenException } from '@nestjs/common'
+import { IWFNMiddleware, IXpertAgent, TXpertGraph, TXpertTeamNode, WorkflowNodeTypeEnum } from '@xpert-ai/contracts'
+import { getConnectorMiddlewareScope } from './connector-runtime'
+import { getRuntimeEnabledMiddlewareNodes } from './middleware'
+
+function connectorNode(key: string, provider: string, connectorId?: string, required = false): TXpertTeamNode {
+    const entity: IWFNMiddleware = {
+        id: key,
+        key,
+        type: WorkflowNodeTypeEnum.MIDDLEWARE,
+        provider: 'ConnectorMiddleware',
+        options: { provider, ...(connectorId ? { connectorId } : {}) },
+        required
+    }
+    return { key, type: 'workflow', entity, position: { x: 0, y: 0 } }
+}
+
+describe('graph Connector runtime scope', () => {
+    it('keeps optional Connector activation and middleware ordering unchanged', () => {
+        const nodes = [connectorNode('optional', 'lark'), connectorNode('required', 'github', undefined, true)]
+        const graph = {
+            nodes,
+            connections: nodes.map(({ key }) => ({ type: 'workflow', from: 'agent-1', to: key }))
+        } as TXpertGraph
+        const agent = { key: 'agent-1', options: { middlewares: { order: ['required', 'optional'] } } } as IXpertAgent
+        const capabilities = { mode: 'allowlist' as const, skills: { ids: [] }, plugins: { nodeKeys: [] as string[] } }
+        const selected = getRuntimeEnabledMiddlewareNodes(graph, agent, { runtimeCapabilities: capabilities })
+        expect(selected.map(({ key }) => key)).toEqual(['required'])
+        expect(getConnectorMiddlewareScope(selected, []).connectorProviders).toEqual(['github'])
+        capabilities.plugins.nodeKeys.push('optional')
+        expect(
+            getRuntimeEnabledMiddlewareNodes(graph, agent, { runtimeCapabilities: capabilities }).map(({ key }) => key)
+        ).toEqual(['required', 'optional'])
+        expect(getRuntimeEnabledMiddlewareNodes(graph, agent).map(({ key }) => key)).toEqual(['required', 'optional'])
+    })
+
+    it('grants exact graph pins without enabling unrestricted lookup by provider', () => {
+        expect(getConnectorMiddlewareScope([connectorNode('lark-node', 'lark', 'lark-1')], [])).toEqual({
+            connectorBindingIds: ['lark-1'],
+            connectorProviders: [],
+            additionalBindings: []
+        })
+    })
+
+    it('deduplicates a selected binding against its graph node and retains graphless selections', () => {
+        const bindings = [
+            { bindingId: 'lark-1', provider: 'lark' },
+            { bindingId: 'github-1', provider: 'github' }
+        ]
+        const result = getConnectorMiddlewareScope([connectorNode('lark-node', 'lark', 'lark-1')], bindings)
+        expect(result.connectorBindingIds).toEqual(['lark-1', 'github-1'])
+        expect(result.additionalBindings).toEqual([bindings[1]])
+    })
+
+    it('rejects a manual binding that conflicts with a graph pin', () => {
+        expect(() =>
+            getConnectorMiddlewareScope(
+                [connectorNode('lark-node', 'lark', 'pinned-lark')],
+                [{ bindingId: 'other-lark', provider: 'lark' }]
+            )
+        ).toThrow(ForbiddenException)
+    })
+
+    it('rejects two conflicting graph pins instead of silently keeping the first provider', () => {
+        expect(() =>
+            getConnectorMiddlewareScope(
+                [connectorNode('first', 'lark', 'lark-1'), connectorNode('second', 'lark', 'lark-2')],
+                []
+            )
+        ).toThrow(ForbiddenException)
+    })
+})

--- a/packages/server-ai/src/shared/agent/connector-runtime.ts
+++ b/packages/server-ai/src/shared/agent/connector-runtime.ts
@@ -1,0 +1,53 @@
+import { ForbiddenException } from '@nestjs/common'
+import { IWFNMiddleware, normalizeMiddlewareProvider, TXpertTeamNode, WorkflowNodeTypeEnum } from '@xpert-ai/contracts'
+import type { SelectedRuntimeConnectorBinding } from '@xpert-ai/plugin-sdk'
+import { t } from 'i18next'
+import { CONNECTOR_MIDDLEWARE_NAME } from '../../xpert-middleware/connector.middleware'
+
+/** Grant only enabled graph nodes; keep their middleware instances and exact pinned IDs. */
+export function getConnectorMiddlewareScope(
+    nodes: TXpertTeamNode[],
+    selectedBindings: SelectedRuntimeConnectorBinding[]
+) {
+    const connectorBindingIds = new Set(selectedBindings.map(({ bindingId }) => bindingId))
+    const connectorProviders = new Set<string>()
+    const graphProviders = new Set<string>()
+    const pinnedBindings = new Map(selectedBindings.map(({ provider, bindingId }) => [provider, bindingId]))
+
+    for (const node of nodes) {
+        if (node.type !== 'workflow' || node.entity.type !== WorkflowNodeTypeEnum.MIDDLEWARE) {
+            continue
+        }
+        const entity = node.entity as IWFNMiddleware
+        if (normalizeMiddlewareProvider(entity.provider) !== CONNECTOR_MIDDLEWARE_NAME) {
+            continue
+        }
+        const provider = typeof entity.options?.provider === 'string' ? entity.options.provider.trim() : ''
+        const connectorId = typeof entity.options?.connectorId === 'string' ? entity.options.connectorId.trim() : ''
+        if (!provider) continue
+
+        graphProviders.add(provider)
+        if (connectorId) {
+            const existing = pinnedBindings.get(provider)
+            if (existing && existing !== connectorId) {
+                throw new ForbiddenException(
+                    t('server-ai:Error.ConnectorAccessDenied', {
+                        defaultValue: 'Connector access is not available in the current scope'
+                    })
+                )
+            }
+            pinnedBindings.set(provider, connectorId)
+            connectorBindingIds.add(connectorId)
+        } else {
+            connectorProviders.add(provider)
+        }
+    }
+
+    return {
+        connectorBindingIds: [...connectorBindingIds],
+        connectorProviders: [...connectorProviders],
+        // One provider has one binding per scope. Its existing graph node owns
+        // tool preferences and ordering; only graphless selections need a builtin.
+        additionalBindings: selectedBindings.filter(({ provider }) => !graphProviders.has(provider))
+    }
+}

--- a/packages/server-ai/src/shared/agent/middleware-runtime/middleware-runtime.service.ts
+++ b/packages/server-ai/src/shared/agent/middleware-runtime/middleware-runtime.service.ts
@@ -91,7 +91,11 @@ export class AgentMiddlewareRuntimeService {
 
     /** Build the middleware runtime API and capability registry for one invocation. */
     createScopedApi(scope: AgentMiddlewareRuntimeScope = {}): AgentMiddlewareRuntimeApi {
-        scope = { ...scope, connectorBindingIds: [...(scope.connectorBindingIds ?? [])] }
+        scope = {
+            ...scope,
+            connectorBindingIds: [...(scope.connectorBindingIds ?? [])],
+            connectorProviders: [...(scope.connectorProviders ?? [])]
+        }
         const workspaceFilesApi = hasBoundRuntimeWorkspaceScope(scope)
             ? this.workspaceFiles.createScopedApi(scope)
             : null

--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.spec.ts
@@ -25,7 +25,7 @@ import {
 import type { CommandBus, QueryBus } from '@nestjs/cqrs'
 import { z } from 'zod'
 import type { AgentMiddlewareRuntimeService } from '../../../shared/agent/middleware-runtime/index'
-import { RequestContext } from '@xpert-ai/plugin-sdk'
+import { IAgentMiddlewareContext, RequestContext } from '@xpert-ai/plugin-sdk'
 import { FILE_UNDERSTANDING_MIDDLEWARE_NAME } from '../../../file-understanding/middlewares'
 import { setModelVisionSupport } from '../../../copilot-model/model-capabilities'
 import { STATE_VARIABLE_PENDING_FOLLOW_UPS } from '../../../shared/agent/state'
@@ -1146,7 +1146,8 @@ describe('XpertAgentSubgraphHandler file understanding middleware', () => {
     function createHandler(
         graph: TestGraph,
         registryGet = jest.fn(),
-        selectedRuntimeBindings: Array<{ bindingId: string; provider: string }> = []
+        selectedRuntimeBindings: Array<{ bindingId: string; provider: string }> = [],
+        createScopedApi = jest.fn().mockReturnValue({})
     ) {
         const commandBus = {
             execute: jest.fn(async (command) => {
@@ -1188,7 +1189,7 @@ describe('XpertAgentSubgraphHandler file understanding middleware', () => {
             null,
             null,
             {
-                createScopedApi: jest.fn().mockReturnValue({}),
+                createScopedApi,
                 resolveSelectedConnectorRuntimeBindings: jest.fn().mockResolvedValue(selectedRuntimeBindings)
             } as unknown as AgentMiddlewareRuntimeService,
             { findOne: jest.fn(async (id: string) => ({ id })) } as never
@@ -1293,6 +1294,72 @@ describe('XpertAgentSubgraphHandler file understanding middleware', () => {
             })
         )
     })
+
+    it.each([false, true])(
+        'preserves the graph Connector node with a repeated runtime selection: %s',
+        async (selected) => {
+            const { graph, command } = createCommand({ fileUnderstanding: { enabled: false } })
+            const connectorNode = {
+                type: 'workflow',
+                key: 'connector-1',
+                entity: {
+                    key: 'connector-1',
+                    type: WorkflowNodeTypeEnum.MIDDLEWARE,
+                    provider: 'ConnectorMiddleware',
+                    required: true,
+                    options: { provider: 'github' },
+                    tools: { disabled_tool: { enabled: false } }
+                }
+            }
+            const runtimeGraph = {
+                nodes: [...graph.nodes, connectorNode],
+                connections: [{ type: 'workflow', from: 'agent-1', to: 'connector-1' }]
+            }
+            command.options.runtimeCapabilities = {
+                mode: 'allowlist',
+                skills: { ids: [] },
+                plugins: { nodeKeys: [] },
+                connectors: { bindingIds: selected ? ['binding-1'] : [] }
+            }
+            const middleware = {
+                name: 'ConnectorMiddleware',
+                tools: ['enabled_tool', 'disabled_tool', 'user_disabled_tool'].map((name) =>
+                    tool(async () => '', { name, description: name, schema: z.object({}) })
+                )
+            }
+            command.options.toolPreferences = {
+                version: 1,
+                middlewares: {
+                    'connector-1': { provider: 'ConnectorMiddleware', disabledTools: ['user_disabled_tool'] }
+                }
+            }
+            let toolMap: IAgentMiddlewareContext['tools']
+            const createMiddleware = jest.fn((_options: unknown, context: IAgentMiddlewareContext) => {
+                toolMap = context.tools
+                return middleware
+            })
+            const registryGet = jest.fn().mockReturnValue({ meta: { name: 'ConnectorMiddleware' }, createMiddleware })
+            const createScopedApi = jest.fn().mockReturnValue({})
+            const handler = createHandler(
+                runtimeGraph,
+                registryGet,
+                selected ? [{ bindingId: 'binding-1', provider: 'github' }] : [],
+                createScopedApi
+            )
+
+            await handler.execute(command)
+
+            expect(createMiddleware).toHaveBeenCalledTimes(1)
+            expect(createMiddleware).toHaveBeenCalledWith(
+                { provider: 'github' },
+                expect.objectContaining({ node: expect.objectContaining({ key: 'connector-1', required: true }) })
+            )
+            expect(middleware.tools.map(({ name }) => name)).toEqual(['enabled_tool'])
+            expect([...toolMap.keys()]).toEqual(['enabled_tool'])
+            expect(createScopedApi).toHaveBeenCalledWith(expect.objectContaining({ connectorProviders: ['github'] }))
+            expect(registryGet).not.toHaveBeenCalledWith('ConnectorRuntime:github', undefined)
+        }
+    )
 })
 
 describe('XpertAgentSubgraphHandler invalid tool call diagnostics', () => {

--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
@@ -43,7 +43,6 @@ import {
     IXpertAgentExecution,
     KnowledgebaseChannel,
     mapTranslationLanguage,
-    normalizeMiddlewareProvider,
     STATE_VARIABLE_HUMAN,
     stringifyMessageContent,
     TAgentRunnableConfigurable,
@@ -151,10 +150,8 @@ import {
 } from './invalid-tool-call-diagnostics'
 import { resolveEffectiveCopilotModel } from '../../effective-copilot-model'
 import { resolveToolRuntimeScope } from '../../../tool-runtime/workspace-scope'
-import {
-    CONNECTOR_MIDDLEWARE_NAME,
-    connectorRuntimeMiddlewareProvider
-} from '../../../xpert-middleware/connector.middleware'
+import { connectorRuntimeMiddlewareProvider } from '../../../xpert-middleware/connector.middleware'
+import { getConnectorMiddlewareScope } from '../../../shared/agent/connector-runtime'
 
 const XPERT_TITLE_MIDDLEWARE_NODE_KEY = '__xpert_title_middleware__'
 const FILE_UNDERSTANDING_MIDDLEWARE_NODE_KEY = '__file_understanding_middleware__'
@@ -811,7 +808,14 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
         }
         const selectedRuntimeConnectorBindings =
             await this.agentMiddlewareRuntimeService.resolveSelectedConnectorRuntimeBindings(middlewareRuntimeScope)
-        const middlewareRuntime = this.agentMiddlewareRuntimeService.createScopedApi(middlewareRuntimeScope)
+        const { additionalBindings, ...connectorScope } = getConnectorMiddlewareScope(
+            visibleMiddlewareNodes,
+            selectedRuntimeConnectorBindings
+        )
+        const middlewareRuntime = this.agentMiddlewareRuntimeService.createScopedApi({
+            ...middlewareRuntimeScope,
+            ...connectorScope
+        })
         const middlewareContext: Omit<IAgentMiddlewareContext, 'node'> = {
             tenantId: runtimeXpert.tenantId,
             organizationId: runtimeOrganizationId,
@@ -857,7 +861,7 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
                 middleware: fileUnderstandingMiddleware
             })
         }
-        for (const binding of selectedRuntimeConnectorBindings) {
+        for (const binding of additionalBindings) {
             const runtimeProvider = connectorRuntimeMiddlewareProvider(binding.provider)
             const strategy = (() => {
                 try {
@@ -904,12 +908,6 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
         const visibleMiddlewareEntries = visibleMiddlewareNodes.reduce<
             Array<{ key: string; middleware: AgentMiddleware }>
         >((entries, node, index) => {
-            const entity = node.entity as IWFNMiddleware
-            const isGraphConnectorMiddleware =
-                normalizeMiddlewareProvider(entity.provider) === CONNECTOR_MIDDLEWARE_NAME
-            if (isRuntimeCapabilitiesAllowlist(options.runtimeCapabilities) && isGraphConnectorMiddleware) {
-                return entries
-            }
             const middleware = visibleAgentMiddlewares[index]
             if (middleware) entries.push({ key: node.key, middleware })
             return entries


### PR DESCRIPTION
Graph-configured Connector middleware stopped working when scoped credentials began requiring explicit binding IDs. Existing workflows usually configure only a provider, and allowlist execution also dropped their Connector middleware instances.

Restore the existing graph middleware path and provider-only credential lookup for host-enabled Connector nodes. Preserve node activation rules, ordering, configured tool filters and user tool preferences. Add a builtin runtime only for a selected binding whose provider has no enabled graph Connector node; reject conflicting pinned bindings.

Provider lookup uses the authorized Xpert workspace or the current Project and then applies the existing identity, membership, binding, personal-grant, credential and audit checks. Explicit IDs remain exact and cannot fall back to provider lookup. SDK scope fields are additive and snapshotted; the existing Connector APIs and provider plugins remain compatible.

Validation:

- All 7 containing Connector, middleware-runtime and subgraph Jest suites passed: 168 tests.
- Plugin SDK TypeScript check passed.
- Prettier and Git diff checks passed; normal commit hooks ran successfully.
- Real Feishu calendar retrieval remains unverified: the local sandbox's npm/DNS connectivity failure is a separate issue outside this change. No sandbox or plugin package changes are included.
