### PR TITLE
feat(knowledge): share chunk settings in spreadsheet imports

### DIFF
--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-dialog.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-dialog.component.html
@@ -188,14 +188,14 @@
           @if (onlySheet()) {
             <xp-knowledge-document-create-settings
               class="block min-w-0"
-              [hidden]="section() === 'audio' || section() === 'questions'"
+              [hidden]="section() === 'chunks' || section() === 'audio' || section() === 'questions'"
               [knowledgebaseValue]="data.knowledgebase"
               [section]="settingsSection()"
               [documents]="documents()"
               [(parserConfig)]="sheetParserConfig"
             />
           }
-          @if (!onlySheet() || section() === 'audio' || section() === 'questions') {
+          @if (!onlySheet() || section() === 'chunks' || section() === 'audio' || section() === 'questions') {
             <xp-knowledge-processing-settings
               class="block min-w-0"
               [form]="processing"

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-dialog.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-dialog.component.spec.ts
@@ -3,8 +3,11 @@ jest.mock('../create/settings/settings.component', () => ({ KnowledgeDocumentCre
 jest.mock('../pipeline/settings/settings.component', () => ({ KnowledgeDocumentPipelineSettingsComponent: class {} }))
 
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog'
+import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
-import { TranslateService } from '@ngx-translate/core'
+import { FormsModule } from '@angular/forms'
+import { By } from '@angular/platform-browser'
+import { TranslateModule } from '@ngx-translate/core'
 import { of, Subject, throwError } from 'rxjs'
 import {
   IKnowledgeDocument,
@@ -20,7 +23,8 @@ describe('DocumentImportDialogComponent', () => {
   async function setup(
     graphEnabled = false,
     editDocument?: IKnowledgeDocument,
-    structure = KnowledgeStructureEnum.General
+    structure = KnowledgeStructureEnum.General,
+    renderTemplate = false
   ) {
     const knowledgebase = {
       id: 'kb',
@@ -46,12 +50,15 @@ describe('DocumentImportDialogComponent', () => {
       getTextSplitterStrategies: () =>
         of([
           { name: 'recursive-character', structure: KnowledgeStructureEnum.General },
+          { name: 'auto', structure: KnowledgeStructureEnum.General },
+          { name: 'structure-aware', structure: KnowledgeStructureEnum.General },
           { name: 'parent-child', structure: KnowledgeStructureEnum.ParentChild }
         ]),
       getDocumentTransformerStrategies: () => of([]),
       createTask: jest.fn(() => of({}))
     }
     TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
       providers: [
         {
           provide: DIALOG_DATA,
@@ -65,14 +72,17 @@ describe('DocumentImportDialogComponent', () => {
         },
         { provide: DialogRef, useValue: ref },
         { provide: KnowledgeDocumentService, useValue: api },
-        { provide: TranslateService, useValue: { instant: (key: string) => key } },
         {
           provide: KnowledgebaseService,
           useValue: kbAPI
         }
       ]
     })
-    TestBed.overrideComponent(DocumentImportDialogComponent, { set: { template: '', imports: [] } })
+    TestBed.overrideComponent(DocumentImportDialogComponent, {
+      set: renderTemplate
+        ? { imports: [FormsModule, TranslateModule], schemas: [NO_ERRORS_SCHEMA] }
+        : { template: '', imports: [] }
+    })
     const fixture = TestBed.createComponent(DocumentImportDialogComponent)
     fixture.detectChanges()
     await fixture.whenStable()
@@ -285,16 +295,125 @@ describe('DocumentImportDialogComponent', () => {
     expect(component.chunkSize()).toBe(800)
   })
 
-  it('keeps spreadsheet and text batch settings separate when sources change', async () => {
+  it('shares chunk settings while preserving spreadsheet parser settings when sources change', async () => {
     const { component } = await setup()
     component.processing.chunkSize.set(800)
     component.externalDocuments.set([{ category: KBDocumentCategoryEnum.Sheet, type: 'xlsx' }])
-    expect(component.activeParserConfig()).toEqual({})
+    expect(component.activeParserConfig()).toMatchObject({ chunkSize: 800 })
     component.sheetParserConfig.set({ spreadsheet: { interpretation: 'form_document' } })
     component.externalDocuments.set([{ category: KBDocumentCategoryEnum.Text, type: 'txt' }])
     expect(component.activeParserConfig()).toMatchObject({ chunkSize: 800 })
+    expect(component.activeParserConfig().spreadsheet).toBeUndefined()
     component.externalDocuments.set([{ category: KBDocumentCategoryEnum.Sheet, type: 'xlsx' }])
-    expect(component.activeParserConfig()).toEqual({ spreadsheet: { interpretation: 'form_document' } })
+    expect(component.activeParserConfig()).toMatchObject({
+      chunkSize: 800,
+      spreadsheet: { interpretation: 'form_document' }
+    })
+  })
+
+  it('renders the shared chunk form for spreadsheets and keeps the parser settings on their existing page', async () => {
+    const { component, fixture } = await setup(
+      false,
+      { id: 'sheet', type: 'xlsx', category: KBDocumentCategoryEnum.Sheet, version: 1 } as IKnowledgeDocument,
+      KnowledgeStructureEnum.General,
+      true
+    )
+    const legacy = fixture.debugElement.query(By.css('xp-knowledge-document-create-settings'))
+    expect(legacy.properties['hidden']).toBe(false)
+    component.section.set('chunks')
+    fixture.detectChanges()
+    const shared = fixture.debugElement.query(By.css('xp-knowledge-processing-settings'))
+    expect(shared).not.toBeNull()
+    expect(shared.properties['section']).toBe('chunk')
+    expect(shared.properties['form']).toBe(component.processing)
+    expect(legacy.properties['hidden']).toBe(true)
+    component.section.set('parser')
+    fixture.detectChanges()
+    expect(legacy.properties['hidden']).toBe(false)
+    expect(fixture.debugElement.query(By.css('xp-knowledge-processing-settings'))).toBeNull()
+  })
+
+  it('saves shared chunk settings for a sheet import alongside existing spreadsheet and image settings', async () => {
+    const { component, api, knowledgebase } = await setup()
+    component.externalDocuments.set([{ category: KBDocumentCategoryEnum.Sheet, type: 'xlsx' }])
+    component.sheetParserConfig.set({
+      spreadsheet: { interpretation: 'records', includeSheets: ['Orders'] },
+      indexedFields: ['sku'],
+      imageUnderstandingEnabled: true
+    })
+    component.processing.selectChunkStrategy('auto')
+    component.processing.chunkSize.set(800)
+    component.processing.chunkOverlap.set(40)
+    component.processing.maxChunkTokensControl.setValue(256)
+    await component.submit()
+    expect(api.createBulk).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          parserConfig: expect.objectContaining({
+            textSplitterType: 'auto',
+            textSplitter: { chunkSize: 800, chunkOverlap: 40 },
+            chunkSize: 800,
+            chunkOverlap: 40,
+            maxChunkTokens: 256,
+            spreadsheet: { interpretation: 'records', includeSheets: ['Orders'] },
+            indexedFields: ['sku'],
+            imageUnderstandingEnabled: true
+          })
+        })
+      ],
+      true
+    )
+    expect(knowledgebase.parserConfig.chunkSize).toBe(512)
+  })
+
+  it('saves and restores shared sheet chunk settings when editing an existing document', async () => {
+    const document = {
+      id: 'sheet',
+      type: 'xlsx',
+      category: KBDocumentCategoryEnum.Sheet,
+      version: 1,
+      parserConfig: {
+        textSplitterType: 'auto',
+        textSplitter: { chunkSize: 900, chunkOverlap: 50 },
+        indexedFields: ['sku'],
+        spreadsheet: { interpretation: 'records' }
+      }
+    } as IKnowledgeDocument
+    const { component, api } = await setup(false, document)
+    expect(component.processing.chunkSize()).toBe(900)
+    component.processing.selectChunkStrategy('structure-aware')
+    component.processing.chunkSize.set(700)
+    component.processing.maxChunkTokensControl.setValue(128)
+    await component.saveAndProcess('full')
+    const saved = api.updateBulk.mock.calls[0][0][0].parserConfig
+    expect(saved).toMatchObject({
+      textSplitterType: 'structure-aware',
+      chunkSize: 700,
+      maxChunkTokens: 128,
+      textSplitter: { chunkSize: 700, chunkOverlap: 50 },
+      indexedFields: ['sku'],
+      spreadsheet: { interpretation: 'records' }
+    })
+    expect(api.startParsing).toHaveBeenCalledWith('sheet', 'full')
+    TestBed.resetTestingModule()
+    const reopened = await setup(false, { ...document, parserConfig: saved })
+    expect(reopened.component.processing.chunkStrategy()).toBe('structure-aware')
+    expect(reopened.component.processing.chunkSize()).toBe(700)
+    expect(reopened.component.processing.maxChunkTokens()).toBe(128)
+  })
+
+  it('blocks invalid shared chunk parameters for sheets before submitting', async () => {
+    const { component, api } = await setup()
+    component.externalDocuments.set([{ category: KBDocumentCategoryEnum.Sheet, type: 'xlsx' }])
+    component.processing.maxChunkTokensControl.setValue(-1)
+    expect(component.configurationError()).toContain('InvalidTokenLimit')
+    await component.submit()
+    expect(api.createBulk).not.toHaveBeenCalled()
+    component.processing.maxChunkTokensControl.setValue(0)
+    component.processing.chunkOverlap.set(512)
+    expect(component.configurationError()).toContain('InvalidLimits')
+    component.processing.chunkOverlap.set(80)
+    expect(component.ready()).toBe(true)
   })
 
   it('prevents duplicate submit while a request is pending', async () => {

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-dialog.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-dialog.component.ts
@@ -21,7 +21,12 @@ import { XpTreeSelectComponent } from '@cloud/app/@shared/form-fields/tree-selec
 import { KnowledgeDocumentCreateSettingsComponent } from '../create/settings/settings.component'
 import { createKnowledgeProcessingForm, KnowledgeProcessingSection } from '../../../processing/processing-form'
 import { KnowledgeProcessingSettingsComponent } from '../../../processing/processing-settings.component'
-import { buildImportDocuments, ImportParserConfig, ImportSettingsSection } from './import-model'
+import {
+  buildImportDocuments,
+  ImportParserConfig,
+  ImportSettingsSection,
+  mergeSheetProcessingConfig
+} from './import-model'
 import { buildImportFolderTree, IMPORT_ROOT_FOLDER } from './import-folder-tree'
 import { documentFileType } from '../../../processing/document-file-types'
 import { documentProcessingDraft, editedDocumentParserConfig } from './document-edit-config'
@@ -90,9 +95,7 @@ export class DocumentImportDialogComponent {
     this.editing ? cloneDeep(this.data.editDocument.parserConfig ?? {}) : {}
   )
   readonly activeParserConfig = computed(() =>
-    this.onlySheet()
-      ? { ...this.sheetParserConfig(), questionGeneration: this.parserConfig().questionGeneration }
-      : this.parserConfig()
+    this.onlySheet() ? mergeSheetProcessingConfig(this.sheetParserConfig(), this.parserConfig()) : this.parserConfig()
   )
   readonly section = signal('parser')
   readonly settingsSection = computed<ImportSettingsSection>(() =>
@@ -147,7 +150,12 @@ export class DocumentImportDialogComponent {
     if (!this.documents().length) return null
     if (this.onlySheet()) {
       const error = this.settings()?.configurationError()
-      return this.processing.validateQuestions()?.key || (error ? this.prefix + '.' + error : null)
+      const sharedError = this.processing.validate({ checkPdfParser: false })
+      return (
+        this.processing.strategiesError() ||
+        (sharedError?.section === 'chunk' || sharedError?.section === 'questions' ? sharedError.key : null) ||
+        (error ? this.prefix + '.' + error : null)
+      )
     }
     return (
       this.processing.strategiesError() ||

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-model.spec.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-model.spec.ts
@@ -34,7 +34,7 @@ describe('document import payloads', () => {
       'kb',
       null
     )
-    expect(docs[0].parserConfig).toEqual({ indexedFields: ['name'] })
+    expect(docs[0].parserConfig).toEqual({ indexedFields: ['name'], chunkSize: 512 })
     expect(docs[1].parserConfig).toEqual({ chunkSize: 512 })
     expect(docs[1].parent).toBeNull()
   })
@@ -76,7 +76,35 @@ describe('document import payloads', () => {
     })
     expect(docs[1].parserConfig.transformerType).toBeUndefined()
     expect(docs[1].parserConfig.chunkSize).toBe(800)
-    expect(docs[2].parserConfig).toEqual({ indexedFields: ['sku'] })
+    expect(docs[2].parserConfig).toEqual({ indexedFields: ['sku'], chunkSize: 800 })
+  })
+  it('applies shared chunk settings to mixed batches without replacing spreadsheet conversion settings', () => {
+    const sheetConfig = {
+      indexedFields: ['sku'],
+      spreadsheet: { includeSheets: ['Orders'] },
+      transformerType: 'sheet-transformer',
+      imageUnderstandingEnabled: false,
+      textSplitterType: 'recursive-character',
+      textSplitter: { chunkSize: 1000 }
+    }
+    const docs = buildImportDocuments(
+      [
+        { category: KBDocumentCategoryEnum.Sheet, parserConfig: sheetConfig },
+        { category: KBDocumentCategoryEnum.Text }
+      ],
+      { textSplitterType: 'auto', textSplitter: { chunkSize: 800, chunkOverlap: 40 }, maxChunkTokens: 256 },
+      'kb',
+      null
+    )
+    expect(docs[0].parserConfig).toEqual({
+      ...sheetConfig,
+      textSplitterType: 'auto',
+      textSplitter: { chunkSize: 800, chunkOverlap: 40 },
+      maxChunkTokens: 256
+    })
+    docs[0].parserConfig.spreadsheet.includeSheets.push('Other')
+    expect(sheetConfig.spreadsheet.includeSheets).toEqual(['Orders'])
+    expect(sheetConfig.textSplitterType).toBe('recursive-character')
   })
   it('uses the existing single-page crawl mode for quick URLs', () => {
     expect(quickWebOptions(' https://example.com/a ')).toEqual({

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-model.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-model.ts
@@ -7,7 +7,7 @@ import {
   TRagWebOptions
 } from '@xpert-ai/contracts'
 import { v4 as uuid } from 'uuid'
-import { cloneDeep } from 'lodash-es'
+import { cloneDeep, pick } from 'lodash-es'
 
 export type DocumentImportSource = 'files' | 'folder' | 'url' | 'crawl' | 'remote' | 'online' | 'pipeline'
 export type KnowledgePipelineImportResult = { taskId: string }
@@ -26,6 +26,26 @@ export const DOCUMENT_IMPORT_SOURCES = [
 
 export function quickWebOptions(url: string): TRagWebOptions {
   return { url: url.trim(), params: { mode: 'scrape' } }
+}
+
+/** Shared chunk controls own these fields; spreadsheet conversion and image settings retain their own draft. */
+export function mergeSheetProcessingConfig(
+  sheetConfig: ImportParserConfig,
+  processingConfig: ImportParserConfig
+): ImportParserConfig {
+  return {
+    ...sheetConfig,
+    ...pick(processingConfig, [
+      'textSplitterType',
+      'textSplitter',
+      'chunkSize',
+      'chunkOverlap',
+      'maxChunkTokens',
+      'delimiter',
+      'separators',
+      'questionGeneration'
+    ])
+  }
 }
 
 export function buildImportDocuments(
@@ -47,10 +67,10 @@ export function buildImportDocuments(
     parent: parentId ? ({ id: parentId } as IKnowledgeDocument) : null,
     parserConfig: cloneDeep(
       document.category === KBDocumentCategoryEnum.Sheet
-        ? {
-            ...(options?.sheetParserConfig ?? (onlySheet ? config : (document.parserConfig ?? {}))),
-            ...(config.questionGeneration ? { questionGeneration: config.questionGeneration } : {})
-          }
+        ? mergeSheetProcessingConfig(
+            options?.sheetParserConfig ?? (onlySheet ? config : (document.parserConfig ?? {})),
+            config
+          )
         : {
             ...config,
             ...(document.type?.replace(/^\./, '').toLowerCase() === 'pdf' ? options?.pdfParser : {}),


### PR DESCRIPTION
# PR

Expose the shared chunk settings form when importing or editing spreadsheet documents, and include those settings in spreadsheet API payloads. Previously, spreadsheet-only imports used a separate settings view and mixed batches did not copy the shared chunk configuration to spreadsheet documents.

- Show the shared chunk form on the spreadsheet **Chunks** tab while retaining the existing spreadsheet parser view.
- Merge strategy, size, overlap, token limit, separators, and question-generation settings into spreadsheet import/edit payloads without replacing spreadsheet-specific configuration.
- Validate shared chunk settings before submission.
- Add regression coverage for spreadsheet-only imports, mixed batches, editing/reopening, template switching, and invalid settings.

No new dependencies are required. This PR contains only the five import dialog/model files. It is based on develop after #1017 was merged; those algorithm changes are not repeated in this diff. The local implementation-status document is excluded.

## Merge blocker: spreadsheet execution is not fully connected

This PR remains a draft because displaying and submitting these controls does not yet make them effective for the built-in spreadsheet loader:

- The default spreadsheet loading path produces record or workbook chunks directly and returns before the generic text splitter.
- Spreadsheet configuration normalization drops the top-level `maxChunkTokens` field. A read-only reproduction with `maxChunkTokens: 256` and `spreadsheet.maxChunkTokens: 6000` retained only the spreadsheet-specific limit. Form-document processing consumes that nested limit.
- The generic executor rejects the Sheet category when a custom spreadsheet transform is routed into `auto` or `structure-aware`.

The frontend controls and backend spreadsheet execution contract must be aligned before this is considered ready to merge. This PR does not change the backend spreadsheet behavior.

## Validation

- Four frontend Jest suites passed: 55 tests covering the import dialog, import payload model, shared processing form, and processing settings component.
- Angular compilation and template type checking passed.
- The spreadsheet configuration gap was reproduced by calling the real configuration normalizer without database writes or model calls.
- Tests ran against an isolated checkout of `develop` with only these five files applied.
- No browser verification or end-to-end spreadsheet reprocessing was performed.

## Checklist

- [x] Reviewed the contributing guidelines and followed the repository contribution workflow.
- [x] Explained the changes, motivation, validation, and remaining merge blocker.
