### PR TITLE
fix(knowledge): restore pipeline imports and reliable processing

### DIFF
--- a/.changeset/knowledge-pipeline-reliability.md
+++ b/.changeset/knowledge-pipeline-reliability.md
@@ -1,0 +1,7 @@
+---
+'@xpert-ai/contracts': patch
+'@xpert-ai/server-ai': patch
+'@xpert-ai/xpert-ui': patch
+---
+
+Restore knowledge pipeline source selection and previews, refresh documents immediately after saving, and track background processing failures. Persist imported documents and task bindings atomically, and prevent stale failure callbacks from overwriting a newer document execution.

--- a/apps/cloud/src/app/@shared/knowledge/file-preview/preview.component.html
+++ b/apps/cloud/src/app/@shared/knowledge/file-preview/preview.component.html
@@ -1,50 +1,44 @@
-@if (file().preview$ | async; as docs) {
-  <div
-    class="relative flex h-full w-full flex-col rounded-t-xl border-l border-t border-components-panel-border bg-background-default-lighter shadow-md shadow-shadow-shadow-5 overflow-auto"
-  >
-    <div
-      class="flex gap-x-2 border-b border-divider-subtle pb-3 pl-6 pr-4 pt-4 sticky top-0 bg-components-panel-bg z-10"
-    >
-      <div class="flex grow flex-col gap-y-1">
-        <div class="system-2xs-semibold-uppercase text-text-accent">
-          {{ 'XP.KEY_WORDS.Preview' | translate: { Default: 'Preview' } }}
-        </div>
-        <div class="title-md-semi-bold text-tex-primary">{{ file().document$.value?.name }}</div>
-        <div class="system-xs-medium flex items-center gap-x-1 text-text-tertiary">
-          <svg
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            fill="currentColor"
-            class="remixicon text-[#309BEC] size-3.5 shrink-0"
-          >
-            <path
-              d="M3 3H21C21.5523 3 22 3.44772 22 4V20C22 20.5523 21.5523 21 21 21H3C2.44772 21 2 20.5523 2 20V4C2 3.44772 2.44772 3 3 3ZM7 15.5V11.5L9 13.5L11 11.5V15.5H13V8.5H11L9 10.5L7 8.5H5V15.5H7ZM18 12.5V8.5H16V12.5H14L17 15.5L20 12.5H18Z"
-            ></path>
-          </svg>
-
-          <p class="text-xs text-text-tertiary">
-            <span class="truncate">{{ file().file.type || 'FILE' }}</span> · {{ file().formatSize() }}
-            <span>·</span>
-            <span
-              >{{ totalChars(docs) }} {{ 'XP.Knowledgebase.Characters' | translate: { Default: 'Characters' } }}</span
-            >
-          </p>
-        </div>
-      </div>
-      <button
-        type="button"
-        class="btn btn-action flex h-8 w-8 shrink-0 items-center justify-center"
-        (click)="closed.emit()"
-      >
-        <i class="ri-close-line"></i>
-      </button>
-    </div>
-    @for (doc of docs; track doc) {
-      <div class="body-md-regular grow px-6 py-5 font-body text-text-secondary">
-        {{ doc.pageContent }}
-      </div>
-    }
+<header class="flex shrink-0 items-start justify-between gap-3 border-b border-divider-subtle px-6 py-4">
+  <div class="min-w-0">
+    <h3 class="text-sm font-semibold text-text-primary">
+      {{ 'XP.KEY_WORDS.Preview' | translate: { Default: 'Preview' } }}
+    </h3>
+    <p class="mt-2 truncate text-sm text-text-primary">{{ file().file.name }}</p>
+    <p class="mt-1 text-xs text-text-tertiary">{{ file().file.type }} · {{ file().formatSize() }}</p>
   </div>
-}
+  <button
+    z-button
+    zType="ghost"
+    zSize="icon"
+    type="button"
+    (click)="closed.emit()"
+    [attr.aria-label]="'XP.Knowledgebase.Import.Close' | translate"
+  >
+    <i class="ri-close-line" aria-hidden="true"></i>
+  </button>
+</header>
+<main class="min-h-0 flex-1 overflow-y-auto px-6 py-5" aria-live="polite">
+  @if (previewState() | async; as state) {
+    @if (state.loading) {
+      <div class="flex min-h-64 items-center justify-center gap-2 text-sm text-text-tertiary">
+        <i class="ri-loader-2-line animate-spin" aria-hidden="true"></i
+        >{{ 'XP.Knowledgebase.PipelineFlow.PreviewLoading' | translate }}
+      </div>
+    } @else if (state.documents; as docs) {
+      <p class="mb-4 text-xs text-text-tertiary">
+        {{ totalChars(docs) }} {{ 'XP.Knowledgebase.Characters' | translate: { Default: 'Characters' } }}
+      </p>
+      @for (doc of docs; track $index) {
+        <p class="mb-4 whitespace-pre-wrap break-words text-sm leading-7 text-text-secondary">{{ doc.pageContent }}</p>
+      } @empty {
+        <p class="py-10 text-center text-sm text-text-tertiary">
+          {{ 'XP.Knowledgebase.PipelineFlow.PreviewEmpty' | translate }}
+        </p>
+      }
+    } @else {
+      <p role="alert" class="py-10 text-center text-sm text-text-destructive">
+        {{ 'XP.Knowledgebase.PipelineProcessing.Failed' | translate }}
+      </p>
+    }
+  }
+</main>

--- a/apps/cloud/src/app/@shared/knowledge/file-preview/preview.component.spec.ts
+++ b/apps/cloud/src/app/@shared/knowledge/file-preview/preview.component.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing'
+import { KnowledgeDocumentService, ToastrService } from '@cloud/app/@core'
+import type { DocumentInterface } from '@langchain/core/documents'
+import { Subject } from 'rxjs'
+import { KnowledgeFilePreviewComponent } from './preview.component'
+
+describe('KnowledgeFilePreviewComponent states', () => {
+  afterEach(() => TestBed.resetTestingModule())
+
+  it.each([null, []])('finishes loading for an unavailable or empty preview (%s)', (documents) => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: KnowledgeDocumentService, useValue: {} },
+        { provide: ToastrService, useValue: {} }
+      ]
+    })
+    TestBed.overrideComponent(KnowledgeFilePreviewComponent, { set: { template: '', imports: [] } })
+    const fixture = TestBed.createComponent(KnowledgeFilePreviewComponent)
+    const response = new Subject<DocumentInterface[] | null>()
+    fixture.componentRef.setInput('file', { preview$: response.asObservable() })
+    const states: { loading: boolean; documents: DocumentInterface[] | null }[] = []
+    const subscription = fixture.componentInstance.previewState().subscribe((state) => states.push(state))
+
+    expect(states).toEqual([{ loading: true, documents: null }])
+    response.next(documents)
+    expect(states[1]).toEqual({ loading: false, documents })
+    subscription.unsubscribe()
+  })
+})

--- a/apps/cloud/src/app/@shared/knowledge/file-preview/preview.component.ts
+++ b/apps/cloud/src/app/@shared/knowledge/file-preview/preview.component.ts
@@ -1,15 +1,17 @@
 import { CommonModule } from '@angular/common'
-import { Component, inject, input, output } from '@angular/core'
+import { Component, computed, inject, input, output } from '@angular/core'
 import { injectToastr, KBDocumentCategoryEnum, KnowledgeDocumentService, KnowledgeFileUploader } from '@cloud/app/@core'
 import { DocumentInterface } from '@langchain/core/documents'
 import { TranslateModule } from '@ngx-translate/core'
