### PR TITLE
feat: support role template catalogs and skill bindings

### DIFF
--- a/.changeset/agency-template-catalog.md
+++ b/.changeset/agency-template-catalog.md
@@ -1,0 +1,8 @@
+---
+'@xpert-ai/contracts': patch
+'@xpert-ai/plugin-sdk': patch
+---
+
+Add opt-in lazy template catalogs, summary pagination, explicit prompt locales and source revision tracking. Existing eager template providers remain compatible.
+
+Restore role skill bindings when switching templates and preserve localized skill names during installation and selection.

--- a/apps/cloud/src/app/@core/services/xpert-template.service.spec.ts
+++ b/apps/cloud/src/app/@core/services/xpert-template.service.spec.ts
@@ -1,61 +1,55 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
 import { TestBed } from '@angular/core/testing'
 import { NGXLogger } from 'ngx-logger'
-
-jest.mock('@cloud/app/@core/state', () => ({
-  API_PREFIX: '/api',
-  toHttpParams: jest.fn()
-}))
-
 import { XpertTemplateService } from './xpert-template.service'
 
-describe('XpertTemplateService', () => {
+describe('Xpert template catalog requests', () => {
   let service: XpertTemplateService
-  let httpMock: HttpTestingController
-
+  let http: HttpTestingController
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [
-        XpertTemplateService,
-        {
-          provide: NGXLogger,
-          useValue: {
-            error: jest.fn()
-          }
-        }
-      ]
+      providers: [{ provide: NGXLogger, useValue: {} }]
     })
-
     service = TestBed.inject(XpertTemplateService)
-    httpMock = TestBed.inject(HttpTestingController)
+    http = TestBed.inject(HttpTestingController)
   })
-
-  afterEach(() => {
-    httpMock.verify()
-  })
+  afterEach(() => http.verify())
 
   it('encodes plugin template ids before loading details', () => {
     const id = '@xpert-ai/plugin-bom-document-intake:bom-contract-intake-business-assistant'
-
     service.getTemplate(id).subscribe()
-
-    const request = httpMock.expectOne(
-      '/api/xpert-template/%40xpert-ai%2Fplugin-bom-document-intake%3Abom-contract-intake-business-assistant'
+    const request = http.expectOne((item) =>
+      item.url.endsWith(
+        '/xpert-template/%40xpert-ai%2Fplugin-bom-document-intake%3Abom-contract-intake-business-assistant'
+      )
     )
-
     expect(request.request.method).toBe('GET')
+    expect(request.request.params.has('locale')).toBe(false)
+    request.flush({ id })
+  })
 
-    request.flush({
-      id,
-      name: 'bom-contract-intake-business-assistant',
-      title: 'BOM Contract Intake',
-      description: '',
-      category: 'Plugin',
-      copyright: null,
-      export_data: '',
-      avatar: {},
-      type: 'agent'
-    })
+  it('sends named query parameters and resolves the explicitly selected language', () => {
+    service.getCatalog({ search: 'frontend', offset: 24, limit: 24 }).subscribe()
+    const catalog = http.expectOne((request) => request.url.endsWith('/xpert-template/catalog'))
+    expect(catalog.request.params.get('search')).toBe('frontend')
+    expect(catalog.request.params.get('offset')).toBe('24')
+    expect(catalog.request.params.has('data')).toBe(false)
+    catalog.flush({ items: [], total: 0, offset: 24, limit: 24, categories: [] })
+    service.getTemplate('@xpert-ai/agency:frontend', 'zh-Hans').subscribe()
+    const detail = http.expectOne((request) => request.url.endsWith(encodeURIComponent('@xpert-ai/agency:frontend')))
+    expect(detail.request.params.get('locale')).toBe('zh-Hans')
+    detail.flush({})
+  })
+
+  it('reads all summary pages without silently truncating the role library', () => {
+    const next = jest.fn()
+    service.getSummaries().subscribe(next)
+    const first = http.expectOne((request) => request.url.endsWith('/catalog'))
+    first.flush({ items: [{ id: 'first' }], total: 2, offset: 0, limit: 1, categories: [] })
+    const second = http.expectOne((request) => request.url.endsWith('/catalog'))
+    expect(second.request.params.get('offset')).toBe('1')
+    second.flush({ items: [{ id: 'second' }], total: 2, offset: 1, limit: 1, categories: [] })
+    expect(next).toHaveBeenCalledWith([{ id: 'first' }, { id: 'second' }])
   })
 })

--- a/apps/cloud/src/app/@core/services/xpert-template.service.ts
+++ b/apps/cloud/src/app/@core/services/xpert-template.service.ts
@@ -6,10 +6,14 @@ import {
   IXpert,
   TAvatar,
   TemplateSkillSyncMode,
+  TXpertTemplateCatalogPage,
+  TXpertTemplateCatalogQuery,
+  TXpertTemplateSummary,
   XpertWorkspaceDataScope
 } from '@xpert-ai/contracts'
 import { API_PREFIX, PaginationParams, TKnowledgePipelineTemplate, toHttpParams } from '@cloud/app/@core/state'
 import { NGXLogger } from 'ngx-logger'
+import { EMPTY, expand, reduce } from 'rxjs'
 import { ISkillMarketConfig, IXpertMCPTemplate, IXpertTemplate, TXpertTemplate } from '../types'
 
 @Injectable({ providedIn: 'root' })
@@ -23,8 +27,34 @@ export class XpertTemplateService {
     )
   }
 
-  getTemplate(id: string) {
-    return this.#httpClient.get<TXpertTemplate>(API_PREFIX + `/xpert-template/${encodeURIComponent(id)}`)
+  getCatalog(query: TXpertTemplateCatalogQuery = {}) {
+    return this.#httpClient.get<TXpertTemplateCatalogPage>(API_PREFIX + '/xpert-template/catalog', {
+      params: {
+        ...(query.search ? { search: query.search } : {}),
+        ...(query.category ? { category: query.category } : {}),
+        ...(query.pluginName ? { pluginName: query.pluginName } : {}),
+        offset: query.offset ?? 0,
+        limit: query.limit ?? 48
+      }
+    })
+  }
+
+  /** Fetch lightweight pages for the existing client-side category/search controls. */
+  getSummaries() {
+    return this.getCatalog({ limit: 500 }).pipe(
+      expand((page) =>
+        page.items.length && page.offset + page.items.length < page.total
+          ? this.getCatalog({ offset: page.offset + page.items.length, limit: page.limit })
+          : EMPTY
+      ),
+      reduce((items: TXpertTemplateSummary[], page) => [...items, ...page.items], [])
+    )
+  }
+
+  getTemplate(id: string, locale?: string) {
+    return this.#httpClient.get<TXpertTemplate>(API_PREFIX + `/xpert-template/${encodeURIComponent(id)}`, {
+      params: locale ? { locale } : {}
+    })
   }
 
   installTemplate(
@@ -32,6 +62,7 @@ export class XpertTemplateService {
     body: {
       workspaceId: string
       publish?: boolean
+      locale?: string
       basic?: {
         name?: string
         title?: string

--- a/apps/cloud/src/app/@shared/skills/skill-select/skill.component.html
+++ b/apps/cloud/src/app/@shared/skills/skill-select/skill.component.html
@@ -70,7 +70,9 @@
 
         <div class="flex-1 space-y-1">
           <div class="flex items-center gap-2">
-            <div class="text-sm font-semibold leading-tight text-text-primary">{{ skill.name }}</div>
+            <div class="text-sm font-semibold leading-tight text-text-primary">
+              {{ (skill.metadata?.displayName | i18n) || skill.name }}
+            </div>
             @if (skill.visibility) {
               <span
                 class="rounded-full border border-divider-regular bg-background-default-subtle px-2 py-[2px] text-xs font-semibold uppercase tracking-wide text-text-tertiary"

--- a/apps/cloud/src/app/@shared/skills/skill-select/skill.component.spec.ts
+++ b/apps/cloud/src/app/@shared/skills/skill-select/skill.component.spec.ts
@@ -1,0 +1,75 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing'
+import { TranslateModule, TranslateService } from '@ngx-translate/core'
+import { of } from 'rxjs'
+import { Store } from '@cloud/app/@core/state'
+import { SkillPackageService } from 'apps/cloud/src/app/@core'
+import { XpertSkillSelectComponent } from './skill.component'
+
+jest.mock('echarts/core', () => ({ registerTheme: jest.fn() }))
+
+describe('XpertSkillSelectComponent role labels', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [XpertSkillSelectComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: Store, useValue: { selectedWorkspace$: of({ id: 'workspace-1' }) } },
+        {
+          provide: SkillPackageService,
+          useValue: {
+            getAllByWorkspace: () =>
+              of({
+                items: [
+                  {
+                    id: 'role',
+                    name: 'agency-role-id',
+                    metadata: {
+                      displayName: { en_US: 'Anthropologist', zh_Hans: '\u4eba\u7c7b\u5b66\u5bb6' },
+                      description: { en_US: 'Cultural methods' }
+                    }
+                  },
+                  { id: 'legacy', name: 'legacy-skill', metadata: {} }
+                ]
+              })
+          }
+        }
+      ]
+    }).compileComponents()
+    TestBed.inject(TranslateService).use('zh-Hans')
+  })
+
+  afterEach(() => TestBed.resetTestingModule())
+
+  it('renders localized role names and falls back to technical names for old skills', fakeAsync(() => {
+    const fixture = TestBed.createComponent(XpertSkillSelectComponent)
+    fixture.detectChanges()
+    tick()
+    fixture.detectChanges()
+    const element: HTMLElement = fixture.nativeElement
+    expect(element.textContent).toContain('\u4eba\u7c7b\u5b66\u5bb6')
+    expect(element.textContent).toContain('legacy-skill')
+    expect(element.textContent).not.toContain('agency-role-id')
+    TestBed.inject(TranslateService).use('en-US')
+    fixture.detectChanges()
+    expect(element.textContent).toContain('Anthropologist')
+  }))
+
+  it('searches localized names and technical identifiers without changing skill selection', fakeAsync(() => {
+    const fixture = TestBed.createComponent(XpertSkillSelectComponent)
+    // Exercise filtering independently of the shared debounce timer.
+    Object.defineProperty(fixture.componentInstance, 'searchTerm', { value: fixture.componentInstance.search })
+    fixture.detectChanges()
+    tick(350)
+    fixture.detectChanges()
+    const component = fixture.componentInstance
+    component.writeValue(['role'])
+    for (const query of ['\u4eba\u7c7b\u5b66\u5bb6', 'agency-role-id']) {
+      component.search.set(query)
+      fixture.detectChanges()
+      tick(350)
+      expect(component.search()).toBe(query)
+      expect(component.searchTerm()).toBe(query)
+      expect(component.skillList().map((skill) => skill.id)).toEqual(['role'])
+      expect(component.skills()).toEqual(['role'])
+    }
+  }))
+})

--- a/apps/cloud/src/app/@shared/skills/skill-select/skill.component.ts
+++ b/apps/cloud/src/app/@shared/skills/skill-select/skill.component.ts
@@ -75,7 +75,8 @@ export class XpertSkillSelectComponent implements ControlValueAccessor {
         terms.every(
           (term) =>
             skill.name.toLowerCase().includes(term) ||
-            this.i18n.transform(skill.metadata?.description).toLowerCase().includes(term)
+            (this.i18n.transform(skill.metadata?.displayName) || '').toLowerCase().includes(term) ||
+            (this.i18n.transform(skill.metadata?.description) || '').toLowerCase().includes(term)
         )
       )
     }

--- a/apps/cloud/src/app/features/explore/agent-square/agent-square.component.html
+++ b/apps/cloud/src/app/features/explore/agent-square/agent-square.component.html
@@ -611,7 +611,7 @@
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             @for (template of visibleTemplates(); track template.id) {
               <article
-                class="flex min-h-64 flex-col rounded-xl border border-border bg-card p-5 shadow-sm transition-colors hover:border-primary/60"
+                class="group/template relative flex min-h-64 flex-col rounded-xl border border-border bg-card p-5 shadow-sm transition-colors hover:border-primary/60"
               >
                 <div class="flex min-w-0 items-center gap-3">
                   <emoji-avatar
@@ -632,7 +632,7 @@
                 <p class="mt-4 line-clamp-3 min-h-[60px] text-sm leading-5 text-muted-foreground">
                   {{ templateSummary(template) }}
                 </p>
-                <div class="mt-4 flex min-h-7 flex-wrap gap-2">
+                <div class="mt-auto flex min-h-7 flex-wrap gap-2 pr-32 pt-4">
                   <span class="rounded-md bg-muted px-2 py-1 text-xs font-medium text-muted-foreground">
                     {{ 'XP.Explore.AgentSquare.TemplateSource.' + templateSource(template) | translate }}
                   </span>
@@ -645,17 +645,15 @@
                     </span>
                   }
                 </div>
