### PR TITLE
chore: prepare Xpert 3.18.4 patch release

### DIFF
--- a/.changeset/prepare-xpert-3-18-4.md
+++ b/.changeset/prepare-xpert-3-18-4.md
@@ -1,0 +1,12 @@
+---
+'@xpert-ai/contracts': patch
+'@xpert-ai/plugin-sdk': patch
+'@xpert-ai/xpert-ui': patch
+---
+
+Prepare the Xpert 3.18.4 patch release.
+
+The target platform version is 3.18.4. Before publishing, align contracts,
+plugin-sdk, and xpert-ui to this version in the release version PR, including
+their internal dependency references, changelogs, and lockfile entries. Their
+current versions differ, so patch bumps alone do not align the three anchors.


### PR DESCRIPTION
Prepare the Xpert 3.18.4 patch release by adding a platform changeset for `@xpert-ai/contracts`, `@xpert-ai/plugin-sdk`, and the private Web package `@xpert-ai/xpert-ui`.

The current anchor versions differ: contracts is 3.18.2, plugin-sdk is 3.18.3, and xpert-ui is 3.18.1. This changeset records 3.18.4 as the intended platform version; patch bumps alone would produce 3.18.3, 3.18.4, and 3.18.2 respectively. The subsequent release version PR must align all three anchors to 3.18.4 and reconcile internal dependencies, changelogs, and the lockfile before publishing.

Scope: one changeset file. This PR targets develop and does not create a platform tag or publish packages.

Validation:
- `corepack pnpm exec changeset status --since origin/main`: seven patch releases, no minor or major releases.
- `git diff --check origin/develop...HEAD`: passed.
- Commit hooks ran successfully without bypassing checks.