+import { ZardButtonComponent } from '@xpert-ai/headless-ui'
+import { map, startWith } from 'rxjs'
 
 @Component({
   standalone: true,
   selector: 'xp-knowledge-file-preview',
   templateUrl: './preview.component.html',
   styleUrl: './preview.component.scss',
-  imports: [CommonModule, TranslateModule]
+  imports: [CommonModule, TranslateModule, ZardButtonComponent]
 })
 export class KnowledgeFilePreviewComponent {
   eKBDocumentCategoryEnum = KBDocumentCategoryEnum
@@ -22,6 +24,12 @@ export class KnowledgeFilePreviewComponent {
 
   // Outputs
   readonly closed = output<void>()
+  readonly previewState = computed(() =>
+    this.file().preview$.pipe(
+      map((documents) => ({ loading: false, documents })),
+      startWith({ loading: true, documents: null })
+    )
+  )
 
   // States
 

--- a/apps/cloud/src/app/@shared/knowledge/source-local-file/local-file.component.html
+++ b/apps/cloud/src/app/@shared/knowledge/source-local-file/local-file.component.html
@@ -1,7 +1,6 @@
-<div class="w-full space-y-4">
-  <!-- Upload box -->
+<div class="w-full space-y-5">
   <div
-    class="border border-dashed border-divider-deep rounded-xl p-6 text-center cursor-pointer hover:border-primary-400 transition"
+    class="flex flex-col items-center gap-4 rounded-xl border border-dashed border-divider-deep bg-background-default-subtle px-6 py-8 text-center"
     (drop)="onDrop($event)"
     (dragover)="onDragOver($event)"
   >
@@ -11,76 +10,84 @@
       class="hidden"
       #fileInput
       [accept]="acceptsStr()"
-      (change)="handleFiles(fileInput.files)"
+      (change)="handleFiles(fileInput.files); fileInput.value = ''"
     />
-    <div (click)="fileInput.click()" class="text-text-secondary">
-      <p class="text-base font-medium">
-        <i class="ri-upload-cloud-2-line"></i>
-        {{ 'XP.Knowledgebase.DragDropOr' | translate: { Default: 'Drag and drop files here, or' } }}
-        <span class="underline cursor-pointer text-[var(--sys-primary)]">{{
-          'XP.Knowledgebase.SelectFiles' | translate: { Default: 'select files' }
-        }}</span>
-      </p>
-      <p class="text-sm font-body text-text-quaternary mt-1 uppercase">
-        {{ 'XP.Knowledgebase.Supports' | translate: { Default: 'Supports' } }}
-        {{ extensionStr() }}
-        {{ 'XP.Knowledgebase.FileMaxSize' | translate: { Default: 'and each file does not exceed 15MB.' } }}
-      </p>
+    <div class="flex size-12 items-center justify-center rounded-xl bg-components-panel-bg text-text-secondary">
+      <i class="ri-upload-cloud-2-line text-2xl" aria-hidden="true"></i>
     </div>
-  </div>
-
-  <!-- File list -->
-  @if (files().length > 0) {
     <div class="space-y-2">
-      @for (file of files(); track $index) {
-        <div
-          class="relative flex flex-col border rounded-lg px-4 py-2 overflow-hidden bg-components-card-bg shadow-sm hover:bg-hover-bg transition"
-          [class.border-primary-300]="selected() === file"
-          (click)="selected.set(file)"
-        >
-          <div class="flex items-center justify-between">
-            <div class="flex items-center space-x-3">
-              <div class="w-8 h-8 shrink-0 bg-blue-100 flex items-center justify-center rounded">
-                <span class="text-blue-600 text-sm font-bold">M↓</span>
-              </div>
-              <div>
-                <p class="text-sm font-medium line-clamp-2 text-text-primary">{{ file.file.name }}</p>
-                <p class="text-xs text-text-tertiary">
-                  <span class="truncate">{{ file.file.type || 'FILE' }}</span> · {{ file.formatSize() }}
-                </p>
-              </div>
-            </div>
-
-            @if (file.progress() < 100) {
-              <button class="w-7 h-7 flex justify-center items-center">{{ file.progress() | number: '0.0-0' }}%</button>
-            } @else {
+      <p class="text-sm font-medium text-text-primary">
+        {{ 'XP.Knowledgebase.DragDropOr' | translate: { Default: 'Drag and drop files here, or' } }}
+      </p>
+      <button z-button zType="outline" type="button" (click)="fileInput.click()">
+        {{ 'XP.Knowledgebase.SelectFiles' | translate: { Default: 'Select files' } }}
+      </button>
+    </div>
+    <p class="max-w-lg text-xs leading-5 text-text-tertiary">
+      {{ 'XP.Knowledgebase.Supports' | translate: { Default: 'Supports' } }}
+      <span class="uppercase">{{ extensionStr() }}</span>
+      <span class="block">{{
+        'XP.Knowledgebase.FileMaxSize' | translate: { Default: 'Each file must not exceed 15MB.' }
+      }}</span>
+    </p>
+  </div>
+  @if (files().length) {
+    <div>
+      <div class="mb-2 flex items-center justify-between text-xs text-text-tertiary">
+        <span>{{ 'XP.Knowledgebase.Import.Files' | translate }}</span
+        ><span class="tabular-nums">{{ files().length }}</span>
+      </div>
+      <div class="divide-y divide-divider-subtle">
+        @for (file of files(); track file) {
+          <div
+            class="relative min-w-0 rounded-lg py-3"
+            [class]="selected() === file ? 'bg-background-default-subtle' : ''"
+          >
+            <div class="flex min-w-0 items-center gap-2">
               <button
-                class="w-7 h-7 flex justify-center items-center rounded-lg text-text-quaternary hover:text-red-500 transition hover:bg-hover-bg"
-                (click)="removeFile($index)"
+                z-button
+                zType="ghost"
+                type="button"
+                class="h-auto min-w-0 flex-1 justify-start gap-3 px-3 py-2 text-start"
+                [disabled]="file.status() !== 'done'"
+                [attr.aria-pressed]="selected() === file"
+                (click)="selected.set(file)"
               >
-                <i class="ri-delete-bin-5-line"></i>
+                <i class="ri-file-text-line shrink-0 text-xl text-text-tertiary" aria-hidden="true"></i>
+                <span class="flex min-w-0 flex-1 flex-col gap-1">
+                  <span class="truncate text-sm font-medium">{{ file.file.name }}</span>
+                  <span class="text-xs text-text-tertiary">{{ file.formatSize() }}</span>
+                </span>
               </button>
+              @if (file.status() === 'uploading' || file.status() === 'pending') {
+                <span class="shrink-0 px-3 text-xs tabular-nums text-text-tertiary"
+                  >{{ file.progress() | number: '0.0-0' }}%</span
+                >
+              } @else {
+                @if (file.status() === 'done') {
+                  <i class="ri-check-line text-text-success" aria-hidden="true"></i>
+                }
+                <button
+                  z-button
+                  zType="ghost"
+                  zSize="icon"
+                  type="button"
+                  (click)="removeFile($index)"
+                  [attr.aria-label]="'XP.Knowledgebase.Import.Remove' | translate"
+                >
+                  <i class="ri-close-line" aria-hidden="true"></i>
+                </button>
+              }
+            </div>
+            @if (file.error(); as error) {
+              <p role="alert" class="px-3 pb-2 text-xs text-text-destructive">{{ error }}</p>
+            }
+            @if (file.status() === 'uploading') {
+              <z-progress-bar class="block px-3" zSize="sm" [progress]="file.progress()" />
             }
           </div>
-
-          <!-- Progress bar -->
-          <div
-            class="absolute left-0 bottom-0 w-full mt-3 h-[2px] bg-components-input-bg-normal rounded overflow-hidden"
-          >
-            <div
-              class="h-full rounded"
-              [style.width.%]="file.progress()"
-              [style.background-color]="
-                file.status() === 'done'
-                  ? 'var(--color-status-success-indicator-bg)'
-                  : file.status() === 'error'
-                    ? 'var(--color-status-error-indicator-bg)'
-                    : 'var(--color-status-running-indicator-bg)'
-              "
-            ></div>
-          </div>
-        </div>
-      }
+        }
+      </div>
     </div>
   }
 </div>

--- a/apps/cloud/src/app/@shared/knowledge/source-local-file/local-file.component.spec.ts
+++ b/apps/cloud/src/app/@shared/knowledge/source-local-file/local-file.component.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing'
+import { KnowledgebaseService, KnowledgeFileUploader } from '@cloud/app/@core'
+import { KnowledgeLocalFileComponent } from './local-file.component'
+
+describe('KnowledgeLocalFileComponent selection', () => {
+  afterEach(() => TestBed.resetTestingModule())
+
+  it('clears a removed preview while retaining the selection when removing another file', () => {
+    TestBed.configureTestingModule({ providers: [{ provide: KnowledgebaseService, useValue: {} }] })
+    TestBed.overrideComponent(KnowledgeLocalFileComponent, { set: { template: '', imports: [] } })
+    const fixture = TestBed.createComponent(KnowledgeLocalFileComponent)
+    fixture.componentRef.setInput('knowledgebaseId', 'kb')
+    const component = fixture.componentInstance
+    const api = TestBed.inject(KnowledgebaseService)
+    const files = ['first.txt', 'second.txt'].map(
+      (name) => new KnowledgeFileUploader('kb', api, new File(['content'], name), { parentId: null, path: null })
+    )
+    component.files.set(files)
+    component.selected.set(files[1])
+
+    component.removeFile(0)
+    expect(component.selected()).toBe(files[1])
+    expect(component.files()).toEqual([files[1]])
+
+    component.removeFile(0)
+    expect(component.selected()).toBeNull()
+    expect(component.files()).toEqual([])
+  })
+})

--- a/apps/cloud/src/app/@shared/knowledge/source-local-file/local-file.component.ts
+++ b/apps/cloud/src/app/@shared/knowledge/source-local-file/local-file.component.ts
@@ -2,10 +2,11 @@ import { CommonModule } from '@angular/common'
 import { Component, computed, inject, input, model } from '@angular/core'
 import { KnowledgebaseService, KnowledgeFileUploader } from '@cloud/app/@core'
 import { TranslateModule } from '@ngx-translate/core'
+import { ZardButtonComponent, ZardProgressBarComponent } from '@xpert-ai/headless-ui'
 
 @Component({
   standalone: true,
-  imports: [CommonModule, TranslateModule],
+  imports: [CommonModule, TranslateModule, ZardButtonComponent, ZardProgressBarComponent],
   selector: 'xp-knowledge-local-file',
   templateUrl: 'local-file.component.html',
   styleUrls: ['local-file.component.scss']
@@ -26,9 +27,27 @@ export class KnowledgeLocalFileComponent {
   readonly extensions = computed(() => {
     const exts = this.accepts()
     if (exts && exts.length) {
-      return exts.filter(Boolean).map((ext) => ext.startsWith('.') ? ext.slice(1) : ext)
+      return exts.filter(Boolean).map((ext) => (ext.startsWith('.') ? ext.slice(1) : ext))
     }
-    return ['txt', 'markdown', 'mdx', 'pdf', 'html', 'xlsx', 'xls', 'docx', 'pptx', 'csv', 'epub', 'md', 'htm', 'csv', 'odt', 'odp', 'ods']
+    return [
+      'txt',
+      'markdown',
+      'mdx',
+      'pdf',
+      'html',
+      'xlsx',
+      'xls',
+      'docx',
+      'pptx',
+      'csv',
+      'epub',
+      'md',
+      'htm',
+      'csv',
+      'odt',
+      'odp',
+      'ods'
+    ]
   })
 
   readonly extensionStr = computed(() => this.extensions()?.join(', '))
@@ -62,7 +81,7 @@ export class KnowledgeLocalFileComponent {
 
   // Remove file
   removeFile(index: number) {
+    if (this.selected() === this.files()[index]) this.selected.set(null)
     this.files.update((prev) => prev.filter((_, i) => i !== index))
   }
-
 }

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/documents.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/documents.component.ts
@@ -4,7 +4,17 @@ import { animate, state, style, transition, trigger } from '@angular/animations'
 import { SelectionModel } from '@angular/cdk/collections'
 import { CdkMenuModule, CdkMenuTrigger } from '@angular/cdk/menu'
 import { NgTemplateOutlet } from '@angular/common'
-import { afterNextRender, Component, computed, effect, inject, model, signal, TemplateRef } from '@angular/core'
+import {
+  afterNextRender,
+  Component,
+  computed,
+  DestroyRef,
+  effect,
+  inject,
+  model,
+  signal,
+  TemplateRef
+} from '@angular/core'
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop'
 import { FormsModule } from '@angular/forms'
 import { Dialog, DialogRef } from '@angular/cdk/dialog'
@@ -324,6 +334,7 @@ export class KnowledgeDocumentsComponent {
   readonly hasPipeline = computed(() => !!this.pipeline()?.publishAt)
 
   readonly refresh$ = new BehaviorSubject<boolean>(true)
+  private readonly destroyRef = inject(DestroyRef)
   readonly documentDelayRefresh$ = new Subject<void>()
   readonly knowledgebaseDelayRefresh$ = new Subject<void>()
 
@@ -1663,23 +1674,28 @@ export class KnowledgeDocumentsComponent {
     }
     const pipelineDocs = documents.filter((doc) => !!doc.sourceConfig)
     if (pipelineDocs.length) {
+      const knowledgebaseId = this.knowledgebase().id
       calls.push(
-        this.kbAPI.createTask(this.knowledgebase().id, {
-          taskType: 'document_reprocess',
-          status: 'running', // Start processing immediately
-          documents: pipelineDocs.map((doc) => ({ id: doc.id }) as IKnowledgeDocument)
-        })
+        this.kbAPI
+          .createTask(knowledgebaseId, {
+            taskType: 'document_reprocess',
+            status: 'running', // Start processing immediately
+            documents: pipelineDocs.map((doc) => ({ id: doc.id }) as IKnowledgeDocument)
+          })
+          .pipe(switchMap((task) => this.kbAPI.pollTaskStatus(knowledgebaseId, task.id).pipe(startWith(task))))
       )
     }
     if (calls.length > 0) {
-      combineLatest(calls).subscribe({
-        next: (task) => {
-          this.refresh()
-        },
-        error: (err) => {
-          this.#toastr.error(getErrorMessage(err))
-        }
-      })
+      combineLatest(calls)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (task) => {
+            this.refresh()
+          },
+          error: (err) => {
+            this.#toastr.error(getErrorMessage(err))
+          }
+        })
     }
   }
 

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-menu.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-menu.component.spec.ts
@@ -1,20 +1,27 @@
 jest.mock('./import-dialog.component', () => ({ DocumentImportDialogComponent: class {} }))
 jest.mock('./source-dialog.component', () => ({ DocumentImportSourceDialogComponent: class {} }))
+jest.mock('../pipeline/pipeline.component', () => ({ KnowledgeDocumentPipelineComponent: class {} }))
 
 import { Dialog } from '@angular/cdk/dialog'
 import { TestBed } from '@angular/core/testing'
 import { TranslateService } from '@ngx-translate/core'
-import { of } from 'rxjs'
+import { Observable, of, Subject, takeWhile } from 'rxjs'
+import { IKnowledgebaseTask, KnowledgebaseService, ToastrService } from '@cloud/app/@core'
 import { DocumentImportMenuComponent } from './import-menu.component'
 import { DocumentImportDialogComponent } from './import-dialog.component'
 import { DocumentImportSourceDialogComponent } from './source-dialog.component'
 
 describe('DocumentImportMenuComponent', () => {
   function setup() {
-    const dialog = { open: jest.fn(() => ({ closed: of(true) })) }
+    const dialog = { open: jest.fn((): { closed: Observable<unknown> } => ({ closed: of(true) })) }
+    const tasks = new Subject<IKnowledgebaseTask>()
+    const api = { pollTaskStatus: jest.fn(() => tasks.pipe(takeWhile((task) => task.status === 'running', true))) }
+    const toastr = { error: jest.fn() }
     TestBed.configureTestingModule({
       providers: [
         { provide: Dialog, useValue: dialog },
+        { provide: KnowledgebaseService, useValue: api },
+        { provide: ToastrService, useValue: toastr },
         { provide: TranslateService, useValue: { instant: (key: string) => key } }
       ]
     })
@@ -23,7 +30,7 @@ describe('DocumentImportMenuComponent', () => {
     fixture.componentRef.setInput('knowledgebase', { id: 'kb' })
     fixture.componentRef.setInput('parentId', 'folder')
     fixture.detectChanges()
-    return { fixture, component: fixture.componentInstance, dialog }
+    return { fixture, component: fixture.componentInstance, dialog, api, tasks, toastr }
   }
 
   afterEach(() => TestBed.resetTestingModule())
@@ -69,5 +76,53 @@ describe('DocumentImportMenuComponent', () => {
       DocumentImportSourceDialogComponent,
       expect.objectContaining({ data: 'url' })
     )
+  })
+
+  it.each(['success', 'failed'] as const)(
+    'refreshes a submitted pipeline until its %s result, even before documents exist',
+    async (status) => {
+      const { component, fixture, dialog, api, tasks } = setup()
+      fixture.componentRef.setInput('hasPipeline', true)
+      dialog.open.mockReturnValue({ closed: of({ taskId: 'task' }) })
+      const refresh = jest.fn()
+      component.imported.subscribe(refresh)
+      await component.open('pipeline')
+      expect(refresh).toHaveBeenCalledTimes(1)
+      expect(api.pollTaskStatus).toHaveBeenCalledWith('kb', 'task')
+      tasks.next({ id: 'task', status: 'running', documents: [] } as IKnowledgebaseTask)
+      tasks.next({ id: 'task', status } as IKnowledgebaseTask)
+      expect(refresh).toHaveBeenCalledTimes(3)
+      expect(tasks.observed).toBe(false)
+    }
+  )
+
+  it('releases task polling when the document page is destroyed', async () => {
+    const { component, fixture, dialog, tasks } = setup()
+    fixture.componentRef.setInput('hasPipeline', true)
+    dialog.open.mockReturnValue({ closed: of({ taskId: 'task' }) })
+    await component.open('pipeline')
+    expect(tasks.observed).toBe(true)
+    fixture.destroy()
+    expect(tasks.observed).toBe(false)
+  })
+
+  it('does not track a cancelled pipeline dialog', async () => {
+    const { component, fixture, dialog, api } = setup()
+    fixture.componentRef.setInput('hasPipeline', true)
+    dialog.open.mockReturnValue({ closed: of(undefined) })
+    await component.open('pipeline')
+    expect(api.pollTaskStatus).not.toHaveBeenCalled()
+  })
+
+  it('refreshes once more and reports a polling error', async () => {
+    const { component, fixture, dialog, tasks, toastr } = setup()
+    fixture.componentRef.setInput('hasPipeline', true)
+    dialog.open.mockReturnValue({ closed: of({ taskId: 'task' }) })
+    const refresh = jest.fn()
+    component.imported.subscribe(refresh)
+    await component.open('pipeline')
+    tasks.error(new Error('Task request failed'))
+    expect(refresh).toHaveBeenCalledTimes(2)
+    expect(toastr.error).toHaveBeenCalledWith('Task request failed')
   })
 })

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-menu.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-menu.component.ts
@@ -1,11 +1,18 @@
 import { Dialog } from '@angular/cdk/dialog'
 import { CdkMenuModule } from '@angular/cdk/menu'
 import { Component, DestroyRef, inject, Injector, input, output } from '@angular/core'
-import { IKnowledgebase, IKnowledgeDocument } from '@cloud/app/@core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
+import {
+  getErrorMessage,
+  IKnowledgebase,
+  IKnowledgeDocument,
+  KnowledgebaseService,
+  ToastrService
+} from '@cloud/app/@core'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { ZardButtonComponent } from '@xpert-ai/headless-ui'
-import { firstValueFrom } from 'rxjs'
-import { DOCUMENT_IMPORT_SOURCES, DocumentImportSource } from './import-model'
+import { firstValueFrom, takeWhile } from 'rxjs'
+import { DOCUMENT_IMPORT_SOURCES, DocumentImportSource, KnowledgePipelineImportResult } from './import-model'
 import { DocumentImportDialogComponent } from './import-dialog.component'
 import { DocumentImportSourceDialogComponent } from './source-dialog.component'
 
@@ -53,6 +60,9 @@ export class DocumentImportMenuComponent {
   readonly dialog = inject(Dialog)
   readonly injector = inject(Injector)
   readonly translate = inject(TranslateService)
+  private readonly destroyRef = inject(DestroyRef)
+  private readonly knowledgebaseAPI = inject(KnowledgebaseService)
+  private readonly toastr = inject(ToastrService)
   readonly prefix = 'XP.Knowledgebase.Import'
   readonly sources = DOCUMENT_IMPORT_SOURCES
   private destroyed = false
@@ -80,14 +90,30 @@ export class DocumentImportMenuComponent {
         const { KnowledgeDocumentPipelineComponent } = await import('../pipeline/pipeline.component')
         if (this.destroyed || this.locked()) return
         const result = await firstValueFrom(
-          this.dialog.open<boolean>(KnowledgeDocumentPipelineComponent, {
+          this.dialog.open<KnowledgePipelineImportResult>(KnowledgeDocumentPipelineComponent, {
             ...options,
             injector: this.injector,
             data: { parentId },
             ariaLabel: this.translate.instant(this.prefix + '.Pipeline')
           }).closed
         )
-        if (result && !this.destroyed) this.imported.emit()
+        if (result && !this.destroyed) {
+          this.imported.emit()
+          // Submission precedes document creation; follow the task even when the table is still empty.
+          this.knowledgebaseAPI
+            .pollTaskStatus(knowledgebase.id, result.taskId)
+            .pipe(
+              takeWhile(() => this.knowledgebase().id === knowledgebase.id),
+              takeUntilDestroyed(this.destroyRef)
+            )
+            .subscribe({
+              next: () => this.imported.emit(),
+              error: (error) => {
+                this.imported.emit()
+                this.toastr.error(getErrorMessage(error))
+              }
+            })
+        }
         return
       }
       let documents: Partial<IKnowledgeDocument>[] = []

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-model.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-model.ts
@@ -10,6 +10,7 @@ import { v4 as uuid } from 'uuid'
 import { cloneDeep } from 'lodash-es'
 
 export type DocumentImportSource = 'files' | 'folder' | 'url' | 'crawl' | 'remote' | 'online' | 'pipeline'
+export type KnowledgePipelineImportResult = { taskId: string }
 export type ImportParserConfig = IKnowledgeDocument['parserConfig']
 export type ImportSettingsSection = 'parser' | 'chunks' | 'images'
 

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/pipeline.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/pipeline.component.html
@@ -1,51 +1,65 @@
 <div class="flex h-[min(48rem,calc(100dvh-3rem))] w-[min(76rem,calc(100vw-3rem))] flex-col">
-  <header class="flex items-center justify-between border-b border-divider-subtle px-5 py-3">
-    <h2 class="font-semibold">{{ 'XP.Knowledgebase.Import.Pipeline' | translate }}</h2>
+  <header class="flex shrink-0 items-center justify-between gap-4 border-b border-divider-subtle px-6 py-4">
+    <h2 class="font-semibold text-text-primary">{{ 'XP.Knowledgebase.Import.Pipeline' | translate }}</h2>
     <button
       z-button
       zType="ghost"
       zSize="icon"
+      type="button"
       [disabled]="submitting()"
       (click)="close()"
       [attr.aria-label]="'XP.Knowledgebase.Import.Close' | translate"
     >
-      <i class="ri-close-line"></i>
+      <i class="ri-close-line" aria-hidden="true"></i>
     </button>
   </header>
-  <div class="min-h-0 flex-1 overflow-auto" [attr.inert]="submitting() ? '' : null">
+  <ol class="flex shrink-0 items-center gap-4 border-b border-divider-subtle px-6 py-3 sm:gap-8">
+    @for (
+      label of [
+        'XP.Knowledgebase.PipelineFlow.Source',
+        'XP.Knowledgebase.PipelineFlow.Settings',
+        'XP.Knowledgebase.PipelineFlow.Result'
+      ];
+      track label;
+      let i = $index
+    ) {
+      <li
+        class="flex min-w-0 items-center gap-2 text-xs sm:text-sm"
+        [attr.aria-current]="step() === i + 1 ? 'step' : null"
+        [class]="step() === i + 1 ? 'font-medium text-text-primary' : 'text-text-tertiary'"
+      >
+        <span
+          class="flex size-6 shrink-0 items-center justify-center rounded-full border"
+          [class]="
+            step() >= i + 1
+              ? 'border-divider-deep bg-background-default-subtle text-text-primary'
+              : 'border-divider-subtle'
+          "
+        >
+          @if (step() > i + 1) {
+            <i class="ri-check-line" aria-hidden="true"></i>
+          } @else {
+            {{ i + 1 }}
+          }
+        </span>
+        <span class="truncate">{{ label | translate }}</span>
+      </li>
+    }
+  </ol>
+  <div class="min-h-0 flex-1 overflow-hidden" [attr.inert]="submitting() ? '' : null">
     @switch (step()) {
       @case (1) {
-        <xp-knowledge-document-pipeline-step-1 class="relative flex h-full min-h-0 w-full overflow-auto" />
+        <xp-knowledge-document-pipeline-step-1 class="flex h-full min-h-0 w-full overflow-hidden" />
       }
       @case (2) {
-        <xp-knowledge-document-pipeline-step-2 class="relative flex h-full min-h-0 w-full overflow-auto" />
+        <xp-knowledge-document-pipeline-step-2 class="flex h-full min-h-0 w-full overflow-hidden" />
       }
       @case (3) {
         <xp-knowledge-document-create-step-3
-          class="relative flex h-full min-h-0 w-full overflow-auto"
+          class="flex h-full min-h-0 w-full overflow-hidden"
           [taskId]="taskId()"
           [parserConfig]="parserConfig()"
-        >
-          <div header class="relative flex flex-col gap-y-0.5 pb-2 pt-4">
-            <div class="flex items-center gap-x-2">
-              <span
-                class="text-xs font-semibold uppercase bg-gradient-to-br from-[rgba(11,165,236,0.95)] to-[rgba(21,90,239,0.95)] bg-clip-text text-transparent"
-                >{{ 'XP.Knowledgebase.AddDocuments' | translate: { Default: 'Add Documents' } }}</span
-              ><span class="system-2xs-regular text-divider-regular">/</span>
-              <div class="flex gap-x-1">
-                <div class="h-1 w-1 rounded-lg bg-divider-deep"></div>
-                <div class="h-1 w-1 rounded-lg bg-divider-deep"></div>
-                <div class="h-1 rounded-lg w-2 bg-primary-600"></div>
-              </div>
-            </div>
-            <div class="system-md-semibold text-text-primary">
-              {{ 'XP.Knowledgebase.ProcessingDocuments' | translate: { Default: 'Processing Documents' } }}
-            </div>
-            <div
-              class="absolute size-[112px] rounded-full bg-util-colors-blue-brand-blue-brand-500 blur-[80px] left-8 top-[-34px] opacity-20"
-            ></div>
-          </div>
-        </xp-knowledge-document-create-step-3>
+        />
       }
     }
   </div>

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/pipeline.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/pipeline.component.ts
@@ -28,6 +28,7 @@ import { KnowledgeDocumentsComponent } from '../documents.component'
 import { KnowledgeDocumentPipelineStep1Component } from './step-1/step.component'
 import { KnowledgeDocumentPipelineStep2Component } from './step-2/step.component'
 import { KnowledgeDocumentCreateStep3Component } from '../step-3/step.component'
+import { KnowledgePipelineImportResult } from '../import/import-model'
 
 @Component({
   standalone: true,
@@ -56,7 +57,7 @@ export class KnowledgeDocumentPipelineComponent {
   readonly knowledgebaseComponent = inject(KnowledgebaseComponent)
   readonly documentsComponent = inject(KnowledgeDocumentsComponent)
   readonly integrationAPI = injectIntegrationAPI()
-  readonly dialogRef = inject<DialogRef<boolean>>(DialogRef, { optional: true })
+  readonly dialogRef = inject<DialogRef<KnowledgePipelineImportResult>>(DialogRef, { optional: true })
   readonly dialogData = inject<{ parentId: string | null }>(DIALOG_DATA, { optional: true })
   readonly routeParentId = injectQueryParams('parentId')
   readonly parentId = computed(() => (this.dialogRef ? this.dialogData?.parentId : this.routeParentId()))
@@ -137,7 +138,7 @@ export class KnowledgeDocumentPipelineComponent {
 
   close(completed = false) {
     if (this.submitting()) return
-    if (this.dialogRef) this.dialogRef.close(completed)
+    if (this.dialogRef) this.dialogRef.close(completed ? { taskId: this.taskId() } : undefined)
     else this.#router.navigate(['..'], { relativeTo: this.#route, queryParams: { parentId: this.parentId() } })
   }
 

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/settings/settings.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/settings/settings.component.html
@@ -1,203 +1,149 @@
-<div class="h-full min-w-0 flex-1 px-14 overflow-y-auto">
-  <div class="flex flex-col gap-y-4 pt-4">
-    <div class="flex w-full flex-col rounded-lg border border-components-panel-border bg-components-panel-bg">
-      <div class="flex items-center gap-x-1 px-4 py-2">
-        <div class="system-sm-semibold-uppercase grow text-text-secondary">
+<div class="flex min-h-0 min-w-0 flex-1 flex-col">
+  <div class="grid min-h-0 flex-1 grid-cols-1 overflow-y-auto lg:grid-cols-2 lg:overflow-hidden">
+    <section class="min-h-0 min-w-0 overflow-y-auto px-6 py-6 lg:px-8">
+      <h3 class="text-xl font-semibold text-text-primary">
+        {{ 'XP.Knowledgebase.ProcessingDocuments' | translate: { Default: 'Processing Documents' } }}
+      </h3>
+      <p class="mt-2 text-sm leading-6 text-text-tertiary">
+        {{ 'XP.Knowledgebase.PipelineProcessing.SettingsHint' | translate }}
+      </p>
+
+      <div class="mt-8 flex items-center justify-between gap-3 border-b border-divider-subtle pb-4">
+        <h4 class="text-sm font-semibold text-text-primary">
           {{ 'XP.Knowledgebase.ChunkSettings' | translate: { Default: 'Chunk Settings' } }}
-        </div>
-        <button type="button" class="btn disabled:btn-disabled btn-ghost btn-medium" disabled="">
-          {{ 'XP.ACTIONS.Reset' | translate: { Default: 'Reset' } }}
-        </button>
+        </h4>
         <button
+          z-button
+          zType="outline"
+          zSize="sm"
           type="button"
-          class="btn disabled:btn-disabled btn-secondary-accent btn-medium gap-x-0.5"
           [disabled]="previewing() || !canPreview()"
+          [zLoading]="previewing()"
           (click)="previewChunks()"
         >
-          <i class="ri-eye-2-line"></i>
-          <span class="px-0.5">{{ 'XP.Knowledgebase.PreviewChunks' | translate: { Default: 'Preview Chunks' } }}</span>
+          <i class="ri-eye-line" aria-hidden="true"></i>
+          {{ 'XP.Knowledgebase.PreviewChunks' | translate: { Default: 'Preview Chunks' } }}
         </button>
       </div>
-      <div class="flex flex-col gap-3 border-t border-divider-subtle px-4 py-3">
-        @if (chunkerNode(); as chunkerNode) {
-          @if (chunkerStrategy(); as chunkerStrategy) {
-            <div
-              class="flex items-start gap-3 rounded-lg border border-divider-subtle bg-background-default-subtle px-3 py-3"
-            >
-              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-components-input-bg-normal">
-                @if (chunkerStrategy.icon; as icon) {
-                  <xp-icon class="!block h-8 w-8" [icon]="icon" />
-                } @else {
-                  <i class="ri-equalizer-3-line text-text-secondary"></i>
-                }
-              </div>
-              <div class="min-w-0 flex-1">
-                <div class="system-md-semibold text-text-secondary">
-                  {{ chunkerStrategy.label | i18n }}
-                </div>
-                <div class="system-xs-regular text-text-tertiary" [title]="chunkerStrategy.description | i18n">
-                  {{ chunkerStrategy.description | i18n }}
-                </div>
-              </div>
-            </div>
-          }
 
-          @if (hasChunkerConfigFields()) {
-            <json-schema-form
-              class="grid grid-cols-2 gap-2"
-              [schema]="chunkerConfigSchema()"
-              [readonly]="true"
-              [ngModel]="chunkerConfig()"
-            />
-          } @else {
-            <div
-              class="rounded-lg border border-divider-subtle bg-background-default-subtle px-3 py-3 text-sm text-text-tertiary"
-            >
-              {{ 'XP.Pipeline.NoPluginConfig' | translate: { Default: 'No configuration required for this plugin.' } }}
+      @if (chunkerNode()) {
+        @if (chunkerStrategy(); as strategy) {
+          <div class="flex items-start gap-3 py-5">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-background-default-subtle">
+              @if (strategy.icon; as icon) {
+                <xp-icon class="block size-6" [icon]="icon" />
+              } @else {
+                <i class="ri-scissors-cut-line text-text-secondary" aria-hidden="true"></i>
+              }
             </div>
-          }
-        } @else {
-          <div
-            class="rounded-lg border border-divider-subtle bg-background-default-subtle px-3 py-3 text-sm text-text-tertiary"
-          >
-            {{ 'XP.Knowledgebase.NoChunkersAvailable' | translate: { Default: 'No chunker providers available' } }}
+            <div class="min-w-0">
+              <div class="text-sm font-medium text-text-primary">{{ strategy.label | i18n }}</div>
+              <p class="mt-1 text-xs leading-5 text-text-tertiary">{{ strategy.description | i18n }}</p>
+            </div>
           </div>
         }
-      </div>
-    </div>
+        @if (hasChunkerConfigFields()) {
+          <json-schema-form
+            class="grid grid-cols-1 gap-5 border-t border-divider-subtle pt-5 sm:grid-cols-2"
+            [schema]="chunkerConfigSchema()"
+            [controlDefaults]="compactControlDefaults"
+            [readonly]="true"
+            [ngModel]="chunkerConfig()"
+          />
+        } @else {
+          <p class="py-5 text-sm leading-6 text-text-tertiary">
+            {{ 'XP.Pipeline.NoPluginConfig' | translate: { Default: 'No configuration required for this plugin.' } }}
+          </p>
+        }
+      } @else {
+        <p class="py-5 text-sm leading-6 text-text-tertiary">
+          {{ 'XP.Knowledgebase.NoChunkersAvailable' | translate: { Default: 'No chunker providers available' } }}
+        </p>
+      }
+    </section>
 
-    <ng-content select="[actions]"></ng-content>
-  </div>
-</div>
-
-<div class="h-full min-w-0 flex-1">
-  <div class="flex h-full flex-col pl-2 pt-2">
-    <div class="relative flex h-full w-full shrink-0">
-      <div
-        class="flex h-full w-full flex-col rounded-tl-xl border-l-[0.5px] border-t-[0.5px] border-components-panel-border bg-background-default-lighter shadow-md shadow-shadow-shadow-5"
+    <section
+      class="flex min-h-80 min-w-0 flex-col border-t border-divider-subtle bg-background-default-subtle lg:min-h-0 lg:border-l lg:border-t-0"
+      [attr.aria-busy]="previewing()"
+    >
+      <header
+        class="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-divider-subtle px-6 py-4"
       >
-        <header class="border-b border-divider-subtle pb-3 pl-5 pr-4 pt-4">
-          <div class="">
-            <div class="system-2xs-semibold-uppercase mb-1 px-1 uppercase text-text-accent">
-              {{ 'XP.KEY_WORDS.Preview' | translate: { Default: 'Preview' } }}
-            </div>
-            <div class="flex items-center gap-1">
-              <div class="inline-block">
-                <div
-                  class="flex h-6 select-none items-center rounded-md px-1 hover:bg-hover-bg"
-                  [cdkMenuTriggerFor]="docsMenu"
-                >
-                  <svg
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="24"
-                    height="24"
-                    fill="currentColor"
-                    class="remixicon shrink-0 size-5 text-[#309BEC]"
-                  >
-                    <path
-                      d="M3 3H21C21.5523 3 22 3.44772 22 4V20C22 20.5523 21.5523 21 21 21H3C2.44772 21 2 20.5523 2 20V4C2 3.44772 2.44772 3 3 3ZM7 15.5V11.5L9 13.5L11 11.5V15.5H13V8.5H11L9 10.5L7 8.5H5V15.5H7ZM18 12.5V8.5H16V12.5H14L17 15.5L20 12.5H18Z"
-                    ></path>
-                  </svg>
-                  <div class="ml-1 flex flex-col items-start">
-                    <div class="flex items-center space-x-0.5">
-                      <span class="system-md-semibold max-w-[200px] font-body truncate text-text-primary">
-                        {{
-                          previewDocName() ||
-                            ('XP.Knowledgebase.SelectDocumentForPreview'
-                              | translate: { Default: 'Select a document to preview its content' })
-                        }}
-                      </span>
-                      <svg
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="24"
-                        height="24"
-                        fill="currentColor"
-                        class="remixicon h-[18px] w-[18px] text-text-primary"
-                      >
-                        <path
-                          d="M11.9999 13.1714L16.9497 8.22168L18.3639 9.63589L11.9999 15.9999L5.63599 9.63589L7.0502 8.22168L11.9999 13.1714Z"
-                        ></path>
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="relative inline-flex h-5 items-center rounded-[5px] border border-divider-deep px-[5px] leading-3 text-text-tertiary system-2xs-medium-uppercase"
-              >
-                0 {{ 'XP.Knowledgebase.EstimatedChunks' | translate: { Default: 'Estimated Chunks' } }}
-              </div>
-            </div>
-          </div>
-        </header>
-        <main class="w-full grow overflow-y-auto px-6 py-5 space-y-2">
-          @if (previewing()) {
-            <bullet-list-content-loader class="w-full" />
-          } @else if (previewDocName()) {
-            @if (taskError(); as error) {
-              <div class="flex h-full w-full items-center justify-center">
-                <div class="flex flex-col items-center justify-center gap-3 pb-4">
-                  <i class="ri-error-warning-line text-2xl text-red-500"></i>
-                  <p class="text-sm text-text-tertiary">
-                    {{ 'XP.Knowledgebase.PreviewDocError' | translate: { Default: 'Failed to load preview:' } }}
-                    {{ error }}
-                  </p>
-                  <button
-                    type="button"
-                    class="btn disabled:btn-disabled btn-secondary btn-medium"
-                    [disabled]="previewing() || !canPreview()"
-                    (click)="previewChunks()"
-                  >
-                    {{ 'XP.Knowledgebase.RetryPreview' | translate: { Default: 'Retry Preview' } }}
-                  </button>
-                </div>
-              </div>
-            } @else {
-              @for (chunk of previewDocChunks(); track chunk; let i = $index) {
-                <xp-knowledge-chunk [chunk]="chunk" [index]="i" />
-              }
-            }
-          } @else {
-            <div class="flex h-full w-full items-center justify-center">
-              <div class="flex flex-col items-center justify-center gap-3 pb-4">
-                <i class="ri-eye-2-line text-2xl"></i>
-                <p class="text-sm text-text-tertiary">
-                  {{
-                    'XP.Knowledgebase.PreviewDocHint'
-                      | translate: { Default: 'Click the "Document" button on the left to load a preview' }
-                  }}
-                </p>
-                <button
-                  type="button"
-                  class="btn disabled:btn-disabled btn-secondary btn-medium"
-                  [disabled]="previewing() || !canPreview()"
-                  (click)="previewChunks()"
-                >
-                  {{ 'XP.Knowledgebase.PreviewChunks' | translate: { Default: 'Preview Chunks' } }}
-                </button>
-              </div>
-            </div>
+        <h3 class="text-sm font-semibold text-text-primary">
+          {{ 'XP.KEY_WORDS.Preview' | translate: { Default: 'Preview' } }}
+        </h3>
+        <div class="flex min-w-0 items-center gap-2">
+          <button
+            z-button
+            zType="ghost"
+            zSize="sm"
+            type="button"
+            class="min-w-0 max-w-64"
+            [disabled]="!documents()?.length"
+            [cdkMenuTriggerFor]="docsMenu"
+          >
+            <i class="ri-file-text-line shrink-0 text-text-tertiary" aria-hidden="true"></i>
+            <span class="truncate">{{
+              previewDocName() ||
+                ('XP.Knowledgebase.SelectFilePreview' | translate: { Default: 'Select file to preview' })
+            }}</span>
+            <i class="ri-arrow-down-s-line shrink-0" aria-hidden="true"></i>
+          </button>
+          @if (previewCompleted()) {
+            <span class="shrink-0 rounded-md bg-components-panel-bg px-2 py-1 text-xs tabular-nums text-text-secondary">
+              {{ previewDocChunks().length }} {{ 'XP.Knowledgebase.PipelineProcessing.Chunks' | translate }}
+            </span>
           }
-        </main>
-      </div>
-    </div>
+        </div>
+      </header>
+      <main class="min-h-0 flex-1 overflow-y-auto p-6" aria-live="polite">
+        @if (previewing()) {
+          <p class="mb-4 text-sm text-text-tertiary">{{ 'XP.Knowledgebase.PipelineProcessing.Loading' | translate }}</p>
+          <bullet-list-content-loader class="block w-full" />
+        } @else if (taskError(); as error) {
+          <div role="alert" class="flex h-full min-h-64 flex-col items-center justify-center gap-3 text-center">
+            <i class="ri-error-warning-line text-2xl text-text-destructive" aria-hidden="true"></i>
+            <p class="max-w-sm break-words text-sm leading-6 text-text-tertiary">{{ error }}</p>
+            <button z-button zType="outline" type="button" [disabled]="!canPreview()" (click)="previewChunks()">
+              {{ 'XP.Knowledgebase.PipelineProcessing.Retry' | translate }}
+            </button>
+          </div>
+        } @else if (previewCompleted()) {
+          <div class="space-y-3">
+            @for (chunk of previewDocChunks(); track $index; let i = $index) {
+              <xp-knowledge-chunk [chunk]="chunk" [index]="i" />
+            } @empty {
+              <div class="flex min-h-64 flex-col items-center justify-center gap-3 text-center text-text-tertiary">
+                <i class="ri-file-search-line text-2xl" aria-hidden="true"></i>
+                <p class="max-w-sm text-sm leading-6">{{ 'XP.Knowledgebase.PipelineProcessing.Empty' | translate }}</p>
+              </div>
+            }
+          </div>
+        } @else {
+          <div class="flex h-full min-h-64 flex-col items-center justify-center gap-3 text-center">
+            <div class="flex size-12 items-center justify-center rounded-xl bg-components-panel-bg text-text-tertiary">
+              <i class="ri-file-search-line text-2xl" aria-hidden="true"></i>
+            </div>
+            <p class="max-w-sm text-sm leading-6 text-text-tertiary">
+              {{ 'XP.Knowledgebase.PipelineProcessing.PreviewHint' | translate }}
+            </p>
+            <button z-button zType="outline" type="button" [disabled]="!canPreview()" (click)="previewChunks()">
+              {{ 'XP.Knowledgebase.PreviewChunks' | translate: { Default: 'Preview Chunks' } }}
+            </button>
+          </div>
+        }
+      </main>
+    </section>
   </div>
+  <ng-content select="[actions]"></ng-content>
 </div>
 
 <ng-template #docsMenu>
   <div cdkMenu class="cdk-menu__large">
-    @for (option of documents(); track option.filePath) {
-      <div cdkMenuItem class="group/item overflow-hidden" (click)="previewDocName.set(option.name)">
-        <div class="max-w-full flex flex-col items-start overflow-hidden">
-          <div class="text-start">{{ option.name }}</div>
-        </div>
-      </div>
-    } @empty {
-      <div class="p-4 text-center text-text-tertiary">
-        {{ 'XP.Knowledgebase.NoDocumentYet' | translate: { Default: 'No document yet!' } }}
-      </div>
+    @for (option of documents(); track option.id) {
+      <button cdkMenuItem type="button" class="min-w-0 text-start" (click)="previewDocName.set(option.name)">
+        <span class="truncate">{{ option.name }}</span>
+      </button>
     }
   </div>
 </ng-template>

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/settings/settings.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/settings/settings.component.spec.ts
@@ -2,13 +2,83 @@ jest.mock('@cloud/app/@shared/knowledge', () => ({ KnowledgeChunkComponent: clas
 jest.mock('@cloud/app/@shared/forms', () => ({ JSONSchemaFormComponent: class {} }))
 
 import { TestBed } from '@angular/core/testing'
-import { KnowledgebaseService, ToastrService, WorkflowNodeTypeEnum } from '@cloud/app/@core'
+import { IKnowledgebaseTask, KnowledgebaseService, ToastrService, WorkflowNodeTypeEnum } from '@cloud/app/@core'
 import { TranslateService } from '@ngx-translate/core'
-import { of, Subject } from 'rxjs'
+import { of, Subject, throwError } from 'rxjs'
 import { KnowledgeDocumentPipelineSettingsComponent } from './settings.component'
 
 describe('pipeline preview task context', () => {
   afterEach(() => TestBed.resetTestingModule())
+
+  it('shows returned chunks without a draft and distinguishes an empty completed preview', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: KnowledgebaseService, useValue: { getTextSplitterStrategies: () => of([]) } },
+        { provide: ToastrService, useValue: { error: jest.fn() } },
+        { provide: TranslateService, useValue: { currentLang: 'en', onLangChange: new Subject() } }
+      ]
+    })
+    TestBed.overrideComponent(KnowledgeDocumentPipelineSettingsComponent, { set: { template: '', imports: [] } })
+    const fixture = TestBed.createComponent(KnowledgeDocumentPipelineSettingsComponent)
+    const component = fixture.componentInstance
+    component.previewDocName.set('Document')
+    expect(component.previewCompleted()).toBe(false)
+    const chunks = [{ pageContent: 'Preview text', metadata: {} }]
+    component.task.set({
+      status: 'success',
+      context: { documents: [{ id: 'doc', name: 'Document', chunks }] }
+    } as IKnowledgebaseTask)
+
+    expect(component.previewDocChunks()).toEqual(chunks)
+    expect(component.previewCompleted()).toBe(true)
+
+    component.task.set({
+      status: 'success',
+      context: { documents: [{ id: 'doc', name: 'Document', chunks: [] }] }
+    } as IKnowledgebaseTask)
+    expect(component.previewDocChunks()).toEqual([])
+    expect(component.previewCompleted()).toBe(true)
+  })
+
+  it('shows request errors inline and clears them when retrying', () => {
+    const api = {
+      getTextSplitterStrategies: () => of([]),
+      processTask: jest
+        .fn()
+        .mockReturnValueOnce(throwError(() => new Error('Preview unavailable')))
+        .mockReturnValue(of({})),
+      pollTaskStatus: jest.fn(() => of({ status: 'success', context: { documents: [] } }))
+    }
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: KnowledgebaseService, useValue: api },
+        { provide: ToastrService, useValue: { error: jest.fn() } },
+        { provide: TranslateService, useValue: { currentLang: 'en', onLangChange: new Subject() } }
+      ]
+    })
+    TestBed.overrideComponent(KnowledgeDocumentPipelineSettingsComponent, { set: { template: '', imports: [] } })
+    const fixture = TestBed.createComponent(KnowledgeDocumentPipelineSettingsComponent)
+    const component = fixture.componentInstance
+    fixture.componentRef.setInput('knowledgebase', { id: 'kb' })
+    fixture.componentRef.setInput('documents', [{ id: 'doc', name: 'Document' }])
+    fixture.componentRef.setInput('taskId', 'task')
+    fixture.componentRef.setInput('selectedSource', { key: 'source' })
+    fixture.componentRef.setInput('pipeline', {
+      graph: {
+        nodes: [{ key: 'chunker', type: 'workflow', entity: { type: WorkflowNodeTypeEnum.CHUNKER } }],
+        connections: []
+      }
+    })
+
+    component.previewChunks()
+    expect(component.taskError()).toBe('Preview unavailable')
+    expect(component.previewing()).toBe(false)
+    expect(component.previewCompleted()).toBe(false)
+
+    component.previewChunks()
+    expect(component.taskError()).toBeNull()
+    expect(component.previewCompleted()).toBe(true)
+  })
 
   it('requires an import task and source before starting a preview', () => {
     const api = {

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/settings/settings.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/settings/settings.component.ts
@@ -19,7 +19,7 @@ import {
   WorkflowNodeTypeEnum
 } from '@cloud/app/@core'
 import { IconComponent } from '@cloud/app/@shared/avatar'
-import { JSONSchemaFormComponent } from '@cloud/app/@shared/forms'
+import { JSONSchemaFormComponent, JsonSchemaControlDefaults } from '@cloud/app/@shared/forms'
 import { KnowledgeChunkComponent } from '@cloud/app/@shared/knowledge'
 import {
   buildJsonSchemaDefaults,
@@ -30,7 +30,7 @@ import { ContentLoaderModule } from '@ngneat/content-loader'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { Subscription } from 'rxjs'
 import { startWith, switchMap } from 'rxjs/operators'
-import { ZardTooltipImports } from '@xpert-ai/headless-ui'
+import { ZardButtonComponent, ZardTooltipImports } from '@xpert-ai/headless-ui'
 
 @Component({
   standalone: true,
@@ -39,6 +39,7 @@ import { ZardTooltipImports } from '@xpert-ai/headless-ui'
   styleUrls: ['./settings.component.scss'],
   imports: [
     FormsModule,
+    ZardButtonComponent,
     TranslateModule,
     CdkMenuModule,
     ...ZardTooltipImports,
@@ -55,6 +56,7 @@ export class KnowledgeDocumentPipelineSettingsComponent {
   readonly kbAPI = inject(KnowledgebaseService)
   readonly #toastr = inject(ToastrService)
   readonly #translate = inject(TranslateService)
+  readonly compactControlDefaults = { switch: { zSize: 'sm' } } satisfies JsonSchemaControlDefaults
 
   // Inputs
   readonly knowledgebase = input<IKnowledgebase>()
@@ -141,7 +143,7 @@ export class KnowledgeDocumentPipelineSettingsComponent {
     }
     if (this.previewDocName()) {
       const doc = docs.find((d) => d.name === this.previewDocName())
-      return doc?.draft.chunks || doc?.chunks || []
+      return doc?.draft?.chunks ?? doc?.chunks ?? []
     }
     return docs[0]?.chunks || []
   })
@@ -149,7 +151,14 @@ export class KnowledgeDocumentPipelineSettingsComponent {
   readonly task = signal<IKnowledgebaseTask>(null)
   readonly _documents = computed(() => this.task()?.context?.documents)
 
-  readonly taskError = computed(() => this.task()?.error)
+  readonly requestError = signal<string | null>(null)
+  readonly previewCompleted = computed(() => this.task()?.status === 'success')
+  readonly taskError = computed(
+    () =>
+      this.requestError() ||
+      this.task()?.error ||
+      (this.task()?.status === 'failed' ? this.#translate.instant('XP.Knowledgebase.PipelineProcessing.Failed') : null)
+  )
 
   constructor() {
     effect(() => {
@@ -163,6 +172,7 @@ export class KnowledgeDocumentPipelineSettingsComponent {
     if (!this.canPreview() || this.previewing()) return
     this.previewing.set(true)
     this.task.set(null)
+    this.requestError.set(null)
     this.previewSub?.unsubscribe()
 
     this.kbAPI
@@ -185,12 +195,14 @@ export class KnowledgeDocumentPipelineSettingsComponent {
             },
             error: (err) => {
               this.previewing.set(false)
+              this.requestError.set(getErrorMessage(err))
               this.#toastr.error(getErrorMessage(err))
             }
           })
         },
         error: (error) => {
           this.previewing.set(false)
+          this.requestError.set(getErrorMessage(error))
           this.#toastr.error(getErrorMessage(error))
         }
       })

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/step-1/step.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/step-1/step.component.html
@@ -1,276 +1,187 @@
-<div class="h-full min-w-0 flex-1">
-  <div class="flex h-full flex-col px-14">
-    <div class="relative flex flex-col gap-y-0.5 pb-2 pt-4">
-      <div class="flex items-center gap-x-2">
-        <span
-          class="text-xs font-semibold uppercase bg-gradient-to-br from-[rgba(11,165,236,0.95)] to-[rgba(21,90,239,0.95)] bg-clip-text text-transparent"
-          >{{ 'XP.Knowledgebase.AddDocuments' | translate: { Default: 'Add Documents' } }}</span
-        ><span class="system-2xs-regular text-divider-regular">/</span>
-        <div class="flex gap-x-1">
-          <div class="h-1 rounded-lg w-2 bg-primary-600"></div>
-          <div class="h-1 w-1 rounded-lg bg-divider-deep"></div>
-          <div class="h-1 w-1 rounded-lg bg-divider-deep"></div>
-        </div>
+<div class="flex min-h-0 min-w-0 flex-1 flex-col">
+  <div
+    class="grid min-h-0 flex-1 overflow-y-auto"
+    [class]="selectedFile() || selectedDocument() ? 'lg:grid-cols-2' : 'grid-cols-1'"
+  >
+    <section class="mx-auto flex min-h-0 w-full max-w-3xl flex-col gap-6 overflow-y-auto px-6 py-6 lg:px-8">
+      <div>
+        <h3 class="text-xl font-semibold text-text-primary">
+          {{ 'XP.Knowledgebase.ChooseADataSource' | translate: { Default: 'Choose a Data Source' } }}
+        </h3>
+        <p class="mt-2 text-sm leading-6 text-text-tertiary">
+          {{ 'XP.Knowledgebase.PipelineFlow.SourceHint' | translate }}
+        </p>
       </div>
-      <div class="system-md-semibold text-text-primary">
-        {{ 'XP.Knowledgebase.ChooseADataSource' | translate: { Default: 'Choose a Data Source' } }}
-      </div>
-      <div class="cursor-pointer">
-        <button
-          type="button"
-          class="btn disabled:btn-disabled btn-secondary-accent btn-medium absolute -left-11 top-3.5 size-9 rounded-full p-0"
-          (click)="pipelineComponent.close()"
-        >
-          <i class="ri-corner-up-left-line"></i>
-        </button>
-      </div>
-      <div class="absolute w-[100px] h-[100px] rounded-full bg-blue-500 blur-[80px] left-8 top-0 opacity-20"></div>
-    </div>
-    <div class="grow overflow-y-auto">
-      <div class="flex flex-col gap-y-5 pt-4">
-        <div class="grid w-full grid-cols-4 gap-1">
-          @for (item of sourceStrategies(); track item.source.key) {
-            <div
-              class="flex cursor-pointer items-center gap-2 rounded-xl border p-3 shadow-sm bg-components-card-bg ring-[0.5px] ring-inset hover:border-divider-deep"
-              [class.border-divider-regular]="item.strategy"
-              [class.ring-gray-50]="item.strategy"
-              [class.border-yellow-400]="!item.strategy"
-              [class.ring-yellow-400]="!item.strategy"
-              [class.!border-primary-600]="selectedSource() && selectedSource().key === item.source.key"
-              [class.!ring-primary-600]="selectedSource() && selectedSource().key === item.source.key"
-              (click)="selectedSource.set(item.source)"
-            >
-              @if (item.strategy) {
-                <div
-                  class="flex size-8 shrink-0 items-center justify-center rounded-lg border-[0.5px] border-components-panel-border bg-background-default-dodge p-1.5"
-                >
-                  <div class="flex items-center justify-center size-6 rounded-md shadow-xs">
-                    <xp-icon class="contents" [icon]="item.strategy.meta.icon" />
-                  </div>
-                </div>
-                <div class="system-sm-medium truncate grow text-text-primary" [title]="item.strategy.meta.label | i18n">
-                  {{ item.strategy.meta.label | i18n }}
-                </div>
-              } @else {
-                <div
-                  class="system-sm-medium truncate grow text-text-tertiary italic"
-                  zTooltip="{{
-                    item.source.entity.provider +
-                      ' ' +
-                      ('XP.Knowledgebase.PluginNotFound' | translate: { Default: 'plugin not found' })
-                  }}"
-                >
-                  {{ item.source.entity.provider }}
-                  {{ 'XP.Knowledgebase.PluginNotFound' | translate: { Default: 'plugin not found' } }}
-                </div>
-              }
-            </div>
-          }
-        </div>
-        <div class="flex flex-col">
-          <div class="flex items-center justify-between gap-x-2">
-            @if (integration(); as integration) {
-              <div class="flex items-center gap-x-1 overflow-hidden">
-                <div class="grow overflow-hidden">
-                  <div class="flex cursor-pointer items-center gap-x-2 rounded-md p-1 pr-2 hover:bg-hover-bg">
-                    <div class="flex grow items-center gap-x-1 overflow-hidden">
-                      @if (selectedIntegration(); as selectedIntegration) {
-                        <span class="system-md-semibold grow truncate text-text-secondary">{{
-                          selectedIntegration.label | i18n
-                        }}</span>
-                      } @else {
-                        <span class="system-md-semibold grow truncate text-text-secondary">{{
-                          integration.service
-                        }}</span>
-                      }
-
-                      <!-- <i class="ri-arrow-down-s-line"></i> -->
-                    </div>
-                  </div>
-                </div>
-                <div class="w-[1px] bg-divider-regular mx-1 h-3.5 shrink-0"></div>
-                @if (selectedIntegration(); as selectedIntegration) {
-                  <a [routerLink]="['/settings/integration', selectedIntegration.value]" class="cursor-pointer">
-                    <button type="button" class="btn disabled:btn-disabled btn-ghost btn-small size-6 shrink-0 px-1">
-                      <i class="ri-equalizer-2-line"></i>
-                    </button>
-                  </a>
-                }
-              </div>
-
-              @if (selectedStrategy()?.meta.helpUrl; as url) {
-                <a
-                  [href]="url"
-                  class="system-xs-medium flex shrink-0 items-center gap-x-1 text-text-accent"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <i class="ri-book-open-line"></i>
-                  {{ 'XP.KEY_WORDS.Help' | translate: { Default: 'Help' } }}
-                </a>
-              }
-            }
-          </div>
-          @if (providerCategory(); as category) {
-            @if (category === eDocumentSourceProviderCategoryEnum.LocalFile) {
-              <xp-knowledge-local-file
-                class="w-full"
-                [knowledgebaseId]="knowledgebaseId()"
-                [parentId]="parentId()"
-                [(files)]="files"
-                [(selected)]="selectedFile"
-                [accepts]="fileExtensions()"
-              />
-            } @else {
-              <div
-                class="w-full mt-2 rounded-xl border border-components-panel-border bg-background-default-subtle ng-star-inserted"
-              >
-                <div class="flex items-center gap-x-1 px-4 py-2">
-                  <div class="flex grow cursor-pointer select-none items-center gap-x-0.5">
-                    <span class="system-sm-semibold-uppercase text-text-secondary">{{
-                      'XP.KEY_WORDS.Options' | translate: { Default: 'Options' }
-                    }}</span>
-                    <i class="ri-arrow-down-s-fill shrink-0 text-text-quaternary"></i>
-                  </div>
-                  <button
-                    type="button"
-                    class="btn disabled:btn-disabled btn-primary btn-medium shrink-0 gap-x-0.5"
-                    (click)="runStep()"
-                  >
-                    <i class="ri-play-line"></i>
-                    <span class="px-0.5">{{ 'XP.ACTIONS.Run' | translate: { Default: 'Run' } }}</span>
-                  </button>
-                </div>
-                <div class="flex flex-col gap-1 border-t border-divider-subtle px-4 py-3">
-                  @if (parameters()?.length) {
-                    <xpert-parameters-form class="w-full" [parameters]="parameters()" [(ngModel)]="parameterValue" />
-                  }
-                  @if (testing()) {
-                    <bullet-list-content-loader></bullet-list-content-loader>
-                  } @else if (error()) {
-                    <div class="px-2 border border-solid border-divider-regular rounded-xl">
-                      <div class="py-2 text-text-destructive">
-                        {{ 'XP.KEY_WORDS.Error' | translate: { Default: 'Error' } }}
-                      </div>
-                      <markdown
-                        class="xp-copilot-markdown block overflow-x-hidden text-sm text-text-tertiary"
-                        [disableSanitizer]="true"
-                        lineNumbers
-                        [start]="5"
-                        [data]="error()"
-                      />
-                    </div>
-                  } @else if (documents()) {
-                    @for (doc of documents(); track doc.id) {
-                      <div
-                        class="relative flex cursor-pointer gap-x-2 rounded-lg p-2 group hover:bg-hover-bg"
-                        (click)="selectedDocument.set(doc)"
-                      >
-                        <xp-checkbox
-                          class="shrink-0"
-                          [ngModel]="documentIds.isSelected(doc.id)"
-                          (ngModelChange)="documentIds.toggle(doc.id)"
-                        />
-                        <div class="flex min-w-0 grow flex-col gap-y-0.5">
-                          <div class="system-sm-medium truncate text-text-secondary" [title]="doc.metadata.title">
-                            {{ doc.metadata.title }}
-                          </div>
-                          <div class="system-xs-regular truncate text-text-tertiary" [title]="doc.metadata.source">
-                            {{ doc.metadata.source }}
-                          </div>
-                        </div>
-                      </div>
-                    } @empty {
-                      <div class="py-4 text-center text-text-tertiary">
-                        {{ 'XP.Knowledgebase.NoPagesFetched' | translate: { Default: 'No pages fetched' } }}
-                      </div>
-                    }
-                  }
-                </div>
-              </div>
-            }
-          } @else {
-            <div class="p-4 text-text-tertiary">
-              {{ 'XP.Knowledgebase.PleaseSelectADataSource' | translate: { Default: 'Please select a data source' } }}
-            </div>
-          }
-        </div>
-        <div class="flex items-center gap-x-2 overflow-hidden">
-          <div class="flex grow items-center justify-end gap-x-2">
-            <a [routerLink]="['../']" class="cursor-pointer">
-              <button type="button" class="btn disabled:btn-disabled btn-ghost btn-medium px-3 py-2">
-                {{ 'XP.KEY_WORDS.Cancel' | translate: { Default: 'Cancel' } }}
-              </button>
-            </a>
-            <button
-              type="button"
-              class="btn disabled:btn-disabled btn-primary btn-medium gap-x-0.5"
-              [disabled]="!selectedSource() || !taskId() || testing()"
-              (click)="nextStep()"
-            >
-              <span class="px-0.5">{{ 'XP.KEY_WORDS.Next' | translate: { Default: 'Next' } }}</span>
-              <i class="ri-arrow-right-line"></i>
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="h-full min-w-0 flex-1">
-  @switch (providerCategory()) {
-    @case (eDocumentSourceProviderCategoryEnum.LocalFile) {
-      @if (selectedFile(); as file) {
-        <xp-knowledge-file-preview class="flex h-full flex-col pl-2 pt-2" [file]="file" (closed)="closePreview()" />
-      }
-    }
-    @case (eDocumentSourceProviderCategoryEnum.WebCrawl) {
-      <div class="flex h-full flex-col pl-2 pt-2">
-        @if (selectedDocument(); as doc) {
-          <div
-            class="flex h-full w-full flex-col rounded-t-xl border-l border-t border-components-panel-border bg-background-default-lighter shadow-md shadow-shadow-shadow-5"
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        @for (item of sourceStrategies(); track item.source.key) {
+          <button
+            z-button
+            zType="outline"
+            type="button"
+            class="h-auto min-h-16 w-full justify-start gap-3 whitespace-normal px-4 py-3 text-start"
+            [class]="
+              selectedSource()?.key === item.source.key ? 'ring-1 ring-text-primary bg-background-default-subtle' : ''
+            "
+            [attr.aria-pressed]="selectedSource()?.key === item.source.key"
+            (click)="selectedSource.set(item.source)"
           >
-            <div class="flex gap-x-2 border-b border-divider-subtle pb-3 pl-6 pr-4 pt-4">
-              <div class="flex grow flex-col gap-y-1">
-                <div class="system-2xs-semibold-uppercase text-text-accent">
-                  {{ 'XP.KEY_WORDS.Preview' | translate: { Default: 'Preview' } }}
-                </div>
-                <div class="title-md-semi-bold text-tex-primary">{{ doc.metadata.title }}</div>
-                <div class="system-xs-medium flex items-center gap-x-1 text-text-tertiary">
-                  <svg
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="24"
-                    height="24"
-                    fill="currentColor"
-                    class="remixicon text-[#309BEC] size-3.5 shrink-0"
-                  >
-                    <path
-                      d="M3 3H21C21.5523 3 22 3.44772 22 4V20C22 20.5523 21.5523 21 21 21H3C2.44772 21 2 20.5523 2 20V4C2 3.44772 2.44772 3 3 3ZM7 15.5V11.5L9 13.5L11 11.5V15.5H13V8.5H11L9 10.5L7 8.5H5V15.5H7ZM18 12.5V8.5H16V12.5H14L17 15.5L20 12.5H18Z"
-                    ></path>
-                  </svg>
-
-                  <p class="text-xs text-text-tertiary">
-                    <span class="truncate">{{ doc.metadata.source || 'WEB PAGE' }}</span> ·
-                    {{ doc.metadata.characters || 0 }}
-                    {{ 'XP.KEY_WORDS.Characters' | translate: { Default: 'Characters' } }}
-                  </p>
-                </div>
-              </div>
-              <button
-                type="button"
-                class="btn btn-action flex h-8 w-8 shrink-0 items-center justify-center"
-                (click)="selectedDocument.set(null)"
+            @if (item.strategy) {
+              <xp-icon class="block size-8 shrink-0" [icon]="item.strategy.meta.icon" />
+              <span class="min-w-0 flex-1 break-words">{{ item.strategy.meta.label | i18n }}</span>
+              @if (selectedSource()?.key === item.source.key) {
+                <i class="ri-check-line shrink-0" aria-hidden="true"></i>
+              }
+            } @else {
+              <i class="ri-error-warning-line shrink-0 text-text-destructive" aria-hidden="true"></i>
+              <span class="min-w-0 break-words"
+                >{{ item.source.entity.provider }} ·
+                {{ 'XP.Knowledgebase.PluginNotFound' | translate: { Default: 'Plugin not found' } }}</span
               >
-                <i class="ri-close-line"></i>
-              </button>
-            </div>
-
-            <xp-knowledge-document-preview [document]="doc" />
-          </div>
+            }
+          </button>
+        } @empty {
+          @if (sourceStrategies() == null) {
+            <bullet-list-content-loader class="col-span-full block w-full" />
+          } @else {
+            <p class="col-span-full text-sm text-text-tertiary">
+              {{ 'XP.Knowledgebase.PipelineFlow.NoSources' | translate }}
+            </p>
+          }
         }
       </div>
+      @if (integration(); as integration) {
+        <div class="flex items-center justify-between gap-3 border-b border-divider-subtle pb-4 text-sm">
+          <div class="flex min-w-0 items-center gap-2">
+            <i class="ri-plug-line text-text-tertiary" aria-hidden="true"></i>
+            <span class="truncate">{{
+              selectedIntegration() ? (selectedIntegration().label | i18n) : integration.service
+            }}</span>
+            @if (selectedIntegration(); as selected) {
+              <a
+                z-button
+                zType="ghost"
+                zSize="icon"
+                [routerLink]="['/settings/integration', selected.value]"
+                [attr.aria-label]="'XP.KEY_WORDS.Settings' | translate: { Default: 'Settings' }"
+                ><i class="ri-settings-3-line" aria-hidden="true"></i
+              ></a>
+            }
+          </div>
+          @if (selectedStrategy()?.meta.helpUrl; as url) {
+            <a
+              [href]="url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="shrink-0 text-text-secondary hover:underline"
+            >
+              <i class="ri-book-open-line" aria-hidden="true"></i>
+              {{ 'XP.KEY_WORDS.Help' | translate: { Default: 'Help' } }}
+            </a>
+          }
+        </div>
+      }
+      @if (providerCategory(); as category) {
+        @if (category === eDocumentSourceProviderCategoryEnum.LocalFile) {
+          <xp-knowledge-local-file
+            class="w-full"
+            [knowledgebaseId]="knowledgebaseId()"
+            [parentId]="parentId()"
+            [(files)]="files"
+            [(selected)]="selectedFile"
+            [accepts]="fileExtensions()"
+          />
+          @if (createFileTask.error(); as error) {
+            <p role="alert" class="text-sm text-text-destructive">{{ error }}</p>
+          }
+        } @else {
+          <section class="min-w-0 space-y-4">
+            <div class="flex items-center justify-between gap-3 border-b border-divider-subtle pb-4">
+              <h4 class="text-sm font-semibold">{{ 'XP.KEY_WORDS.Options' | translate: { Default: 'Options' } }}</h4>
+              <button z-button type="button" [disabled]="testing()" [zLoading]="testing()" (click)="runStep()">
+                <i class="ri-play-line" aria-hidden="true"></i>{{ 'XP.ACTIONS.Run' | translate: { Default: 'Run' } }}
+              </button>
+            </div>
+            @if (parameters()?.length) {
+              <xpert-parameters-form class="block w-full" [parameters]="parameters()" [(ngModel)]="parameterValue" />
+            }
+            @if (testing()) {
+              <bullet-list-content-loader />
+            } @else if (error()) {
+              <div role="alert" class="rounded-lg border border-divider-subtle p-4 text-sm text-text-destructive">
+                <markdown class="xp-copilot-markdown block break-words" [data]="error()" />
+              </div>
+            } @else if (documents()) {
+              <div class="divide-y divide-divider-subtle">
+                @for (doc of documents(); track doc.id) {
+                  <div class="flex min-w-0 items-center gap-3 py-3">
+                    <z-checkbox
+                      [ngModel]="documentIds.isSelected(doc.id)"
+                      (ngModelChange)="documentIds.toggle(doc.id)"
+                      [attr.aria-label]="doc.name || doc.metadata?.title"
+                    />
+                    <button
+                      z-button
+                      zType="ghost"
+                      type="button"
+                      class="h-auto min-w-0 flex-1 justify-start px-2 py-2 text-start"
+                      (click)="selectedDocument.set(doc)"
+                    >
+                      <span class="flex min-w-0 flex-col gap-1">
+                        <span class="truncate text-sm">{{ doc.name || doc.metadata?.title }}</span>
+                        <span class="truncate text-xs text-text-tertiary">{{ doc.metadata?.source }}</span>
+                      </span>
+                    </button>
+                  </div>
+                } @empty {
+                  <p class="py-6 text-center text-sm text-text-tertiary">
+                    {{ 'XP.Knowledgebase.NoPagesFetched' | translate: { Default: 'No pages fetched' } }}
+                  </p>
+                }
+              </div>
+            }
+          </section>
+        }
+      } @else {
+        <p class="py-6 text-sm text-text-tertiary">
+          {{ 'XP.Knowledgebase.PleaseSelectADataSource' | translate: { Default: 'Please select a data source' } }}
+        </p>
+      }
+    </section>
+    @if (selectedFile() || selectedDocument()) {
+      <aside
+        class="flex min-h-80 min-w-0 flex-col border-t border-divider-subtle bg-background-default-subtle lg:min-h-0 lg:border-l lg:border-t-0"
+      >
+        @if (providerCategory() === eDocumentSourceProviderCategoryEnum.LocalFile && selectedFile(); as file) {
+          <xp-knowledge-file-preview class="flex min-h-0 flex-1 flex-col" [file]="file" (closed)="closePreview()" />
+        } @else if (selectedDocument(); as doc) {
+          <header class="flex shrink-0 items-start justify-between gap-3 border-b border-divider-subtle px-6 py-4">
+            <div class="min-w-0">
+              <h3 class="text-sm font-semibold">{{ 'XP.KEY_WORDS.Preview' | translate: { Default: 'Preview' } }}</h3>
+              <p class="mt-2 truncate text-sm">{{ doc.name || doc.metadata?.title }}</p>
+              <p class="mt-1 truncate text-xs text-text-tertiary">{{ doc.metadata?.source }}</p>
+            </div>
+            <button
+              z-button
+              zType="ghost"
+              zSize="icon"
+              type="button"
+              (click)="selectedDocument.set(null)"
+              [attr.aria-label]="'XP.Knowledgebase.Import.Close' | translate"
+            >
+              <i class="ri-close-line" aria-hidden="true"></i>
+            </button>
+          </header>
+          <xp-knowledge-document-preview class="min-h-0 flex-1 overflow-y-auto" [document]="doc" />
+        }
+      </aside>
     }
-  }
+  </div>
+  <footer class="flex shrink-0 items-center justify-between gap-3 border-t border-divider-subtle px-6 py-4">
+    <button z-button zType="outline" type="button" (click)="pipelineComponent.close()">
+      {{ 'XP.KEY_WORDS.Cancel' | translate: { Default: 'Cancel' } }}
+    </button>
+    <button z-button type="button" [disabled]="!canContinue()" (click)="nextStep()">
+      {{ 'XP.KEY_WORDS.Next' | translate: { Default: 'Next' } }}<i class="ri-arrow-right-line" aria-hidden="true"></i>
+    </button>
+  </footer>
 </div>

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/step-1/step.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/step-1/step.component.spec.ts
@@ -1,0 +1,97 @@
+jest.mock('../../../knowledgebase.component', () => ({ KnowledgebaseComponent: class {} }))
+jest.mock('../../documents.component', () => ({ KnowledgeDocumentsComponent: class {} }))
+jest.mock('../pipeline.component', () => ({ KnowledgeDocumentPipelineComponent: class {} }))
+jest.mock('apps/cloud/src/app/@shared/knowledge', () => ({
+  KnowledgeChunkComponent: class {},
+  KnowledgeDocumentPreviewComponent: class {},
+  KnowledgeFilePreviewComponent: class {},
+  KnowledgeLocalFileComponent: class {}
+}))
+jest.mock('@cloud/app/@shared/xpert', () => ({ XpertParametersFormComponent: class {} }))
+
+import { signal } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { SelectionModel } from '@angular/cdk/collections'
+import { ActivatedRoute, Router } from '@angular/router'
+import { TranslateService } from '@ngx-translate/core'
+import { Subject } from 'rxjs'
+import {
+  DocumentSourceProviderCategoryEnum,
+  IKnowledgebaseTask,
+  IKnowledgeDocument,
+  KnowledgebaseService,
+  KnowledgeFileUploader,
+  ToastrService,
+  XpertAgentService
+} from '@cloud/app/@core'
+import { KnowledgebaseComponent } from '../../../knowledgebase.component'
+import { KnowledgeDocumentsComponent } from '../../documents.component'
+import { KnowledgeDocumentPipelineComponent } from '../pipeline.component'
+import { KnowledgeDocumentPipelineStep1Component } from './step.component'
+
+describe('pipeline local file task creation', () => {
+  afterEach(() => TestBed.resetTestingModule())
+
+  it('does not create another task in response to its returned ID and waits for changed files', () => {
+    const responses = new Subject<IKnowledgebaseTask>()
+    const api = { createTask: jest.fn(() => responses) }
+    const pipeline = {
+      taskId: signal<string>(null),
+      parentId: signal(null),
+      knowledgebaseId: signal('kb'),
+      selectedSource: signal({ key: 'local' }),
+      providerCategory: signal(DocumentSourceProviderCategoryEnum.LocalFile),
+      files: signal<KnowledgeFileUploader[]>([]),
+      documentIds: new SelectionModel<string>(true),
+      nextStep: jest.fn()
+    }
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: KnowledgebaseService, useValue: api },
+        { provide: XpertAgentService, useValue: {} },
+        { provide: ToastrService, useValue: {} },
+        { provide: Router, useValue: {} },
+        { provide: ActivatedRoute, useValue: {} },
+        { provide: KnowledgebaseComponent, useValue: { knowledgebase: signal({ id: 'kb' }) } },
+        { provide: KnowledgeDocumentsComponent, useValue: {} },
+        { provide: KnowledgeDocumentPipelineComponent, useValue: pipeline },
+        { provide: TranslateService, useValue: { currentLang: 'en', onLangChange: new Subject() } }
+      ]
+    })
+    TestBed.overrideComponent(KnowledgeDocumentPipelineStep1Component, { set: { imports: [], template: '' } })
+    const fixture = TestBed.createComponent(KnowledgeDocumentPipelineStep1Component)
+    const component = fixture.componentInstance
+    const file = new KnowledgeFileUploader('kb', TestBed.inject(KnowledgebaseService), new File(['text'], 'test.md'), {
+      parentId: null,
+      path: null
+    })
+    const document = signal<Partial<IKnowledgeDocument>>({ id: 'doc-1', name: 'test.md' })
+    Object.defineProperty(file, 'document', { value: document })
+    pipeline.files.set([file])
+    fixture.detectChanges()
+    expect(api.createTask).toHaveBeenCalledTimes(1)
+    expect(component.canContinue()).toBe(false)
+
+    responses.next({ id: 'task-1', context: { documents: [{ id: 'doc-1' }] } } as IKnowledgebaseTask)
+    fixture.detectChanges()
+    fixture.detectChanges()
+    expect(pipeline.taskId()).toBe('task-1')
+    expect(api.createTask).toHaveBeenCalledTimes(1)
+    expect(component.canContinue()).toBe(true)
+
+    document.set({ id: 'doc-2', name: 'changed.md' })
+    fixture.detectChanges()
+    expect(api.createTask).toHaveBeenCalledTimes(2)
+    expect(component.canContinue()).toBe(false)
+    component.nextStep()
+    expect(pipeline.nextStep).not.toHaveBeenCalled()
+
+    responses.next({ id: 'task-2', context: { documents: [{ id: 'doc-2' }] } } as IKnowledgebaseTask)
+    fixture.detectChanges()
+    expect(api.createTask).toHaveBeenCalledTimes(2)
+    expect(component.canContinue()).toBe(true)
+    pipeline.files.set([])
+    fixture.detectChanges()
+    expect(component.canContinue()).toBe(false)
+  })
+})

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/step-1/step.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/step-1/step.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, effect, inject, model, signal } from '@angular/cor
 import { FormsModule } from '@angular/forms'
 import { ActivatedRoute, Router, RouterModule } from '@angular/router'
 import { IconComponent } from '@cloud/app/@shared/avatar'
-import { myRxResource, XpI18nPipe, omitBlank } from '@xpert-ai/headless-ui'
+import { myRxResource, XpI18nPipe } from '@xpert-ai/headless-ui'
 import { nonNullable } from '@xpert-ai/contracts'
 import { ContentLoaderModule } from '@ngneat/content-loader'
 import { TranslateModule } from '@ngx-translate/core'
@@ -35,8 +35,7 @@ import { KnowledgeDocumentsComponent } from '../../documents.component'
 import { KnowledgeDocumentPipelineComponent } from '../pipeline.component'
 import { XpertParametersFormComponent } from '@cloud/app/@shared/xpert'
 import { MarkdownModule } from 'ngx-markdown'
-import { XpCheckboxComponent } from '@xpert-ai/headless-ui'
-import { ZardTooltipImports } from '@xpert-ai/headless-ui'
+import { ZardButtonComponent, ZardCheckboxComponent, ZardTooltipImports } from '@xpert-ai/headless-ui'
 
 @Component({
   standalone: true,
@@ -53,7 +52,8 @@ import { ZardTooltipImports } from '@xpert-ai/headless-ui'
     ContentLoaderModule,
     MarkdownModule,
     XpI18nPipe,
-    XpCheckboxComponent,
+    ZardButtonComponent,
+    ZardCheckboxComponent,
     IconComponent,
     KnowledgeFilePreviewComponent,
     KnowledgeLocalFileComponent,
@@ -109,30 +109,37 @@ export class KnowledgeDocumentPipelineStep1Component {
   // local files
   readonly createFileTask = myRxResource({
     request: () => ({
-      taskId: this.taskId(),
+      knowledgebaseId: this.knowledgebaseId(),
+      parentId: this.parentId(),
       files: this.files()
         .map((file) => file.document())
         .filter(nonNullable)
     }),
     loader: ({ request }) => {
       return request.files.length > 0
-        ? this.knowledgebaseAPI.createTask(
-            this.knowledgebaseId(),
-            omitBlank({
-              id: request.taskId,
-              context: {
-                documents: request.files.map((file) => ({
-                  ...file,
-                  status: KBDocumentStatusEnum.WAITING,
-                  parent: this.parentId() ? { id: this.parentId() } : null
-                }))
-              }
-            })
-          )
+        ? this.knowledgebaseAPI.createTask(request.knowledgebaseId, {
+            context: {
+              documents: request.files.map((file) => ({
+                ...file,
+                status: KBDocumentStatusEnum.WAITING,
+                parent: request.parentId ? ({ id: request.parentId } as IKnowledgeDocument) : null
+              }))
+            }
+          })
         : null
     }
   })
   readonly selectedFile = model<KnowledgeFileUploader | null>(null)
+
+  readonly canContinue = computed(() => {
+    if (!this.selectedSource() || !this.taskId() || this.testing()) return false
+    return (
+      this.providerCategory() !== DocumentSourceProviderCategoryEnum.LocalFile ||
+      (this.files().length > 0 &&
+        this.files().every((file) => !!file.document()) &&
+        this.createFileTask.status() === 'success')
+    )
+  })
 
   // Web Crawl
   readonly selectedDocument = model<Partial<IKnowledgeDocument> | null>(null)
@@ -159,6 +166,7 @@ export class KnowledgeDocumentPipelineStep1Component {
   }
 
   nextStep() {
+    if (!this.canContinue()) return
     this.pipelineComponent.nextStep()
   }
 

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/step-2/step.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/step-2/step.component.html
@@ -1,33 +1,5 @@
-<div class="relative flex flex-col gap-y-0.5 pb-2 pt-4 px-14">
-  <div class="flex items-center gap-x-2">
-    <span
-      class="text-xs font-semibold uppercase bg-gradient-to-br from-[rgba(11,165,236,0.95)] to-[rgba(21,90,239,0.95)] bg-clip-text text-transparent"
-      >{{ 'XP.Knowledgebase.AddDocuments' | translate: { Default: 'Add Documents' } }}</span
-    ><span class="system-2xs-regular text-divider-regular">/</span>
-    <div class="flex gap-x-1">
-      <div class="h-1 w-1 rounded-lg bg-divider-deep"></div>
-      <div class="h-1 rounded-lg w-2 bg-primary-600"></div>
-      <div class="h-1 w-1 rounded-lg bg-divider-deep"></div>
-    </div>
-  </div>
-  <div class="system-md-semibold text-text-primary">
-    {{ 'XP.Knowledgebase.ProcessingDocuments' | translate: { Default: 'Processing Documents' } }}
-  </div>
-  <div>
-    <button
-      type="button"
-      class="btn disabled:btn-disabled btn-secondary-accent btn-medium absolute left-2.5 top-3.5 size-9 rounded-full p-0"
-      [disabled]="loading()"
-      (click)="pipelineComponent.close()"
-    >
-      <i class="ri-corner-up-left-line"></i>
-    </button>
-  </div>
-  <div class="absolute w-[100px] h-[100px] rounded-full bg-blue-500 blur-[80px] left-8 top-0 opacity-20"></div>
-</div>
-
 <xp-knowledge-document-pipeline-settings
-  class="flex-1"
+  class="min-h-0 flex-1"
   [knowledgebase]="knowledgebase()"
   [pipeline]="pipeline()"
   [selectedSource]="selectedSource()"
@@ -35,18 +7,13 @@
   [documents]="documents()"
   [(parametersValue)]="parametersValue"
 >
-  <div actions class="flex items-center justify-between">
-    <button type="button" class="btn disabled:btn-disabled btn-secondary btn-medium gap-x-0.5" (click)="previousStep()">
-      <i class="ri-arrow-left-line"></i>
-      <span class="px-0.5">{{ 'XP.Knowledgebase.DocumentSource' | translate: { Default: 'Document Source' } }}</span>
+  <footer actions class="flex shrink-0 items-center justify-between gap-3 border-t border-divider-subtle px-6 py-4">
+    <button z-button zType="outline" type="button" [disabled]="loading()" (click)="previousStep()">
+      <i class="ri-arrow-left-line" aria-hidden="true"></i>
+      {{ 'XP.Knowledgebase.DocumentSource' | translate: { Default: 'Document Source' } }}
     </button>
-    <button
-      type="button"
-      class="btn disabled:btn-disabled btn-primary btn-medium"
-      [disabled]="loading()"
-      (click)="saveAndProcess()"
-    >
+    <button z-button type="button" [disabled]="loading()" [zLoading]="loading()" (click)="saveAndProcess()">
       {{ 'XP.Knowledgebase.SaveAndProcess' | translate: { Default: 'Save and Process' } }}
     </button>
-  </div>
+  </footer>
 </xp-knowledge-document-pipeline-settings>

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/step-2/step.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/pipeline/step-2/step.component.ts
@@ -17,7 +17,7 @@ import { KnowledgeDocumentsComponent } from '../../documents.component'
 import { KnowledgeDocumentPipelineComponent } from '../pipeline.component'
 import { ContentLoaderModule } from '@ngneat/content-loader'
 import { KnowledgeDocumentPipelineSettingsComponent } from '../settings/settings.component'
-import { ZardTooltipImports } from '@xpert-ai/headless-ui'
+import { ZardButtonComponent, ZardTooltipImports } from '@xpert-ai/headless-ui'
 
 @Component({
   standalone: true,
@@ -25,6 +25,7 @@ import { ZardTooltipImports } from '@xpert-ai/headless-ui'
   templateUrl: './step.component.html',
   styleUrls: ['./step.component.scss'],
   imports: [
+    ZardButtonComponent,
     RouterModule,
     CdkMenuModule,
     FormsModule,

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/step-3/step.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/step-3/step.component.html
@@ -1,177 +1,160 @@
-<div class="flex justify-center w-full max-h-full h-full overflow-y-auto">
-  <div class="grow shrink-0 h-full max-w-[960px] overflow-y-auto px-14 sm:px-16">
+<div class="flex min-h-0 w-full flex-1 flex-col">
+  <div class="min-h-0 flex-1 overflow-y-auto px-6 py-6 lg:px-8">
     <ng-content select="[header]"></ng-content>
-
-    <div class="mx-auto max-w-[640px]">
-      <div class="pt-10">
-        <div class="mb-1 text-xl leading-[22px] font-semibold text-text-primary">
-          🎉 {{ 'XP.Knowledgebase.DocumentUploaded' | translate: { Default: 'Document uploaded' } }}
+    <div class="mx-auto grid max-w-5xl gap-8 lg:grid-cols-3">
+      <section class="min-w-0 lg:col-span-2">
+        <div class="mb-6 flex items-start gap-3">
+          <div
+            class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-background-default-subtle text-text-secondary"
+          >
+            <i class="ri-file-check-line text-xl" aria-hidden="true"></i>
+          </div>
+          <div>
+            <h3 class="text-xl font-semibold text-text-primary">
+              {{ 'XP.Knowledgebase.DocumentUploaded' | translate: { Default: 'Document uploaded' } }}
+            </h3>
+            <p class="mt-2 text-sm leading-6 text-text-tertiary">
+              {{
+                'XP.Knowledgebase.DocumentUploadedKB'
+                  | translate: { Default: 'Documents have been uploaded to the knowledgebase:' }
+              }}
+              <span class="font-medium text-text-secondary">{{ knowledgebase().name }}</span>
+            </p>
+          </div>
         </div>
-        <div class="mb-7 text-[13px] leading-4 text-text-tertiary">
-          {{
-            'XP.Knowledgebase.DocumentUploadedKB'
-              | translate: { Default: 'Documents have been uploaded to the knowledgebase:' }
-          }}
-          {{ knowledgebase().name }}
-          {{
-            'XP.Knowledgebase.YouFindItIn'
-              | translate: { Default: ', you can find it in the document list of the knowledgebase.' }
-          }}
-        </div>
-      </div>
-      <div class="h-5 flex items-center mb-3">
-        <div class="flex items-center justify-between text-text-primary font-medium text-sm mr-2">
+        <div class="mb-2 flex items-center justify-between gap-3 border-b border-divider-subtle pb-3">
+          <h4 class="text-sm font-medium text-text-primary">
+            @if (waited() || running()) {
+              {{ 'XP.Knowledgebase.Embedding' | translate: { Default: 'Embedding' } }}
+            } @else if (failed()) {
+              {{ 'XP.Knowledgebase.PipelineFlow.ProcessingFailed' | translate }}
+            } @else if (cancel()) {
+              {{ 'XP.Knowledgebase.EmbedCancelled' | translate: { Default: 'Embedding cancelled' } }}
+            } @else if (documents()?.length) {
+              {{ 'XP.Knowledgebase.EmbedCompleted' | translate: { Default: 'Embedding completed' } }}
+            } @else {
+              {{ 'XP.Knowledgebase.ProcessingDocuments' | translate: { Default: 'Processing Documents' } }}
+            }
+          </h4>
           @if (waited() || running()) {
             <button
+              z-button
+              zType="outline"
+              zSize="sm"
               type="button"
-              class="btn btn-small pressable danger w-7 h-7 justify-center mr-1"
-              [zTooltip]="
-                'XP.Knowledgebase.StopEmbed'
-                  | translate: { Default: 'Terminate embedding and start from scratch if you need to embed again' }
-              "
-              zPosition="top"
               (click)="stopJob()"
+              [zTooltip]="'XP.Knowledgebase.StopEmbed' | translate: { Default: 'Stop processing' }"
             >
-              <i class="ri-stop-circle-line text-lg"></i>
+              <i class="ri-stop-circle-line text-text-destructive" aria-hidden="true"></i
+              >{{ 'XP.ACTIONS.Stop' | translate: { Default: 'Stop' } }}
             </button>
-            {{ 'XP.Knowledgebase.Embedding' | translate: { Default: 'Embedding' } }}...
-          } @else if (cancel()) {
-            {{ 'XP.Knowledgebase.EmbedCancelled' | translate: { Default: 'Embed Cancelled' } }}
-          } @else {
-            {{ 'XP.Knowledgebase.EmbedCompleted' | translate: { Default: 'Embed Completed' } }}
           }
         </div>
-      </div>
-      <div class="flex flex-col gap-0.5 pb-2">
-        @for (item of documents(); track item.id) {
-          <div class="relative h-[26px] bg-background-default-subtle rounded-md overflow-hidden">
-            <div class="flex gap-1 pl-[6px] pr-2 h-full items-center z-[1]">
-              <knowledge-doc-id [doc]="item" class="grow text-text-secondary" />
-
-              @if (item.status === 'running') {
-                <i class="ri-loader-2-line flex justify-center items-center w-3.5 h-3.5 animate-spin"></i>
-              } @else if (item.status === 'finish') {
-                <i class="ri-checkbox-circle-fill text-text-success"></i>
-              } @else if (item.status === 'error') {
-                <i class="ri-close-circle-fill text-text-destructive" [zTooltip]="item.processMsg" zPosition="top"></i>
+        <div class="divide-y divide-divider-subtle">
+          @for (item of documents(); track item.id) {
+            <div class="min-w-0 py-3">
+              <div class="flex min-w-0 items-center gap-3">
+                <knowledge-doc-id [doc]="item" class="min-w-0 flex-1 text-sm text-text-secondary" />
+                @if (item.status === 'running' || item.status === 'embedding') {
+                  <i class="ri-loader-2-line animate-spin text-text-tertiary" aria-hidden="true"></i>
+                } @else if (item.status === 'finish') {
+                  <i class="ri-checkbox-circle-line text-text-success" aria-hidden="true"></i>
+                } @else if (item.status === 'error') {
+                  <i
+                    class="ri-error-warning-line text-text-destructive"
+                    [zTooltip]="item.processMsg"
+                    aria-hidden="true"
+                  ></i>
+                } @else {
+                  <span class="text-xs text-text-tertiary">{{ item.progress || 0 }}%</span>
+                }
+              </div>
+              @if (item.status === 'error' && item.processMsg) {
+                <p role="alert" class="mt-2 break-words text-xs text-text-destructive">{{ item.processMsg }}</p>
+              }
+              @if (item.status === 'running' || item.status === 'embedding') {
+                <z-progress-bar class="mt-3 block" zSize="sm" [progress]="item.progress || 0" />
               }
             </div>
-
-            @if (item.status === 'running') {
-              <z-progress-bar
-                class="absolute bottom-0 left-0 w-full"
-                zShape="square"
-                zSize="sm"
-                [progress]="item.progress"
-                [zType]="item.progress === 100 ? 'default' : 'accent'"
-              />
-            }
-          </div>
-        } @empty {
-          <bullet-list-content-loader class="w-72" />
-        }
-      </div>
-      <hr class="my-3 h-[1px] bg-divider-subtle border-0" />
-      <div class="flex flex-col gap-1">
-        <div class="flex items-center gap-1 py-0.5 min-h-5 text-sm">
-          <div class="w-[200px] text-text-tertiary overflow-hidden text-ellipsis whitespace-nowrap shrink-0">
-            {{ 'XP.Knowledgebase.ChunkMode' | translate: { Default: 'Chunk Mode' } }}
-          </div>
-          <div class="grow flex items-center gap-1 text-text-secondary">
-            @if (chunkModeStandard()) {
-              {{ 'XP.Knowledgebase.ChunkModeStandard' | translate: { Default: 'Standard' } }}
-            } @else {
-              {{ 'XP.Knowledgebase.ChunkModeCustom' | translate: { Default: 'Custom' } }}
-            }
-          </div>
+          } @empty {
+            <bullet-list-content-loader class="block w-full py-4" />
+          }
         </div>
-
-        <div class="flex items-center gap-1 py-0.5 min-h-5 text-sm">
-          <div class="w-[200px] text-text-tertiary overflow-hidden text-ellipsis whitespace-nowrap shrink-0">
-            {{ 'XP.Knowledgebase.ChunkDelimiter' | translate: { Default: 'Delimiter' } }}
-          </div>
-          <div class="grow flex items-center gap-1 text-text-secondary">
-            {{ parserConfig()?.delimiter }}
-          </div>
-        </div>
-        <div class="flex items-center gap-1 py-0.5 min-h-5 text-sm">
-          <div class="w-[200px] text-text-tertiary overflow-hidden text-ellipsis whitespace-nowrap shrink-0">
-            {{ 'XP.Knowledgebase.ChunkSize' | translate: { Default: 'Chunk Size' } }}
-          </div>
-          <div class="grow flex items-center gap-1 text-text-secondary">
-            {{ parserConfig()?.chunkSize }}
-          </div>
-        </div>
-        <div class="flex items-center gap-1 py-0.5 min-h-5 text-sm">
-          <div class="w-[200px] text-text-tertiary overflow-hidden text-ellipsis whitespace-nowrap shrink-0">
-            {{ 'XP.Knowledgebase.ChunkOverlap' | translate: { Default: 'Chunk Overlap' } }}
-          </div>
-          <div class="grow flex items-center gap-1 text-text-secondary">
-            {{ parserConfig()?.chunkOverlap }}
-          </div>
-        </div>
-
-        <div class="flex gap-1 py-0.5 min-h-5 text-sm !items-start pt-1">
-          <div class="w-[200px] text-text-tertiary overflow-hidden text-ellipsis whitespace-nowrap shrink-0">
-            {{ 'XP.Knowledgebase.TextPreprocessingRules' | translate: { Default: 'Text preprocessing rules' } }}
-          </div>
-          <div class="grow flex items-center gap-1 text-text-secondary">
-            @if (parserConfig()?.replaceWhitespace) {
-              <span
-                >{{
-                  'XP.Knowledgebase.ReplaceWhiteChar'
-                    | translate: { Default: 'Replace consecutive spaces, newlines, and tabs' }
-                }}.
-              </span>
-            }
-            @if (parserConfig()?.removeSensitive) {
-              <span>{{
-                'XP.Knowledgebase.RemoveEmailUrls' | translate: { Default: 'Remove all URLs and email addresses' }
-              }}</span>
-            }
-          </div>
-        </div>
-      </div>
-      <div class="flex items-center gap-2 my-10">
-        <!-- <button type="button" class="btn disabled:btn-disabled btn-secondary btn-medium w-fit">
-          <i class="ri-terminal-box-line"></i>
-          <span>Access the API</span></button
-        > -->
-        <button type="button" class="btn disabled:btn-disabled btn-primary btn-medium w-fit" (click)="apply()">
-          <span>{{ 'XP.Knowledgebase.GotoDocuments' | translate: { Default: 'Goto documents' } }}</span>
-          <i class="ri-arrow-right-line"></i>
-        </button>
-      </div>
-    </div>
-  </div>
-  <div class="shrink-0 pt-[88px] pr-8 text-sm">
-    <div class="flex flex-col gap-3 w-[328px] p-6 text-text-tertiary bg-background-default-subtle rounded-xl">
-      <div class="flex justify-center items-center w-10 h-10 bg-components-card-bg rounded-[10px] shadow-lg">
-        <i class="ri-book-open-line text-xl text-purple-500"></i>
-      </div>
-      <div class="text-base font-semibold text-text-secondary">
-        {{ 'XP.Knowledgebase.WhatDoNext' | translate: { Default: 'What to do next' } }}
-      </div>
-      <div class="text-text-tertiary">
-        {{
-          'XP.Knowledgebase.DoNextDesc'
-            | translate
-              : {
-                  Default:
-                    'Once the documents have been embedded, the knowledgebase can be added to the digital expert agents for use as context.'
+        <dl class="mt-6 divide-y divide-divider-subtle border-t border-divider-subtle text-sm">
+          @if (parserConfig()?.delimiter) {
+            <div class="grid grid-cols-2 gap-4 py-3">
+              <dt class="text-text-tertiary">
+                {{ 'XP.Knowledgebase.ChunkDelimiter' | translate: { Default: 'Delimiter' } }}
+              </dt>
+              <dd class="break-words">{{ parserConfig().delimiter }}</dd>
+            </div>
+          }
+          @if (parserConfig()?.chunkSize) {
+            <div class="grid grid-cols-2 gap-4 py-3">
+              <dt class="text-text-tertiary">
+                {{ 'XP.Knowledgebase.ChunkSize' | translate: { Default: 'Chunk size' } }}
+              </dt>
+              <dd>{{ parserConfig().chunkSize }}</dd>
+            </div>
+          }
+          @if (parserConfig()?.chunkOverlap != null) {
+            <div class="grid grid-cols-2 gap-4 py-3">
+              <dt class="text-text-tertiary">
+                {{ 'XP.Knowledgebase.ChunkOverlap' | translate: { Default: 'Chunk overlap' } }}
+              </dt>
+              <dd>{{ parserConfig().chunkOverlap }}</dd>
+            </div>
+          }
+          @if (parserConfig()?.replaceWhitespace || parserConfig()?.removeSensitive) {
+            <div class="grid grid-cols-2 gap-4 py-3">
+              <dt class="text-text-tertiary">
+                {{ 'XP.Knowledgebase.TextPreprocessingRules' | translate: { Default: 'Text preprocessing rules' } }}
+              </dt>
+              <dd class="space-y-2 text-text-secondary">
+                @if (parserConfig().replaceWhitespace) {
+                  <p>
+                    {{ 'XP.Knowledgebase.ReplaceWhiteChar' | translate: { Default: 'Replace consecutive whitespace' } }}
+                  </p>
                 }
-        }}
-      </div>
-      <div class="w-full flex justify-end pt-2">
+                @if (parserConfig().removeSensitive) {
+                  <p>
+                    {{ 'XP.Knowledgebase.RemoveEmailUrls' | translate: { Default: 'Remove URLs and email addresses' } }}
+                  </p>
+                }
+              </dd>
+            </div>
+          }
+        </dl>
+      </section>
+      <aside class="min-w-0 border-t border-divider-subtle pt-6 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0">
+        <div class="flex items-center gap-2 text-sm font-semibold">
+          <i class="ri-book-open-line text-text-tertiary" aria-hidden="true"></i
+          >{{ 'XP.Knowledgebase.WhatDoNext' | translate: { Default: 'What to do next' } }}
+        </div>
+        <p class="mt-3 text-sm leading-6 text-text-tertiary">
+          {{
+            'XP.Knowledgebase.DoNextDesc'
+              | translate: { Default: 'After processing, use this knowledgebase as context for your agents.' }
+          }}
+        </p>
         <a
-          class="group flex items-center gap-2 text-sm font-light text-text-primary transition-all duration-100 hover:text-primary-500"
+          z-button
+          zType="outline"
+          class="mt-5"
           [href]="'/xpert/w/' + workspaceId()"
           target="_blank"
+          rel="noopener noreferrer"
         >
-          {{ 'XP.Knowledgebase.GotoWorkspace' | translate: { Default: 'Goto workspace' } }}
-          <i class="ri-external-link-line transition-all group-hover:translate-x-1"></i>
+          {{ 'XP.Knowledgebase.GotoWorkspace' | translate: { Default: 'Go to workspace' }
+          }}<i class="ri-external-link-line" aria-hidden="true"></i>
         </a>
-      </div>
+      </aside>
     </div>
   </div>
+  <footer class="flex shrink-0 items-center justify-end gap-3 border-t border-divider-subtle px-6 py-4">
+    <button z-button type="button" (click)="apply()">
+      {{ 'XP.Knowledgebase.GotoDocuments' | translate: { Default: 'Go to documents' }
+      }}<i class="ri-arrow-right-line" aria-hidden="true"></i>
+    </button>
+  </footer>
 </div>

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/step-3/step.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/step-3/step.component.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../../../../@core'
 import { KnowledgebaseComponent } from '../../knowledgebase.component'
 import { KnowledgeDocumentsComponent } from '../documents.component'
-import { ZardProgressBarComponent, ZardTooltipImports } from '@xpert-ai/headless-ui'
+import { ZardButtonComponent, ZardProgressBarComponent, ZardTooltipImports } from '@xpert-ai/headless-ui'
 
 @Component({
   standalone: true,
@@ -36,6 +36,7 @@ import { ZardProgressBarComponent, ZardTooltipImports } from '@xpert-ai/headless
     CdkMenuModule,
     CdkListboxModule,
     ContentLoaderModule,
+    ZardButtonComponent,
     ZardProgressBarComponent,
     ...ZardTooltipImports,
     KnowledgeDocIdComponent
@@ -98,6 +99,7 @@ export class KnowledgeDocumentCreateStep3Component {
     )
   )
   readonly cancel = computed(() => this.documents()?.some((_) => _.status === KBDocumentStatusEnum.CANCEL))
+  readonly failed = computed(() => this.documents()?.some((doc) => doc.status === KBDocumentStatusEnum.ERROR))
   readonly delayRefresh$ = new Subject<boolean>()
 
   constructor() {

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -653,6 +653,25 @@
       }
     },
     "Knowledgebase": {
+      "PipelineFlow": {
+        "Source": "Data source",
+        "Settings": "Processing settings",
+        "Result": "Result",
+        "SourceHint": "Choose a pipeline source, then upload files or fetch documents.",
+        "NoSources": "No sources are available. Check that the published pipeline contains a data source.",
+        "PreviewLoading": "Loading document preview…",
+        "PreviewEmpty": "This document has no preview content.",
+        "ProcessingFailed": "Some documents failed to process"
+      },
+      "PipelineProcessing": {
+        "SettingsHint": "This import uses the published pipeline settings. To change them, edit and publish the pipeline.",
+        "Chunks": "chunks",
+        "Loading": "Running the pipeline to generate a chunk preview…",
+        "Empty": "No chunks were generated for this document. Check its content and pipeline settings.",
+        "PreviewHint": "Preview how the pipeline splits your documents before starting the import.",
+        "Retry": "Retry preview",
+        "Failed": "The preview failed. Try again or check the pipeline."
+      },
       "SharedProcessing": {
         "ParentChild": {
           "ParentTitle": "Parent chunks · Context",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -4549,6 +4549,25 @@
       "NoMatchingMembersHint": "Try another search keyword."
     },
     "Knowledgebase": {
+      "PipelineFlow": {
+        "Source": "Data source",
+        "Settings": "Processing settings",
+        "Result": "Result",
+        "SourceHint": "Choose a pipeline source, then upload files or fetch documents.",
+        "NoSources": "No sources are available. Check that the published pipeline contains a data source.",
+        "PreviewLoading": "Loading document preview…",
+        "PreviewEmpty": "This document has no preview content.",
+        "ProcessingFailed": "Some documents failed to process"
+      },
+      "PipelineProcessing": {
+        "SettingsHint": "This import uses the published pipeline settings. To change them, edit and publish the pipeline.",
+        "Chunks": "chunks",
+        "Loading": "Running the pipeline to generate a chunk preview…",
+        "Empty": "No chunks were generated for this document. Check its content and pipeline settings.",
+        "PreviewHint": "Preview how the pipeline splits your documents before starting the import.",
+        "Retry": "Retry preview",
+        "Failed": "The preview failed. Try again or check the pipeline."
+      },
       "SharedProcessing": {
         "ParentChild": {
           "ParentTitle": "Parent chunks · Context",

--- a/apps/cloud/src/assets/i18n/zh-CN.json
+++ b/apps/cloud/src/assets/i18n/zh-CN.json
@@ -1944,6 +1944,25 @@
       "Unavailable": "请先配置 Claw Xpert。"
     },
     "Knowledgebase": {
+      "PipelineFlow": {
+        "Source": "选择数据源",
+        "Settings": "处理设置",
+        "Result": "处理结果",
+        "SourceHint": "选择流水线中的数据源，再上传文件或获取文档。",
+        "NoSources": "暂无可用数据源，请确认已发布的流水线包含数据源节点。",
+        "PreviewLoading": "正在加载文档预览…",
+        "PreviewEmpty": "此文档暂无可预览内容。",
+        "ProcessingFailed": "部分文档处理失败"
+      },
+      "PipelineProcessing": {
+        "SettingsHint": "本次导入使用已发布的流水线配置。如需调整，请编辑并重新发布流水线。",
+        "Chunks": "个分块",
+        "Loading": "正在运行流水线，生成分块预览…",
+        "Empty": "此文档未生成分块，请检查文档内容和流水线配置。",
+        "PreviewHint": "先预览文档的分块效果，确认后再开始导入。",
+        "Retry": "重新预览",
+        "Failed": "预览失败，请重试或检查流水线。"
+      },
       "SharedProcessing": {
         "ParentChild": {
           "ParentTitle": "父块 · 补充上下文",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -6513,6 +6513,25 @@
       "TakeMeThere": "带我去！"
     },
     "Knowledgebase": {
+      "PipelineFlow": {
+        "Source": "选择数据源",
+        "Settings": "处理设置",
+        "Result": "处理结果",
+        "SourceHint": "选择流水线中的数据源，再上传文件或获取文档。",
+        "NoSources": "暂无可用数据源，请确认已发布的流水线包含数据源节点。",
+        "PreviewLoading": "正在加载文档预览…",
+        "PreviewEmpty": "此文档暂无可预览内容。",
+        "ProcessingFailed": "部分文档处理失败"
+      },
+      "PipelineProcessing": {
+        "SettingsHint": "本次导入使用已发布的流水线配置。如需调整，请编辑并重新发布流水线。",
+        "Chunks": "个分块",
+        "Loading": "正在运行流水线，生成分块预览…",
+        "Empty": "此文档未生成分块，请检查文档内容和流水线配置。",
+        "PreviewHint": "先预览文档的分块效果，确认后再开始导入。",
+        "Retry": "重新预览",
+        "Failed": "预览失败，请重试或检查流水线。"
+      },
       "SharedProcessing": {
         "ParentChild": {
           "ParentTitle": "父块 · 补充上下文",

--- a/apps/cloud/src/assets/i18n/zh-Hant.json
+++ b/apps/cloud/src/assets/i18n/zh-Hant.json
@@ -5053,6 +5053,25 @@
       "Unavailable": "請先配置 Claw Xpert。"
     },
     "Knowledgebase": {
+      "PipelineFlow": {
+        "Source": "選擇資料來源",
+        "Settings": "處理設定",
+        "Result": "處理結果",
+        "SourceHint": "選擇流水線中的資料來源，再上傳檔案或取得文件。",
+        "NoSources": "暫無可用資料來源，請確認已發佈的流水線包含資料來源節點。",
+        "PreviewLoading": "正在載入文件預覽…",
+        "PreviewEmpty": "此文件暫無可預覽內容。",
+        "ProcessingFailed": "部分文件處理失敗"
+      },
+      "PipelineProcessing": {
+        "SettingsHint": "本次匯入使用已發佈的流水線設定。如需調整，請編輯並重新發佈流水線。",
+        "Chunks": "個分塊",
+        "Loading": "正在執行流水線，產生分塊預覽…",
+        "Empty": "此文件未產生分塊，請檢查文件內容和流水線設定。",
+        "PreviewHint": "先預覽文件的分塊效果，確認後再開始匯入。",
+        "Retry": "重新預覽",
+        "Failed": "預覽失敗，請重試或檢查流水線。"
+      },
       "SharedProcessing": {
         "ParentChild": {
           "ParentTitle": "父塊 · 補充上下文",

--- a/packages/contracts/src/ai/knowledge-doc.model.ts
+++ b/packages/contracts/src/ai/knowledge-doc.model.ts
@@ -308,6 +308,9 @@ export type TKnowledgeDocument = {
    */
   jobId?: string
 
+  /** Server-owned pipeline attempt allowed to update this document on dispatch failure. */
+  processingExecutionId?: string | null
+
   options?: TDocumentWebOptions
 
   integrationId?: string

--- a/packages/contracts/src/ai/knowledgebase-task.model.ts
+++ b/packages/contracts/src/ai/knowledgebase-task.model.ts
@@ -29,6 +29,8 @@ export interface IKnowledgebaseTask extends IBasePerTenantAndOrganizationEntityM
     documents?: Partial<IKnowledgeDocument>[]
     /** Propagates full conversion vs. snapshot-only rechunking through the background task. */
     processingMode?: KnowledgeDocumentProcessingMode
+    /** Server-created preview ID -> saved document ID bindings, grouped by source node. */
+    materializedSources?: Record<string, Record<string, string>>
   }
 
   /**

--- a/packages/server-ai/src/i18n/en-US.json
+++ b/packages/server-ai/src/i18n/en-US.json
@@ -1,5 +1,7 @@
 {
     "Error": {
+        "KnowledgePipelineFailed": "Knowledge pipeline execution failed",
+        "InvalidKnowledgePipelineCallback": "Invalid knowledge pipeline callback context",
         "KnowledgebaseChunkStructureConflict": "This knowledgebase already uses a different chunk structure. Keep its structure or use a new knowledgebase.",
         "InvalidKnowledgeParserConfig": "Invalid or unavailable document processing setting: {{field}}",
         "KnowledgebaseWikiMarkdownResponseInvalid": "Wiki generation must return a SUMMARY line followed by a Markdown title and body on separate lines.",

--- a/packages/server-ai/src/i18n/en.json
+++ b/packages/server-ai/src/i18n/en.json
@@ -1,5 +1,7 @@
 {
     "Error": {
+        "KnowledgePipelineFailed": "Knowledge pipeline execution failed",
+        "InvalidKnowledgePipelineCallback": "Invalid knowledge pipeline callback context",
         "KnowledgebaseChunkStructureConflict": "This knowledgebase already uses a different chunk structure. Keep its structure or use a new knowledgebase.",
         "InvalidKnowledgeParserConfig": "Invalid or unavailable document processing setting: {{field}}",
         "KnowledgebaseWikiMarkdownResponseInvalid": "Wiki generation must return a SUMMARY line followed by a Markdown title and body on separate lines.",

--- a/packages/server-ai/src/i18n/zh-Hans.json
+++ b/packages/server-ai/src/i18n/zh-Hans.json
@@ -1,5 +1,7 @@
 {
     "Error": {
+        "KnowledgePipelineFailed": "知识流水线执行失败",
+        "InvalidKnowledgePipelineCallback": "知识流水线回调上下文无效",
         "KnowledgebaseChunkStructureConflict": "知识库中已有其他分块结构，请保留当前结构或使用新的知识库。",
         "InvalidKnowledgeParserConfig": "无效或不可用的文档处理设置：{{field}}",
         "KnowledgebaseWikiMarkdownResponseInvalid": "Wiki 生成结果格式不正确：需要单独的摘要行，以及分行的 Markdown 标题和正文。",

--- a/packages/server-ai/src/knowledge-document/document.entity.ts
+++ b/packages/server-ai/src/knowledge-document/document.entity.ts
@@ -288,6 +288,10 @@ export class KnowledgeDocument<T extends KnowledgeDocumentMetadata = KnowledgeDo
     @Column({ nullable: true })
     jobId?: string
 
+    // Excluded from ordinary reads so a stale document snapshot cannot reclaim a newer attempt.
+    @Column({ type: 'varchar', nullable: true, select: false })
+    processingExecutionId?: string | null
+
     @ApiPropertyOptional({ type: () => Object })
     @IsJSON()
     @IsOptional()

--- a/packages/server-ai/src/knowledge-document/document.service.spec.ts
+++ b/packages/server-ai/src/knowledge-document/document.service.spec.ts
@@ -66,6 +66,10 @@ jest.mock('@xpert-ai/server-core', () => ({
         async save(entity: T | T[]) {
             return this.repository.save?.(entity)
         }
+
+        protected writeToCurrentScope(entity: Partial<T>) {
+            return { ...entity, tenantId: 'tenant-1', organizationId: 'org-1' }
+        }
     }
 }))
 
@@ -85,7 +89,11 @@ import { CommandBus, QueryBus } from '@nestjs/cqrs'
 import { Queue } from 'bull'
 import type { KnowledgebaseService, KnowledgeDocumentStore } from '../knowledgebase'
 import type { KnowledgeWorkAreaResolver } from '../shared'
-import { computeKnowledgeDocumentChunkHash, computeKnowledgeDocumentProcessingHash } from './document-hash'
+import {
+    computeKnowledgeDocumentChunkHash,
+    computeKnowledgeDocumentContentHash,
+    computeKnowledgeDocumentProcessingHash
+} from './document-hash'
 import { KnowledgeDocument } from './document.entity'
 import { buildLogicalFolderPath, KnowledgeDocumentService } from './document.service'
 import { resolveKnowledgeDocumentParserConfig } from './parser-config'
@@ -911,6 +919,32 @@ describe('KnowledgeDocumentService optimistic locks', () => {
 })
 
 describe('KnowledgeDocumentService incremental ingestion', () => {
+    it('keeps new document, tree lookup and folder writes on the caller transaction', async () => {
+        const outsideSave = jest.fn()
+        const save = jest.fn(async (doc) => ({ ...doc, id: 'saved' }))
+        const service = createService([], {
+            repo: { save: outsideSave },
+            knowledgebaseService: {
+                assertNotRebuilding: jest.fn(),
+                findOneByIdString: jest.fn(async () => ({ id: 'kb', incrementalSyncEnabled: false }))
+            }
+        })
+        const findOneBy = jest.fn(async () => ({ id: 'saved' }))
+        const findAncestorsTree = jest.fn(async (doc) => doc)
+        const manager = {
+            getRepository: jest.fn(() => ({ save })),
+            getTreeRepository: jest.fn(() => ({ findOneBy, findAncestorsTree }))
+        }
+        await service.createBulk([{ knowledgebaseId: 'kb', name: 'test.md', type: 'md' }], manager as never)
+        expect(outsideSave).not.toHaveBeenCalled()
+        expect(save).toHaveBeenCalledTimes(2)
+        expect(save.mock.calls[0][0]).toEqual(
+            expect.objectContaining({ tenantId: 'tenant-1', organizationId: 'org-1' })
+        )
+        expect(findOneBy).toHaveBeenCalledWith({ id: 'saved' })
+        expect(save.mock.calls[1][0]).toHaveProperty('folder')
+    })
+
     it('reuses unchanged source documents without scheduling processing', async () => {
         const incoming = {
             knowledgebaseId: 'kb-1',
@@ -1358,7 +1392,7 @@ describe('KnowledgeDocumentService incremental ingestion', () => {
             {
                 id: 'doc-1',
                 knowledgebaseId: 'kb-1',
-                contentHash: 'old-content-hash',
+                contentHash: computeKnowledgeDocumentContentHash([unchangedExisting, changedExisting, deletedExisting]),
                 chunks: [unchangedIncoming, changedIncoming, addedIncoming]
             } as IKnowledgeDocument,
             vectorStore
@@ -1375,7 +1409,43 @@ describe('KnowledgeDocumentService incremental ingestion', () => {
         expect(result.embeddingChunks.map((chunk) => chunk.pageContent)).toEqual(
             expect.arrayContaining(['new content', 'added content'])
         )
+        expect(result.embeddingChunks).toHaveLength(2)
     })
+
+    it.each([null, 'previous-published-hash'])(
+        're-embeds persisted chunks after an interrupted sync (published hash: %s)',
+        async (contentHash) => {
+            const chunk = {
+                id: 'row-a',
+                pageContent: 'stored before embedding failed',
+                metadata: { chunkId: 'chunk-a', chunkIndex: 0 }
+            } as IKnowledgeDocumentChunk
+            chunk.contentHash = computeKnowledgeDocumentChunkHash(chunk)
+            const service = createService([])
+            Object.assign(service, {
+                chunkService: {
+                    findAll: jest.fn(async () => ({ items: [chunk] })),
+                    upsertBulk: jest.fn(async (chunks: IKnowledgeDocumentChunk[]) => chunks),
+                    delete: jest.fn(),
+                    findAllEmbeddingNodes: jest.fn((chunks: IKnowledgeDocumentChunk[]) => chunks)
+                }
+            })
+            const vectorStore = { deleteChunks: jest.fn() } as unknown as KnowledgeDocumentStore
+            const result = await service.syncChunksIncrementally(
+                {
+                    id: 'doc',
+                    knowledgebaseId: 'kb',
+                    contentHash,
+                    chunks: [chunk]
+                } as IKnowledgeDocument,
+                vectorStore
+            )
+            expect(result.embeddingChunks).toHaveLength(1)
+            expect(result.embeddingChunks[0].id).toBe('row-a')
+            expect(vectorStore.deleteChunks).toHaveBeenCalledWith(['row-a'])
+            expect(result.statistics).toMatchObject({ skipped: 0, updated: 1 })
+        }
+    )
 
     it('adds stored chunk versions to vector search results', async () => {
         const vectorStore = {

--- a/packages/server-ai/src/knowledge-document/document.service.ts
+++ b/packages/server-ai/src/knowledge-document/document.service.ts
@@ -40,6 +40,7 @@ import { compact, uniq } from 'lodash'
 import {
     DataSource,
     DeepPartial,
+    EntityManager,
     FindManyOptions,
     FindOneOptions,
     FindOptionsWhere,
@@ -518,6 +519,7 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
             delete document.processDuation
             delete document.processDuration
             delete document.jobId
+            delete document.processingExecutionId
             delete document.tokenNum
             delete document.chunkNum
 
@@ -686,8 +688,8 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
         }
     }
 
-    async findAncestors(id: string) {
-        const treeRepo = this.dataSource.getTreeRepository(KnowledgeDocument)
+    async findAncestors(id: string, manager?: EntityManager) {
+        const treeRepo = (manager ?? this.dataSource).getTreeRepository(KnowledgeDocument)
         const entity = await treeRepo.findOneBy({ id })
         if (!entity) {
             throw new NotFoundException(`Knowledge document "${id}" not found`)
@@ -820,7 +822,7 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
         return this.createDocument(document as Partial<IKnowledgeDocument>)
     }
 
-    async createDocument(document: Partial<IKnowledgeDocument>): Promise<KnowledgeDocument> {
+    async createDocument(document: Partial<IKnowledgeDocument>, manager?: EntityManager): Promise<KnowledgeDocument> {
         await this.prepareDocumentRelations(document)
         await this.completeDocumentSystemAttributes(document)
         await this.validateDocumentMetadataInput(document)
@@ -829,13 +831,19 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
         document.sourceKey ??= resolveKnowledgeDocumentSourceKey(document)
         document.processingHash ??= computeKnowledgeDocumentProcessingHash(document)
 
-        const doc = await super.create({
-            ...document
-        })
+        const doc = manager
+            ? await manager.getRepository(KnowledgeDocument).save(
+                  this.writeToCurrentScope({
+                      ...document,
+                      createdById: RequestContext.currentUserId(),
+                      updatedById: RequestContext.currentUserId()
+                  })
+              )
+            : await super.create({ ...document })
         // Init folder path for document entity
-        const parents = await this.findAncestors(doc.id)
+        const parents = await this.findAncestors(doc.id, manager)
         doc.folder = buildLogicalFolderPath(parents, doc.id)
-        await this.repository.save(doc)
+        await (manager?.getRepository(KnowledgeDocument) ?? this.repository).save(doc)
 
         return doc
     }
@@ -863,7 +871,8 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
      * @returns
      */
     async createBulkWithIncrementalSync(
-        documents: Partial<IKnowledgeDocument>[]
+        documents: Partial<IKnowledgeDocument>[],
+        manager?: EntityManager
     ): Promise<IncrementalDocumentSyncResult> {
         if (!documents?.length) {
             return {
@@ -875,6 +884,7 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
             }
         }
         for (const document of documents) {
+            delete document.processingExecutionId
             document.parserConfig = await this.resolveNewDocumentParserConfig(document, true)
             document.sourceHash ??= resolveKnowledgeDocumentSourceHash(document)
             document.sourceKey ??= resolveKnowledgeDocumentSourceKey(document)
@@ -898,9 +908,9 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
                 ? incrementalSyncByKnowledgebaseId.get(document.knowledgebaseId) === true
                 : false
             const synced = incrementalSyncEnabled
-                ? await this.createOrReuseSourceDocument(document)
+                ? await this.createOrReuseSourceDocument(document, manager)
                 : {
-                      document: await this.createDocument(document),
+                      document: await this.createDocument(document, manager),
                       shouldProcess: true,
                       action: 'created' as const
                   }
@@ -972,12 +982,13 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
      * @param documents
      * @returns
      */
-    async createBulk(documents: Partial<IKnowledgeDocument>[]): Promise<KnowledgeDocument[]> {
-        return (await this.createBulkWithIncrementalSync(documents)).documents
+    async createBulk(documents: Partial<IKnowledgeDocument>[], manager?: EntityManager): Promise<KnowledgeDocument[]> {
+        return (await this.createBulkWithIncrementalSync(documents, manager)).documents
     }
 
     private async createOrReuseSourceDocument(
-        document: Partial<IKnowledgeDocument>
+        document: Partial<IKnowledgeDocument>,
+        manager?: EntityManager
     ): Promise<IncrementalDocumentSyncItemResult> {
         await this.completeDocumentSystemAttributes(document)
         await this.validateDocumentMetadataInput(document)
@@ -986,9 +997,9 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
         document.sourceKey = sourceKey
         document.sourceHash = sourceHash
 
-        const existing = await this.findExistingSourceDocument(document)
+        const existing = await this.findExistingSourceDocument(document, manager)
         if (!existing) {
-            const created = await this.createDocument(document)
+            const created = await this.createDocument(document, manager)
             return {
                 document: created,
                 shouldProcess: true,
@@ -1008,7 +1019,7 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
         const documentChanges = { ...document }
         delete documentChanges.id
         delete documentChanges.version
-        const updated = await this.save({
+        const changes: DeepPartial<KnowledgeDocument> = {
             ...existing,
             ...documentChanges,
             id: existing.id,
@@ -1018,7 +1029,10 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
             processingHash,
             chunkNum: existing.chunkNum,
             tokenNum: existing.tokenNum
-        } as DeepPartial<KnowledgeDocument>)
+        }
+        const updated = manager
+            ? await manager.getRepository(KnowledgeDocument).save(this.writeToCurrentScope(changes))
+            : await this.save(changes)
 
         return {
             document: updated,
@@ -1027,7 +1041,10 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
         }
     }
 
-    private async findExistingSourceDocument(document: Partial<IKnowledgeDocument>): Promise<KnowledgeDocument | null> {
+    private async findExistingSourceDocument(
+        document: Partial<IKnowledgeDocument>,
+        manager?: EntityManager
+    ): Promise<KnowledgeDocument | null> {
         if (!document.knowledgebaseId) {
             return null
         }
@@ -1041,6 +1058,17 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
             knowledgebaseId: document.knowledgebaseId,
             sourceType: document.sourceType,
             sourceKey
+        }
+
+        if (manager) {
+            return manager.findOne(KnowledgeDocument, {
+                where: {
+                    ...where,
+                    tenantId: RequestContext.currentTenantId(),
+                    organizationId: RequestContext.getOrganizationId() ?? IsNull()
+                },
+                order: { updatedAt: 'DESC' }
+            })
         }
 
         const { items } = await this.findAll({
@@ -1180,6 +1208,7 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
         delete changes.updatedAt
         delete changes.deletedAt
         delete changes.publicationEpoch
+        delete changes.processingExecutionId
         delete changes.knowledgebase
         delete changes.storageFile
 
@@ -1818,7 +1847,12 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
             order: { createdAt: 'ASC' }
         })
 
-        if (document.contentHash && document.contentHash === contentHash) {
+        // Chunk rows are saved before vectors. Only a matching published hash proves those rows were indexed.
+        const recoverInterruptedSync =
+            existingChunks.length > 0 &&
+            (!document.contentHash ||
+                computeKnowledgeDocumentContentHash(sortChunksByDocumentOrder(existingChunks)) !== document.contentHash)
+        if (!recoverInterruptedSync && document.contentHash && document.contentHash === contentHash) {
             return {
                 chunks: existingChunks as IKnowledgeDocumentChunk<TDocChunkMetadata>[],
                 embeddingChunks: [],
@@ -1839,16 +1873,20 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
             incomingChunks,
             existingChunks as IKnowledgeDocumentChunk<TDocChunkMetadata>[]
         )
-        const skippedCount = matches.filter((match) => match.operation === 'unchanged').length
+        const skippedCount = recoverInterruptedSync
+            ? 0
+            : matches.filter((match) => match.operation === 'unchanged').length
         const addedCount = matches.filter((match) => match.operation === 'added').length
-        const updatedCount = matches.filter((match) => match.operation === 'changed').length
+        const updatedCount = matches.filter(
+            (match) => match.operation === 'changed' || (recoverInterruptedSync && match.operation === 'unchanged')
+        ).length
         const chunksToPersist = matches.map((match) => ({
             ...match.chunk,
             documentId: document.id,
             knowledgebaseId: document.knowledgebaseId
         }))
         const changedIds = matches
-            .filter((match) => match.operation === 'changed' && match.chunk.id)
+            .filter((match) => (match.operation === 'changed' || recoverInterruptedSync) && match.chunk.id)
             .map((match) => match.chunk.id)
             .filter((id): id is string => !!id)
         const usedIds = new Set(matches.map((match) => match.previous?.id).filter((id): id is string => !!id))
@@ -1868,13 +1906,13 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
 
         const changedChunkIds = new Set(
             matches
-                .filter((match) => match.operation !== 'unchanged')
+                .filter((match) => recoverInterruptedSync || match.operation !== 'unchanged')
                 .map((match) => getChunkLogicalId(match.chunk))
                 .filter((id): id is string => !!id)
         )
         const changedRowIds = new Set(
             matches
-                .filter((match) => match.operation !== 'unchanged')
+                .filter((match) => recoverInterruptedSync || match.operation !== 'unchanged')
                 .map((match) => match.chunk.id)
                 .filter((id): id is string => !!id)
         )
@@ -2151,6 +2189,7 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
         delete document.deletedAt
         delete document.hardDeletePendingAt
         delete document.publicationEpoch
+        delete document.processingExecutionId
         delete document.knowledgebase
         delete document.storageFile
         if (hasParent) {
@@ -2248,6 +2287,7 @@ export class KnowledgeDocumentService extends TenantOrganizationAwareCrudService
 
         docs.forEach((item) => {
             item.jobId = job.id as string
+            item.processingExecutionId = null
             item.status = KBDocumentStatusEnum.RUNNING
             item.processMsg = ''
             item.progress = 0

--- a/packages/server-ai/src/knowledgebase/dto/knowledgebase-detail.dto.spec.ts
+++ b/packages/server-ai/src/knowledgebase/dto/knowledgebase-detail.dto.spec.ts
@@ -1,8 +1,59 @@
-import { AiModelTypeEnum, DEFAULT_KNOWLEDGEBASE_WIKI_CONFIG, KnowledgebaseTypeEnum } from '@xpert-ai/contracts'
+import {
+    AiModelTypeEnum,
+    DEFAULT_KNOWLEDGEBASE_WIKI_CONFIG,
+    IWFNSource,
+    KnowledgebaseTypeEnum,
+    TXpertGraph,
+    WorkflowNodeTypeEnum,
+    XpertParameterTypeEnum,
+    XpertTypeEnum
+} from '@xpert-ai/contracts'
 import { instanceToPlain } from 'class-transformer'
 import { KnowledgebaseDetailDTO } from './knowledgebase-detail.dto'
 
 describe('KnowledgebaseDetailDTO', () => {
+    it('preserves published source nodes for document import without exposing draft or linked expert graphs', () => {
+        const source: IWFNSource<{ fileExtensions: string[] }> = {
+            id: 'source-1',
+            key: 'source-1',
+            type: WorkflowNodeTypeEnum.SOURCE,
+            provider: 'local-file',
+            config: { fileExtensions: ['pdf'] },
+            integrationId: 'integration-1',
+            parameters: [{ name: 'folder', type: XpertParameterTypeEnum.STRING }]
+        }
+        const graph: TXpertGraph = {
+            nodes: [{ key: source.key, type: 'workflow', position: { x: 0, y: 0 }, entity: source }],
+            connections: []
+        }
+        const dto = new KnowledgebaseDetailDTO({
+            id: 'kb-1',
+            pipeline: {
+                id: 'pipeline-1',
+                slug: 'knowledge-pipeline',
+                name: 'Knowledge pipeline',
+                type: XpertTypeEnum.Knowledge,
+                publishAt: new Date('2026-07-08T08:00:00.000Z'),
+                version: '1.0.0',
+                graph,
+                draft: { nodes: [], connections: [], team: {} }
+            },
+            xperts: [{ id: 'xpert-1', slug: 'linked-expert', name: 'Linked expert', type: XpertTypeEnum.Agent, graph }]
+        })
+
+        const payload = instanceToPlain(dto)
+
+        expect(payload.pipeline.graph).toEqual(graph)
+        expect(payload.pipeline).not.toHaveProperty('draft')
+        expect(payload.xperts[0]).not.toHaveProperty('graph')
+    })
+
+    it.each([undefined, null])('keeps absent pipelines empty (%s)', (pipeline) => {
+        const payload = instanceToPlain(new KnowledgebaseDetailDTO({ id: 'kb-1', pipeline }))
+
+        expect(payload.pipeline).toBeNull()
+    })
+
     it('exposes legacy knowledgebases without a type as standard document knowledgebases', () => {
         const dto = new KnowledgebaseDetailDTO({
             id: 'legacy-knowledgebase',

--- a/packages/server-ai/src/knowledgebase/dto/knowledgebase-detail.dto.ts
+++ b/packages/server-ai/src/knowledgebase/dto/knowledgebase-detail.dto.ts
@@ -66,6 +66,9 @@ class KnowledgebasePipelineDetailDTO implements Partial<IXpert> {
     @Expose()
     declare version?: string
 
+    @Expose()
+    declare graph?: IXpert['graph']
+
     constructor(partial: Partial<IXpert>) {
         Object.assign(this, partial)
     }

--- a/packages/server-ai/src/knowledgebase/knowledgebase.module.ts
+++ b/packages/server-ai/src/knowledgebase/knowledgebase.module.ts
@@ -51,6 +51,7 @@ import {
 } from './wiki/entities'
 import { KnowledgeWikiSearchScopeService } from './wiki/knowledge-wiki-search-scope.service'
 import { KnowledgeParserSettingsService } from './parser-settings.service'
+import { KnowledgePipelineCallbackProcessor } from './task/pipeline-callback.processor'
 
 @Module({
     imports: [
@@ -80,6 +81,7 @@ import { KnowledgeParserSettingsService } from './parser-settings.service'
     ],
     controllers: [KnowledgebaseController, KnowledgeFAQController],
     providers: [
+        KnowledgePipelineCallbackProcessor,
         KnowledgeParserSettingsService,
         KnowledgebaseService,
         KnowledgebaseRuntimeService,

--- a/packages/server-ai/src/knowledgebase/knowledgebase.service.spec.ts
+++ b/packages/server-ai/src/knowledgebase/knowledgebase.service.spec.ts
@@ -1494,7 +1494,13 @@ describe('KnowledgebaseService', () => {
                     wikiModelId: true,
                     apiEnabled: true,
                     workspaceId: true,
-                    pipelineId: true
+                    pipelineId: true,
+                    pipeline: {
+                        id: true,
+                        publishAt: true,
+                        version: true,
+                        graph: true
+                    }
                 }),
                 where: expect.objectContaining({
                     id: 'kb-1',
@@ -1542,7 +1548,7 @@ describe('KnowledgebaseService', () => {
         expect(payload).not.toHaveProperty('tenantId')
         expect(payload).not.toHaveProperty('organizationId')
         expect(payload.xperts[0]).not.toHaveProperty('graph')
-        expect(payload.pipeline).not.toHaveProperty('graph')
+        expect(payload.pipeline.graph).toEqual(knowledgebase.pipeline.graph)
     })
 
     it('rejects a task conversation before creating the task when conversation access fails', async () => {

--- a/packages/server-ai/src/knowledgebase/knowledgebase.service.ts
+++ b/packages/server-ai/src/knowledgebase/knowledgebase.service.ts
@@ -1,3 +1,5 @@
+import { dispatchKnowledgePipeline } from './task/pipeline-task'
+import { prepareKnowledgePipelineDocuments } from './task/prepare-pipeline-documents'
 import { resolveKnowledgeDocumentParserConfig } from '../knowledge-document/parser-config'
 import { KnowledgeParserSettingsService } from './parser-settings.service'
 import {
@@ -8,7 +10,6 @@ import { Embeddings } from '@langchain/core/embeddings'
 import { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import {
     AiModelTypeEnum,
-    channelName,
     DEFAULT_KNOWLEDGEBASE_FAQ_CONFIG,
     DocumentMetadata,
     DocumentTypeEnum,
@@ -21,22 +22,17 @@ import {
     IWFNProcessor,
     IWFNSource,
     KBDocumentStatusEnum,
-    KnowledgebaseChannel,
     KnowledgebaseFAQConfig,
     KnowledgebasePermission,
     KnowledgebaseStatusEnum,
     KnowledgebaseTypeEnum,
     KnowledgeProviderEnum,
-    KNOWLEDGE_SOURCES_NAME,
-    KnowledgeTask,
     mapTranslationLanguage,
-    STATE_VARIABLE_HUMAN,
     WorkflowNodeTypeEnum,
     XpertTypeEnum,
     genXpertTriggerKey,
     IWFNTrigger,
     KnowledgeStructureEnum,
-    XpertAgentExecutionStatusEnum,
     classificateDocumentCategory,
     TCopilotModel,
     KnowledgeDocumentMetadata,
@@ -48,7 +44,6 @@ import {
     KnowledgeFilterSources,
     KnowledgeRetrievalContentScope,
     KnowledgeGraphStatus,
-    KNOWLEDGE_PROCESSING_MODE_NAME,
     KBMetadataFieldDef,
     MetadataFieldType,
     KnowledgeFilterJSONValue,
@@ -125,9 +120,8 @@ import { VolumeSubtreeClient } from '../shared/volume/volume-subtree'
 import { KnowledgeDocumentService } from '../knowledge-document/document.service'
 import { KnowledgeDocumentChunk } from '../knowledge-document/chunk/chunk.entity'
 import { TDocChunkMetadata } from '../knowledge-document/types'
-import { XpertAgentExecutionUpsertCommand } from '../xpert-agent-execution'
 import { PluginPermissionsCommand } from './commands'
-import { XpertEnqueueTriggerDispatchCommand, XpertPublishTriggersCommand } from '../xpert/commands'
+import { XpertPublishTriggersCommand } from '../xpert/commands'
 import { JOB_REBUILD_KNOWLEDGEBASE_EMBEDDING, TKnowledgebaseRebuildEmbeddingJob } from './types'
 import { KnowledgebaseDetailDTO } from './dto'
 import { KnowledgeFilterFieldDefinition } from './filter'
@@ -280,7 +274,8 @@ const KNOWLEDGEBASE_DETAIL_SELECT: FindOptionsSelect<Knowledgebase> = {
     pipeline: {
         id: true,
         publishAt: true,
-        version: true
+        version: true,
+        graph: true
     }
 }
 
@@ -2231,41 +2226,20 @@ export class KnowledgebaseService extends XpertWorkspaceBaseService<Knowledgebas
             relations: ['documents']
         })
         this.assertKnowledgebaseTaskSources(task, inputs.sources)
-        const execution = await this.commandBus.execute(
-            new XpertAgentExecutionUpsertCommand({
-                // threadId: conversation.threadId,
-                status: XpertAgentExecutionStatusEnum.RUNNING
-            })
+        const prepared = await prepareKnowledgePipelineDocuments(
+            task,
+            kb.pipeline?.graph,
+            inputs,
+            this.documentService,
+            this.taskService
         )
-        await this.taskService.update(taskId, { status: 'running', executionId: execution.id })
-        const sources = inputs.sources ? Object.keys(inputs.sources) : null
-
-        await this.commandBus.execute(
-            new XpertEnqueueTriggerDispatchCommand(
-                kb.pipelineId,
-                RequestContext.currentUserId(),
-                {
-                    [STATE_VARIABLE_HUMAN]: {
-                        input: 'Process knowledges pipeline'
-                    },
-                    [KnowledgebaseChannel]: {
-                        knowledgebaseId: knowledgebaseId,
-                        [KnowledgeTask]: taskId,
-                        [KNOWLEDGE_SOURCES_NAME]: sources,
-                        [KNOWLEDGE_PROCESSING_MODE_NAME]: inputs.mode ?? 'full',
-                        stage: inputs.stage
-                    },
-                    ...(sources ?? []).reduce(
-                        (obj, key) => ({ ...obj, [channelName(key)]: { documents: inputs.sources[key].documents } }),
-                        {}
-                    )
-                },
-                {
-                    isDraft: inputs.isDraft,
-                    from: 'knowledge',
-                    executionId: execution.id
-                }
-            )
+        await dispatchKnowledgePipeline(
+            this.commandBus,
+            this.taskService,
+            knowledgebaseId,
+            kb.pipelineId,
+            taskId,
+            prepared
         )
     }
 

--- a/packages/server-ai/src/knowledgebase/pipeline-processing.spec.ts
+++ b/packages/server-ai/src/knowledgebase/pipeline-processing.spec.ts
@@ -1,0 +1,105 @@
+import { KnowledgebaseService } from './knowledgebase.service'
+import { XpertAgentExecutionUpsertCommand } from '../xpert-agent-execution'
+import { XpertEnqueueTriggerDispatchCommand } from '../xpert/commands'
+import { channelName, WorkflowNodeTypeEnum } from '@xpert-ai/contracts'
+
+describe('knowledge pipeline dispatch', () => {
+    function setup() {
+        const taskService = {
+            findOneByOptions: jest.fn().mockResolvedValue({ id: 'task-1', context: { documents: [] } }),
+            update: jest.fn(),
+            failExecution: jest.fn(),
+            startDocumentExecution: jest.fn(),
+            savePreparedSource: jest.fn(),
+            withLockedTask: jest.fn(async (_id, work) => work(await taskService.findOneByOptions(), undefined))
+        }
+        const commandBus = { execute: jest.fn().mockResolvedValue({ id: 'execution-1' }) }
+        const documentService = { createBulk: jest.fn().mockResolvedValue([{ id: 'saved-1' }]) }
+        const service = {
+            assertKnowledgebaseTaskWriteAccess: jest.fn().mockResolvedValue({ pipelineId: 'pipeline-1' }),
+            assertKnowledgebaseTaskSources: jest.fn(),
+            taskService,
+            commandBus,
+            documentService
+        }
+        const process = () =>
+            KnowledgebaseService.prototype.processTask.call(service as never, 'kb-1', 'task-1', {
+                stage: 'preview',
+                sources: { source: { documents: ['doc-1'] } }
+            })
+        return { process, taskService, commandBus, service, documentService }
+    }
+
+    it('returns from saving after document persistence and dispatch, without waiting for parsing', async () => {
+        const { service, taskService, documentService, commandBus } = setup()
+        service.assertKnowledgebaseTaskWriteAccess.mockResolvedValue({
+            pipelineId: 'pipeline-1',
+            pipeline: {
+                graph: {
+                    nodes: [
+                        {
+                            key: 'source',
+                            type: 'workflow',
+                            entity: {
+                                type: WorkflowNodeTypeEnum.SOURCE,
+                                provider: 'local-file'
+                            }
+                        }
+                    ]
+                }
+            }
+        })
+        taskService.findOneByOptions.mockResolvedValue({
+            id: 'task-1',
+            knowledgebaseId: 'kb-1',
+            context: { documents: [{ id: 'doc-1', name: 'small.md' }] }
+        })
+        commandBus.execute.mockImplementation(async (command) => {
+            if (command instanceof XpertEnqueueTriggerDispatchCommand) {
+                expect(taskService.startDocumentExecution).toHaveBeenCalledWith('task-1', 'execution-1', ['saved-1'])
+                expect(documentService.createBulk).toHaveBeenCalledTimes(1)
+                expect(taskService.savePreparedSource).toHaveBeenCalledTimes(1)
+                expect(command.state[channelName('source')].documents).toEqual(['saved-1'])
+            }
+            return { id: 'execution-1' }
+        })
+        await KnowledgebaseService.prototype.processTask.call(service as never, 'kb-1', 'task-1', {
+            stage: 'prod',
+            sources: { source: { documents: ['doc-1'] } }
+        })
+        const dispatch = commandBus.execute.mock.calls[1][0] as XpertEnqueueTriggerDispatchCommand
+        expect(dispatch.state[channelName('source')].documents).toEqual(['saved-1'])
+    })
+
+    it('leaves a preallocated execution unbound until Chat assigns its authoritative thread', async () => {
+        const { process, commandBus } = setup()
+        await process()
+        const create = commandBus.execute.mock.calls[0][0] as XpertAgentExecutionUpsertCommand
+        expect(create.execution.threadId).toBeNull()
+        const dispatch = commandBus.execute.mock.calls[1][0] as XpertEnqueueTriggerDispatchCommand
+        expect(dispatch.params).toEqual(
+            expect.objectContaining({
+                executionId: 'execution-1',
+                callback: expect.objectContaining({
+                    context: { knowledgebaseId: 'kb-1', taskId: 'task-1', executionId: 'execution-1' }
+                })
+            })
+        )
+    })
+
+    it('records enqueue failure and propagates the error to the request', async () => {
+        const { process, commandBus, taskService } = setup()
+        commandBus.execute
+            .mockResolvedValueOnce({ id: 'execution-1' })
+            .mockRejectedValueOnce(new Error('Queue unavailable'))
+        await expect(process()).rejects.toThrow('Queue unavailable')
+        expect(taskService.failExecution).toHaveBeenCalledWith(
+            expect.objectContaining({
+                knowledgebaseId: 'kb-1',
+                taskId: 'task-1',
+                executionId: 'execution-1'
+            }),
+            'Queue unavailable'
+        )
+    })
+})

--- a/packages/server-ai/src/knowledgebase/plugins/knowledgebase/strategy.spec.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/knowledgebase/strategy.spec.ts
@@ -1,0 +1,140 @@
+jest.mock('yargs', () => ({ __esModule: true, default: () => ({ argv: {} }) }))
+
+import { CommandBus, QueryBus } from '@nestjs/cqrs'
+import {
+    channelName,
+    IEnvironment,
+    IKnowledgeDocument,
+    IWFNKnowledgeBase,
+    KBDocumentStatusEnum,
+    KnowledgebaseChannel,
+    KnowledgeTask,
+    TXpertGraph,
+    TXpertTeamNode,
+    WorkflowNodeTypeEnum
+} from '@xpert-ai/contracts'
+import { AgentStateAnnotation } from '../../../shared'
+import { WorkflowKnowledgeBaseNodeStrategy } from './strategy'
+
+describe('knowledge pipeline indexing', () => {
+    function setup() {
+        const chunks = [{ id: 'chunk', pageContent: 'A short document', metadata: {} }]
+        const document = {
+            id: 'document',
+            knowledgebaseId: 'kb',
+            name: 'test.md',
+            status: KBDocumentStatusEnum.SPLITTED,
+            draft: { chunks },
+            metadata: {}
+        } as IKnowledgeDocument
+        const documents = {
+            findAll: jest.fn(async () => ({ items: [document] })),
+            findOne: jest.fn(async () => document),
+            update: jest.fn(async () => undefined),
+            findAllEmbeddingNodes: jest.fn(async () => chunks),
+            syncChunksIncrementally: jest.fn(async () => ({
+                chunks,
+                embeddingChunks: chunks,
+                contentChanged: true,
+                contentHash: 'hash',
+                statistics: { total: 1, skipped: 0, added: 1, updated: 0, deleted: 0 }
+            })),
+            updateChunkMetadataBulk: jest.fn(async () => undefined)
+        }
+        const tasks = { update: jest.fn(async () => undefined) }
+        const vectorStore = { addKnowledgeDocument: jest.fn(async () => undefined) }
+        const publication = { publish: jest.fn(async () => undefined) }
+        const strategy = new WorkflowKnowledgeBaseNodeStrategy(
+            { execute: jest.fn(async () => ({ id: 'execution' })) } as unknown as CommandBus,
+            { execute: jest.fn(async () => ({ id: 'execution' })) } as unknown as QueryBus
+        )
+        Object.assign(strategy, {
+            documentService: documents,
+            taskService: tasks,
+            publicationService: publication,
+            knowledgebaseService: {
+                findOne: jest.fn(async () => ({
+                    id: 'kb',
+                    copilotModel: { copilot: { id: 'copilot' } }
+                })),
+                getActiveVectorStore: jest.fn(async () => vectorStore)
+            }
+        })
+        const entity: IWFNKnowledgeBase = {
+            id: 'result',
+            key: 'result',
+            type: WorkflowNodeTypeEnum.KNOWLEDGE_BASE,
+            inputs: ['input.documents']
+        }
+        const node = strategy.create({
+            graph: { nodes: [], connections: [] } as TXpertGraph,
+            node: { key: 'result', type: 'workflow', entity } as TXpertTeamNode & { type: 'workflow' },
+            xpertId: 'pipeline',
+            environment: {} as IEnvironment,
+            isDraft: false
+        })
+        const run = () =>
+            node.graph.invoke(
+                {
+                    [KnowledgebaseChannel]: { knowledgebaseId: 'kb', [KnowledgeTask]: 'task', stage: 'prod' },
+                    input: { documents: [{ id: document.id }] }
+                } as unknown as typeof AgentStateAnnotation.State,
+                { configurable: {} }
+            )
+        return { strategy, documents, tasks, vectorStore, publication, run }
+    }
+
+    it('includes the primary key when reading cancellation status under tenant joins', async () => {
+        const { strategy, documents } = setup()
+        expect(await strategy.checkIfJobCancelled('document')).toBe(false)
+        expect(documents.findOne).toHaveBeenCalledWith('document', { select: ['id', 'status'] })
+    })
+
+    it('finishes indexing and publishes only after persisting document completion', async () => {
+        const { run, documents, tasks, vectorStore, publication } = setup()
+        const result = await run()
+        expect(vectorStore.addKnowledgeDocument).toHaveBeenCalledTimes(1)
+        expect(documents.update).toHaveBeenCalledWith(
+            'document',
+            expect.objectContaining({ status: KBDocumentStatusEnum.FINISH })
+        )
+        expect(publication.publish).toHaveBeenCalledTimes(1)
+        expect(tasks.update).toHaveBeenLastCalledWith('task', {
+            status: 'success',
+            error: null,
+            finishedAt: expect.any(Date)
+        })
+        expect(result[channelName('result')].task.status).toBe('success')
+    })
+
+    it('waits for document failure persistence and reports a failed batch instead of success', async () => {
+        const { run, documents, tasks, vectorStore, publication } = setup()
+        vectorStore.addKnowledgeDocument.mockRejectedValueOnce(new Error('Embedding failed'))
+        let releaseFailure: () => void
+        const persisted = new Promise<void>((resolve) => {
+            releaseFailure = resolve
+        })
+        let signalFailure: () => void
+        const failing = new Promise<void>((resolve) => {
+            signalFailure = resolve
+        })
+        documents.update.mockImplementation(async (_id?: string, patch?: Partial<IKnowledgeDocument>) => {
+            if (patch?.status === KBDocumentStatusEnum.ERROR) {
+                signalFailure()
+                await persisted
+            }
+        })
+        const processing = run()
+        await failing
+        expect(tasks.update).not.toHaveBeenCalled()
+        releaseFailure()
+        const result = await processing
+        expect(tasks.update).toHaveBeenLastCalledWith('task', {
+            status: 'failed',
+            error: 'Embedding failed',
+            finishedAt: expect.any(Date)
+        })
+        expect(result[channelName('result')].task.status).toBe('failed')
+        expect(publication.publish).not.toHaveBeenCalled()
+    })
+})

--- a/packages/server-ai/src/knowledgebase/plugins/knowledgebase/strategy.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/knowledgebase/strategy.ts
@@ -163,6 +163,7 @@ export class WorkflowKnowledgeBaseNodeStrategy implements IWorkflowNodeStrategy 
                             // relations: ['chunks']
                         })
 
+                        const errors: string[] = []
                         const tasks = documents.map((document, index) => async () => {
                             statisticsInformation += `- Document ${index + 1} - ${document.name}: \n`
                             try {
@@ -315,19 +316,25 @@ export class WorkflowKnowledgeBaseNodeStrategy implements IWorkflowNodeStrategy 
                                     statisticsInformation += ` - Cancelled by user. \n`
                                     return
                                 }
-                                this.documentService.update(document.id, {
+                                const message = getErrorMessage(err)
+                                await this.documentService.update(document.id, {
                                     status: KBDocumentStatusEnum.ERROR,
-                                    processMsg: getErrorMessage(err)
+                                    processMsg: message
                                 })
-                                statisticsInformation += ` - Error: ${getErrorMessage(err)} \n`
+                                errors.push(message)
+                                statisticsInformation += ` - Error: ${message} \n`
                             }
                         })
 
-                        const results = await runWithConcurrencyLimit(tasks, 3)
+                        await runWithConcurrencyLimit(tasks, 3)
+                        const status = errors.length ? 'failed' : 'success'
+                        const error = errors.length ? errors.join('\n') : null
 
                         // Update task status
                         await this.taskService.update(knowledgeTaskId, {
-                            status: 'success'
+                            status,
+                            error,
+                            finishedAt: new Date()
                         })
 
                         return {
@@ -335,9 +342,9 @@ export class WorkflowKnowledgeBaseNodeStrategy implements IWorkflowNodeStrategy 
                                 [channelName(node.key)]: {
                                     [InfoChannelName]: statisticsInformation.trim(),
                                     [TaskChannelName]: {
-                                        status: 'success'
+                                        status
                                     },
-                                    [ERROR_CHANNEL_NAME]: null
+                                    [ERROR_CHANNEL_NAME]: error
                                 }
                             }
                         }
@@ -471,7 +478,8 @@ export class WorkflowKnowledgeBaseNodeStrategy implements IWorkflowNodeStrategy 
 
     async checkIfJobCancelled(docId: string): Promise<boolean> {
         // Check database/cache for cancellation flag
-        const doc = await this.documentService.findOne(docId, { select: ['status'] })
+        // Tenant-scoped joins need the primary key in TypeORM's distinct subquery.
+        const doc = await this.documentService.findOne(docId, { select: ['id', 'status'] })
         if (doc) {
             return doc?.status === KBDocumentStatusEnum.CANCEL
         }

--- a/packages/server-ai/src/knowledgebase/plugins/source/strategy.spec.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/source/strategy.spec.ts
@@ -1,7 +1,55 @@
 import { Document } from '@langchain/core/documents'
-import { resolveWorkflowSourceDocumentSourceKey } from './strategy'
+import { resolveWorkflowSourceDocumentSourceKey, WorkflowSourceNodeStrategy } from './strategy'
+import { CommandBus, QueryBus } from '@nestjs/cqrs'
+import {
+    channelName,
+    IEnvironment,
+    KnowledgebaseChannel,
+    KnowledgeTask,
+    TXpertGraph,
+    TXpertTeamNode,
+    WorkflowNodeTypeEnum
+} from '@xpert-ai/contracts'
+import { AgentStateAnnotation } from '../../../shared'
 
 describe('WorkflowSourceNodeStrategy source identity', () => {
+    it('uses the document saved before dispatch instead of creating it again', async () => {
+        const strategy = new WorkflowSourceNodeStrategy(
+            { execute: jest.fn(async () => ({ id: 'execution' })) } as unknown as CommandBus,
+            { execute: jest.fn(async () => ({ id: 'execution' })) } as unknown as QueryBus
+        )
+        const createBulk = jest.fn()
+        Object.assign(strategy, {
+            documentService: { createBulk },
+            taskService: {
+                findOne: jest.fn(async () => ({
+                    context: { documents: [{ id: 'preview' }], materializedSources: { source: { preview: 'saved' } } },
+                    documents: [{ id: 'saved', name: 'small.md' }]
+                }))
+            }
+        })
+        const { graph } = strategy.create({
+            graph: { nodes: [], connections: [] } as TXpertGraph,
+            node: {
+                key: 'source',
+                type: 'workflow',
+                entity: { type: WorkflowNodeTypeEnum.SOURCE }
+            } as TXpertTeamNode & { type: 'workflow' },
+            xpertId: 'pipeline',
+            environment: {} as IEnvironment,
+            isDraft: false
+        })
+        const state = await graph.invoke(
+            {
+                [KnowledgebaseChannel]: { knowledgebaseId: 'kb', [KnowledgeTask]: 'task', stage: 'prod' },
+                [channelName('source')]: { documents: ['saved'] }
+            } as unknown as typeof AgentStateAnnotation.State,
+            { configurable: {} }
+        )
+        expect(state[channelName('source')].documents).toEqual([expect.objectContaining({ id: 'saved' })])
+        expect(createBulk).not.toHaveBeenCalled()
+    })
+
     it('derives a source key from external source token metadata', () => {
         const document = new Document({
             id: 'docx-token',

--- a/packages/server-ai/src/knowledgebase/plugins/source/strategy.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/source/strategy.ts
@@ -2,29 +2,29 @@ import { Document } from '@langchain/core/documents'
 import { RunnableLambda } from '@langchain/core/runnables'
 import { Command, END } from '@langchain/langgraph'
 import {
-	channelName,
-	IEnvironment,
-	IIntegration,
-	IWFNSource,
-	IWorkflowNode,
-	TAgentRunnableConfigurable,
-	TXpertGraph,
-	TXpertParameter,
-	TXpertTeamNode,
-	WorkflowNodeTypeEnum,
-	XpertParameterTypeEnum,
-	KnowledgebaseChannel,
-	KnowledgeTask,
-	KNOWLEDGE_SOURCES_NAME,
-	KNOWLEDGE_DOCUMENTS_NAME,
-	KBDocumentStatusEnum,
-	IKnowledgeDocument,
-	IXpertAgentExecution,
-	STATE_VARIABLE_HUMAN,
-	IKnowledgebaseTask,
-	KNOWLEDGE_FOLDER_ID_NAME,
-	DocumentSourceProviderCategoryEnum,
-	TWorkflowNodeMeta
+    channelName,
+    IEnvironment,
+    IIntegration,
+    IWFNSource,
+    IWorkflowNode,
+    TAgentRunnableConfigurable,
+    TXpertGraph,
+    TXpertParameter,
+    TXpertTeamNode,
+    WorkflowNodeTypeEnum,
+    XpertParameterTypeEnum,
+    KnowledgebaseChannel,
+    KnowledgeTask,
+    KNOWLEDGE_SOURCES_NAME,
+    KNOWLEDGE_DOCUMENTS_NAME,
+    KBDocumentStatusEnum,
+    IKnowledgeDocument,
+    IXpertAgentExecution,
+    STATE_VARIABLE_HUMAN,
+    IKnowledgebaseTask,
+    KNOWLEDGE_FOLDER_ID_NAME,
+    DocumentSourceProviderCategoryEnum,
+    TWorkflowNodeMeta
 } from '@xpert-ai/contracts'
 import { PromptTemplate } from '@langchain/core/prompts'
 import { getErrorMessage, omit, shortuuid } from '@xpert-ai/server-common'
@@ -105,292 +105,317 @@ export function resolveWorkflowSourceDocumentSourceKey(input: {
 @Injectable()
 @WorkflowNodeStrategy(WorkflowNodeTypeEnum.SOURCE)
 export class WorkflowSourceNodeStrategy implements IWorkflowNodeStrategy {
-	readonly meta: TWorkflowNodeMeta = {
-		name: WorkflowNodeTypeEnum.SOURCE,
-		label: {
-			en_US: 'Document Source',
-			zh_Hans: '文档源'
-		},
-		icon: null,
-		configSchema: {
-			type: 'object',
-			properties: {},
-			required: []
-		}
-	}
+    readonly meta: TWorkflowNodeMeta = {
+        name: WorkflowNodeTypeEnum.SOURCE,
+        label: {
+            en_US: 'Document Source',
+            zh_Hans: '文档源'
+        },
+        icon: null,
+        configSchema: {
+            type: 'object',
+            properties: {},
+            required: []
+        }
+    }
 
-	@Inject(KnowledgebaseTaskService)
-	private readonly taskService: KnowledgebaseTaskService
+    @Inject(KnowledgebaseTaskService)
+    private readonly taskService: KnowledgebaseTaskService
 
-	@Inject(KnowledgeDocumentService)
-	private readonly documentService: KnowledgeDocumentService
+    @Inject(KnowledgeDocumentService)
+    private readonly documentService: KnowledgeDocumentService
 
-	constructor(
-		private readonly commandBus: CommandBus,
-		private readonly queryBus: QueryBus) {}
+    constructor(
+        private readonly commandBus: CommandBus,
+        private readonly queryBus: QueryBus
+    ) {}
 
-	create(payload: {
-		graph: TXpertGraph
-		node: TXpertTeamNode & { type: 'workflow' }
-		xpertId: string
-		environment: IEnvironment
-		isDraft: boolean
-	}) {
-		const { graph, node, xpertId, environment, isDraft } = payload
-		const entity = node.entity as IWFNSource
+    create(payload: {
+        graph: TXpertGraph
+        node: TXpertTeamNode & { type: 'workflow' }
+        xpertId: string
+        environment: IEnvironment
+        isDraft: boolean
+    }) {
+        const { graph, node, xpertId, environment, isDraft } = payload
+        const entity = node.entity as IWFNSource
 
-		return {
-			graph: RunnableLambda.from(async (state: typeof AgentStateAnnotation.State, config) => {
-				const configurable: TAgentRunnableConfigurable = config.configurable
-				const { thread_id, checkpoint_ns, checkpoint_id, subscriber, executionId } = configurable
-				const stateEnv = stateWithEnvironment(state, environment)
+        return {
+            graph: RunnableLambda.from(async (state: typeof AgentStateAnnotation.State, config) => {
+                const configurable: TAgentRunnableConfigurable = config.configurable
+                const { thread_id, checkpoint_ns, checkpoint_id, subscriber, executionId } = configurable
+                const stateEnv = stateWithEnvironment(state, environment)
 
-				const knowledgebaseState = state[KnowledgebaseChannel]
-				// console.log('================== Source Node state ===================')
-				// console.log(JSON.stringify(state, null, 2))
-				// console.log('================== Source Node End ===================')
+                const knowledgebaseState = state[KnowledgebaseChannel]
+                // console.log('================== Source Node state ===================')
+                // console.log(JSON.stringify(state, null, 2))
+                // console.log('================== Source Node End ===================')
 
-				let knowledgeTaskId = knowledgebaseState?.[KnowledgeTask]
-				const knowledgebaseId = knowledgebaseState?.['knowledgebaseId']
-				const stage = knowledgebaseState?.['stage']
-				const isTest = stage === 'preview' || isDraft
-				const knowledgeSources = knowledgebaseState?.[KNOWLEDGE_SOURCES_NAME] as string[]
-				const folderId = knowledgebaseState?.[KNOWLEDGE_FOLDER_ID_NAME] as string
-				// Skip this node if the source is not in the selected knowledge sources
-				if (knowledgeSources && !knowledgeSources.includes(node.key)) {
-					return new Command({
-						goto: END
-					})
-				}
+                let knowledgeTaskId = knowledgebaseState?.[KnowledgeTask]
+                const knowledgebaseId = knowledgebaseState?.['knowledgebaseId']
+                const stage = knowledgebaseState?.['stage']
+                const isTest = stage === 'preview' || isDraft
+                const knowledgeSources = knowledgebaseState?.[KNOWLEDGE_SOURCES_NAME] as string[]
+                const folderId = knowledgebaseState?.[KNOWLEDGE_FOLDER_ID_NAME] as string
+                // Skip this node if the source is not in the selected knowledge sources
+                if (knowledgeSources && !knowledgeSources.includes(node.key)) {
+                    return new Command({
+                        goto: END
+                    })
+                }
 
-				const execution: IXpertAgentExecution = {
-									category: 'workflow',
-									type: WorkflowNodeTypeEnum.SOURCE,
-									inputs: entity.config,
-									parentId: executionId,
-									threadId: thread_id,
-									checkpointNs: checkpoint_ns,
-									checkpointId: checkpoint_id,
-									agentKey: node.key,
-									title: entity.title
-								}
-				return await wrapAgentExecution<any>(
-					async () => {
-						let documents: IKnowledgeDocument[] = null
+                const execution: IXpertAgentExecution = {
+                    category: 'workflow',
+                    type: WorkflowNodeTypeEnum.SOURCE,
+                    inputs: entity.config,
+                    parentId: executionId,
+                    threadId: thread_id,
+                    checkpointNs: checkpoint_ns,
+                    checkpointId: checkpoint_id,
+                    agentKey: node.key,
+                    title: entity.title
+                }
+                return await wrapAgentExecution<any>(
+                    async () => {
+                        let documents: IKnowledgeDocument[] = null
 
-						// If the node has already loaded documents
-						const cachedDocuments = state[channelName(node.key)]?.[KNOWLEDGE_DOCUMENTS_NAME] as string[]
-						if (cachedDocuments?.length) {
-							// Create as formal documents during non-testing phases
-							const task = await this.taskService.findOne(knowledgeTaskId, { relations: ['documents'] })
-							const _docs = task.context?.documents?.filter(doc => cachedDocuments.includes(doc.id)) ?? []
-							if (isTest) {
-								return {
-									state: {
-										[channelName(node.key)]: {
-											[DOCUMENTS_CHANNEL_NAME]: serializeDocuments(_docs),
-											[ERROR_CHANNEL_NAME]: null
-										},
-									}
-								}
-							}
+                        // If the node has already loaded documents
+                        const cachedDocuments = state[channelName(node.key)]?.[KNOWLEDGE_DOCUMENTS_NAME] as string[]
+                        if (cachedDocuments?.length) {
+                            // Create as formal documents during non-testing phases
+                            const task = await this.taskService.findOne(knowledgeTaskId, { relations: ['documents'] })
+                            const _docs =
+                                task.context?.documents?.filter((doc) => cachedDocuments.includes(doc.id)) ?? []
+                            if (isTest) {
+                                return {
+                                    state: {
+                                        [channelName(node.key)]: {
+                                            [DOCUMENTS_CHANNEL_NAME]: serializeDocuments(_docs),
+                                            [ERROR_CHANNEL_NAME]: null
+                                        }
+                                    }
+                                }
+                            }
 
-							if (task.context?.documents) {
-								if (_docs.length > 0) {
-									documents = await this.documentService.createBulk(_docs.map((doc) => {
-										return {
-											...omit(doc, 'id'),
-											sourceConfig: {
-												key: node.key,
-											},
-											status: KBDocumentStatusEnum.WAITING,
-											knowledgebaseId,
-											sourceType: entity.provider as DocumentSourceProviderCategoryEnum,
-											// pages: doc.pages?.map(page => omit(page, 'id')),
-											tasks: [{id: knowledgeTaskId} as IKnowledgebaseTask]
-										}
-									}))
-								}
-							} else {
-								documents = task.documents.filter(doc => cachedDocuments.includes(doc.id))
-								documents.forEach(doc => {
-									doc.sourceType = entity.provider as DocumentSourceProviderCategoryEnum
-									doc.sourceConfig = { key: node.key }
-									doc.status = KBDocumentStatusEnum.RUNNING
-									if (doc.tasks?.findIndex(t => t.id === knowledgeTaskId) < 0) {
-										doc.tasks.push({id: knowledgeTaskId} as IKnowledgebaseTask)
-									}
-								})
-								if (documents.length > 0) {
-								  await this.documentService.save(documents)
-								}
-							}
-							
-							return {
-								state: {
-									[channelName(node.key)]: {
-										[DOCUMENTS_CHANNEL_NAME]: serializeDocuments(documents),
-										[ERROR_CHANNEL_NAME]: null
-									},
-								},
-								output: documents?.map((doc) => {
-									doc.chunks = doc.chunks?.slice(0, 2) // only return first 2 chunks for preview
-									// doc.pages = doc.pages?.slice(0, 2)
-									return doc
-								})
-							}
-						}
+                            if (task.context?.materializedSources?.[node.key]) {
+                                const bindings = task.context.materializedSources[node.key]
+                                const ids = cachedDocuments.map((id) => bindings[id] ?? id)
+                                documents = task.documents.filter((doc) => ids.includes(doc.id))
+                            } else if (task.context?.documents) {
+                                if (_docs.length > 0) {
+                                    documents = await this.documentService.createBulk(
+                                        _docs.map((doc) => {
+                                            return {
+                                                ...omit(doc, 'id'),
+                                                sourceConfig: {
+                                                    key: node.key
+                                                },
+                                                status: KBDocumentStatusEnum.WAITING,
+                                                knowledgebaseId,
+                                                sourceType: entity.provider as DocumentSourceProviderCategoryEnum,
+                                                // pages: doc.pages?.map(page => omit(page, 'id')),
+                                                tasks: [{ id: knowledgeTaskId } as IKnowledgebaseTask]
+                                            }
+                                        })
+                                    )
+                                }
+                            } else {
+                                documents = task.documents.filter((doc) => cachedDocuments.includes(doc.id))
+                                documents.forEach((doc) => {
+                                    doc.sourceType = entity.provider as DocumentSourceProviderCategoryEnum
+                                    doc.sourceConfig = { key: node.key }
+                                    doc.status = KBDocumentStatusEnum.RUNNING
+                                    if (doc.tasks?.findIndex((t) => t.id === knowledgeTaskId) < 0) {
+                                        doc.tasks.push({ id: knowledgeTaskId } as IKnowledgebaseTask)
+                                    }
+                                })
+                                if (documents.length > 0) {
+                                    await this.documentService.save(documents)
+                                }
+                            }
 
-						const strategy = await this.queryBus.execute<KnowledgeStrategyQuery, IDocumentSourceStrategy>(
-							new KnowledgeStrategyQuery({
-								type: 'source',
-								name: entity.provider
-							})
-						)
-						const permissions: { integration?: IIntegration } = {}
-						if (strategy.permissions) {
-							const integrationPermission = strategy.permissions.find(
-								(permission) => permission.type === 'integration'
-							)
-							if (integrationPermission) {
-								const integration = await this.queryBus.execute<GetIntegrationQuery, IIntegration>(
-									new GetIntegrationQuery(entity.integrationId)
-								)
-								permissions[integrationPermission.type] = integration
-							}
-						}
-						
-						// Transform parameters with state
-						const parameters = entity.config ? await deepTransformValue(entity.config, async (v) => {
-							return await PromptTemplate.fromTemplate(v, { templateFormat: 'mustache' }).format(stateEnv)
-						}) : {}
+                            return {
+                                state: {
+                                    [channelName(node.key)]: {
+                                        [DOCUMENTS_CHANNEL_NAME]: serializeDocuments(documents),
+                                        [ERROR_CHANNEL_NAME]: null
+                                    }
+                                },
+                                output: documents?.map((doc) => {
+                                    doc.chunks = doc.chunks?.slice(0, 2) // only return first 2 chunks for preview
+                                    // doc.pages = doc.pages?.slice(0, 2)
+                                    return doc
+                                })
+                            }
+                        }
 
-						const results = await strategy.loadDocuments({
-							...parameters,
-							[STATE_VARIABLE_HUMAN]: state[STATE_VARIABLE_HUMAN]
-						}, permissions)
+                        const strategy = await this.queryBus.execute<KnowledgeStrategyQuery, IDocumentSourceStrategy>(
+                            new KnowledgeStrategyQuery({
+                                type: 'source',
+                                name: entity.provider
+                            })
+                        )
+                        const permissions: { integration?: IIntegration } = {}
+                        if (strategy.permissions) {
+                            const integrationPermission = strategy.permissions.find(
+                                (permission) => permission.type === 'integration'
+                            )
+                            if (integrationPermission) {
+                                const integration = await this.queryBus.execute<GetIntegrationQuery, IIntegration>(
+                                    new GetIntegrationQuery(entity.integrationId)
+                                )
+                                permissions[integrationPermission.type] = integration
+                            }
+                        }
 
-						documents = results.map((doc) => ({
-							id: doc.id || shortuuid(),
-							sourceType: entity.provider as DocumentSourceProviderCategoryEnum,
-							sourceKey: resolveWorkflowSourceDocumentSourceKey({
-								document: doc,
-								sourceType: entity.provider,
-								sourceConfigKey: node.key
-							}),
-							sourceConfig: {
-								key: node.key
-							},
-							type: doc.metadata.type,
-							name: doc.metadata.originalName || doc.metadata.title,
-							filePath: doc.metadata.filePath,
-							fileUrl: doc.metadata.fileUrl,
-							category: doc.metadata.category,
-							mimeType: doc.metadata.mimeType,
-							status: KBDocumentStatusEnum.WAITING,
-							metadata: doc.metadata,
-							draft: doc.pageContent ?
-								{
-									chunks: [
-										{
-											pageContent: doc.pageContent,
-											metadata: {
-												...(doc.metadata || {}),
-												chunkId: shortuuid(),
-											},
-										}
-									]
-								} : null,
-							parent: folderId ? { id: folderId } : null,
-						} as IKnowledgeDocument))
-						
-						if (isTest) {
-							if (!knowledgeTaskId) {
-								// create a new task id if not exists
-								const task = await this.taskService.createTask(knowledgebaseId, {
-									taskType: 'preprocess',
-									context: {
-										documents
-									}
-								})
+                        // Transform parameters with state
+                        const parameters = entity.config
+                            ? await deepTransformValue(entity.config, async (v) => {
+                                  return await PromptTemplate.fromTemplate(v, { templateFormat: 'mustache' }).format(
+                                      stateEnv
+                                  )
+                              })
+                            : {}
 
-								knowledgeTaskId = task.id
-							} else {
-								await this.taskService.upsertDocuments(knowledgeTaskId, documents)
-							}
-						} else {
-							documents = await this.documentService.createBulk(documents.map((doc) => {
-								return {
-									...omit(doc, 'id'),
-									status: KBDocumentStatusEnum.WAITING,
-									// taskId: KnowledgeTaskId,
-									knowledgebaseId,
-									// pages: doc.pages?.map(page => omit(page, 'id')),
-									tasks: [{id: knowledgeTaskId} as IKnowledgebaseTask]
-								}
-							}))
-						}
+                        const results = await strategy.loadDocuments(
+                            {
+                                ...parameters,
+                                [STATE_VARIABLE_HUMAN]: state[STATE_VARIABLE_HUMAN]
+                            },
+                            permissions
+                        )
 
-						return {
-							state: {
-								[channelName(node.key)]: {
-									[DOCUMENTS_CHANNEL_NAME]: serializeDocuments((documents ?? results)),
-									[ERROR_CHANNEL_NAME]: null
-								},
-								[KnowledgebaseChannel]: {
-									[KnowledgeTask]: knowledgeTaskId,
-									knowledgebaseId,
-								}
-							},
-							output: (documents ?? results).map((doc) => {
-								doc.chunks = doc.chunks?.slice(0, 2) // only return first 2 chunks for preview
-								// doc.pages = doc.pages?.slice(0, 2)
-								return doc
-							})
-						}
-					},
-					{
-						commandBus: this.commandBus,
-						queryBus: this.queryBus,
-						subscriber: subscriber,
-						execution,
-						catchError: async (error) => {
-							await this.taskService.update(knowledgeTaskId, { status: 'failed', error: getErrorMessage(error) })
-						}
-					})()
-			}),
-			ends: [END],
-			navigator: async (state, config) => {
-				if (state[channelName(node.key)]['error']) {
-					return (
-						graph.connections.find((conn) => conn.type === 'edge' && conn.from === `${node.key}/fail`)?.to ??
-						END
-					)
-				}
+                        documents = results.map(
+                            (doc) =>
+                                ({
+                                    id: doc.id || shortuuid(),
+                                    sourceType: entity.provider as DocumentSourceProviderCategoryEnum,
+                                    sourceKey: resolveWorkflowSourceDocumentSourceKey({
+                                        document: doc,
+                                        sourceType: entity.provider,
+                                        sourceConfigKey: node.key
+                                    }),
+                                    sourceConfig: {
+                                        key: node.key
+                                    },
+                                    type: doc.metadata.type,
+                                    name: doc.metadata.originalName || doc.metadata.title,
+                                    filePath: doc.metadata.filePath,
+                                    fileUrl: doc.metadata.fileUrl,
+                                    category: doc.metadata.category,
+                                    mimeType: doc.metadata.mimeType,
+                                    status: KBDocumentStatusEnum.WAITING,
+                                    metadata: doc.metadata,
+                                    draft: doc.pageContent
+                                        ? {
+                                              chunks: [
+                                                  {
+                                                      pageContent: doc.pageContent,
+                                                      metadata: {
+                                                          ...(doc.metadata || {}),
+                                                          chunkId: shortuuid()
+                                                      }
+                                                  }
+                                              ]
+                                          }
+                                        : null,
+                                    parent: folderId ? { id: folderId } : null
+                                }) as IKnowledgeDocument
+                        )
 
-				if (!state[channelName(node.key)][DOCUMENTS_CHANNEL_NAME]) {
-					return END
-				}
-	
-				return nextWorkflowNodes(graph, node.key, state)
-			}
-		}
-	}
+                        if (isTest) {
+                            if (!knowledgeTaskId) {
+                                // create a new task id if not exists
+                                const task = await this.taskService.createTask(knowledgebaseId, {
+                                    taskType: 'preprocess',
+                                    context: {
+                                        documents
+                                    }
+                                })
 
-	outputVariables(entity: IWorkflowNode): TXpertParameter[] {
-		const source = entity as IWFNSource
-		return [
-			...(source.parameters ?? []),
-			createDocumentsParameter(DOCUMENTS_CHANNEL_NAME),
-			{
-				type: XpertParameterTypeEnum.STRING,
-				name: ERROR_CHANNEL_NAME,
-				title: 'Error',
-				description: {
-					en_US: 'Error info',
-					zh_Hans: '错误信息'
-				}
-			},
-		]
-	}
+                                knowledgeTaskId = task.id
+                            } else {
+                                await this.taskService.upsertDocuments(knowledgeTaskId, documents)
+                            }
+                        } else {
+                            documents = await this.documentService.createBulk(
+                                documents.map((doc) => {
+                                    return {
+                                        ...omit(doc, 'id'),
+                                        status: KBDocumentStatusEnum.WAITING,
+                                        // taskId: KnowledgeTaskId,
+                                        knowledgebaseId,
+                                        // pages: doc.pages?.map(page => omit(page, 'id')),
+                                        tasks: [{ id: knowledgeTaskId } as IKnowledgebaseTask]
+                                    }
+                                })
+                            )
+                        }
+
+                        return {
+                            state: {
+                                [channelName(node.key)]: {
+                                    [DOCUMENTS_CHANNEL_NAME]: serializeDocuments(documents ?? results),
+                                    [ERROR_CHANNEL_NAME]: null
+                                },
+                                [KnowledgebaseChannel]: {
+                                    [KnowledgeTask]: knowledgeTaskId,
+                                    knowledgebaseId
+                                }
+                            },
+                            output: (documents ?? results).map((doc) => {
+                                doc.chunks = doc.chunks?.slice(0, 2) // only return first 2 chunks for preview
+                                // doc.pages = doc.pages?.slice(0, 2)
+                                return doc
+                            })
+                        }
+                    },
+                    {
+                        commandBus: this.commandBus,
+                        queryBus: this.queryBus,
+                        subscriber: subscriber,
+                        execution,
+                        catchError: async (error) => {
+                            await this.taskService.update(knowledgeTaskId, {
+                                status: 'failed',
+                                error: getErrorMessage(error)
+                            })
+                        }
+                    }
+                )()
+            }),
+            ends: [END],
+            navigator: async (state, config) => {
+                if (state[channelName(node.key)]['error']) {
+                    return (
+                        graph.connections.find((conn) => conn.type === 'edge' && conn.from === `${node.key}/fail`)
+                            ?.to ?? END
+                    )
+                }
+
+                if (!state[channelName(node.key)][DOCUMENTS_CHANNEL_NAME]) {
+                    return END
+                }
+
+                return nextWorkflowNodes(graph, node.key, state)
+            }
+        }
+    }
+
+    outputVariables(entity: IWorkflowNode): TXpertParameter[] {
+        const source = entity as IWFNSource
+        return [
+            ...(source.parameters ?? []),
+            createDocumentsParameter(DOCUMENTS_CHANNEL_NAME),
+            {
+                type: XpertParameterTypeEnum.STRING,
+                name: ERROR_CHANNEL_NAME,
+                title: 'Error',
+                description: {
+                    en_US: 'Error info',
+                    zh_Hans: '错误信息'
+                }
+            }
+        ]
+    }
 }

--- a/packages/server-ai/src/knowledgebase/task/pipeline-callback.processor.spec.ts
+++ b/packages/server-ai/src/knowledgebase/task/pipeline-callback.processor.spec.ts
@@ -1,0 +1,72 @@
+import { AgentChatCallbackEnvelopePayload, HandoffMessage } from '@xpert-ai/plugin-sdk'
+import { KnowledgePipelineCallbackProcessor } from './pipeline-callback.processor'
+import { KNOWLEDGE_PIPELINE_CALLBACK } from '../types'
+
+describe('knowledge pipeline callback', () => {
+    function setup(kind: AgentChatCallbackEnvelopePayload['kind'] = 'error') {
+        const tasks = { failExecution: jest.fn(), syncExecutionFailure: jest.fn() }
+        const processor = new KnowledgePipelineCallbackProcessor(tasks as never)
+        const message: HandoffMessage<AgentChatCallbackEnvelopePayload> = {
+            id: 'callback',
+            type: KNOWLEDGE_PIPELINE_CALLBACK,
+            version: 1,
+            tenantId: 'tenant',
+            headers: { organizationId: 'org' },
+            sessionKey: 'execution',
+            businessKey: 'execution',
+            attempt: 1,
+            maxAttempts: 1,
+            enqueuedAt: 0,
+            traceId: 'trace',
+            payload: {
+                kind,
+                sourceMessageId: 'dispatch',
+                sequence: 1,
+                error: 'Thread conflict',
+                context: { knowledgebaseId: 'kb', taskId: 'task', executionId: 'execution' }
+            }
+        }
+        return { processor, tasks, message }
+    }
+
+    it('writes asynchronous failure using the envelope scope instead of ambient request context', async () => {
+        const { processor, tasks, message } = setup()
+        await expect(processor.process(message)).resolves.toEqual({ status: 'ok' })
+        expect(tasks.failExecution).toHaveBeenCalledWith(
+            {
+                tenantId: 'tenant',
+                organizationId: 'org',
+                knowledgebaseId: 'kb',
+                taskId: 'task',
+                executionId: 'execution'
+            },
+            'Thread conflict'
+        )
+    })
+
+    it('checks persisted execution errors even when the chat stream completes normally', async () => {
+        const { processor, tasks, message } = setup('complete')
+        await processor.process(message)
+        expect(tasks.syncExecutionFailure).toHaveBeenCalledWith({
+            tenantId: 'tenant',
+            organizationId: 'org',
+            knowledgebaseId: 'kb',
+            taskId: 'task',
+            executionId: 'execution'
+        })
+        expect(tasks.failExecution).not.toHaveBeenCalled()
+    })
+
+    it.each(['stream'] as const)('leaves %s persistence to the workflow', async (kind) => {
+        const { processor, tasks, message } = setup(kind)
+        await processor.process(message)
+        expect(tasks.failExecution).not.toHaveBeenCalled()
+    })
+
+    it('rejects malformed callback identity', async () => {
+        const { processor, tasks, message } = setup()
+        message.payload.context.executionId = 12
+        expect((await processor.process(message)).status).toBe('dead')
+        expect(tasks.failExecution).not.toHaveBeenCalled()
+    })
+})

--- a/packages/server-ai/src/knowledgebase/task/pipeline-callback.processor.ts
+++ b/packages/server-ai/src/knowledgebase/task/pipeline-callback.processor.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common'
+import { t } from 'i18next'
+import {
+    AgentChatCallbackEnvelopePayload,
+    HandoffMessage,
+    HandoffProcessorStrategy,
+    IHandoffProcessor,
+    ProcessResult
+} from '@xpert-ai/plugin-sdk'
+import { KnowledgebaseTaskService } from './task.service'
+import { KNOWLEDGE_PIPELINE_CALLBACK } from '../types'
+
+@Injectable()
+@HandoffProcessorStrategy(KNOWLEDGE_PIPELINE_CALLBACK, {
+    types: [KNOWLEDGE_PIPELINE_CALLBACK],
+    policy: { lane: 'main' }
+})
+export class KnowledgePipelineCallbackProcessor implements IHandoffProcessor<AgentChatCallbackEnvelopePayload> {
+    constructor(private readonly tasks: KnowledgebaseTaskService) {}
+
+    async process(message: HandoffMessage<AgentChatCallbackEnvelopePayload>): Promise<ProcessResult> {
+        // Agent streams can persist an error and still complete normally.
+        if (message.payload.kind === 'stream') return { status: 'ok' }
+        const context = message.payload.context
+        if (
+            !message.tenantId ||
+            typeof context?.knowledgebaseId !== 'string' ||
+            typeof context.taskId !== 'string' ||
+            typeof context.executionId !== 'string'
+        ) {
+            return {
+                status: 'dead',
+                reason: t('server-ai:Error.InvalidKnowledgePipelineCallback', {
+                    defaultValue: 'Invalid knowledge pipeline callback context'
+                })
+            }
+        }
+        const scope = {
+            tenantId: message.tenantId,
+            organizationId: message.headers?.organizationId ?? null,
+            knowledgebaseId: context.knowledgebaseId,
+            taskId: context.taskId,
+            executionId: context.executionId
+        }
+        if (message.payload.kind === 'complete') {
+            await this.tasks.syncExecutionFailure(scope)
+            return { status: 'ok' }
+        }
+        await this.tasks.failExecution(
+            scope,
+            message.payload.error ||
+                t('server-ai:Error.KnowledgePipelineFailed', {
+                    defaultValue: 'Knowledge pipeline execution failed'
+                })
+        )
+        return { status: 'ok' }
+    }
+}

--- a/packages/server-ai/src/knowledgebase/task/pipeline-task.ts
+++ b/packages/server-ai/src/knowledgebase/task/pipeline-task.ts
@@ -1,0 +1,92 @@
+import { CommandBus } from '@nestjs/cqrs'
+import {
+    channelName,
+    KnowledgebaseChannel,
+    KnowledgeTask,
+    KNOWLEDGE_SOURCES_NAME,
+    KNOWLEDGE_PROCESSING_MODE_NAME,
+    KnowledgeDocumentProcessingMode,
+    STATE_VARIABLE_HUMAN,
+    XpertAgentExecutionStatusEnum,
+    IXpertAgentExecution
+} from '@xpert-ai/contracts'
+import { RequestContext } from '@xpert-ai/server-core'
+import { getErrorMessage } from '@xpert-ai/server-common'
+import { XpertAgentExecutionUpsertCommand } from '../../xpert-agent-execution'
+import { XpertEnqueueTriggerDispatchCommand } from '../../xpert/commands'
+import type { KnowledgebaseTaskService } from './task.service'
+import { KNOWLEDGE_PIPELINE_CALLBACK } from '../types'
+
+export interface KnowledgePipelineInputs {
+    sources?: { [key: string]: { documents: string[] } }
+    stage: 'preview' | 'prod'
+    mode?: KnowledgeDocumentProcessingMode
+    isDraft?: boolean
+}
+
+// Preallocation tracks dispatch; Chat owns the first thread binding.
+export async function dispatchKnowledgePipeline(
+    commandBus: CommandBus,
+    taskService: KnowledgebaseTaskService,
+    knowledgebaseId: string,
+    pipelineId: string,
+    taskId: string,
+    inputs: KnowledgePipelineInputs
+) {
+    const execution = await commandBus.execute<XpertAgentExecutionUpsertCommand, IXpertAgentExecution>(
+        new XpertAgentExecutionUpsertCommand({ threadId: null, status: XpertAgentExecutionStatusEnum.RUNNING })
+    )
+    const context = { knowledgebaseId, taskId, executionId: execution.id }
+    if (inputs.stage === 'prod' && !inputs.isDraft) {
+        await taskService.startDocumentExecution(
+            taskId,
+            execution.id,
+            inputs.sources ? Object.values(inputs.sources).flatMap((source) => source.documents) : undefined
+        )
+    } else {
+        await taskService.update(taskId, {
+            status: 'running',
+            executionId: execution.id,
+            error: null,
+            finishedAt: null
+        })
+    }
+    const sources = inputs.sources ? Object.keys(inputs.sources) : null
+    try {
+        await commandBus.execute(
+            new XpertEnqueueTriggerDispatchCommand(
+                pipelineId,
+                RequestContext.currentUserId(),
+                {
+                    [STATE_VARIABLE_HUMAN]: { input: 'Process knowledges pipeline' },
+                    [KnowledgebaseChannel]: {
+                        knowledgebaseId,
+                        [KnowledgeTask]: taskId,
+                        [KNOWLEDGE_SOURCES_NAME]: sources,
+                        [KNOWLEDGE_PROCESSING_MODE_NAME]: inputs.mode ?? 'full',
+                        stage: inputs.stage
+                    },
+                    ...Object.fromEntries(
+                        (sources ?? []).map((key) => [channelName(key), { documents: inputs.sources[key].documents }])
+                    )
+                },
+                {
+                    isDraft: inputs.isDraft,
+                    from: 'knowledge',
+                    executionId: execution.id,
+                    callback: { messageType: KNOWLEDGE_PIPELINE_CALLBACK, context }
+                }
+            )
+        )
+    } catch (error) {
+        await taskService.failExecution(
+            {
+                ...context,
+                tenantId: RequestContext.currentTenantId(),
+                organizationId: RequestContext.getOrganizationId() ?? null
+            },
+            getErrorMessage(error)
+        )
+        throw error
+    }
+}

--- a/packages/server-ai/src/knowledgebase/task/prepare-pipeline-documents.spec.ts
+++ b/packages/server-ai/src/knowledgebase/task/prepare-pipeline-documents.spec.ts
@@ -1,0 +1,179 @@
+import {
+    IKnowledgebaseTask,
+    IKnowledgeDocument,
+    KBDocumentStatusEnum,
+    TXpertGraph,
+    WorkflowNodeTypeEnum
+} from '@xpert-ai/contracts'
+import { prepareKnowledgePipelineDocuments } from './prepare-pipeline-documents'
+import type { KnowledgeDocument } from '../../knowledge-document/document.entity'
+
+describe('saving a pipeline import before background processing', () => {
+    const graph = {
+        nodes: [
+            { key: 'source', type: 'workflow', entity: { type: WorkflowNodeTypeEnum.SOURCE, provider: 'local-file' } }
+        ],
+        connections: []
+    } as unknown as TXpertGraph
+    const task = {
+        id: 'task',
+        knowledgebaseId: 'kb',
+        documents: [],
+        context: {
+            documents: [{ id: 'preview', name: 'small.md', parent: { id: 'folder' }, filePath: 'files/small.md' }]
+        }
+    } as IKnowledgebaseTask
+    const inputs = { stage: 'prod' as const, sources: { source: { documents: ['preview'] } } }
+
+    function setup() {
+        const documents = {
+            createBulk: jest.fn(async (_documents: Partial<IKnowledgeDocument>[]) => [
+                { id: 'saved' } as KnowledgeDocument
+            ])
+        }
+        const tasks = {
+            savePreparedSource: jest.fn(async () => undefined),
+            withLockedTask: jest.fn(async (_id, work) => work(task, undefined))
+        }
+        return { documents, tasks }
+    }
+
+    it('saves the visible row and its task relation before returning IDs for dispatch', async () => {
+        const { documents, tasks } = setup()
+        const result = await prepareKnowledgePipelineDocuments(task, graph, inputs, documents, tasks)
+        expect(documents.createBulk).toHaveBeenCalledWith(
+            [
+                expect.objectContaining({
+                    name: 'small.md',
+                    knowledgebaseId: 'kb',
+                    parent: { id: 'folder' },
+                    status: KBDocumentStatusEnum.WAITING,
+                    sourceConfig: { key: 'source' },
+                    progress: 0
+                })
+            ],
+            undefined
+        )
+        expect(documents.createBulk.mock.calls[0][0][0]).not.toHaveProperty('id')
+        expect(tasks.savePreparedSource).toHaveBeenCalledWith(
+            'task',
+            'source',
+            { preview: 'saved' },
+            [{ id: 'saved' }],
+            expect.objectContaining({ task })
+        )
+        expect(result.sources.source.documents).toEqual(['saved'])
+    })
+
+    it('does not create formal documents during preview', async () => {
+        const { documents, tasks } = setup()
+        await prepareKnowledgePipelineDocuments(task, graph, { ...inputs, stage: 'preview' }, documents, tasks)
+        expect(documents.createBulk).not.toHaveBeenCalled()
+        expect(tasks.savePreparedSource).not.toHaveBeenCalled()
+    })
+
+    it('reuses saved IDs when retrying the same selection', async () => {
+        const { documents, tasks } = setup()
+        const preparedTask = {
+            ...task,
+            context: { ...task.context, materializedSources: { source: { preview: 'saved' } } }
+        }
+        tasks.withLockedTask.mockImplementation(async (_id, work) => work(preparedTask, undefined))
+        const result = await prepareKnowledgePipelineDocuments(preparedTask, graph, inputs, documents, tasks)
+        expect(documents.createBulk).not.toHaveBeenCalled()
+        expect(result.sources.source.documents).toEqual(['saved'])
+    })
+
+    it('waits for persistence but does not require a workflow execution result', async () => {
+        const { documents, tasks } = setup()
+        let finish: () => void
+        tasks.savePreparedSource.mockReturnValue(
+            new Promise<void>((resolve) => {
+                finish = resolve
+            })
+        )
+        let done = false
+        const saving = prepareKnowledgePipelineDocuments(task, graph, inputs, documents, tasks).then(() => {
+            done = true
+        })
+        await Promise.resolve()
+        expect(done).toBe(false)
+        finish()
+        await saving
+        expect(done).toBe(true)
+    })
+
+    it('validates all source nodes before creating any documents', async () => {
+        const { documents, tasks } = setup()
+        await expect(
+            prepareKnowledgePipelineDocuments(
+                task,
+                graph,
+                {
+                    ...inputs,
+                    sources: { ...inputs.sources, missing: { documents: ['preview'] } }
+                },
+                documents,
+                tasks
+            )
+        ).rejects.toThrow()
+        expect(documents.createBulk).not.toHaveBeenCalled()
+    })
+
+    it.each(['binding', 'partial batch'])(
+        'rolls back %s failure, then retries without orphan rows',
+        async (failure) => {
+            const committed: KnowledgeDocument[] = []
+            const transaction = { rows: [] as KnowledgeDocument[] }
+            let failBatch = failure === 'partial batch'
+            const documents = {
+                createBulk: jest.fn(async (_input, manager?) => {
+                    const row = { id: `saved-${committed.length + transaction.rows.length}` } as KnowledgeDocument
+                    const target = manager === transaction ? transaction.rows : committed
+                    target.push(row)
+                    if (failBatch) {
+                        failBatch = false
+                        throw new Error('Second document failed')
+                    }
+                    return [row]
+                })
+            }
+            const tasks = {
+                savePreparedSource: jest.fn().mockResolvedValue(undefined),
+                withLockedTask: jest.fn(async (_id, work) => {
+                    transaction.rows = []
+                    const result = await work(task, transaction)
+                    committed.push(...transaction.rows)
+                    return result
+                })
+            }
+            if (failure === 'binding') tasks.savePreparedSource.mockRejectedValueOnce(new Error('Binding failed'))
+            await expect(prepareKnowledgePipelineDocuments(task, graph, inputs, documents, tasks)).rejects.toThrow()
+            expect(committed).toHaveLength(0)
+            await prepareKnowledgePipelineDocuments(task, graph, inputs, documents, tasks)
+            expect(committed).toHaveLength(1)
+        }
+    )
+
+    it('uses the latest bindings under the lock when concurrent callers have the same stale task snapshot', async () => {
+        const latest = structuredClone(task)
+        let previous = Promise.resolve()
+        const { documents } = setup()
+        const tasks = {
+            withLockedTask: jest.fn((_id, work) => {
+                const pending = previous.then(() => work(latest, undefined))
+                previous = pending.then(() => undefined)
+                return pending
+            }),
+            savePreparedSource: jest.fn(async (_id, key, bindings) => {
+                latest.context.materializedSources = { ...latest.context.materializedSources, [key]: bindings }
+            })
+        }
+        const results = await Promise.all([
+            prepareKnowledgePipelineDocuments(task, graph, inputs, documents, tasks),
+            prepareKnowledgePipelineDocuments(task, graph, inputs, documents, tasks)
+        ])
+        expect(documents.createBulk).toHaveBeenCalledTimes(1)
+        expect(results.map((result) => result.sources.source.documents)).toEqual([['saved'], ['saved']])
+    })
+})

--- a/packages/server-ai/src/knowledgebase/task/prepare-pipeline-documents.ts
+++ b/packages/server-ai/src/knowledgebase/task/prepare-pipeline-documents.ts
@@ -1,0 +1,68 @@
+import {
+    DocumentSourceProviderCategoryEnum,
+    IKnowledgebaseTask,
+    KBDocumentStatusEnum,
+    TXpertGraph,
+    WorkflowNodeTypeEnum
+} from '@xpert-ai/contracts'
+import { ForbiddenException } from '@nestjs/common'
+import { t } from 'i18next'
+import type { KnowledgeDocumentService } from '../../knowledge-document/document.service'
+import type { KnowledgebaseTaskService } from './task.service'
+import type { KnowledgePipelineInputs } from './pipeline-task'
+
+/** Save selected preview documents before dispatch so the first list refresh can see them. */
+export async function prepareKnowledgePipelineDocuments(
+    task: IKnowledgebaseTask,
+    graph: TXpertGraph | undefined,
+    inputs: KnowledgePipelineInputs,
+    documentService: Pick<KnowledgeDocumentService, 'createBulk'>,
+    taskService: Pick<KnowledgebaseTaskService, 'savePreparedSource' | 'withLockedTask'>
+): Promise<KnowledgePipelineInputs> {
+    if (inputs.stage !== 'prod' || inputs.isDraft || !task.context?.documents?.length || !inputs.sources) {
+        return inputs
+    }
+
+    // Validate the entire selection before saving the first source.
+    const sources = Object.entries(inputs.sources).map(([key, selection]) => {
+        const node = graph?.nodes.find((node) => node.key === key)
+        if (
+            node?.type !== 'workflow' ||
+            node.entity.type !== WorkflowNodeTypeEnum.SOURCE ||
+            !('provider' in node.entity) ||
+            typeof node.entity.provider !== 'string'
+        ) {
+            throw new ForbiddenException(t('server-ai:Error.KnowledgebaseTaskAccessDenied'))
+        }
+        return { key, selection, provider: node.entity.provider }
+    })
+    return taskService.withLockedTask(task.id, async (lockedTask, manager) => {
+        const preparedSources: NonNullable<KnowledgePipelineInputs['sources']> = {}
+        for (const { key, selection, provider } of sources) {
+            const bindings = { ...lockedTask.context.materializedSources?.[key] }
+            const pending = lockedTask.context.documents.filter(
+                (doc) => selection.documents.includes(doc.id) && !bindings[doc.id]
+            )
+            if (pending.length) {
+                const documents = await documentService.createBulk(
+                    pending.map(({ id: _id, ...doc }) => ({
+                        ...doc,
+                        knowledgebaseId: task.knowledgebaseId,
+                        sourceType: provider as DocumentSourceProviderCategoryEnum,
+                        sourceConfig: { key },
+                        status: KBDocumentStatusEnum.WAITING,
+                        processMsg: null,
+                        progress: 0
+                    })),
+                    manager
+                )
+                pending.forEach((doc, index) => {
+                    bindings[doc.id] = documents[index].id
+                })
+                await taskService.savePreparedSource(task.id, key, bindings, documents, { task: lockedTask, manager })
+            }
+            preparedSources[key] = { documents: selection.documents.map((id) => bindings[id] ?? id) }
+        }
+        return { ...inputs, sources: preparedSources }
+    })
+}

--- a/packages/server-ai/src/knowledgebase/task/task.entity.ts
+++ b/packages/server-ai/src/knowledgebase/task/task.entity.ts
@@ -1,4 +1,11 @@
-import { IChatConversation, IKnowledgebase, IKnowledgebaseTask, IKnowledgeDocument, IXpertAgentExecution, TaskStep } from '@xpert-ai/contracts'
+import {
+    IChatConversation,
+    IKnowledgebase,
+    IKnowledgebaseTask,
+    IKnowledgeDocument,
+    IXpertAgentExecution,
+    TaskStep
+} from '@xpert-ai/contracts'
 import { TenantOrganizationBaseEntity } from '@xpert-ai/server-core'
 import { Optional } from '@nestjs/common'
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
@@ -8,98 +15,96 @@ import { ChatConversation, Knowledgebase, KnowledgeDocument, XpertAgentExecution
 
 @Entity('knowledgebase_task')
 export class KnowledgebaseTask extends TenantOrganizationBaseEntity implements IKnowledgebaseTask {
-	@ApiProperty({ type: () => Knowledgebase, readOnly: true })
-	@ManyToOne(() => Knowledgebase, {
-		nullable: true,
-		onUpdate: 'CASCADE',
-		onDelete: 'CASCADE'
-	})
-	@JoinColumn()
-	@IsOptional()
-	knowledgebase?: IKnowledgebase
+    @ApiProperty({ type: () => Knowledgebase, readOnly: true })
+    @ManyToOne(() => Knowledgebase, {
+        nullable: true,
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+    })
+    @JoinColumn()
+    @IsOptional()
+    knowledgebase?: IKnowledgebase
 
-	@ApiProperty({ type: () => String, readOnly: true })
-	@RelationId((it: KnowledgebaseTask) => it.knowledgebase)
-	@IsString()
-	@IsOptional()
-	@Column({ nullable: true })
-	knowledgebaseId?: string
+    @ApiProperty({ type: () => String, readOnly: true })
+    @RelationId((it: KnowledgebaseTask) => it.knowledgebase)
+    @IsString()
+    @IsOptional()
+    @Column({ nullable: true })
+    knowledgebaseId?: string
 
-	@ApiProperty({ type: () => ChatConversation, readOnly: true })
-	@ManyToOne(() => ChatConversation, {
-		nullable: true,
-		onUpdate: 'CASCADE',
-		onDelete: 'CASCADE'
-	})
-	@JoinColumn()
-	@IsOptional()
-	conversation?: IChatConversation
+    @ApiProperty({ type: () => ChatConversation, readOnly: true })
+    @ManyToOne(() => ChatConversation, {
+        nullable: true,
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+    })
+    @JoinColumn()
+    @IsOptional()
+    conversation?: IChatConversation
 
-	@ApiProperty({ type: () => String, readOnly: true })
-	@RelationId((it: KnowledgebaseTask) => it.conversation)
-	@IsString()
-	@IsOptional()
-	@Column({ nullable: true })
-	conversationId?: string
+    @ApiProperty({ type: () => String, readOnly: true })
+    @RelationId((it: KnowledgebaseTask) => it.conversation)
+    @IsString()
+    @IsOptional()
+    @Column({ nullable: true })
+    conversationId?: string
 
-	@ApiProperty({ type: () => String })
-	@Column({ type: 'varchar', length: 50, default: 'embedding' })
-	taskType: string // preprocess / re-embed / cleanup ...
+    @ApiProperty({ type: () => String })
+    @Column({ type: 'varchar', length: 50, default: 'embedding' })
+    taskType: string // preprocess / re-embed / cleanup ...
 
-	@ApiPropertyOptional({ type: () => String })
-	@IsString()
-	@Optional()
-	@Column({ type: 'varchar', nullable: true })
-	status?: 'pending' | 'running' | 'success' | 'failed' | 'cancelled'
+    @ApiPropertyOptional({ type: () => String })
+    @IsString()
+    @Optional()
+    @Column({ type: 'varchar', nullable: true })
+    status?: 'pending' | 'running' | 'success' | 'failed' | 'cancelled'
 
-	@Column({ type: 'jsonb', nullable: true })
-	steps: TaskStep[]
+    @Column({ type: 'jsonb', nullable: true })
+    steps: TaskStep[]
 
-	@Column({ type: 'text', nullable: true })
-	error?: string
+    @Column({ type: 'text', nullable: true })
+    error?: string
 
-	@ApiProperty({
-		type: 'string',
-		format: 'date-time',
-		example: '2018-11-21T06:20:32.232Z'
-	})
-	@Column({
-		type: 'timestamptz',
-		nullable: true
-	})
-	finishedAt?: Date
+    @ApiProperty({
+        type: 'string',
+        format: 'date-time',
+        example: '2018-11-21T06:20:32.232Z'
+    })
+    @Column({
+        type: 'timestamptz',
+        nullable: true
+    })
+    finishedAt?: Date
 
     @Optional()
     @IsObject()
-	@Column({ type: 'jsonb', nullable: true })
-	context?: {
-		documents?: Partial<IKnowledgeDocument>[]
-	}
+    @Column({ type: 'jsonb', nullable: true })
+    context?: IKnowledgebaseTask['context']
 
-	/*
+    /*
 	|--------------------------------------------------------------------------
 	| @ManyToMany 
 	|--------------------------------------------------------------------------
 	*/
-	@ManyToMany(() => KnowledgeDocument, {
-		cascade: true,
-		onDelete: 'CASCADE',
-	})
-	@JoinTable({
-		name: 'knowledgebase_task_document'
-	})
-	documents?: IKnowledgeDocument[] | null
+    @ManyToMany(() => KnowledgeDocument, {
+        cascade: true,
+        onDelete: 'CASCADE'
+    })
+    @JoinTable({
+        name: 'knowledgebase_task_document'
+    })
+    documents?: IKnowledgeDocument[] | null
 
-	@ApiProperty({ type: () => XpertAgentExecution })
-	@ManyToOne(() => XpertAgentExecution, {
-		onDelete: 'CASCADE'
-	})
-	@JoinColumn()
-	execution?: IXpertAgentExecution
+    @ApiProperty({ type: () => XpertAgentExecution })
+    @ManyToOne(() => XpertAgentExecution, {
+        onDelete: 'CASCADE'
+    })
+    @JoinColumn()
+    execution?: IXpertAgentExecution
 
-	@ApiProperty({ type: () => String })
-	@RelationId((it: KnowledgebaseTask) => it.execution)
-	@IsString()
-	@Column({ nullable: true })
-	executionId?: string
+    @ApiProperty({ type: () => String })
+    @RelationId((it: KnowledgebaseTask) => it.execution)
+    @IsString()
+    @Column({ nullable: true })
+    executionId?: string
 }

--- a/packages/server-ai/src/knowledgebase/task/task.service.spec.ts
+++ b/packages/server-ai/src/knowledgebase/task/task.service.spec.ts
@@ -32,9 +32,21 @@ jest.mock('../knowledgebase.entity', () => ({
     Knowledgebase: class Knowledgebase {}
 }))
 
+jest.mock('../../xpert-agent-execution/agent-execution.entity', () => ({
+    XpertAgentExecution: class XpertAgentExecution {}
+}))
+jest.mock('../../knowledge-document/document.entity', () => ({
+    KnowledgeDocument: class KnowledgeDocument {}
+}))
+
 import { ForbiddenException, NotFoundException } from '@nestjs/common'
 import { RequestContext } from '@xpert-ai/server-core'
 import { KnowledgebaseTaskService } from './task.service'
+import { KnowledgebaseTask } from './task.entity'
+import { XpertAgentExecution } from '../../xpert-agent-execution/agent-execution.entity'
+import { IKnowledgeDocument, KBDocumentStatusEnum, XpertAgentExecutionStatusEnum } from '@xpert-ai/contracts'
+import { KnowledgeDocument } from '../../knowledge-document/document.entity'
+import { IsNull } from 'typeorm'
 
 describe('KnowledgebaseTaskService scope', () => {
     const currentTenantId = RequestContext.currentTenantId as jest.Mock
@@ -47,10 +59,12 @@ describe('KnowledgebaseTaskService scope', () => {
     })
 
     function createService() {
+        const manager = { update: jest.fn().mockResolvedValue({ affected: 1 }), findOne: jest.fn() }
         const taskRepo = {
             create: jest.fn((entity) => ({ id: 'task-1', ...entity })),
             findOne: jest.fn(),
-            save: jest.fn()
+            save: jest.fn(),
+            manager: { transaction: jest.fn(async (callback) => callback(manager)), findOne: jest.fn() }
         }
         const baseRepo = {
             findOne: jest.fn()
@@ -58,8 +72,266 @@ describe('KnowledgebaseTaskService scope', () => {
         const service = new KnowledgebaseTaskService(taskRepo as never)
         Object.defineProperty(service, 'baseRepo', { value: baseRepo })
 
-        return { service, taskRepo, baseRepo }
+        return { service, taskRepo, baseRepo, manager }
     }
+
+    it('propagates a persisted execution error after a normally completed stream', async () => {
+        const { service, taskRepo, manager } = createService()
+        taskRepo.manager.findOne.mockResolvedValue({
+            status: XpertAgentExecutionStatusEnum.ERROR,
+            error: 'Null toolsets'
+        })
+        await service.syncExecutionFailure({
+            taskId: 'task',
+            knowledgebaseId: 'kb',
+            executionId: 'execution',
+            tenantId: 'tenant',
+            organizationId: 'org'
+        })
+        expect(taskRepo.manager.findOne).toHaveBeenCalledWith(XpertAgentExecution, {
+            where: { id: 'execution', tenantId: 'tenant', organizationId: 'org' },
+            select: { status: true, error: true }
+        })
+        expect(manager.update).toHaveBeenCalledWith(
+            KnowledgebaseTask,
+            expect.objectContaining({
+                id: 'task',
+                executionId: 'execution',
+                status: 'running'
+            }),
+            expect.objectContaining({ status: 'failed', error: 'Null toolsets' })
+        )
+    })
+
+    it.each([XpertAgentExecutionStatusEnum.SUCCESS, XpertAgentExecutionStatusEnum.RUNNING])(
+        'does not turn a %s execution into a failed task on stream completion',
+        async (status) => {
+            const { service, taskRepo, manager } = createService()
+            taskRepo.manager.findOne.mockResolvedValue({ status })
+            await service.syncExecutionFailure({
+                taskId: 'task',
+                knowledgebaseId: 'kb',
+                executionId: 'execution',
+                tenantId: 'tenant',
+                organizationId: null
+            })
+            expect(manager.update).not.toHaveBeenCalled()
+        }
+    )
+
+    it('ignores an execution missing from the callback tenant and organization', async () => {
+        const { service, taskRepo, manager } = createService()
+        taskRepo.manager.findOne.mockResolvedValue(null)
+        await service.syncExecutionFailure({
+            taskId: 'task',
+            knowledgebaseId: 'kb',
+            executionId: 'execution',
+            tenantId: 'tenant',
+            organizationId: null
+        })
+        expect(manager.update).not.toHaveBeenCalled()
+    })
+
+    it('atomically records failure only for the current running attempt in its tenant and organization', async () => {
+        const { service, manager, taskRepo } = createService()
+        await service.failExecution(
+            {
+                taskId: 'task',
+                knowledgebaseId: 'kb',
+                executionId: 'execution',
+                tenantId: 'tenant',
+                organizationId: 'org'
+            },
+            'Dispatch failed'
+        )
+        expect(taskRepo.manager.transaction).toHaveBeenCalledTimes(1)
+        expect(manager.update).toHaveBeenNthCalledWith(
+            1,
+            KnowledgebaseTask,
+            {
+                id: 'task',
+                knowledgebaseId: 'kb',
+                executionId: 'execution',
+                tenantId: 'tenant',
+                organizationId: 'org',
+                status: 'running'
+            },
+            { status: 'failed', error: 'Dispatch failed', finishedAt: expect.any(Date) }
+        )
+        expect(manager.update).toHaveBeenNthCalledWith(
+            2,
+            XpertAgentExecution,
+            {
+                id: 'execution',
+                tenantId: 'tenant',
+                organizationId: 'org',
+                status: XpertAgentExecutionStatusEnum.RUNNING
+            },
+            { status: XpertAgentExecutionStatusEnum.ERROR, error: 'Dispatch failed' }
+        )
+    })
+
+    it('ignores stale, duplicate, completed and out-of-scope callbacks without changing an execution', async () => {
+        const { service, manager } = createService()
+        manager.update.mockResolvedValue({ affected: 0 })
+        await service.failExecution(
+            {
+                taskId: 'task',
+                knowledgebaseId: 'kb',
+                executionId: 'old-execution',
+                tenantId: 'tenant',
+                organizationId: null
+            },
+            'Late failure'
+        )
+        expect(manager.update).toHaveBeenCalledTimes(1)
+        expect(manager.update.mock.calls[0][1].organizationId).toEqual(IsNull())
+    })
+
+    it('marks saved pending documents as failed if background dispatch fails', async () => {
+        const { service, manager } = createService()
+        manager.findOne.mockResolvedValue({ documents: [{ id: 'saved' }] })
+        await service.failExecution(
+            {
+                taskId: 'task',
+                knowledgebaseId: 'kb',
+                executionId: 'execution',
+                tenantId: 'tenant',
+                organizationId: 'org'
+            },
+            'Queue failed'
+        )
+        expect(manager.update).toHaveBeenLastCalledWith(
+            KnowledgeDocument,
+            expect.objectContaining({
+                knowledgebaseId: 'kb',
+                tenantId: 'tenant',
+                organizationId: 'org',
+                id: expect.objectContaining({ _value: ['saved'] }),
+                status: expect.objectContaining({ _value: expect.not.arrayContaining([KBDocumentStatusEnum.FINISH]) })
+            }),
+            { status: KBDocumentStatusEnum.ERROR, processMsg: 'Queue failed' }
+        )
+    })
+
+    it('does not let task A failure overwrite a document already claimed by task B', async () => {
+        const { service, manager } = createService()
+        const document = { id: 'shared', status: KBDocumentStatusEnum.EMBEDDING, processingExecutionId: 'execution-B' }
+        manager.findOne.mockResolvedValue({ documents: [{ id: document.id }] })
+        manager.update.mockImplementation(async (entity, where, changes) => {
+            if (entity !== KnowledgeDocument) return { affected: 1 }
+            if (where.processingExecutionId && where.processingExecutionId !== document.processingExecutionId) {
+                return { affected: 0 }
+            }
+            Object.assign(document, changes)
+            return { affected: 1 }
+        })
+        await service.failExecution(
+            {
+                taskId: 'task-A',
+                knowledgebaseId: 'kb',
+                executionId: 'execution-A',
+                tenantId: 'tenant',
+                organizationId: 'org'
+            },
+            'Late A failure'
+        )
+        expect(document.status).toBe(KBDocumentStatusEnum.EMBEDDING)
+        expect(document).not.toHaveProperty('processMsg')
+    })
+
+    it('claims only selected task documents before starting the new attempt', async () => {
+        const { service, manager } = createService()
+        manager.findOne.mockResolvedValue({
+            id: 'task-B',
+            knowledgebaseId: 'kb',
+            documents: [{ id: 'selected' }, { id: 'unselected' }]
+        })
+        await service.startDocumentExecution('task-B', 'execution-B', ['selected', 'not-in-task'])
+        expect(manager.findOne.mock.calls[0][1]).toEqual({
+            where: { id: 'task-B', tenantId: 'tenant-1', organizationId: 'org-1' },
+            lock: { mode: 'pessimistic_write' }
+        })
+        expect(manager.update).toHaveBeenLastCalledWith(
+            KnowledgeDocument,
+            {
+                id: expect.objectContaining({ _value: ['selected'] }),
+                knowledgebaseId: 'kb',
+                tenantId: 'tenant-1',
+                organizationId: 'org-1'
+            },
+            {
+                processingExecutionId: 'execution-B',
+                status: KBDocumentStatusEnum.WAITING,
+                processMsg: null,
+                progress: 0
+            }
+        )
+    })
+
+    it('uses the transaction repository for bindings and preserves other sources', async () => {
+        const { service, taskRepo, manager } = createService()
+        const task = Object.assign(new KnowledgebaseTask(), {
+            id: 'task',
+            taskType: 'ingest',
+            steps: [],
+            documents: [Object.assign(new KnowledgeDocument(), { id: 'old' })],
+            context: { documents: [{ id: 'preview' }], materializedSources: { other: { cached: 'old' } } }
+        })
+        const save = jest.fn(async (value) => value)
+        const transactionalManager = { ...manager, getRepository: jest.fn(() => ({ save })) }
+        await service.savePreparedSource(
+            'task',
+            'source',
+            { preview: 'saved' },
+            [{ id: 'saved' }] as IKnowledgeDocument[],
+            {
+                task,
+                manager: transactionalManager as never
+            }
+        )
+        expect(taskRepo.save).not.toHaveBeenCalled()
+        expect(taskRepo.findOne).not.toHaveBeenCalled()
+        expect(save).toHaveBeenCalledWith(expect.objectContaining({ documents: [{ id: 'old' }, { id: 'saved' }] }))
+        expect(task.context.materializedSources).toEqual({ other: { cached: 'old' }, source: { preview: 'saved' } })
+    })
+
+    it('attaches saved documents without overwriting preview content or other source bindings', async () => {
+        const { service, taskRepo } = createService()
+        taskRepo.findOne.mockResolvedValue({
+            id: 'task',
+            documents: [{ id: 'old' }],
+            context: { documents: [{ id: 'preview' }], materializedSources: { other: { cached: 'old' } } }
+        })
+        await service.savePreparedSource('task', 'source', { preview: 'saved' }, [
+            { id: 'saved' }
+        ] as IKnowledgeDocument[])
+        expect(taskRepo.save).toHaveBeenCalledWith({
+            id: 'task',
+            documents: [{ id: 'old' }, { id: 'saved' }],
+            context: {
+                documents: [{ id: 'preview' }],
+                materializedSources: { other: { cached: 'old' }, source: { preview: 'saved' } }
+            }
+        })
+    })
+
+    it('rejects failure writes without a tenant', async () => {
+        const { service, manager } = createService()
+        await expect(
+            service.failExecution(
+                {
+                    taskId: 'task',
+                    knowledgebaseId: 'kb',
+                    executionId: 'execution',
+                    tenantId: '',
+                    organizationId: null
+                },
+                'Failure'
+            )
+        ).rejects.toBeInstanceOf(ForbiddenException)
+        expect(manager.update).not.toHaveBeenCalled()
+    })
 
     it('loads the knowledgebase only inside the current tenant and organization', async () => {
         const { service, taskRepo, baseRepo } = createService()

--- a/packages/server-ai/src/knowledgebase/task/task.service.ts
+++ b/packages/server-ai/src/knowledgebase/task/task.service.ts
@@ -1,11 +1,27 @@
-import { IKnowledgebaseTask, IKnowledgeDocument, TaskStep } from '@xpert-ai/contracts'
+import {
+    IKnowledgebaseTask,
+    IKnowledgeDocument,
+    KBDocumentStatusEnum,
+    TaskStep,
+    XpertAgentExecutionStatusEnum
+} from '@xpert-ai/contracts'
 import { RequestContext, TenantOrganizationAwareCrudService } from '@xpert-ai/server-core'
 import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { IsNull, Repository } from 'typeorm'
+import { EntityManager, In, IsNull, Repository } from 'typeorm'
 import { KnowledgebaseTask } from './task.entity'
 import { Knowledgebase } from '../knowledgebase.entity'
 import { t } from 'i18next'
+import { XpertAgentExecution } from '../../xpert-agent-execution/agent-execution.entity'
+import { KnowledgeDocument } from '../../knowledge-document/document.entity'
+
+export interface KnowledgePipelineExecutionScope {
+    tenantId: string
+    organizationId: string | null
+    knowledgebaseId: string
+    taskId: string
+    executionId: string
+}
 
 function knowledgebaseTaskAccessDeniedMessage() {
     return t('server-ai:Error.KnowledgebaseTaskAccessDenied', {
@@ -89,5 +105,170 @@ export class KnowledgebaseTaskService extends TenantOrganizationAwareCrudService
         const updatedDocuments = Array.from(docMap.values())
         task.context.documents = updatedDocuments
         return await this.taskRepo.save(task)
+    }
+
+    async syncExecutionFailure(scope: KnowledgePipelineExecutionScope): Promise<void> {
+        if (!scope.tenantId) throw new ForbiddenException(knowledgebaseTaskAccessDeniedMessage())
+        const execution = await this.taskRepo.manager.findOne(XpertAgentExecution, {
+            where: {
+                id: scope.executionId,
+                tenantId: scope.tenantId,
+                organizationId: scope.organizationId ?? IsNull()
+            },
+            select: { status: true, error: true }
+        })
+        if (execution?.status === XpertAgentExecutionStatusEnum.ERROR) {
+            await this.failExecution(
+                scope,
+                execution.error ||
+                    t('server-ai:Error.KnowledgePipelineFailed', {
+                        defaultValue: 'Knowledge pipeline execution failed'
+                    })
+            )
+        }
+    }
+
+    /** Serialize materialization for one task and commit its documents and bindings together. */
+    async withLockedTask<T>(
+        taskId: string,
+        work: (task: KnowledgebaseTask, manager: EntityManager) => Promise<T>
+    ): Promise<T> {
+        const tenantId = RequestContext.currentTenantId()
+        if (!tenantId) throw new ForbiddenException(knowledgebaseTaskAccessDeniedMessage())
+        return this.taskRepo.manager.transaction(async (manager) => {
+            const task = await manager.findOne(KnowledgebaseTask, {
+                where: { id: taskId, tenantId, organizationId: RequestContext.getOrganizationId() ?? IsNull() },
+                lock: { mode: 'pessimistic_write' }
+            })
+            if (!task) throw new NotFoundException(knowledgebaseTaskAccessDeniedMessage())
+            // Load relations separately: PostgreSQL cannot lock the nullable side of an outer join.
+            const related = await manager.findOne(KnowledgebaseTask, {
+                where: { id: task.id, tenantId, organizationId: RequestContext.getOrganizationId() ?? IsNull() },
+                relations: ['documents']
+            })
+            task.documents = related?.documents ?? []
+            return work(task, manager)
+        })
+    }
+
+    async savePreparedSource(
+        taskId: string,
+        sourceKey: string,
+        bindings: Record<string, string>,
+        documents: IKnowledgeDocument[],
+        prepared?: { task: KnowledgebaseTask; manager: EntityManager }
+    ): Promise<void> {
+        const task = prepared?.task ?? (await this.findOneByIdString(taskId, { relations: ['documents'] }))
+        const documentIds = new Set([...(task.documents ?? []).map((doc) => doc.id), ...documents.map((doc) => doc.id)])
+        const saved = await (prepared?.manager.getRepository(KnowledgebaseTask) ?? this.taskRepo).save({
+            id: task.id,
+            context: {
+                ...task.context,
+                materializedSources: { ...task.context?.materializedSources, [sourceKey]: bindings }
+            },
+            documents: Array.from(documentIds, (id) => ({ id }))
+        })
+        if (prepared) {
+            task.context = saved.context
+            task.documents = saved.documents
+        }
+    }
+
+    /** Claim documents before enqueueing; later callbacks must match this exact execution. */
+    async startDocumentExecution(taskId: string, executionId: string, documentIds?: string[]): Promise<void> {
+        await this.withLockedTask(taskId, async (task, manager) => {
+            const ids = (task.documents ?? [])
+                .map((doc) => doc.id)
+                .filter((id) => !documentIds || documentIds.includes(id))
+            await manager.update(
+                KnowledgebaseTask,
+                { id: task.id },
+                {
+                    status: 'running',
+                    executionId,
+                    error: null,
+                    finishedAt: null
+                }
+            )
+            if (ids.length) {
+                await manager.update(
+                    KnowledgeDocument,
+                    {
+                        id: In(ids),
+                        knowledgebaseId: task.knowledgebaseId,
+                        tenantId: RequestContext.currentTenantId(),
+                        organizationId: RequestContext.getOrganizationId() ?? IsNull()
+                    },
+                    {
+                        processingExecutionId: executionId,
+                        status: KBDocumentStatusEnum.WAITING,
+                        processMsg: null,
+                        progress: 0
+                    }
+                )
+            }
+        })
+    }
+
+    async failExecution(scope: KnowledgePipelineExecutionScope, error: string): Promise<void> {
+        if (!scope.tenantId) throw new ForbiddenException(knowledgebaseTaskAccessDeniedMessage())
+        await this.taskRepo.manager.transaction(async (manager) => {
+            const result = await manager.update(
+                KnowledgebaseTask,
+                {
+                    id: scope.taskId,
+                    knowledgebaseId: scope.knowledgebaseId,
+                    executionId: scope.executionId,
+                    tenantId: scope.tenantId,
+                    organizationId: scope.organizationId ?? IsNull(),
+                    status: 'running'
+                },
+                { status: 'failed', error, finishedAt: new Date() }
+            )
+            // Ignore duplicate callbacks and failures from a previous attempt.
+            if (!result.affected) return
+            await manager.update(
+                XpertAgentExecution,
+                {
+                    id: scope.executionId,
+                    tenantId: scope.tenantId,
+                    organizationId: scope.organizationId ?? IsNull(),
+                    status: XpertAgentExecutionStatusEnum.RUNNING
+                },
+                { status: XpertAgentExecutionStatusEnum.ERROR, error }
+            )
+            const task = await manager.findOne(KnowledgebaseTask, {
+                where: {
+                    id: scope.taskId,
+                    knowledgebaseId: scope.knowledgebaseId,
+                    tenantId: scope.tenantId,
+                    organizationId: scope.organizationId ?? IsNull()
+                },
+                relations: ['documents'],
+                select: { id: true, documents: { id: true } }
+            })
+            if (task?.documents?.length) {
+                // Imports are visible before dispatch; a failed dispatch must not leave their rows waiting forever.
+                await manager.update(
+                    KnowledgeDocument,
+                    {
+                        id: In(task.documents.map((document) => document.id)),
+                        processingExecutionId: scope.executionId,
+                        knowledgebaseId: scope.knowledgebaseId,
+                        tenantId: scope.tenantId,
+                        organizationId: scope.organizationId ?? IsNull(),
+                        status: In([
+                            KBDocumentStatusEnum.WAITING,
+                            KBDocumentStatusEnum.RUNNING,
+                            KBDocumentStatusEnum.TRANSFORMED,
+                            KBDocumentStatusEnum.SPLITTED,
+                            KBDocumentStatusEnum.UNDERSTOOD,
+                            KBDocumentStatusEnum.EMBEDDING
+                        ])
+                    },
+                    { status: KBDocumentStatusEnum.ERROR, processMsg: error }
+                )
+            }
+        })
     }
 }

--- a/packages/server-ai/src/knowledgebase/types.ts
+++ b/packages/server-ai/src/knowledgebase/types.ts
@@ -1,4 +1,5 @@
 export const JOB_REBUILD_KNOWLEDGEBASE_EMBEDDING = 'rebuild-knowledgebase-embedding'
+export const KNOWLEDGE_PIPELINE_CALLBACK = 'knowledge.pipeline_callback.v1'
 
 export type TKnowledgebaseRebuildEmbeddingJob = {
     userId: string

--- a/packages/server-ai/src/xpert-agent-execution/commands/handlers/upsert.handler.spec.ts
+++ b/packages/server-ai/src/xpert-agent-execution/commands/handlers/upsert.handler.spec.ts
@@ -4,6 +4,21 @@ import { XpertAgentExecutionUpsertCommand } from '../upsert.command'
 import { XpertAgentExecutionUpsertHandler } from './upsert.handler'
 
 describe('XpertAgentExecutionUpsertHandler', () => {
+    it('binds a preallocated pipeline execution to its first authoritative Chat thread', async () => {
+        const service = {
+            findOneOrFailByIdString: jest.fn(async () => ({
+                success: true,
+                record: { id: 'execution-1', threadId: null }
+            })),
+            update: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn()
+        }
+        const handler = new XpertAgentExecutionUpsertHandler(service as never, {} as never, {} as never)
+        await handler.execute(new XpertAgentExecutionUpsertCommand({ id: 'execution-1', threadId: 'chat-thread' }))
+        expect(service.update).toHaveBeenCalledWith('execution-1', { id: 'execution-1', threadId: 'chat-thread' })
+        expect(service.create).not.toHaveBeenCalled()
+    })
     it('creates a caller-specified execution id when it does not exist', async () => {
         const service = {
             findOneOrFailByIdString: jest.fn(async () => ({ success: false })),

--- a/packages/server-ai/src/xpert-agent/commands/handlers/knowledge-preview.integration.spec.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/knowledge-preview.integration.spec.ts
@@ -1,0 +1,226 @@
+jest.mock('yargs', () => ({ __esModule: true, default: () => ({ argv: {} }) }))
+
+import { Document } from '@langchain/core/documents'
+import { CommandBus, QueryBus } from '@nestjs/cqrs'
+import {
+    channelName,
+    IEnvironment,
+    IKnowledgebaseTask,
+    IKnowledgeDocument,
+    IXpert,
+    IXpertAgent,
+    IXpertAgentExecution,
+    KnowledgebaseChannel,
+    KnowledgeTask,
+    TXpertGraph,
+    WorkflowNodeTypeEnum,
+    XpertTypeEnum
+} from '@xpert-ai/contracts'
+import { WorkflowSourceNodeStrategy } from '../../../knowledgebase/plugins/source/strategy'
+import { WorkflowProcessorNodeStrategy } from '../../../knowledgebase/plugins/processor/strategy'
+import { WorkflowChunkerNodeStrategy } from '../../../knowledgebase/plugins/chunker/strategy'
+import { WorkflowKnowledgeBaseNodeStrategy } from '../../../knowledgebase/plugins/knowledgebase/strategy'
+import { RecursiveCharacterStrategy } from '../../../knowledgebase/plugins/textsplitter-common/recursive-character.strategy'
+import { KnowledgeStrategyQuery } from '../../../knowledgebase/queries'
+import { GetXpertWorkflowQuery } from '../../../xpert/queries'
+import { ToolsetGetToolsCommand } from '../../../xpert-toolset/commands/get-tools.command'
+import { XpertAgentExecutionUpsertCommand } from '../../../xpert-agent-execution'
+import { XpertAgentExecutionOneQuery } from '../../../xpert-agent-execution/queries'
+import { CreateWorkflowNodeCommand } from '../../workflow/create-workflow.command'
+import { CreateWorkflowNodeHandler } from '../../workflow/handlers/create-workflow.handler'
+import { XpertAgentSubgraphCommand } from '../subgraph.command'
+import { XpertAgentSubgraphHandler } from './subgraph.handler'
+
+describe('published knowledge pipeline preview', () => {
+    it('preserves task scope through real source, processor, splitter and result nodes without a loaded knowledgebase relation', async () => {
+        const xpert = {
+            id: 'pipeline',
+            type: XpertTypeEnum.Knowledge,
+            workspaceId: 'workspace',
+            agentConfig: {}
+        } as IXpert
+        const agent = {
+            key: 'hidden',
+            name: 'Hidden',
+            options: { hidden: true },
+            toolsetIds: [],
+            knowledgebaseIds: [],
+            team: xpert
+        } as IXpertAgent
+        const graphFixture = {
+            nodes: [
+                {
+                    key: 'trigger',
+                    type: 'workflow',
+                    entity: { key: 'trigger', type: WorkflowNodeTypeEnum.TRIGGER, from: 'chat' }
+                },
+                {
+                    key: 'source',
+                    type: 'workflow',
+                    entity: { key: 'source', type: WorkflowNodeTypeEnum.SOURCE, provider: 'local-file' }
+                },
+                {
+                    key: 'processor',
+                    type: 'workflow',
+                    entity: {
+                        key: 'processor',
+                        type: WorkflowNodeTypeEnum.PROCESSOR,
+                        provider: 'default',
+                        input: `${channelName('source')}.documents`
+                    }
+                },
+                {
+                    key: 'chunker',
+                    type: 'workflow',
+                    entity: {
+                        key: 'chunker',
+                        type: WorkflowNodeTypeEnum.CHUNKER,
+                        provider: 'recursive-character',
+                        input: `${channelName('processor')}.documents`,
+                        config: { chunkSize: 1000, chunkOverlap: 200 }
+                    }
+                },
+                {
+                    key: 'result',
+                    type: 'workflow',
+                    entity: {
+                        key: 'result',
+                        type: WorkflowNodeTypeEnum.KNOWLEDGE_BASE,
+                        inputs: [`${channelName('chunker')}.documents`]
+                    }
+                }
+            ],
+            connections: ['trigger/source', 'source/processor', 'processor/chunker', 'chunker/result'].map((key) => ({
+                key,
+                type: 'edge',
+                from: key.split('/')[0],
+                to: key.split('/')[1]
+            }))
+        }
+        const graph: TXpertGraph = {
+            nodes: graphFixture.nodes.map((node) => ({
+                ...node,
+                type: 'workflow',
+                position: { x: 0, y: 0 },
+                entity: { ...node.entity, id: node.key }
+            })),
+            connections: graphFixture.connections.map((connection) => ({ ...connection, type: 'edge' }))
+        }
+        let cachedDocuments: Partial<IKnowledgeDocument>[] = [{ id: 'doc', name: 'test.md' }]
+        const task = { id: 'task', status: 'running' } as IKnowledgebaseTask
+        const tasks = {
+            findOne: jest.fn(async (id: string) => {
+                if (id !== task.id) throw new Error('Preview lost its task ID')
+                return { ...task, context: { documents: structuredClone(cachedDocuments) } }
+            }),
+            upsertDocuments: jest.fn(async (id: string, docs: Partial<IKnowledgeDocument>[]) => {
+                expect(id).toBe(task.id)
+                cachedDocuments = structuredClone(docs)
+            }),
+            update: jest.fn(async (id: string, update: Partial<IKnowledgebaseTask>) => {
+                expect(id).toBe(task.id)
+                Object.assign(task, update)
+            })
+        }
+        const transformDocuments = jest.fn(async (kbId: string) => {
+            expect(kbId).toBe('kb')
+            // File parsing is the external boundary; all workflow nodes and text splitting below are real.
+            return [
+                {
+                    id: 'doc',
+                    name: 'test.md',
+                    chunks: [
+                        new Document({
+                            pageContent: '# Preview test\n\n'.repeat(1200),
+                            metadata: {}
+                        })
+                    ]
+                }
+            ]
+        })
+        const executions = new Map<string, Partial<IXpertAgentExecution>>()
+        const commandBus = {
+            execute: jest.fn(async (command: unknown) => {
+                if (command instanceof ToolsetGetToolsCommand) return []
+                if (command instanceof CreateWorkflowNodeCommand) return workflowHandler.execute(command)
+                if (command instanceof XpertAgentExecutionUpsertCommand) {
+                    const id = command.execution.id ?? `execution-${executions.size}`
+                    const execution = { ...executions.get(id), ...command.execution, id }
+                    executions.set(id, execution)
+                    return execution
+                }
+                throw new Error(`Unexpected command: ${command?.constructor.name}`)
+            })
+        }
+        const queryBus = {
+            execute: jest.fn(async (query: unknown) => {
+                if (query instanceof GetXpertWorkflowQuery) return { agent, graph, next: [], fail: [] }
+                if (query instanceof KnowledgeStrategyQuery) return new RecursiveCharacterStrategy()
+                if (query instanceof XpertAgentExecutionOneQuery) return { id: 'node-execution' }
+                throw new Error(`Unexpected query: ${query?.constructor.name}`)
+            })
+        }
+        const strategies = [
+            new WorkflowSourceNodeStrategy(commandBus as never, queryBus as never),
+            new WorkflowProcessorNodeStrategy(commandBus as never, queryBus as never),
+            new WorkflowChunkerNodeStrategy(commandBus as never, queryBus as never),
+            new WorkflowKnowledgeBaseNodeStrategy(commandBus as never, queryBus as never)
+        ]
+        for (const strategy of strategies) {
+            Object.defineProperty(strategy, 'taskService', { value: tasks })
+            Object.defineProperty(strategy, 'knowledgebaseService', { value: { transformDocuments } })
+            // Production document writes must not be reached by preview.
+            Object.defineProperty(strategy, 'documentService', { value: {} })
+        }
+        const workflowHandler = new CreateWorkflowNodeHandler(commandBus as never, queryBus as never)
+        Object.defineProperty(workflowHandler, 'nodeRegistry', {
+            value: { get: (type: WorkflowNodeTypeEnum) => strategies.find((strategy) => strategy.meta.name === type) }
+        })
+        const handler = new XpertAgentSubgraphHandler(
+            null,
+            commandBus as unknown as CommandBus,
+            queryBus as unknown as QueryBus,
+            null,
+            null,
+            {
+                createScopedApi: () => ({}),
+                resolveSelectedConnectorRuntimeBindings: async () => []
+            } as never,
+            { findOne: async (id: string) => ({ id }) } as never
+        )
+        Object.defineProperty(handler, 'agentMiddlewareRegistry', {
+            value: { get: () => ({ createMiddleware: () => ({ name: 'ClientToolMiddleware', tools: [] }) }) }
+        })
+        const controller = new AbortController()
+        const { graph: compiled } = await handler.execute(
+            new XpertAgentSubgraphCommand('hidden', xpert, {
+                isStart: true,
+                isDraft: false,
+                disableCheckpointer: true,
+                mute: [],
+                store: null,
+                subscriber: null,
+                execution: { id: 'execution' } as IXpertAgentExecution,
+                rootController: controller,
+                signal: controller.signal,
+                channel: channelName('hidden'),
+                thread_id: 'thread',
+                environment: { variables: [] } as IEnvironment,
+                from: 'knowledge'
+            })
+        )
+        const context = { knowledgebaseId: 'kb', [KnowledgeTask]: task.id, sources: ['source'], stage: 'preview' }
+        const output = await compiled.invoke(
+            {
+                [KnowledgebaseChannel]: context,
+                [channelName('source')]: { documents: ['doc'] }
+            },
+            { configurable: { thread_id: 'thread', executionId: 'execution' } }
+        )
+        expect(output[KnowledgebaseChannel]).toEqual(context)
+        expect(task.status).toBe('success')
+        expect(transformDocuments).toHaveBeenCalledTimes(1)
+        expect(cachedDocuments[0].draft.chunks.length).toBeGreaterThan(2)
+        expect(cachedDocuments[0].draft.chunks.every((chunk) => chunk.pageContent.length <= 1000)).toBe(true)
+    })
+})

--- a/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
+++ b/packages/server-ai/src/xpert-agent/commands/handlers/subgraph.handler.ts
@@ -52,6 +52,7 @@ import {
     TXpertParameter,
     TXpertTeamNode,
     WorkflowNodeTypeEnum,
+    XpertTypeEnum,
     XpertAgentExecutionStatusEnum
 } from '@xpert-ai/contracts'
 import { getErrorMessage } from '@xpert-ai/server-common'
@@ -1045,7 +1046,8 @@ export class XpertAgentSubgraphHandler implements ICommandHandler<XpertAgentSubg
 
         // State
         // State channel for knowledgebase pipeline
-        if (runtimeXpert.knowledgebase) {
+        // Runtime projections may omit the relation; pipeline state must survive regardless.
+        if (runtimeXpert.type === XpertTypeEnum.Knowledge || runtimeXpert.knowledgebase) {
             channels.push({
                 name: KnowledgebaseChannel,
                 annotation: Annotation<Record<string, unknown>>({

--- a/packages/server-ai/src/xpert-toolset/commands/get-tools.command.ts
+++ b/packages/server-ai/src/xpert-toolset/commands/get-tools.command.ts
@@ -10,7 +10,7 @@ export class ToolsetGetToolsCommand implements ICommand {
     static readonly type = '[Xpert Toolset] Get tools'
 
     constructor(
-        public readonly ids: string[],
+        public readonly ids: string[] | null | undefined,
         public readonly environment?: {
             projectId?: string | null
             workspaceId?: string | null

--- a/packages/server-ai/src/xpert-toolset/commands/handlers/get-tools.handler.test.ts
+++ b/packages/server-ai/src/xpert-toolset/commands/handlers/get-tools.handler.test.ts
@@ -24,6 +24,17 @@ describe('ToolsetGetToolsHandler', () => {
 
     afterEach(() => jest.restoreAllMocks())
 
+    it.each([{ ids: null }, { ids: undefined }, { ids: [] }])(
+        'supports an unconfigured legacy toolset list: %p',
+        async ({ ids }) => {
+            loadToolsets.mockImplementation((request) =>
+                ToolRuntimeService.prototype.loadToolsets.call({} as never, request)
+            )
+            await expect(handler.execute(new ToolsetGetToolsCommand(ids))).resolves.toEqual([])
+            expect(loadToolsets).toHaveBeenCalledWith(expect.objectContaining({ toolsetIds: [] }))
+        }
+    )
+
     it('adapts the current Agent identity and environment to an explicit runtime request', async () => {
         jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue('tenant-1')
         jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue('organization-1')

--- a/packages/server-ai/src/xpert-toolset/commands/handlers/get-tools.handler.ts
+++ b/packages/server-ai/src/xpert-toolset/commands/handlers/get-tools.handler.ts
@@ -16,7 +16,7 @@ export class ToolsetGetToolsHandler implements ICommandHandler<ToolsetGetToolsCo
             organizationId: RequestContext.getOrganizationId(),
             workspaceId: command.environment?.workspaceId,
             principal: userId ? { type: 'user', id: userId, userId } : { type: 'service_account', id: 'xpert-runtime' },
-            toolsetIds: command.ids,
+            toolsetIds: command.ids ?? [],
             ...command.environment
         })
     }

--- a/packages/server-ai/src/xpert/commands/enqueue-trigger-dispatch.command.ts
+++ b/packages/server-ai/src/xpert/commands/enqueue-trigger-dispatch.command.ts
@@ -1,5 +1,6 @@
 import { STATE_VARIABLE_HUMAN, type IWFNTrigger } from '@xpert-ai/contracts'
 import { ICommand } from '@nestjs/cqrs'
+import type { AgentChatHandoffMessageCallbackTarget } from '@xpert-ai/plugin-sdk'
 
 /**
  * Enqueues one trigger-driven chat dispatch request into the handoff pipeline.
@@ -25,6 +26,7 @@ export class XpertEnqueueTriggerDispatchCommand implements ICommand {
             isDraft: boolean
             from: IWFNTrigger['from']
             executionId?: string
+            callback?: AgentChatHandoffMessageCallbackTarget
         }
     ) {}
 }

--- a/packages/server-ai/src/xpert/commands/handlers/enqueue-trigger-dispatch.handler.spec.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/enqueue-trigger-dispatch.handler.spec.ts
@@ -4,6 +4,25 @@ import { XpertEnqueueTriggerDispatchCommand } from '../enqueue-trigger-dispatch.
 import { XpertEnqueueTriggerDispatchHandler } from './enqueue-trigger-dispatch.handler'
 
 describe('XpertEnqueueTriggerDispatchHandler', () => {
+    it('preserves an explicit domain callback and its execution identity', async () => {
+        const { handler, xpertService, handoffQueue } = createHandler()
+        xpertService.findOne.mockResolvedValue({ id: 'pipeline', tenantId: 'tenant', organizationId: 'org' })
+        const callback = {
+            messageType: 'knowledge.pipeline_callback.v1',
+            context: { taskId: 'task', executionId: 'execution' }
+        }
+        await handler.execute(
+            new XpertEnqueueTriggerDispatchCommand(
+                'pipeline',
+                'user',
+                {
+                    [STATE_VARIABLE_HUMAN]: { input: 'Process pipeline' }
+                },
+                { isDraft: false, from: 'knowledge', executionId: 'execution', callback }
+            )
+        )
+        expect(handoffQueue.enqueue.mock.calls[0][0].payload.callback).toEqual(callback)
+    })
     function createHandler() {
         const xpertService = {
             findOne: jest.fn()

--- a/packages/server-ai/src/xpert/commands/handlers/enqueue-trigger-dispatch.handler.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/enqueue-trigger-dispatch.handler.ts
@@ -87,7 +87,7 @@ export class XpertEnqueueTriggerDispatchHandler implements ICommandHandler<Xpert
                     ...(params.isDraft ? { isDraft: true } : {}),
                     ...(params.executionId ? { execution: { id: params.executionId } } : {})
                 } as AgentChatDispatchPayload['options'],
-                callback: {
+                callback: params.callback ?? {
                     messageType: AGENT_CHAT_CALLBACK_NOOP_MESSAGE_TYPE
                 }
             },


### PR DESCRIPTION
# PR

Knowledge pipeline imports could show no sources, repeatedly create preview tasks, hang or fail during preview, and leave the document list unchanged until background processing finished. Saving now persists visible documents before dispatch, refreshes the list immediately, and continues tracking processing through completion or failure.

- Expose the published source graph and preserve the knowledge channel in projected runtime graphs; accept legacy null toolset selections.
- Update the source, processing and result steps with consistent layouts, loading/error states and translated copy.
- Keep preallocated executions unbound until Chat assigns their thread, propagate dispatch/runtime failures, and select document IDs in status queries.
- Save imported documents, folder paths and task bindings in one transaction under a task lock. Concurrent retries reuse committed bindings.
- Claim the selected documents before dispatch and fence failure callbacks by the current execution ID, so an older task cannot overwrite a newer attempt.
- Report per-document processing failures accurately and rebuild vectors when a prior indexing attempt was interrupted.

No new dependencies. Adds patch changesets for the contracts, server and UI packages.

## Validation

- 13 backend suites: 172 tests passed, including the graph preview integration and regression cases for rollback, concurrent retries and stale callbacks.
- 5 frontend suites: 16 tests passed.
- Angular `ngc --noEmit` passed.
- Backend `tsc --noEmit --declaration false` passed. Full declaration checking in the isolated worktree encounters two TS2742 dependency-symlink portability errors in unchanged `xpert-tool` files.
- Normal commit hooks, formatting, hardcoded-color checks, TypeORM column checks and `git diff --check` passed. The committed tree matches the tested tree.
- Browser verification remains manual: import a small file, confirm its row appears immediately after save, then confirm status updates through completion or failure and retry.

## Deployment and follow-up

Run the existing schema-sync step before rolling out the API: this adds nullable `knowledge_document.processingExecutionId`. The field is server-owned and excluded from ordinary reads to prevent stale snapshots from restoring previous ownership.

Known performance follow-up: unchanged parent-child chunks can still be unnecessarily re-embedded during reprocessing because the interrupted-index hash check uses display ordering. This PR does not resolve that separate review finding.

# Checklist

- [x] Followed the contributing guidelines and repository development checks.
- [x] Explained the changes, their value, dependencies and remaining validation limits.