-                <div class="mt-auto pt-5">
-                  <button
-                    z-button
-                    zSize="sm"
-                    type="button"
-                    class="w-full cursor-pointer"
-                    (click)="openTemplate(template, $event)"
-                  >
-                    {{ 'XP.Explore.AgentSquare.UseTemplate' | translate: { Default: 'Use template' } }}
-                  </button>
-                </div>
+                <button
+                  z-button
+                  zSize="sm"
+                  type="button"
+                  class="pointer-events-none absolute bottom-5 right-5 w-auto max-w-[calc(100%-2.5rem)] translate-y-1 cursor-pointer opacity-0 shadow-sm transition-all duration-200 group-hover/template:pointer-events-auto group-hover/template:translate-y-0 group-hover/template:opacity-100 group-focus-within/template:pointer-events-auto group-focus-within/template:translate-y-0 group-focus-within/template:opacity-100 [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:translate-y-0 [@media(hover:none)]:opacity-100"
+                  (click)="openTemplate(template, $event)"
+                >
+                  {{ 'XP.Explore.AgentSquare.UseTemplate' | translate: { Default: 'Use template' } }}
+                </button>
               </article>
             }
           </div>

--- a/apps/cloud/src/app/features/explore/agent-square/agent-square.component.html
+++ b/apps/cloud/src/app/features/explore/agent-square/agent-square.component.html
@@ -609,7 +609,7 @@
           </div>
         } @else if (filteredTemplates().length) {
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-            @for (template of filteredTemplates(); track template.id) {
+            @for (template of visibleTemplates(); track template.id) {
               <article
                 class="flex min-h-64 flex-col rounded-xl border border-border bg-card p-5 shadow-sm transition-colors hover:border-primary/60"
               >
@@ -659,6 +659,18 @@
               </article>
             }
           </div>
+          @if (visibleTemplates().length < filteredTemplates().length) {
+            <button
+              z-button
+              zType="outline"
+              type="button"
+              class="mt-4"
+              (click)="visibleTemplateCount.set(visibleTemplateCount() + 24)"
+            >
+              {{ 'XP.Knowledgebase.Wiki.Organization.LoadMore' | translate: { Default: 'Load more' } }}
+              ({{ visibleTemplates().length }} / {{ filteredTemplates().length }})
+            </button>
+          }
         } @else if (templateLoadError(); as error) {
           <div
             class="flex min-h-80 items-center justify-center rounded-xl border border-destructive/40 bg-destructive/5 px-6 text-center"

--- a/apps/cloud/src/app/features/explore/agent-square/agent-square.component.spec.ts
+++ b/apps/cloud/src/app/features/explore/agent-square/agent-square.component.spec.ts
@@ -160,7 +160,7 @@ describe('ExploreAgentSquareComponent', () => {
   let fixture: ComponentFixture<ExploreAgentSquareComponent>
   let marketplaceService: { findMarketplace: jest.Mock; requestAccess: jest.Mock }
   let applicationService: { getCatalog: jest.Mock }
-  let templateService: { getAll: jest.Mock }
+  let templateService: { getSummaries: jest.Mock }
   let dialog: { open: jest.Mock }
   let router: { navigate: jest.Mock }
   let matchMedia: jest.Mock
@@ -171,7 +171,7 @@ describe('ExploreAgentSquareComponent', () => {
       requestAccess: jest.fn(() => of({}))
     }
     applicationService = { getCatalog: jest.fn(() => of([])) }
-    templateService = { getAll: jest.fn(() => of({ categories: [], recommendedApps: [] })) }
+    templateService = { getSummaries: jest.fn(() => of([])) }
     dialog = { open: jest.fn(() => ({ closed: of(null) })) }
     router = { navigate: jest.fn() }
     matchMedia = jest.fn(() => ({ matches: false }))

--- a/apps/cloud/src/app/features/explore/agent-square/agent-square.component.ts
+++ b/apps/cloud/src/app/features/explore/agent-square/agent-square.component.ts
@@ -23,7 +23,7 @@ import {
   resolveI18nText,
   TXpertMarketplaceBusinessCategory,
   TXpertMarketplaceTechnicalCategory,
-  TXpertTemplate,
+  TXpertTemplateSummary,
   XpertMarketplaceBusinessCategories,
   XpertMarketplaceService,
   XpertTemplateService,
@@ -115,7 +115,9 @@ export class ExploreAgentSquareComponent {
   readonly selectedApplicationScopes = signal<ApplicationScope[]>([])
   readonly applicationSort = signal<CatalogSort>('comprehensive')
 
-  readonly templates = signal<TXpertTemplate[]>([])
+  readonly templates = signal<TXpertTemplateSummary[]>([])
+  readonly visibleTemplateCount = signal(24)
+  readonly visibleTemplates = computed(() => this.filteredTemplates().slice(0, this.visibleTemplateCount()))
   readonly loadingTemplates = signal(false)
   readonly templateLoadError = signal<string | null>(null)
   readonly selectedTemplateCategories = signal<string[]>([])
@@ -287,6 +289,10 @@ export class ExploreAgentSquareComponent {
   #carouselTimer: ReturnType<typeof setInterval> | null = null
 
   constructor() {
+    effect(() => {
+      this.filteredTemplates()
+      this.visibleTemplateCount.set(24)
+    })
     void this.loadFeaturedExperts()
     void this.loadApplications(this.catalog() !== 'applications')
 
@@ -395,8 +401,8 @@ export class ExploreAgentSquareComponent {
     this.loadingTemplates.set(true)
     this.templateLoadError.set(null)
     try {
-      const result = await firstValueFrom(this.#templateService.getAll())
-      this.templates.set(result.recommendedApps ?? [])
+      const result = await firstValueFrom(this.#templateService.getSummaries())
+      this.templates.set(result)
     } catch (error) {
       this.#templatesLoaded = false
       this.templates.set([])
@@ -702,19 +708,19 @@ export class ExploreAgentSquareComponent {
     return `XP.Explore.Application.Scope.${keys[scope]}`
   }
 
-  templateTitle(template: TXpertTemplate) {
+  templateTitle(template: TXpertTemplateSummary) {
     return this.localizedCatalogText(template.title) || this.localizedCatalogText(template.name)
   }
 
-  templateSummary(template: TXpertTemplate) {
+  templateSummary(template: TXpertTemplateSummary) {
     return this.localizedCatalogText(template.description)
   }
 
-  templateSource(template: TXpertTemplate): TemplateSource {
+  templateSource(template: TXpertTemplateSummary): TemplateSource {
     return template.source === 'plugin' ? 'plugin' : 'builtin'
   }
 
-  templateProvider(template: TXpertTemplate) {
+  templateProvider(template: TXpertTemplateSummary) {
     if (this.templateSource(template) === 'plugin') {
       return (
         template.pluginDisplayName ||
@@ -725,7 +731,7 @@ export class ExploreAgentSquareComponent {
     return this.#translate.instant('XP.Explore.AgentSquare.TemplateSource.builtin', { Default: 'Built in' })
   }
 
-  templateSearchText(template: TXpertTemplate) {
+  templateSearchText(template: TXpertTemplateSummary) {
     return [
       template.title,
       template.name,
@@ -739,7 +745,7 @@ export class ExploreAgentSquareComponent {
       .toLowerCase()
   }
 
-  openTemplate(template: TXpertTemplate, event?: Event) {
+  openTemplate(template: TXpertTemplateSummary, event?: Event) {
     event?.stopPropagation()
     this.#dialog
       .open<BlankXpertWizardResult>(XpertNewBlankComponent, {

--- a/apps/cloud/src/app/features/explore/skills/plaza/skill-featured-grid.component.html
+++ b/apps/cloud/src/app/features/explore/skills/plaza/skill-featured-grid.component.html
@@ -36,7 +36,7 @@
         (keydown.enter)="open(featured)"
         (keydown.space)="open(featured)"
       >
-        <div class="flex min-h-36 gap-4 p-4">
+        <div class="relative flex min-h-36 gap-4 p-4">
           <div
             class="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-primary/10 text-primary"
           >
@@ -84,17 +84,25 @@
               }
             </div>
 
-            <div class="mt-4 flex items-center justify-between gap-3">
+            <div class="mt-4 flex min-h-8 items-center gap-3 pr-24">
               <span class="text-sm text-muted-foreground">
                 {{ featured.skill.stats?.downloads ?? '--' }}
                 {{ 'XP.Explore.AddedTimes' | translate: { Default: 'adds' } }}
               </span>
-              <button z-button zSize="sm" type="button" (click)="add(featured, $event)">
-                <z-icon zType="plus" zSize="sm" />
-                {{ 'XP.ACTIONS.Add' | translate: { Default: 'Add' } }}
-              </button>
             </div>
           </div>
+          <button
+            z-button
+            zSize="sm"
+            type="button"
+            class="pointer-events-none absolute bottom-4 right-4 w-auto translate-y-1 cursor-pointer opacity-0 shadow-sm transition-all duration-200 group-hover:pointer-events-auto group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:translate-y-0 group-focus-within:opacity-100 [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:translate-y-0 [@media(hover:none)]:opacity-100"
+            (click)="add(featured, $event)"
+            (keydown.enter)="$event.stopPropagation()"
+            (keydown.space)="$event.stopPropagation()"
+          >
+            <z-icon zType="plus" zSize="sm" />
+            {{ 'XP.ACTIONS.Add' | translate: { Default: 'Add' } }}
+          </button>
         </div>
       </z-card>
     }

--- a/apps/cloud/src/app/features/explore/skills/skills.component.html
+++ b/apps/cloud/src/app/features/explore/skills/skills.component.html
@@ -109,14 +109,14 @@
               <div class="grid grid-cols-1 gap-3 lg:grid-cols-2 2xl:grid-cols-3">
                 @for (skill of mineSkills(); track skill.id || skill.name || skill.packagePath) {
                   <z-card
-                    class="cursor-pointer rounded-lg border-border bg-card/95 py-0 shadow-none transition-colors hover:border-primary/40"
+                    class="group/favorite cursor-pointer rounded-lg border-border bg-card/95 py-0 shadow-none transition-colors hover:border-primary/40"
                     role="button"
                     tabindex="0"
                     (click)="openInstalledSkill(skill)"
                     (keydown.enter)="openInstalledSkill(skill)"
                     (keydown.space)="openInstalledSkill(skill)"
                   >
-                    <div class="flex min-h-32 flex-col gap-4 p-4">
+                    <div class="relative flex min-h-32 flex-col gap-4 p-4">
                       <div class="flex items-start justify-between gap-4">
                         <div class="min-w-0">
                           <h4 class="line-clamp-1 text-base font-semibold text-foreground">
@@ -137,20 +137,28 @@
                         </div>
                       }
 
-                      <div class="mt-auto flex items-center justify-between gap-3">
+                      <div class="mt-auto flex min-h-8 items-center gap-3 pr-32">
                         <span class="text-xs text-muted-foreground">
                           {{ skill.updatedAt || skill.createdAt | date: 'yyyy-MM-dd' }}
                         </span>
-                        @if (isLocalSkill(skill)) {
-                          <button z-button zSize="sm" type="button" (click)="openShareDialog(skill, $event)">
-                            {{
-                              skill.publishAt
-                                ? ('XP.Explore.RepublishSkill' | translate: { Default: 'Update Share' })
-                                : ('XP.Explore.ShareSkill' | translate: { Default: 'Share' })
-                            }}
-                          </button>
-                        }
                       </div>
+                      @if (isLocalSkill(skill)) {
+                        <button
+                          z-button
+                          zSize="sm"
+                          type="button"
+                          class="pointer-events-none absolute bottom-4 right-4 w-auto translate-y-1 cursor-pointer opacity-0 shadow-sm transition-all duration-200 group-hover/favorite:pointer-events-auto group-hover/favorite:translate-y-0 group-hover/favorite:opacity-100 group-focus-within/favorite:pointer-events-auto group-focus-within/favorite:translate-y-0 group-focus-within/favorite:opacity-100 [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:translate-y-0 [@media(hover:none)]:opacity-100"
+                          (click)="openShareDialog(skill, $event)"
+                          (keydown.enter)="$event.stopPropagation()"
+                          (keydown.space)="$event.stopPropagation()"
+                        >
+                          {{
+                            skill.publishAt
+                              ? ('XP.Explore.RepublishSkill' | translate: { Default: 'Update Share' })
+                              : ('XP.Explore.ShareSkill' | translate: { Default: 'Share' })
+                          }}
+                        </button>
+                      }
                     </div>
                   </z-card>
                 }

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.spec.ts
@@ -75,7 +75,8 @@ describe('blank draft util', () => {
       skills: ['Skill A'],
       repositoryDefault: null,
       middlewares: ['guard', BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER],
-      middlewareRequired: {}
+      middlewareRequired: {},
+      preserveSkillsMiddleware: false
     })
 
     expect(hasBlankWizardSelections()).toBe(false)
@@ -90,7 +91,8 @@ describe('blank draft util', () => {
       skills: [],
       repositoryDefault: null,
       middlewares: ['guard'],
-      middlewareRequired: {}
+      middlewareRequired: {},
+      preserveSkillsMiddleware: false
     })
     expect(
       normalizeBlankTriggerSelections(
@@ -145,7 +147,8 @@ describe('blank draft util', () => {
         disabledSkillIds: ['skill-b']
       },
       middlewares: [BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER],
-      middlewareRequired: {}
+      middlewareRequired: {},
+      preserveSkillsMiddleware: false
     })
     expect(
       hasBlankWizardSelections({

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank-draft.util.ts
@@ -105,6 +105,8 @@ export type XpertBlankWizardSelections = {
   repositoryDefault?: BlankRepositoryDefaultSelection | null
   middlewares?: string[]
   middlewareRequired?: Record<string, boolean>
+  // A template may provide the skill capability before any packages are selected.
+  preserveSkillsMiddleware?: boolean
 }
 
 export type KnowledgeBlankWizardSelections = {
@@ -150,12 +152,19 @@ export function normalizeBlankWizardSelections(
 ): Required<XpertBlankWizardSelections> {
   const skills = uniqueStrings(selections?.skills)
   const repositoryDefault = normalizeBlankRepositoryDefaultSelection(selections?.repositoryDefault)
-  const middlewares = normalizeBlankMiddlewareSelections(selections?.middlewares, skills, repositoryDefault)
+  const preserveSkillsMiddleware = selections?.preserveSkillsMiddleware ?? false
+  const middlewares = normalizeBlankMiddlewareSelections(
+    selections?.middlewares,
+    skills,
+    repositoryDefault,
+    preserveSkillsMiddleware
+  )
   return {
     triggers: normalizeBlankTriggerSelections(selections?.triggers, selections?.triggerProviders),
     triggerProviders: uniqueStrings(selections?.triggerProviders),
     skills,
     repositoryDefault,
+    preserveSkillsMiddleware,
     middlewares,
     middlewareRequired: normalizeBlankMiddlewareRequiredSelections(middlewares, selections?.middlewareRequired)
   }
@@ -846,7 +855,8 @@ export function normalizeBlankTriggerSelections(
 export function normalizeBlankMiddlewareSelections(
   middlewares?: string[] | null,
   skills?: string[] | null,
-  repositoryDefault?: BlankRepositoryDefaultSelection | null
+  repositoryDefault?: BlankRepositoryDefaultSelection | null,
+  preserveSkillsMiddleware = false
 ): string[] {
   const normalized = uniqueStrings(middlewares)
   const hasSkillsMiddleware = normalized.includes(BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER)
@@ -854,7 +864,7 @@ export function normalizeBlankMiddlewareSelections(
   const hasSkillSelection = !!skills?.length || !!normalizeBlankRepositoryDefaultSelection(repositoryDefault)
 
   return uniqueStrings(
-    hasSkillSelection
+    hasSkillSelection || (preserveSkillsMiddleware && hasSkillsMiddleware)
       ? hasSkillsMiddleware
         ? normalized
         : [...visibleMiddlewares, BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER]

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank-template-selection.component.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank-template-selection.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common'
 import { ChangeDetectionStrategy, Component, computed, effect, input, model } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { TranslateModule } from '@ngx-translate/core'
-import { ZardSearchInputComponent } from '@xpert-ai/headless-ui'
+import { ZardSearchInputComponent, ZardButtonComponent } from '@xpert-ai/headless-ui'
 import { IconDefinition, TAvatar } from '../../../../@core'
 import { EmojiAvatarComponent } from 'apps/cloud/src/app/@shared/avatar/emoji-avatar/avatar.component'
 import { IconComponent } from 'apps/cloud/src/app/@shared/avatar/icon/icon.component'
@@ -25,7 +25,15 @@ export type BlankTemplateChoice = {
 @Component({
   selector: 'xpert-blank-template-selection',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslateModule, EmojiAvatarComponent, IconComponent, ZardSearchInputComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    TranslateModule,
+    EmojiAvatarComponent,
+    IconComponent,
+    ZardSearchInputComponent,
+    ZardButtonComponent
+  ],
   template: `
     <div class="space-y-3">
       <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -89,7 +97,7 @@ export type BlankTemplateChoice = {
         </div>
       } @else {
         <div class="grid gap-3 lg:grid-cols-2">
-          @for (template of filteredTemplates(); track template.id) {
+          @for (template of visibleTemplates(); track template.id) {
             <button
               type="button"
               class="group rounded-xl border bg-components-card-bg p-4 text-left transition-all"
@@ -137,12 +145,20 @@ export type BlankTemplateChoice = {
             </button>
           }
         </div>
+        @if (visibleTemplates().length < filteredTemplates().length) {
+          <button z-button zType="outline" type="button" (click)="visibleCount.set(visibleCount() + 24)">
+            {{ 'XP.Knowledgebase.Wiki.Organization.LoadMore' | translate: { Default: 'Load more' } }}
+            ({{ visibleTemplates().length }} / {{ filteredTemplates().length }})
+          </button>
+        }
       }
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class BlankTemplateSelectionComponent {
+  readonly visibleCount = model(24)
+  readonly visibleTemplates = computed(() => this.filteredTemplates().slice(0, this.visibleCount()))
   readonly templates = input<BlankTemplateChoice[]>([])
   readonly fixedCategory = input<string | null>(null, { alias: 'category' })
   readonly loading = input(false)
@@ -159,6 +175,10 @@ export class BlankTemplateSelectionComponent {
   readonly categories = computed(() => getBlankTemplateCategories(this.templates()))
 
   constructor() {
+    effect(() => {
+      this.filteredTemplates()
+      this.visibleCount.set(24)
+    })
     effect(() => {
       if (!this.showCategoryFilters()) {
         return

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank-template.util.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank-template.util.ts
@@ -94,7 +94,10 @@ export function extractAgentTemplateWizardState(draft: TXpertTeamDraft): BlankAg
       skills: extractExplicitSkillsFromMiddlewares(middlewareNodes),
       repositoryDefault: extractRepositoryDefaultFromMiddlewares(middlewareNodes),
       middlewares: middlewareNodes.map((node) => node.entity.provider).filter(Boolean),
-      middlewareRequired: extractMiddlewareRequiredSelections(middlewareNodes)
+      middlewareRequired: extractMiddlewareRequiredSelections(middlewareNodes),
+      preserveSkillsMiddleware: middlewareNodes.some(
+        (node) => node.entity.provider === BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER
+      )
     })
   }
 }

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.spec.ts
@@ -24,9 +24,9 @@ jest.mock('apps/cloud/src/app/@shared/skills', () => {
 import { Dialog, DIALOG_DATA, DialogRef } from '@angular/cdk/dialog'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { PluginAPIService, Store } from '@cloud/app/@core/state'
-import { AiModelTypeEnum, AiProviderRole, PLUGIN_RESOURCE_ERROR_CODE } from '@xpert-ai/contracts'
+import { AiModelTypeEnum, AiProviderRole, PLUGIN_RESOURCE_ERROR_CODE, TXpertTeamDraft } from '@xpert-ai/contracts'
 import { TranslateService } from '@ngx-translate/core'
-import { BehaviorSubject, of, throwError } from 'rxjs'
+import { BehaviorSubject, Subject, of, throwError } from 'rxjs'
 import { NgxPermissionsService } from 'ngx-permissions'
 import {
   AIPermissionsEnum,
@@ -84,7 +84,7 @@ type BlankSpecContext = {
     getAllInOrg: jest.Mock
   }
   templateService: {
-    getAll: jest.Mock
+    getSummaries: jest.Mock
     getAllKnowledgePipelines: jest.Mock
     getKnowledgePipelineTemplate: jest.Mock
     getTemplate: jest.Mock
@@ -149,7 +149,7 @@ function buildExpectedClawPrompt() {
   ].join('\n')
 }
 
-function createAgentTemplateYaml() {
+function createAgentTemplateYaml(skills: string[] = ['writer']) {
   return `
 team:
   name: template-agent
@@ -210,8 +210,7 @@ nodes:
       provider: ${BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER}
       title: Skills Middleware
       options:
-        skills:
-          - writer
+        skills: ${JSON.stringify(skills)}
 connections:
   - key: Trigger_schedule/Agent_primary
     type: edge
@@ -666,7 +665,7 @@ async function createComponent(
     )
   }
   const templateService = {
-    getAll: jest.fn(() => of({ categories: ['Agent'], recommendedApps: agentTemplates })),
+    getSummaries: jest.fn(() => of(agentTemplates)),
     getAllKnowledgePipelines: jest.fn(() => of({ categories: ['Pipeline'], templates: [] })),
     getKnowledgePipelineTemplate: jest.fn(),
     getTemplate: jest.fn(() => of(agentTemplateDetail))
@@ -1247,6 +1246,30 @@ describe('XpertNewBlankComponent', () => {
     expect(xpertService.importDSL).not.toHaveBeenCalled()
   })
 
+  it('uses the template default language without requesting a language override', async () => {
+    const agent = { key: 'Agent_role', prompt: 'Chinese role body' }
+    const { component, templateService } = await createComponent(
+      { type: XpertTypeEnum.Agent, initialTemplateId: 'role', initialStartMode: 'template' },
+      {
+        agentTemplateDetail: {
+          id: 'role',
+          title: 'Chinese role',
+          description: 'Default Chinese prompt',
+          locale: 'zh-Hans',
+          availableLocales: ['en-US', 'zh-Hans'],
+          defaultLocale: 'zh-Hans',
+          export_data: JSON.stringify({
+            team: { name: 'role', title: 'Chinese role', type: 'agent', agent },
+            nodes: [{ type: 'agent', key: agent.key, entity: agent, position: { x: 0, y: 0 } }],
+            connections: []
+          })
+        }
+      }
+    )
+    expect(templateService.getTemplate).toHaveBeenLastCalledWith('role')
+    expect(component.selectedTemplateDraft()?.team.agent.prompt).toBe('Chinese role body')
+  })
+
   it('loads the selected agent template into the wizard state', async () => {
     const { component, fixture, templateService } = await createComponent(
       {
@@ -1404,6 +1427,141 @@ describe('XpertNewBlankComponent', () => {
     const importedDraft = xpertService.importDSL.mock.calls[0][0]
     const skillsMiddleware = findSkillsMiddlewareNode(importedDraft)
     expect(skillsMiddleware.entity.options.skills).toEqual(expect.arrayContaining(['writer', 'skill-package-canvas']))
+  })
+
+  it.each([false, true])(
+    'restores role bindings after switching templates and back (other has skill: %s)',
+    async (otherHasSkill) => {
+      const role = createPluginSkillTemplateDetail({ export_data: createAgentTemplateYaml([]) })
+      const { component, fixture, templateService, xpertService, pluginAPI, toastr } = await createComponent(
+        {
+          allowWorkspaceSelection: true,
+          allowedModes: [XpertTypeEnum.Agent],
+          completionMode: 'create',
+          initialStartMode: 'template',
+          initialTemplateId: 'role-a',
+          lockStartMode: true,
+          lockType: true,
+          type: XpertTypeEnum.Agent
+        },
+        {
+          agentTemplateDetail: role,
+          pluginSkillInstallResult: createPluginSkillInstallResult('skill-role-a'),
+          selectedWorkspace: { id: 'workspace-1', name: 'Workspace One' },
+          workspaces: [{ id: 'workspace-1', name: 'Workspace One' }]
+        }
+      )
+      const prepareSkills = () =>
+        component.onAgentStepChange({
+          selectedIndex: component.agentSkillStepIndex()
+        } as Parameters<typeof component.onAgentStepChange>[0])
+      await prepareSkills()
+      const other = otherHasSkill
+        ? createPluginSkillTemplateDetail({
+            export_data: createAgentTemplateYaml([]).replaceAll('Agent_primary', 'Agent_second'),
+            dependencies: { skills: [{ componentKey: 'canvas-agent-skill', targetAgentKey: 'Agent_second' }] }
+          })
+        : { export_data: createAgentTemplateYaml([]) }
+      templateService.getTemplate.mockReturnValue(of(other))
+      pluginAPI.installResourcesToWorkspace.mockReturnValue(of(createPluginSkillInstallResult('skill-role-b')))
+      component.selectedTemplateId.set('role-b')
+      fixture.detectChanges()
+      await fixture.whenStable()
+      await flushPromises()
+      await prepareSkills()
+      templateService.getTemplate.mockReturnValue(of(role))
+      component.selectedTemplateId.set('role-a')
+      fixture.detectChanges()
+      await fixture.whenStable()
+      await flushPromises()
+      await prepareSkills()
+      await component.create()
+      expect(toastr.error).not.toHaveBeenCalled()
+      expect(pluginAPI.installResourcesToWorkspace).toHaveBeenCalledTimes(otherHasSkill ? 2 : 1)
+      expect(xpertService.importDSL).toHaveBeenCalledTimes(1)
+      const draft: TXpertTeamDraft = xpertService.importDSL.mock.calls[0][0]
+      expect(findSkillsMiddlewareNode(draft).entity.options.skills).toEqual(['skill-role-a'])
+    }
+  )
+
+  it.each([false, true])(
+    'ignores an old role installation after selecting another template (failure: %s)',
+    async (failure) => {
+      const { component, fixture, templateService, pluginAPI, toastr } = await createComponent(
+        {
+          allowWorkspaceSelection: true,
+          allowedModes: [XpertTypeEnum.Agent],
+          completionMode: 'create',
+          initialStartMode: 'template',
+          initialTemplateId: 'role-a',
+          lockStartMode: true,
+          lockType: true,
+          type: XpertTypeEnum.Agent
+        },
+        {
+          agentTemplateDetail: createPluginSkillTemplateDetail({ export_data: createAgentTemplateYaml([]) }),
+          selectedWorkspace: { id: 'workspace-1', name: 'Workspace One' },
+          workspaces: [{ id: 'workspace-1', name: 'Workspace One' }]
+        }
+      )
+      const result = new Subject<ReturnType<typeof createPluginSkillInstallResult>>()
+      pluginAPI.installResourcesToWorkspace.mockReturnValue(result)
+      const preparing = component.onAgentStepChange({
+        selectedIndex: component.agentSkillStepIndex()
+      } as Parameters<typeof component.onAgentStepChange>[0])
+      templateService.getTemplate.mockReturnValue(of({ export_data: createAgentTemplateYaml([]) }))
+      component.selectedTemplateId.set('role-b')
+      fixture.detectChanges()
+      await fixture.whenStable()
+      await flushPromises()
+      if (failure) result.error(new Error('Old role installation failed'))
+      else result.next(createPluginSkillInstallResult('skill-role-a'))
+      await preparing
+      expect(component.templatePluginSkillBindings()).toEqual([])
+      expect(component.selectedExplicitSkills()).toEqual([])
+      expect(component.templatePluginSkillInstallError()).toBeNull()
+      expect(toastr.error).not.toHaveBeenCalled()
+    }
+  )
+
+  it('defaults only to the template role skill when creating directly with existing workspace skills', async () => {
+    const { component, pluginAPI, skillPackageService, xpertService } = await createComponent(
+      {
+        completionMode: 'create',
+        type: XpertTypeEnum.Agent,
+        initialStartMode: 'template',
+        initialTemplateId: '@xpert-ai/plugin-canvas:canvas-assistant',
+        lockStartMode: true,
+        lockType: true,
+        allowWorkspaceSelection: true,
+        allowedModes: [XpertTypeEnum.Agent]
+      },
+      {
+        agentTemplateDetail: createPluginSkillTemplateDetail({
+          export_data: createAgentTemplateYaml([]).replace(
+            '  copilotModel:\n    modelType: llm',
+            '  copilotModel:\n    copilotId: copilot-primary\n    modelType: llm'
+          )
+        }),
+        pluginSkillInstallResult: createPluginSkillInstallResult('skill-package-canvas'),
+        basicForm: null,
+        workspaceSkills: [{ id: 'pdf' }, { id: 'slides' }],
+        selectedWorkspace: { id: 'workspace-1', name: 'Workspace One' },
+        workspaces: [{ id: 'workspace-1', name: 'Workspace One' }]
+      }
+    )
+
+    await component.createDirectly()
+
+    expect(pluginAPI.installResourcesToWorkspace).toHaveBeenCalledTimes(1)
+    expect(skillPackageService.installRepositoryPackages).not.toHaveBeenCalled()
+    expect(component.selectedExplicitSkills()).toEqual(['skill-package-canvas'])
+    expect(component.selectedRepositoryDefault()).toBeNull()
+    expect(xpertService.importDSL).toHaveBeenCalledTimes(1)
+    const draft: TXpertTeamDraft = xpertService.importDSL.mock.calls[0][0]
+    const middleware = findSkillsMiddlewareNode(draft)
+    expect(middleware.entity.options.skills).toEqual(['skill-package-canvas'])
+    expect(middleware.entity.options.repositoryDefault).toBeUndefined()
   })
 
   it('binds a plugin template skill to a non-primary Agent Skills Middleware', async () => {
@@ -2900,6 +3058,67 @@ describe('XpertNewBlankComponent', () => {
       status: 'published'
     })
   })
+
+  it.each([false, true])(
+    'retains template skills middleware without packages (switch workspace: %s)',
+    async (switchWorkspace) => {
+      const { component, fixture, xpertService } = await createComponent(
+        { allowWorkspaceSelection: true, completionMode: 'create', type: XpertTypeEnum.Agent },
+        {
+          agentTemplates: [{ id: 'template-agent', name: 'template-agent', type: XpertTypeEnum.Agent }],
+          agentTemplateDetail: { export_data: createAgentTemplateYaml([]) },
+          selectedWorkspace: { id: 'workspace-1', name: 'Workspace One' },
+          workspaces: [
+            { id: 'workspace-1', name: 'Workspace One' },
+            { id: 'workspace-2', name: 'Workspace Two' }
+          ]
+        }
+      )
+      component.setStartMode('template')
+      component.selectedTemplateId.set('template-agent')
+      fixture.detectChanges()
+      await fixture.whenStable()
+      await flushPromises()
+
+      expect(component.selectedSkills()).toEqual([])
+      expect(component.selectedMiddlewares()).toContain(BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER)
+      component.toggleSkill('writer', true)
+      if (switchWorkspace) {
+        component.workspaceId.set('workspace-2')
+        fixture.detectChanges()
+        await fixture.whenStable()
+        await flushPromises()
+      } else {
+        component.toggleSkill('writer', false)
+      }
+      component.toggleMiddleware('guard', false)
+      component.toggleMiddleware('guard', true)
+      expect(component.selectedSkills()).toEqual([])
+      expect(component.selectedMiddlewares()).toContain(BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER)
+
+      await component.create()
+      expect(xpertService.importDSL).toHaveBeenCalledTimes(1)
+      const draft: TXpertTeamDraft = xpertService.importDSL.mock.calls[0][0]
+      const middleware = findSkillsMiddlewareNode(draft)
+      expect(middleware).toBeDefined()
+      expect(middleware.entity.required).toBe(true)
+      expect(middleware.entity.options?.skills ?? []).toEqual([])
+      expect(draft.nodes.filter((node) => node.key === middleware.key)).toHaveLength(1)
+      expect(draft.connections).toContainEqual(
+        expect.objectContaining({
+          type: 'workflow',
+          from: 'Agent_primary',
+          to: middleware.key
+        })
+      )
+      expect(draft.team.agent?.options?.middlewares?.order).toContain(middleware.key)
+
+      component.setStartMode('blank')
+      component.toggleSkill('writer', true)
+      component.toggleSkill('writer', false)
+      expect(component.selectedMiddlewares()).not.toContain(BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER)
+    }
+  )
 
   it('auto-enables required middleware features when importing a template', async () => {
     const importedXpert = createAgentXpert('imported-xpert')

--- a/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.ts
+++ b/apps/cloud/src/app/features/xpert/xpert/blank/blank.component.ts
@@ -150,7 +150,7 @@ type BlankWorkflowNodeOption = {
 
 type BlankTemplateCatalog = {
   choices: BlankTemplateChoice[]
-  items: Array<TXpertTemplate | TKnowledgePipelineTemplate>
+  items: Array<Omit<TXpertTemplate, 'export_data'> | TKnowledgePipelineTemplate>
 }
 
 type BlankWorkspaceSkillItem = {
@@ -449,9 +449,9 @@ export class XpertNewBlankComponent {
     { initialValue: [] as IXpertWorkspace[] }
   )
   readonly agentTemplateCatalog = toSignal(
-    this.templateService.getAll().pipe(
-      map(({ recommendedApps }) => {
-        const items = recommendedApps.filter((template) => template.type === XpertTypeEnum.Agent)
+    this.templateService.getSummaries().pipe(
+      map((summaries) => {
+        const items = summaries.filter((template) => template.type === XpertTypeEnum.Agent)
         return {
           choices: items.map((template) => ({
             id: template.id,
@@ -689,6 +689,7 @@ export class XpertNewBlankComponent {
   readonly selectedExplicitSkills = model<string[]>([])
   readonly selectedRepositoryDefault = signal<BlankRepositoryDefaultSelection | null>(null)
   readonly selectedMiddlewares = model<string[]>([])
+  readonly preserveSkillsMiddleware = signal(false)
   readonly selectedMiddlewareRequired = signal<Record<string, boolean>>({})
   readonly middlewareSearch = signal('')
   readonly selectedKnowledgeTriggers = model<BlankTriggerSelection[]>([])
@@ -698,7 +699,7 @@ export class XpertNewBlankComponent {
   readonly selectedUnderstandings = model<string[]>([])
   readonly selectedWorkflowNodes = model<BlankWorkflowStarterNodeKey[]>([])
   readonly preparedSkillWorkspaces = signal<Set<string>>(new Set())
-  readonly preparedTemplatePluginSkillDependencies = signal<Set<string>>(new Set())
+  readonly preparedTemplatePluginSkillDependencies = signal<Map<string, BlankTemplatePluginSkillBinding[]>>(new Map())
   readonly preparedTemplateToolsetDependencies = signal<BlankTemplateToolsetPreparation | null>(null)
   readonly loadedTemplateToolsetDependencyKey = signal<string | null>(null)
   readonly templateToolsetSelectionStates = signal<BlankTemplateToolsetSelectionState[]>([])
@@ -907,7 +908,8 @@ export class XpertNewBlankComponent {
       triggers: this.selectedTriggers(),
       skills: this.selectedExplicitSkills(),
       repositoryDefault: this.selectedRepositoryDefault(),
-      middlewares: this.selectedMiddlewares()
+      middlewares: this.selectedMiddlewares(),
+      preserveSkillsMiddleware: this.preserveSkillsMiddleware()
     })
   )
 
@@ -1298,7 +1300,8 @@ export class XpertNewBlankComponent {
     const middlewares = normalizeBlankMiddlewareSelections(
       this.toggleValue(this.selectedMiddlewares(), provider, enabled),
       this.selectedExplicitSkills(),
-      this.selectedRepositoryDefault()
+      this.selectedRepositoryDefault(),
+      this.preserveSkillsMiddleware()
     )
     this.selectedMiddlewares.set(middlewares)
     this.syncMiddlewareRequiredSelections(middlewares)
@@ -1611,6 +1614,7 @@ export class XpertNewBlankComponent {
   }
 
   private applyBlankDefaults() {
+    this.templatePluginSkillBindings.set([])
     this.name.set(undefined)
     this.description.set(undefined)
     this.avatar.set(undefined)
@@ -1647,7 +1651,7 @@ export class XpertNewBlankComponent {
     this.templateLoadError.set(null)
     this.templatePluginSkillInstallError.set(null)
     this.clearTemplateToolsetSelections()
-    this.preparedTemplatePluginSkillDependencies.set(new Set())
+    this.preparedTemplatePluginSkillDependencies.set(new Map())
   }
 
   private async initializeDraftIfNeeded(xpert: IXpert): Promise<DraftPreparationResult> {
@@ -1867,7 +1871,8 @@ export class XpertNewBlankComponent {
       skills: this.selectedExplicitSkills(),
       repositoryDefault: this.selectedRepositoryDefault(),
       middlewares: this.selectedMiddlewares(),
-      middlewareRequired: this.selectedMiddlewareRequired()
+      middlewareRequired: this.selectedMiddlewareRequired(),
+      preserveSkillsMiddleware: this.preserveSkillsMiddleware()
     }
   }
 
@@ -1981,12 +1986,14 @@ export class XpertNewBlankComponent {
   }
 
   private applyAgentSkillSelections(selections: BlankAgentSkillSelections) {
+    this.preserveSkillsMiddleware.set(selections.preserveSkillsMiddleware ?? false)
     this.selectedExplicitSkills.set(selections.skills)
     this.selectedRepositoryDefault.set(cloneRepositoryDefaultSelection(selections.repositoryDefault))
     const middlewares = normalizeBlankMiddlewareSelections(
       selections.middlewares,
       selections.skills,
-      selections.repositoryDefault
+      selections.repositoryDefault,
+      selections.preserveSkillsMiddleware
     )
     this.selectedMiddlewares.set(middlewares)
     this.selectedMiddlewareRequired.set(
@@ -2001,15 +2008,14 @@ export class XpertNewBlankComponent {
     // and their idempotency keys so switching back to a workspace refreshes
     // the IDs instead of reusing bindings resolved for another workspace.
     this.templatePluginSkillBindings.set([])
-    this.preparedTemplatePluginSkillDependencies.set(new Set())
+    this.preparedTemplatePluginSkillDependencies.set(new Map())
     this.clearTemplateToolsetSelections()
     this.applyAgentSkillSelections({
       skills: [],
       repositoryDefault: null,
-      middlewares: this.selectedMiddlewares().filter(
-        (provider) => provider !== BLANK_WIZARD_SKILLS_MIDDLEWARE_PROVIDER
-      ),
-      middlewareRequired: this.selectedMiddlewareRequired()
+      middlewares: this.selectedMiddlewares(),
+      middlewareRequired: this.selectedMiddlewareRequired(),
+      preserveSkillsMiddleware: this.preserveSkillsMiddleware()
     })
   }
 
@@ -2065,6 +2071,13 @@ export class XpertNewBlankComponent {
   private async prepareAgentSkillStep() {
     const workspaceId = this.workspaceId()
     if (!workspaceId || this.installingSkillPackage()) {
+      return
+    }
+
+    // Template-declared packages define its defaults; do not also select the
+    // workspace's unrelated shared skills or repository-wide defaults.
+    if (this.templatePluginSkillDependencyGroups().length) {
+      await this.prepareTemplatePluginSkillsForCurrentWorkspace()
       return
     }
 
@@ -2142,7 +2155,13 @@ export class XpertNewBlankComponent {
     }
 
     const dependencyKey = this.templatePluginSkillDependencyInstallKey(workspaceId, groups)
-    if (this.preparedTemplatePluginSkillDependencies().has(dependencyKey)) {
+    const isCurrentSelection = () =>
+      this.workspaceId() === workspaceId &&
+      this.templatePluginSkillDependencyInstallKey(workspaceId, this.templatePluginSkillDependencyGroups()) ===
+        dependencyKey
+    const prepared = this.preparedTemplatePluginSkillDependencies().get(dependencyKey)
+    if (prepared) {
+      this.restoreTemplatePluginSkillBindings(prepared)
       this.templatePluginSkillInstallError.set(null)
       return true
     }
@@ -2155,8 +2174,6 @@ export class XpertNewBlankComponent {
     this.templatePluginSkillInstallError.set(null)
 
     try {
-      const primaryAgentKey = this.selectedTemplateDraft()?.team?.agent?.key
-      const primarySkillPackageIds: string[] = []
       const skillBindings: BlankTemplatePluginSkillBinding[] = []
       for (const group of groups) {
         const result = await firstValueFrom(
@@ -2168,6 +2185,10 @@ export class XpertNewBlankComponent {
             .pipe(take(1))
         )
 
+        // Do not bind a completed request into a different template or workspace.
+        if (!isCurrentSelection()) {
+          return false
+        }
         const skillInstallations = result.installations.filter(
           (installation) =>
             installation.componentType === PLUGIN_COMPONENT_TYPE.SKILL &&
@@ -2200,27 +2221,17 @@ export class XpertNewBlankComponent {
             runtimeId: installation.runtimeId,
             ...(component.targetAgentKey ? { targetAgentKey: component.targetAgentKey } : {})
           })
-          // selectedExplicitSkills configures the primary Agent. Keep an
-          // explicitly targeted specialist skill out of that primary grant;
-          // applyTemplatePluginSkillBindings authorizes its target instead.
-          if (!component.targetAgentKey || component.targetAgentKey === primaryAgentKey) {
-            primarySkillPackageIds.push(installation.runtimeId)
-          }
         }
       }
 
-      if (primarySkillPackageIds.length) {
-        this.selectedExplicitSkills.set(
-          Array.from(new Set([...this.selectedExplicitSkills(), ...primarySkillPackageIds]))
-        )
-      }
-      this.templatePluginSkillBindings.set(skillBindings)
-
-      this.preparedTemplatePluginSkillDependencies.update((value) => new Set([...value, dependencyKey]))
-      this.refreshAgentSkillMiddlewareSelections()
+      this.preparedTemplatePluginSkillDependencies.update((value) => new Map(value).set(dependencyKey, skillBindings))
+      this.restoreTemplatePluginSkillBindings(skillBindings)
       this.refreshSkills()
       return true
     } catch (error) {
+      if (!isCurrentSelection()) {
+        return false
+      }
       const localizedError = resolveTemplatePluginSkillInstallError(error)
       const message = localizedError
         ? (this.#translate.instant(localizedError.key, { Default: localizedError.defaultMessage }) as string)
@@ -2234,6 +2245,16 @@ export class XpertNewBlankComponent {
     } finally {
       this.installingSkillPackage.set(false)
     }
+  }
+
+  private restoreTemplatePluginSkillBindings(bindings: BlankTemplatePluginSkillBinding[]) {
+    const primaryAgentKey = this.selectedTemplateDraft()?.team?.agent?.key
+    const primarySkillIds = bindings
+      .filter((binding) => !binding.targetAgentKey || binding.targetAgentKey === primaryAgentKey)
+      .map((binding) => binding.runtimeId)
+    this.selectedExplicitSkills.update((skills) => [...new Set([...skills, ...primarySkillIds])])
+    this.templatePluginSkillBindings.set(bindings)
+    this.refreshAgentSkillMiddlewareSelections()
   }
 
   /**
@@ -2680,7 +2701,8 @@ export class XpertNewBlankComponent {
     const middlewares = normalizeBlankMiddlewareSelections(
       this.selectedMiddlewares(),
       this.selectedExplicitSkills(),
-      this.selectedRepositoryDefault()
+      this.selectedRepositoryDefault(),
+      this.preserveSkillsMiddleware()
     )
     this.selectedMiddlewares.set(middlewares)
     this.syncMiddlewareRequiredSelections(middlewares)
@@ -2698,6 +2720,7 @@ type BlankAgentSkillSelections = {
   repositoryDefault: BlankRepositoryDefaultSelection | null
   middlewares: string[]
   middlewareRequired?: Record<string, boolean>
+  preserveSkillsMiddleware?: boolean
 }
 
 function cloneRepositoryDefaultSelection(

--- a/packages/contracts/src/ai/xpert-template.model.ts
+++ b/packages/contracts/src/ai/xpert-template.model.ts
@@ -110,6 +110,11 @@ export type TTemplate = {
   startPrompts?: string[]
   promptWorkflows?: TPromptWorkflow[]
   releaseNotes?: string
+  availableLocales?: string[]
+  defaultLocale?: string
+  locale?: string
+  pluginVersion?: string
+  contentHash?: string
   xpertName?: string
   dependencies?: XpertTemplatePluginDependencies
   /** Trusted plugin App explicitly linked to this Assistant template. */
@@ -121,6 +126,24 @@ export type TXpertTemplate = TTemplate & {
   // icon: IconDefinition | string
   type: XpertTypeEnum | 'project'
   copilotModel?: Partial<TCopilotModel>
+}
+
+export type TXpertTemplateSummary = Omit<TXpertTemplate, 'export_data'>
+
+export interface TXpertTemplateCatalogQuery {
+  search?: string
+  category?: string
+  pluginName?: string
+  offset?: number
+  limit?: number
+}
+
+export interface TXpertTemplateCatalogPage {
+  items: TXpertTemplateSummary[]
+  total: number
+  offset: number
+  limit: number
+  categories: string[]
 }
 
 export interface IXpertMCPTemplate extends TTemplate {

--- a/packages/contracts/src/ai/xpert.model.ts
+++ b/packages/contracts/src/ai/xpert.model.ts
@@ -327,6 +327,9 @@ export type TXpertTemplateSource = {
   installedAt?: string
   lastSyncedAt?: string
   releaseNotes?: string
+  locale?: string
+  pluginVersion?: string
+  contentHash?: string
 }
 
 export type TXpertTemplateSyncResult = {

--- a/packages/plugin-sdk/src/lib/types.ts
+++ b/packages/plugin-sdk/src/lib/types.ts
@@ -97,7 +97,7 @@ export interface XpertPlugin<TConfig extends object = any> extends PluginLifecyc
    * template ids as `${pluginName}:${key}` when exposing them through the
    * xpert-template API.
    */
-  templates?: XpertTemplateContribution[] | XpertTemplateProvider
+  templates?: XpertTemplateContribution[] | XpertTemplateProvider | XpertTemplateCatalogProvider
   /** Declares the required system-level permissions for this plugin. */
   permissions?: Permissions
   /** Returns the DynamicModule to be mounted to the main application (can be set as global) */
@@ -125,6 +125,11 @@ export interface XpertTemplateContribution {
   startPrompts?: string[]
   promptWorkflows?: TPromptWorkflow[]
   releaseNotes?: string
+  availableLocales?: string[]
+  defaultLocale?: string
+  locale?: string
+  pluginVersion?: string
+  contentHash?: string
   xpertName?: string
   dependencies?: XpertTemplatePluginDependencies
   [key: string]: unknown
@@ -132,6 +137,13 @@ export interface XpertTemplateContribution {
 
 export interface XpertTemplateProvider {
   listTemplates(ctx: PluginContext): PromiseOrValue<XpertTemplateContribution[]>
+}
+
+/** Lists metadata without DSL; resolves exactly one immutable language variant on demand. */
+export interface XpertTemplateCatalogProvider {
+  kind: 'catalog'
+  listTemplates(ctx: PluginContext): PromiseOrValue<XpertTemplateContribution[]>
+  resolveTemplate(ctx: PluginContext, key: string, locale?: string): PromiseOrValue<XpertTemplateContribution>
 }
 
 export interface PluginContext<TConfig extends object = any> {

--- a/packages/server-ai/src/plugin-resource/commands/install-template.command.ts
+++ b/packages/server-ai/src/plugin-resource/commands/install-template.command.ts
@@ -18,6 +18,7 @@ export class PluginTemplateInstallCommand implements ICommand {
         public readonly workspaceId: string,
         public readonly language: LanguagesEnum,
         public readonly basic?: PluginTemplateInstallBasic,
-        public readonly publish = false
+        public readonly publish = false,
+        public readonly locale?: string
     ) {}
 }

--- a/packages/server-ai/src/plugin-resource/commands/install-template.handler.ts
+++ b/packages/server-ai/src/plugin-resource/commands/install-template.handler.ts
@@ -56,7 +56,11 @@ export class PluginTemplateInstallHandler implements ICommandHandler<PluginTempl
 
     async execute(command: PluginTemplateInstallCommand): Promise<PluginResourceInstallResult> {
         await this.workspaceAccess.assertCanAuthor(command.workspaceId)
-        const template = await this.xpertTemplateService.getTemplateDetail(command.templateId, command.language)
+        const template = command.locale
+            ? await this.xpertTemplateService.getTemplateDetail(command.templateId, command.language, {
+                  locale: command.locale
+              })
+            : await this.xpertTemplateService.getTemplateDetail(command.templateId, command.language)
         const parsed = yaml.parse(template.export_data) as unknown
         const sandboxProviders = await this.xpertService.getSandboxProviders()
         const draft = this.normalizeDraft(parsed, command.workspaceId, command.basic, sandboxProviders)

--- a/packages/server-ai/src/skill-package/skill-package.service.spec.ts
+++ b/packages/server-ai/src/skill-package/skill-package.service.spec.ts
@@ -153,6 +153,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { SkillPackageService } from './skill-package.service'
+import { SkillPackage } from './skill-package.entity'
 import { RequestContext } from '@xpert-ai/plugin-sdk'
 import {
     cleanupExtractedSkillArchive,
@@ -170,6 +171,7 @@ describe('SkillPackageService', () => {
         findOneInOrganizationOrTenant: jest.Mock
         findAll: jest.Mock
         create: jest.Mock
+        update: jest.Mock
         softDelete: jest.Mock
     }
     let skillRepositoryService: {
@@ -208,6 +210,7 @@ describe('SkillPackageService', () => {
 
         skillIndexService = {
             findOneInOrganizationOrTenant: jest.fn(),
+            update: jest.fn().mockResolvedValue({ affected: 1 }),
             findAll: jest.fn().mockResolvedValue({ items: [] }),
             create: jest.fn().mockImplementation(async (item: any) => item),
             softDelete: jest.fn().mockResolvedValue({ affected: 1 })
@@ -1199,6 +1202,52 @@ describe('SkillPackageService', () => {
         )
     })
 
+    it.each([false, true])(
+        'preserves plugin role presentation metadata on bundle publish (existing: %s)',
+        async (existing) => {
+            tempRoot = await mkdtemp(join(tmpdir(), 'skill-role-metadata-'))
+            const bundleRoot = join(tempRoot, 'bundle')
+            await mkdir(bundleRoot, { recursive: true })
+            const markdown = '---\nname: agency-role-id\ndescription: Role methods.\n---\n# Role\n'
+            await writeFile(join(bundleRoot, 'SKILL.md'), markdown)
+            ;(getWorkspaceSkillsRoot as jest.Mock).mockReturnValue(join(tempRoot, 'workspace'))
+            ;(getOrganizationSharedSkillPath as jest.Mock).mockReturnValue(join(tempRoot, 'shared'))
+            const sharedSkillId = 'plugin:agency:skill:agency-role-id'
+            if (existing) {
+                repository.findOne.mockResolvedValue({
+                    id: 'skill-role',
+                    workspaceId: 'workspace-1',
+                    sharedSkillId,
+                    packagePath: 'agency-role-id',
+                    metadata: { name: 'agency-role-id', provenance: { templateBundleHash: 'old' } }
+                })
+            }
+            createSpy.mockImplementationOnce(async (item) =>
+                Object.assign(new SkillPackage(), item, { id: 'skill-role' })
+            )
+            const displayName = { en_US: 'Anthropologist', zh_Hans: '\u4eba\u7c7b\u5b66\u5bb6' }
+            const description = { en_US: 'Cultural research.', zh_Hans: '\u6587\u5316\u7814\u7a76' }
+            await service.syncTemplateSkillBundle('workspace-1', {
+                bundleRootPath: bundleRoot,
+                sharedSkillId,
+                metadata: { displayName, description }
+            })
+            const published = jest.mocked(service.update).mock.calls.find(([, value]) => 'publishAt' in value)
+            expect(published?.[1]).toEqual(
+                expect.objectContaining({
+                    metadata: expect.objectContaining({ name: 'agency-role-id', displayName, description })
+                })
+            )
+            expect(skillIndexService.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    name: 'Anthropologist',
+                    description: 'Cultural research.'
+                })
+            )
+            await expect(readFile(join(tempRoot, 'workspace/agency-role-id/SKILL.md'), 'utf8')).resolves.toBe(markdown)
+        }
+    )
+
     it('skips template bundle republish when the stored bundle hash is still current', async () => {
         tempRoot = await mkdtemp(join(tmpdir(), 'skill-package-template-bundle-current-'))
         const bundleRoot = join(tempRoot, 'bundle')
@@ -1257,6 +1306,56 @@ describe('SkillPackageService', () => {
         })
         expect(createSpy).not.toHaveBeenCalled()
         expect(service.update).not.toHaveBeenCalled()
+        expect(skillIndexService.create).not.toHaveBeenCalled()
+    })
+
+    it('repairs installed role names and their shared index without republishing unchanged files', async () => {
+        tempRoot = await mkdtemp(join(tmpdir(), 'skill-role-existing-metadata-'))
+        const bundleRoot = join(tempRoot, 'bundle')
+        await mkdir(bundleRoot, { recursive: true })
+        await writeFile(
+            join(bundleRoot, 'SKILL.md'),
+            '---\nname: agency-role-id\ndescription: Role methods.\n---\n# Role\n'
+        )
+        const input = { bundleRootPath: bundleRoot, sharedSkillId: 'plugin:agency:skill:agency-role-id' }
+        skillRepositoryService.findAll.mockResolvedValue({
+            items: [{ id: 'repo-public', provider: 'workspace-public' }]
+        })
+        const { hash } = await service.syncTemplateSkillBundle('workspace-1', input, { validateOnly: true })
+        repository.findOne.mockResolvedValue({
+            id: 'skill-role',
+            workspaceId: 'workspace-1',
+            sharedSkillId: input.sharedSkillId,
+            metadata: {
+                name: 'agency-role-id',
+                displayName: { en_US: 'agency-role-id' },
+                provenance: { templateBundleHash: hash }
+            }
+        })
+        skillIndexService.findAll.mockResolvedValue({
+            items: [
+                {
+                    id: 'role-index',
+                    repositoryId: 'repo-public',
+                    skillId: input.sharedSkillId,
+                    name: 'agency-role-id',
+                    description: 'Role methods.'
+                }
+            ]
+        })
+        const displayName = { en_US: 'Anthropologist', zh_Hans: '\u4eba\u7c7b\u5b66\u5bb6' }
+        const result = await service.syncTemplateSkillBundle('workspace-1', { ...input, metadata: { displayName } })
+        expect(result.status).toBe('updated')
+        expect(service.update).toHaveBeenCalledWith(
+            'skill-role',
+            expect.objectContaining({
+                metadata: expect.objectContaining({ name: 'agency-role-id', displayName })
+            })
+        )
+        expect(skillIndexService.update).toHaveBeenCalledWith(
+            'role-index',
+            expect.objectContaining({ name: 'Anthropologist' })
+        )
         expect(skillIndexService.create).not.toHaveBeenCalled()
     })
 

--- a/packages/server-ai/src/skill-package/skill-package.service.ts
+++ b/packages/server-ai/src/skill-package/skill-package.service.ts
@@ -845,16 +845,28 @@ export class SkillPackageService extends XpertWorkspaceBaseService<SkillPackage>
             const metadataOverrides = normalizeSkillMetadataOverrides(input.metadata)
             if (existingSkillPackage?.id && metadataOverrides) {
                 const metadata = this.mergeInstalledMetadata(existingSkillPackage.metadata, metadataOverrides)
-                if (!isSkillMetadataEqual(existingSkillPackage.metadata, metadata)) {
+                const metadataChanged = !isSkillMetadataEqual(existingSkillPackage.metadata, metadata)
+                const presentation = {
+                    name: readI18nText(metadataOverrides.displayName) || existingIndex.name,
+                    description: readI18nText(metadataOverrides.description) || existingIndex.description
+                }
+                const indexChanged =
+                    presentation.name !== existingIndex.name || presentation.description !== existingIndex.description
+                if (metadataChanged) {
                     await this.update(existingSkillPackage.id, {
                         workspaceId,
                         metadata
                     } as Partial<SkillPackage>)
+                }
+                if (indexChanged) {
+                    await this.skillIndexService.update(existingIndex.id, presentation)
+                }
+                if (metadataChanged || indexChanged) {
                     return {
                         status: 'updated',
                         hash: bundleHash,
                         sharedSkillId,
-                        index: existingIndex
+                        index: { ...existingIndex, ...presentation }
                     }
                 }
             }
@@ -923,10 +935,16 @@ export class SkillPackageService extends XpertWorkspaceBaseService<SkillPackage>
         }
 
         try {
-            const sharedMetadata = this.normalizeTemplateSharedSkillInputFromFrontmatter(frontmatter, skillBaseName)
-            const metadata = this.mergeSharedMetadata(skillPackage, sharedMetadata, currentUser, {
-                templateBundleHash: bundleHash
-            })
+            const sharedMetadata = this.normalizeTemplateSharedSkillInputFromFrontmatter(
+                frontmatter,
+                skillBaseName,
+                input.metadata
+            )
+            // Publication must preserve the plugin's localized presentation metadata.
+            const metadata = mergeSkillMetadataOverrides(
+                this.mergeSharedMetadata(skillPackage, sharedMetadata, currentUser, { templateBundleHash: bundleHash }),
+                input.metadata
+            )
             const sourcePath = absolutePackagePath
 
             const publishedIndex = await this.publishSharedSkillPackage(skillPackage, sourcePath, metadata, {
@@ -1476,14 +1494,15 @@ export class SkillPackageService extends XpertWorkspaceBaseService<SkillPackage>
 
     private normalizeTemplateSharedSkillInputFromFrontmatter(
         frontmatter: WorkspaceSkillFrontmatter,
-        fallbackName: string
+        fallbackName: string,
+        metadata?: Partial<SkillMetadata> | null
     ): SharedSkillMetadataInput {
-        const displayName = frontmatter.name?.trim() || fallbackName.trim()
+        const displayName = readI18nText(metadata?.displayName) || frontmatter.name?.trim() || fallbackName.trim()
         if (!displayName) {
             throw new BadRequestException('Template skill bundle is missing a skill name')
         }
 
-        const description = frontmatter.description?.trim()
+        const description = readI18nText(metadata?.description) || frontmatter.description?.trim()
         if (!description) {
             throw new BadRequestException('Template skill bundle is missing a skill description')
         }

--- a/packages/server-ai/src/xpert-template/plugin-template-descriptor.ts
+++ b/packages/server-ai/src/xpert-template/plugin-template-descriptor.ts
@@ -1,0 +1,102 @@
+import {
+    LanguagesEnum,
+    PluginTargetAppMeta,
+    PluginTemplateApplicationSummary,
+    resolveI18nText,
+    TAvatar,
+    TPromptWorkflow,
+    TXpertTemplate,
+    XpertTemplatePluginDependencies,
+    XpertTypeEnum
+} from '@xpert-ai/contracts'
+import { LoadedPluginRecord } from '@xpert-ai/server-core'
+import { XpertTemplateContribution } from '@xpert-ai/plugin-sdk'
+import { readXpertTemplateDslMetadata } from './xpert-template-dsl-metadata'
+
+export type TXpertTemplateDescriptor = {
+    id: string
+    key?: string
+    name?: string
+    type?: XpertTypeEnum | 'project'
+    title?: string
+    description?: string
+    avatar?: TAvatar
+    copilotModel?: TXpertTemplate['copilotModel']
+    category?: string
+    copyright?: string | null
+    privacyPolicy?: string | null
+    export_data?: string
+    targetApps?: string[]
+    targetAppMeta?: PluginTargetAppMeta | null
+    source?: string
+    pluginName?: string
+    pluginDisplayName?: string
+    order?: number
+    default?: boolean
+    startPrompts?: string[]
+    promptWorkflows?: TPromptWorkflow[]
+    releaseNotes?: string
+    availableLocales?: string[]
+    defaultLocale?: string
+    locale?: string
+    pluginVersion?: string
+    contentHash?: string
+    xpertName?: string
+    dependencies?: XpertTemplatePluginDependencies
+    application?: PluginTemplateApplicationSummary
+}
+
+export function normalizePluginPackageName(pluginName: string): string {
+    const lastAt = pluginName.lastIndexOf('@')
+    return lastAt > 0 ? pluginName.slice(0, lastAt) : pluginName
+}
+
+function normalizeTemplateString(value: unknown): string | null {
+    return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+/** Maps eager DSL and lazy catalog metadata through the same identity and localization rules. */
+export function describePluginTemplate(
+    plugin: LoadedPluginRecord,
+    contribution: XpertTemplateContribution,
+    language: LanguagesEnum,
+    summaryOnly = false,
+    application?: PluginTemplateApplicationSummary | null
+): TXpertTemplateDescriptor {
+    const key = normalizeTemplateString(contribution?.key ?? contribution?.id)
+    const exportData = normalizeTemplateString(contribution?.export_data ?? contribution?.dslContent)
+    if (!key || (!summaryOnly && !exportData)) {
+        throw new Error(`Plugin template is missing key or DSL content`)
+    }
+
+    const pluginName = normalizePluginPackageName(
+        normalizeTemplateString(plugin.packageName ?? plugin.name ?? plugin.instance?.meta?.name) ?? ''
+    )
+    const namespacedId = `${pluginName}:${key}`
+    const targetApps = contribution.targetApps ?? plugin.instance?.meta?.targetApps
+    const targetAppMeta = contribution.targetAppMeta ?? plugin.instance?.meta?.targetAppMeta ?? null
+    const dslMetadata = exportData && !summaryOnly ? readXpertTemplateDslMetadata(exportData, language) : {}
+
+    return {
+        ...contribution,
+        id: namespacedId,
+        key: namespacedId,
+        name: normalizeTemplateString(contribution.name) ?? key,
+        title: resolveI18nText(contribution.title ?? contribution.name, language) ?? dslMetadata.title ?? key,
+        description: dslMetadata.description ?? resolveI18nText(contribution.description, language) ?? '',
+        category: normalizeTemplateString(contribution.category) ?? 'Plugin',
+        copyright: contribution.copyright ?? null,
+        privacyPolicy: contribution.privacyPolicy ?? null,
+        export_data: summaryOnly ? undefined : exportData,
+        ...(summaryOnly ? { dslContent: undefined } : {}),
+        targetApps,
+        targetAppMeta,
+        source: 'plugin',
+        pluginName,
+        pluginDisplayName: resolveI18nText(plugin.instance?.meta?.displayName, language) ?? pluginName,
+        dependencies: contribution.dependencies,
+        ...(application ? { application } : {}),
+        avatar: contribution.avatar ?? dslMetadata.avatar,
+        order: typeof contribution.order === 'number' ? contribution.order : Number.MAX_SAFE_INTEGER
+    }
+}

--- a/packages/server-ai/src/xpert-template/template-catalog.spec.ts
+++ b/packages/server-ai/src/xpert-template/template-catalog.spec.ts
@@ -1,0 +1,41 @@
+import { XpertTypeEnum, TXpertTemplate } from '@xpert-ai/contracts'
+import { paginateTemplateCatalog } from './template-catalog'
+
+describe('template catalog', () => {
+    const templates: TXpertTemplate[] = Array.from({ length: 120 }, (_, index) => ({
+        id: `role-${index}`,
+        name: `role-${index}`,
+        title: `Role ${index}`,
+        description: 'Role prompt',
+        category: index % 2 ? 'design' : 'engineering',
+        copyright: '',
+        avatar: {},
+        type: XpertTypeEnum.Agent,
+        export_data: 'private full DSL',
+        pluginName: 'agency'
+    }))
+
+    it('filters before pagination and omits both DSL aliases', () => {
+        const result = paginateTemplateCatalog(
+            templates.map((item) => ({ ...item, dslContent: 'other DSL' })),
+            {
+                category: 'engineering',
+                offset: 10,
+                limit: 12
+            }
+        )
+        expect(result.total).toBe(60)
+        expect(result.items).toHaveLength(12)
+        expect(result.items[0].id).toBe('role-20')
+        expect(result.categories).toEqual(['design', 'engineering'])
+        expect(JSON.stringify(result)).not.toContain('DSL')
+        expect(result.items[0]).not.toHaveProperty('export_data')
+        expect(result.items[0]).not.toHaveProperty('dslContent')
+    })
+
+    it('bounds page sizes and searches the complete catalog', () => {
+        expect(paginateTemplateCatalog(templates, { limit: 10000, offset: -4 }).limit).toBe(500)
+        expect(paginateTemplateCatalog(templates, { search: 'Role 119' }).items[0].id).toBe('role-119')
+        expect(paginateTemplateCatalog(templates, { offset: NaN }).offset).toBe(0)
+    })
+})

--- a/packages/server-ai/src/xpert-template/template-catalog.ts
+++ b/packages/server-ai/src/xpert-template/template-catalog.ts
@@ -1,0 +1,39 @@
+import { TXpertTemplate, TXpertTemplateCatalogPage, TXpertTemplateCatalogQuery } from '@xpert-ai/contracts'
+import { XpertPlugin, XpertTemplateCatalogProvider } from '@xpert-ai/plugin-sdk'
+
+export function isTemplateCatalogProvider(source: XpertPlugin['templates']): source is XpertTemplateCatalogProvider {
+    return !!source && !Array.isArray(source) && 'kind' in source && source.kind === 'catalog'
+}
+
+/** Catalog responses never contain DSL, including legacy contributions with both content aliases. */
+export function paginateTemplateCatalog(
+    templates: TXpertTemplate[],
+    query: TXpertTemplateCatalogQuery = {}
+): TXpertTemplateCatalogPage {
+    const offset = Number.isFinite(query.offset) ? Math.max(0, Math.trunc(query.offset)) : 0
+    const limit = Number.isFinite(query.limit) ? Math.max(1, Math.min(500, Math.trunc(query.limit))) : 48
+    const search = query.search?.trim().toLowerCase()
+    const matches = templates.filter(
+        (template) =>
+            (!query.category || template.category === query.category) &&
+            (!query.pluginName || template.pluginName === query.pluginName) &&
+            (!search ||
+                [template.title, template.name, template.description, template.pluginDisplayName].some((value) =>
+                    value?.toLowerCase().includes(search)
+                ))
+    )
+    return {
+        items: matches.slice(offset, offset + limit).map((template) => {
+            const { export_data, ...summary } = template
+            // Old provider objects may retain the SDK input alias after normalization.
+            if ('dslContent' in summary) delete summary.dslContent
+            // Plugin-wide marketplace content can contain hundreds of sibling templates.
+            delete summary.targetAppMeta
+            return summary
+        }),
+        total: matches.length,
+        offset,
+        limit,
+        categories: [...new Set(templates.map((template) => template.category).filter(Boolean))].sort()
+    }
+}

--- a/packages/server-ai/src/xpert-template/xpert-template.controller.ts
+++ b/packages/server-ai/src/xpert-template/xpert-template.controller.ts
@@ -42,6 +42,24 @@ export class XpertTemplateController {
         return this.service.getAll(LanguagesMap[language] ?? language, { targetApp, templateType })
     }
 
+    @Get('catalog')
+    async getCatalog(
+        @I18nLang() language: LanguagesEnum,
+        @Query('search') search?: string,
+        @Query('category') category?: string,
+        @Query('pluginName') pluginName?: string,
+        @Query('offset') offset?: string,
+        @Query('limit') limit?: string
+    ) {
+        return this.service.getCatalog(LanguagesMap[language] ?? language, {
+            search,
+            category,
+            pluginName,
+            offset: Number(offset ?? 0),
+            limit: Number(limit ?? 48)
+        })
+    }
+
     @Get('mcps')
     async getMCPTemplates(
         @I18nLang() language: LanguagesEnum,
@@ -96,7 +114,8 @@ export class XpertTemplateController {
                 input.workspaceId,
                 LanguagesMap[language] ?? language,
                 input.basic,
-                input.publish
+                input.publish,
+                input.locale
             )
         )
     }
@@ -106,9 +125,14 @@ export class XpertTemplateController {
         @I18nLang() language: LanguagesEnum,
         @Param('id') id: string,
         @Query('targetApp') targetApp?: string,
-        @Query('templateType') templateType?: string
+        @Query('templateType') templateType?: string,
+        @Query('locale') locale?: string
     ) {
-        return await this.service.getTemplateDetail(id, LanguagesMap[language] ?? language, { targetApp, templateType })
+        return await this.service.getTemplateDetail(id, LanguagesMap[language] ?? language, {
+            targetApp,
+            templateType,
+            locale
+        })
     }
 }
 
@@ -116,6 +140,7 @@ function parseTemplateInstallInput(value: unknown): {
     workspaceId: string
     basic?: PluginTemplateInstallBasic
     publish: boolean
+    locale?: string
 } {
     if (!isObjectValue(value)) {
         throw new BadRequestException('Request body is required')
@@ -131,6 +156,7 @@ function parseTemplateInstallInput(value: unknown): {
     return {
         workspaceId,
         publish,
+        locale: readStringField(value, 'locale') || undefined,
         ...(basic ? { basic } : {})
     }
 }

--- a/packages/server-ai/src/xpert-template/xpert-template.service.spec.ts
+++ b/packages/server-ai/src/xpert-template/xpert-template.service.spec.ts
@@ -1411,6 +1411,73 @@ describe('XpertTemplateService', () => {
         expect(updatedBundleFingerprint).not.toBe(updatedYamlFingerprint)
     })
 
+    it('lists a scoped catalog without resolving bodies, then resolves only the chosen language', async () => {
+        const workspaceRoot = createTempDir()
+        const dataRoot = createTempDir()
+        seedBuiltinTemplates(workspaceRoot, {
+            templatesJson: { templates: { 'en-US': { categories: [], recommendedApps: [] } }, details: {} },
+            templatesMarketYaml: 'recommendedApps: []'
+        })
+        const resolveTemplate = jest.fn((_ctx: object, key: string, locale: string) => ({
+            key,
+            title: 'Resolved role',
+            type: XpertTypeEnum.Agent,
+            locale,
+            contentHash: 'body-v1',
+            pluginVersion: '0.1.0',
+            dslContent: JSON.stringify({ team: { name: key, agent: { prompt: locale } } })
+        }))
+        const { service } = createService({
+            serverRoot: workspaceRoot,
+            dataPath: dataRoot,
+            loadedPlugins: [
+                {
+                    organizationId: 'global',
+                    name: '@xpert-ai/agency',
+                    packageName: '@xpert-ai/agency@0.1.0',
+                    ctx: {},
+                    instance: {
+                        meta: { displayName: { en_US: 'Agency', zh_Hans: 'Agency roles' } },
+                        templates: {
+                            kind: 'catalog',
+                            resolveTemplate,
+                            listTemplates: () =>
+                                Array.from({ length: 110 }, (_, index) => ({
+                                    key: `role-${index}`,
+                                    title: `Role ${index}`,
+                                    category: 'engineering',
+                                    availableLocales: ['en-US', 'zh-Hans'],
+                                    defaultLocale: 'zh-Hans'
+                                }))
+                        }
+                    }
+                }
+            ]
+        })
+        const page = await service.getCatalog(LanguagesEnum.English, { offset: 24, limit: 24 })
+        expect(page.total).toBe(110)
+        expect(page.items).toHaveLength(24)
+        expect(page.items[0]).not.toHaveProperty('export_data')
+        expect(page.items[0]).not.toHaveProperty('dslContent')
+        expect(resolveTemplate).not.toHaveBeenCalled()
+        expect(await service.getMarketplaceRecommendedTemplates(LanguagesEnum.English)).toEqual([])
+        const detail = await service.getTemplateDetail('@xpert-ai/agency:role-7', LanguagesEnum.English, {
+            locale: 'zh-Hans'
+        })
+        expect(resolveTemplate).toHaveBeenCalledTimes(1)
+        expect(resolveTemplate).toHaveBeenCalledWith({}, 'role-7', 'zh-Hans')
+        expect(detail.locale).toBe('zh-Hans')
+        expect(detail.contentHash).toBe('body-v1')
+        expect(JSON.parse(detail.export_data).team.agent.prompt).toBe('zh-Hans')
+        await expect(service.getTemplateDetail('@xpert-ai/agency:missing', LanguagesEnum.English)).rejects.toThrow()
+        expect(resolveTemplate).toHaveBeenCalledTimes(1)
+        const preferred = await service.getTemplateDetail('@xpert-ai/agency:role-8', LanguagesEnum.English)
+        expect(resolveTemplate).toHaveBeenLastCalledWith({}, 'role-8', 'zh-Hans')
+        expect(preferred.locale).toBe('zh-Hans')
+        await service.getTemplateDetail('@xpert-ai/agency:role-8', LanguagesEnum.English, { locale: 'en-US' })
+        expect(resolveTemplate).toHaveBeenLastCalledWith({}, 'role-8', 'en-US')
+    })
+
     function createService({
         serverRoot,
         dataPath,

--- a/packages/server-ai/src/xpert-template/xpert-template.service.ts
+++ b/packages/server-ai/src/xpert-template/xpert-template.service.ts
@@ -14,11 +14,10 @@ import {
     PluginTemplateApplicationSummary,
     resolveI18nText,
     WORKSPACE_PUBLIC_SKILL_SOURCE_PROVIDER,
-    TAvatar,
     TKnowledgePipelineTemplate,
-    type TPromptWorkflow,
     TXpertExportedTemplate,
     TXpertTemplate,
+    TXpertTemplateCatalogQuery,
     XpertTemplatePluginDependencies,
     XpertTypeEnum
 } from '@xpert-ai/contracts'
@@ -44,8 +43,13 @@ import { In, Repository } from 'typeorm'
 import { SkillRepositoryService } from '../skill-repository/skill-repository.service'
 import { SkillRepositoryIndexService } from '../skill-repository/repository-index/skill-repository-index.service'
 import { XpertTemplate } from './xpert-template.entity'
-import { readXpertTemplateDslMetadata } from './xpert-template-dsl-metadata'
+import {
+    describePluginTemplate,
+    normalizePluginPackageName,
+    TXpertTemplateDescriptor
+} from './plugin-template-descriptor'
 import { resolvePluginApplicationConfigAssets } from '../plugin-resource/plugin-application-assets'
+import { isTemplateCatalogProvider, paginateTemplateCatalog } from './template-catalog'
 
 const builtinTemplatePath = 'packages/server-ai/src/xpert-template'
 const fallbackLanguage = 'en-US'
@@ -61,34 +65,6 @@ const templateFiles = [
     'workspace-defaults.yaml'
 ] as const
 const builtinTemplateFiles = [...templateFiles, 'templates-market.yaml'] as const
-
-type TXpertTemplateDescriptor = {
-    id: string
-    key?: string
-    name?: string
-    type?: XpertTypeEnum | 'project'
-    title?: string
-    description?: string
-    avatar?: TAvatar
-    copilotModel?: TXpertTemplate['copilotModel']
-    category?: string
-    copyright?: string | null
-    privacyPolicy?: string | null
-    export_data?: string
-    targetApps?: string[]
-    targetAppMeta?: Record<string, any> | null
-    source?: string
-    pluginName?: string
-    pluginDisplayName?: string
-    order?: number
-    default?: boolean
-    startPrompts?: string[]
-    promptWorkflows?: TPromptWorkflow[]
-    releaseNotes?: string
-    xpertName?: string
-    dependencies?: XpertTemplatePluginDependencies
-    application?: PluginTemplateApplicationSummary
-}
 
 type TXpertTemplateGroup = {
     categories?: string[]
@@ -158,6 +134,7 @@ type TExportXpertTemplateInput = {
 type TXpertTemplateQuery = {
     targetApp?: string
     templateType?: string
+    locale?: string
 }
 
 const DEFAULT_SKILL_MARKET_FILTERS: ISkillMarketFilterGroups = {
@@ -181,16 +158,6 @@ const TEMPLATE_SKILL_BUNDLE_SHARED_PREFIX = 'template-bundle'
 const TEMPLATE_SKILL_BUNDLE_SKILL_FILE = 'SKILL.md'
 const TEMPLATE_SKILL_BUNDLE_LOCAL_PROVIDER = 'local'
 const TEMPLATE_SKILL_BUNDLE_LOCAL_REPOSITORY = 'root/skills'
-
-/** Convert `<pkg>@1.2.3` -> `<pkg>` to align install/load paths. */
-const normalizePluginPackageName = (pluginName: string) => {
-    if (!pluginName.includes('@')) {
-        return pluginName
-    }
-
-    const lastAt = pluginName.lastIndexOf('@')
-    return lastAt > 0 ? pluginName.slice(0, lastAt) : pluginName
-}
 
 const isObjectValue = (value: unknown): value is object =>
     typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -387,6 +354,14 @@ export class XpertTemplateService extends TenantAwareCrudService<XpertTemplate> 
             ),
             recommendedApps
         }
+    }
+
+    async getCatalog(language: LanguagesEnum, query: TXpertTemplateCatalogQuery = {}) {
+        const catalog = await this.getAll(language)
+        return paginateTemplateCatalog(
+            catalog.recommendedApps.map((item) => this.toXpertTemplate(item)),
+            query
+        )
     }
 
     async getMarketplaceRecommendedTemplates(
@@ -856,7 +831,21 @@ export class XpertTemplateService extends TenantAwareCrudService<XpertTemplate> 
         query?: TXpertTemplateQuery
     ): Promise<TXpertTemplateDescriptor | null> {
         const templates = await this.getPluginTemplates(language, query)
-        return this.findPluginTemplateById(templates, id)
+        const template = this.findPluginTemplateById(templates, id)
+        if (!template) return null
+        const plugin = this.getEffectivePluginRecords().find(
+            (record) => normalizePluginPackageName(record.packageName ?? record.name) === template.pluginName
+        )
+        const source = plugin?.instance?.templates
+        if (!plugin || !isTemplateCatalogProvider(source)) return template
+        const key = template.id.slice(template.pluginName.length + 1)
+        const contribution = await source.resolveTemplate(
+            plugin.ctx,
+            key,
+            query?.locale ?? template.defaultLocale ?? language
+        )
+        if (contribution.key !== key) throw new Error('Resolved template key does not match its catalog entry')
+        return this.toPluginTemplateDescriptor(plugin, contribution, language)
     }
 
     private findPluginTemplateById(templates: TXpertTemplateDescriptor[], id: string) {
@@ -962,7 +951,9 @@ export class XpertTemplateService extends TenantAwareCrudService<XpertTemplate> 
               : []
 
         return (contributions ?? [])
-            .map((contribution) => this.toPluginTemplateDescriptor(plugin, contribution, language))
+            .map((contribution) =>
+                this.toPluginTemplateDescriptor(plugin, contribution, language, isTemplateCatalogProvider(source))
+            )
             .filter((template): template is TXpertTemplateDescriptor => !!template)
             .filter((template) => this.matchesTemplateQuery(template, query))
     }
@@ -970,44 +961,16 @@ export class XpertTemplateService extends TenantAwareCrudService<XpertTemplate> 
     private toPluginTemplateDescriptor(
         plugin: LoadedPluginRecord,
         contribution: XpertTemplateContribution,
-        language: LanguagesEnum
-    ): TXpertTemplateDescriptor | null {
-        const key = this.normalizeTemplateString(contribution?.key ?? contribution?.id)
-        const exportData = this.normalizeTemplateString(contribution?.export_data ?? contribution?.dslContent)
-        if (!key || !exportData) {
-            throw new Error(`Plugin template is missing key or DSL content`)
-        }
-
-        const pluginName = normalizePluginPackageName(
-            this.normalizeTemplateString(plugin.packageName ?? plugin.name ?? plugin.instance?.meta?.name) ?? ''
+        language: LanguagesEnum,
+        summaryOnly = false
+    ): TXpertTemplateDescriptor {
+        return describePluginTemplate(
+            plugin,
+            contribution,
+            language,
+            summaryOnly,
+            this.resolveTemplateApplication(plugin, contribution.key?.trim() || contribution.id?.trim())
         )
-        const namespacedId = `${pluginName}:${key}`
-        const targetApps = contribution.targetApps ?? plugin.instance?.meta?.targetApps
-        const targetAppMeta = contribution.targetAppMeta ?? plugin.instance?.meta?.targetAppMeta ?? null
-        const dslMetadata = readXpertTemplateDslMetadata(exportData, language)
-        const application = this.resolveTemplateApplication(plugin, key)
-
-        return {
-            ...contribution,
-            id: namespacedId,
-            key: namespacedId,
-            name: this.normalizeTemplateString(contribution.name) ?? key,
-            title: resolveI18nText(contribution.title ?? contribution.name, language) ?? dslMetadata.title ?? key,
-            description: dslMetadata.description ?? resolveI18nText(contribution.description, language) ?? '',
-            category: this.normalizeTemplateString(contribution.category) ?? 'Plugin',
-            copyright: contribution.copyright ?? null,
-            privacyPolicy: contribution.privacyPolicy ?? null,
-            export_data: exportData,
-            targetApps,
-            targetAppMeta,
-            source: 'plugin',
-            pluginName,
-            pluginDisplayName: this.normalizeTemplateString(plugin.instance?.meta?.displayName ?? pluginName),
-            dependencies: contribution.dependencies,
-            ...(application ? { application } : {}),
-            avatar: contribution.avatar ?? dslMetadata.avatar,
-            order: typeof contribution.order === 'number' ? contribution.order : Number.MAX_SAFE_INTEGER
-        }
     }
 
     /**

--- a/packages/server-ai/src/xpert/commands/handlers/import.handler.spec.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/import.handler.spec.ts
@@ -286,7 +286,16 @@ describe('XpertImportHandler', () => {
                         name: 'Imported Expert',
                         title: 'Imported Expert',
                         type: 'agent',
-                        agent: { key: 'Agent_imported' }
+                        agent: { key: 'Agent_imported' },
+                        options: {
+                            templateSource: {
+                                templateId: '@xpert-ai/plugin-example:assistant',
+                                templateKey: 'assistant',
+                                locale: 'zh-Hans',
+                                pluginVersion: '0.1.0',
+                                contentHash: 'role-body-1'
+                            }
+                        }
                     },
                     nodes: [
                         {
@@ -310,7 +319,10 @@ describe('XpertImportHandler', () => {
                     templateSource: expect.objectContaining({
                         templateId: '@xpert-ai/plugin-example:assistant',
                         templateKey: 'assistant',
-                        pluginName: '@xpert-ai/plugin-example'
+                        pluginName: '@xpert-ai/plugin-example',
+                        locale: 'zh-Hans',
+                        pluginVersion: '0.1.0',
+                        contentHash: 'role-body-1'
                     })
                 })
             })

--- a/packages/server-ai/src/xpert/commands/handlers/import.handler.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/import.handler.ts
@@ -284,10 +284,12 @@ export class XpertImportHandler implements ICommandHandler<XpertImportCommand> {
     }
 
     private resolveImportTemplateSource(command: XpertImportCommand, draft: XpertDraftDslDTO) {
+        const identity = createTemplateSourceFromIds(command.options.templateId, command.options.sourceTemplateId)
+        const embedded = resolveTemplateSourceFromOptions(draft.team.options)
+        // The selected ID owns identity; only its matching DSL may supply locale/revision metadata.
         const source =
             command.options.templateSource ??
-            createTemplateSourceFromIds(command.options.templateId, command.options.sourceTemplateId) ??
-            resolveTemplateSourceFromOptions(draft.team.options)
+            (identity ? { ...(embedded?.templateId === identity.templateId ? embedded : {}), ...identity } : embedded)
         if (!source) {
             return null
         }

--- a/packages/server-ai/src/xpert/commands/handlers/sync-template.handler.spec.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/sync-template.handler.spec.ts
@@ -70,6 +70,34 @@ describe('XpertSyncTemplateHandler', () => {
         }
     }
 
+    it('keeps the installed prompt language when the UI language changes', async () => {
+        const { handler, xpertTemplateService } = buildHandler(
+            {
+                id: 'xpert-1',
+                name: 'My role',
+                options: {
+                    templateSource: {
+                        templateId: '@xpert-ai/plugin-example:assistant',
+                        templateKey: 'assistant',
+                        locale: 'zh-Hans'
+                    }
+                }
+            },
+            { locale: 'zh-Hans', pluginVersion: '0.2.0', contentHash: 'revision-2' }
+        )
+        const result = await handler.execute(new XpertSyncTemplateCommand('xpert-1'))
+        expect(xpertTemplateService.getTemplateDetail).toHaveBeenCalledWith(
+            '@xpert-ai/plugin-example:assistant',
+            'en',
+            { locale: 'zh-Hans' }
+        )
+        expect(result.templateSource).toMatchObject({
+            locale: 'zh-Hans',
+            pluginVersion: '0.2.0',
+            contentHash: 'revision-2'
+        })
+    })
+
     it('resolves a legacy plugin template source and overwrites only the existing draft', async () => {
         const xpert = {
             id: 'xpert-1',

--- a/packages/server-ai/src/xpert/commands/handlers/sync-template.handler.ts
+++ b/packages/server-ai/src/xpert/commands/handlers/sync-template.handler.ts
@@ -38,7 +38,11 @@ export class XpertSyncTemplateHandler implements ICommandHandler<XpertSyncTempla
         const templateId = resolveTemplateLookupId(currentSource)
         let template
         try {
-            template = await this.xpertTemplateService.getTemplateDetail(templateId, language)
+            template = currentSource.locale
+                ? await this.xpertTemplateService.getTemplateDetail(templateId, language, {
+                      locale: currentSource.locale
+                  })
+                : await this.xpertTemplateService.getTemplateDetail(templateId, language)
         } catch {
             throw new BadRequestException(
                 `Source template '${templateId}' is not available. Refresh or reinstall its plugin first.`

--- a/packages/server-ai/src/xpert/template-source.spec.ts
+++ b/packages/server-ai/src/xpert/template-source.spec.ts
@@ -1,0 +1,24 @@
+import { createXpertTemplateSource, resolveTemplateSourceFromOptions } from './template-source'
+
+jest.mock('@xpert-ai/server-core', () => ({ normalizePluginName: (name: string) => name }))
+
+describe('template source snapshot', () => {
+    it('records the resolved language and content revision and preserves installation time on sync', () => {
+        const descriptor = {
+            id: '@xpert-ai/agency:frontend',
+            pluginName: '@xpert-ai/agency',
+            locale: 'zh-Hans',
+            pluginVersion: '0.1.0',
+            contentHash: 'revision-1'
+        }
+        const original = createXpertTemplateSource(descriptor)
+        const next = createXpertTemplateSource(
+            { ...descriptor, pluginVersion: '0.2.0', contentHash: 'revision-2' },
+            original
+        )
+        expect(next.installedAt).toBe(original.installedAt)
+        expect(next).toMatchObject({ locale: 'zh-Hans', pluginVersion: '0.2.0', contentHash: 'revision-2' })
+        expect(resolveTemplateSourceFromOptions({ templateSource: next })).toEqual(next)
+        expect(original.contentHash).toBe('revision-1')
+    })
+})

--- a/packages/server-ai/src/xpert/template-source.ts
+++ b/packages/server-ai/src/xpert/template-source.ts
@@ -9,6 +9,9 @@ type XpertTemplateSourceDescriptor = {
     pluginDisplayName?: string
     source?: string
     releaseNotes?: string
+    locale?: string
+    pluginVersion?: string
+    contentHash?: string
 }
 
 export function resolveXpertTemplateSource(xpert: XpertTemplateSourceCarrier): TXpertTemplateSource | null {
@@ -66,6 +69,9 @@ export function createXpertTemplateSource(
         ...(readString(template.source) ? { source: template.source } : {}),
         installedAt: previous?.installedAt ?? now,
         lastSyncedAt: now,
+        ...(template.locale ? { locale: template.locale } : {}),
+        ...(template.pluginVersion ? { pluginVersion: template.pluginVersion } : {}),
+        ...(template.contentHash ? { contentHash: template.contentHash } : {}),
         ...(readString(template.releaseNotes) ? { releaseNotes: readString(template.releaseNotes) } : {})
     }
 }


### PR DESCRIPTION
# PR

Large plugin role libraries currently require eager template payloads, and role skill bindings can be lost when switching templates. Add an opt-in catalog provider and metadata-only listing with on-demand detail loading, then install and bind each selected template's declared role skill. Preserve template-provided Skills Middleware, localized skill names, and locale/source revision metadata during import and synchronization.

For example, switching from the anthropology template to another expert and back now restores the anthropology skill instead of dropping it or binding the other agent's skill. Existing eager template providers and blank-agent skill defaults retain their existing behavior.

## Scope and dependencies

- Plugin SDK/contracts: catalog provider, summary/query types, and source metadata; both changesets use **patch** releases (planned contracts 3.18.3 and plugin-sdk 3.18.4).
- Host API/UI: catalog summaries and incremental card rendering, detail resolution, source tracking, and template skill binding/cache restoration.
- Skill installation/selection: retain localized display names, repair existing shared index names on reinitialization, and search names while keeping technical identifiers stable.
- Companion Agency Agents plugin: https://github.com/xpert-ai/xpert-plugins/pull/619 (targets `main`); the plugin requires this host capability.

## Validation

- Cloud: 6 focused suites, **113 tests passed**.
- Server AI: 6 focused suites, **102 tests passed**.
- Angular compiler: `ngc -p apps/cloud/tsconfig.app.json --noEmit` passed.
- Commit hooks passed, including formatting, staged color checks and TypeORM column checks.
- Browser validation was not run during PR preparation. Existing installations need skill reinitialization to refresh persisted display names.

# Checklist

- [x] Have you followed the contributing guidelines?
- [x] Have you explained what your changes do, and why they add value?
