### PR TITLE
feat(knowledge): add document chunk language hints

### DIFF
--- a/.changeset/knowledge-chunk-language-hints.md
+++ b/.changeset/knowledge-chunk-language-hints.md
@@ -1,0 +1,7 @@
+---
+'@xpert-ai/contracts': patch
+'@xpert-ai/plugin-sdk': patch
+'@xpert-ai/server-ai': patch
+---
+
+Add a shared knowledge document language hint and bounded, model-free language detection for natural text chunk boundaries. Preserve Auto strategy routing, explicit separators, token limits, and parent-child behavior, and expose the requested and detected languages in chunk previews.

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/document-edit-config.spec.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/document-edit-config.spec.ts
@@ -1,5 +1,17 @@
 import { documentProcessingDraft, editedDocumentParserConfig } from './document-edit-config'
 
+it('inherits, overrides and reopens public document language settings', () => {
+  const defaults = { chunkSize: 512, chunkOverlap: 0, delimiter: null, chunkLanguageHint: 'Chinese' as const }
+  expect(documentProcessingDraft({ type: 'txt' }, defaults).chunkLanguageHint).toBe('Chinese')
+  const document = { type: 'txt', parserConfig: { chunkLanguageHint: 'English' as const } }
+  const draft = { ...defaults, ...documentProcessingDraft(document, defaults) }
+  expect(draft.chunkLanguageHint).toBe('English')
+  const saved = editedDocumentParserConfig(document, draft, defaults)
+  expect(saved.chunkLanguageHint).toBe('English')
+  expect(saved.textSplitter).not.toHaveProperty('chunkLanguageHint')
+  expect(documentProcessingDraft({ ...document, parserConfig: saved }, defaults).chunkLanguageHint).toBe('English')
+})
+
 describe('editing document processing settings', () => {
   it('inherits the library token budget and preserves an explicit per-document opt-out when reopening and saving', () => {
     const defaults = { chunkSize: 512, chunkOverlap: 0, delimiter: null, maxChunkTokens: 256 }

--- a/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-model.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/knowledgebase/documents/import/import-model.ts
@@ -41,6 +41,7 @@ export function mergeSheetProcessingConfig(
       'chunkSize',
       'chunkOverlap',
       'maxChunkTokens',
+      'chunkLanguageHint',
       'delimiter',
       'separators',
       'questionGeneration'

--- a/apps/cloud/src/app/features/xpert/knowledge/new/chunk-preview.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/chunk-preview.component.spec.ts
@@ -37,6 +37,16 @@ describe('KnowledgeChunkPreviewComponent', () => {
       fixture.componentRef.setInput('config', { chunkSize: 512, chunkOverlap: 0, delimiter: null, maxChunkTokens: 16 })
       fixture.detectChanges()
       fixture.componentInstance.result.set({
+        languages: [
+          {
+            languageHint: 'auto',
+            detectedLanguage: 'Mixed',
+            resolvedLanguage: 'Mixed',
+            sourceIndexes: [0],
+            sampledCodeUnits: 100,
+            naturalUnits: 2
+          }
+        ],
         decisions: [
           {
             inputHash: 'source-hash',
@@ -84,6 +94,9 @@ describe('KnowledgeChunkPreviewComponent', () => {
       fixture.detectChanges()
       await fixture.whenStable()
       const root: HTMLElement = fixture.nativeElement
+      expect(root.querySelector('[data-chunk-language]').textContent).toContain('Language.Hint')
+      expect(root.querySelector('[data-chunk-language]').textContent).toContain('Language.Values.auto')
+      expect(root.querySelector('[data-chunk-language]').textContent).toContain('Language.Values.Mixed')
       expect(root.textContent).toContain('retrieval child text')
       expect(root.textContent).toContain('8 tokens')
       expect(root.textContent).toContain('# Inventory')
@@ -104,13 +117,13 @@ describe('KnowledgeChunkPreviewComponent', () => {
     await component.preview()
     expect(service.previewChunks).not.toHaveBeenCalled()
     fixture.componentRef.setInput('configInvalid', false)
-    fixture.componentRef.setInput('config', { ...component.config(), maxChunkTokens: 64 })
+    fixture.componentRef.setInput('config', { ...component.config(), maxChunkTokens: 64, chunkLanguageHint: 'Chinese' })
     fixture.detectChanges()
     await component.preview()
     expect(service.previewChunks).toHaveBeenCalledWith(
       'workspace',
       expect.objectContaining({
-        parserConfig: expect.objectContaining({ maxChunkTokens: 64 })
+        parserConfig: expect.objectContaining({ maxChunkTokens: 64, chunkLanguageHint: 'Chinese' })
       })
     )
   })

--- a/apps/cloud/src/app/features/xpert/knowledge/new/chunk-preview.component.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/new/chunk-preview.component.ts
@@ -42,6 +42,18 @@ import { ZardButtonComponent, ZardFormImports, ZardInputDirective, ZardSelectImp
         <p role="alert" class="text-sm text-text-destructive">{{ error() }}</p>
       }
       @if (result(); as result) {
+        @for (language of result.languages ?? []; track $index) {
+          <div class="space-y-1 text-sm text-text-secondary" data-chunk-language>
+            <p>
+              {{ 'XP.Knowledgebase.Chunking.Language.Hint' | translate }}:
+              {{ 'XP.Knowledgebase.Chunking.Language.Values.' + language.languageHint | translate }}
+            </p>
+            <p>
+              {{ 'XP.Knowledgebase.Chunking.Language.Detected' | translate }}:
+              {{ 'XP.Knowledgebase.Chunking.Language.Values.' + (language.detectedLanguage ?? 'Unknown') | translate }}
+            </p>
+          </div>
+        }
         @for (decision of result.decisions ?? []; track $index) {
           <div
             class="space-y-1 border-l-2 border-divider-subtle pl-3 text-sm text-text-secondary"

--- a/apps/cloud/src/app/features/xpert/knowledge/processing/processing-form.spec.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/processing/processing-form.spec.ts
@@ -32,6 +32,28 @@ describe('shared knowledge processing draft', () => {
 
   afterEach(() => TestBed.resetTestingModule())
 
+  it('saves and restores all public language hints without serializing implicit separators', () => {
+    const { form } = setup()
+    expect(form.chunkLanguageHint()).toBe('auto')
+    expect(form.config().separators).toBeUndefined()
+    expect(form.config().delimiter).toBeNull()
+    for (const chunkLanguageHint of ['auto', 'Chinese', 'English'] as const) {
+      form.chunkLanguageHint.set(chunkLanguageHint)
+      const config = form.config()
+      expect(config.chunkLanguageHint).toBe(chunkLanguageHint)
+      expect(config.textSplitter).not.toHaveProperty('chunkLanguageHint')
+      const reopened = TestBed.runInInjectionContext(() => createKnowledgeProcessingForm({ config }))
+      expect(reopened.chunkLanguageHint()).toBe(chunkLanguageHint)
+      expect(reopened.config().separators).toBeUndefined()
+    }
+    form.updateSeparators([';'])
+    expect(form.config().separators).toEqual([';'])
+    form.chunkLanguageHint.set('Chinese')
+    expect(form.config().separators).toEqual([';'])
+    form.updateSeparators([])
+    expect(form.config().separators).toEqual([])
+  })
+
   it('defaults to auto, preserves explicit strategies and restores auto after leaving parent-child mode', () => {
     const { form } = setup()
     expect(form.config().textSplitterType).toBe('auto')

--- a/apps/cloud/src/app/features/xpert/knowledge/processing/processing-form.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/processing/processing-form.ts
@@ -11,6 +11,7 @@ import {
   IDocumentChunkerProvider,
   IDocumentProcessorProvider,
   KnowledgebaseParserConfig,
+  KnowledgeChunkLanguageHint,
   KnowledgebaseService,
   KnowledgeStructureEnum
 } from '@cloud/app/@core'
@@ -89,7 +90,7 @@ export function createKnowledgeProcessingForm(options: KnowledgeProcessingFormOp
         ? decodeKnowledgeSeparators(storedSeparators)
         : initialConfig.delimiter != null
           ? initialConfig.delimiter.split(' ')
-          : ['\\n\\n', '\\n', '。', '！', '？', '；', ';'])
+          : [])
   )
   const parentChildChunkingEnabled = computed(() => chunkStrategy() === 'parent-child')
   const maxChunkTokensControl = new FormControl(initialConfig.maxChunkTokens ?? 0, [
@@ -99,8 +100,10 @@ export function createKnowledgeProcessingForm(options: KnowledgeProcessingFormOp
     Validators.pattern(/^\d+$/)
   ])
   const maxChunkTokens = toSignal(maxChunkTokensControl.valueChanges, { initialValue: maxChunkTokensControl.value })
-  // Language hints remain reserved for a later batch.
-  const chunkLanguageHint = signal<'auto' | 'Chinese' | 'English'>('auto')
+  const chunkLanguageHint = signal<KnowledgeChunkLanguageHint>(initialConfig.chunkLanguageHint ?? 'auto')
+  const separatorsConfigured = signal(
+    initialConfig.separators !== undefined || storedSeparators !== undefined || initialConfig.delimiter != null
+  )
 
   const { separatorOptions, compareSeparators, displaySeparator, separatorTagOptions, separatorLabelKey } =
     createSeparatorSelectOptions()
@@ -166,6 +169,7 @@ export function createKnowledgeProcessingForm(options: KnowledgeProcessingFormOp
     if (!value || separators().includes(value)) {
       return
     }
+    separatorsConfigured.set(true)
     separators.update((current) => [...current, value])
   }
 
@@ -175,11 +179,13 @@ export function createKnowledgeProcessingForm(options: KnowledgeProcessingFormOp
     }
 
     const nextSeparators = value.filter((separator): separator is string => typeof separator === 'string')
+    separatorsConfigured.set(true)
     separators.set(nextSeparators)
     delimiter.set(nextSeparators[0] || '\n\n')
   }
 
   function removeSeparator(value: string) {
+    separatorsConfigured.set(true)
     separators.update((current) => current.filter((separator) => separator !== value))
   }
 
@@ -197,6 +203,7 @@ export function createKnowledgeProcessingForm(options: KnowledgeProcessingFormOp
     chunkSize: chunkSize(),
     chunkOverlap: chunkOverlap(),
     maxChunkTokens: maxChunkTokens() ?? 0,
+    chunkLanguageHint: chunkLanguageHint(),
     questionGeneration: {
       enabled: questionGenerationEnabled(),
       questionCount:
@@ -216,8 +223,8 @@ export function createKnowledgeProcessingForm(options: KnowledgeProcessingFormOp
           }
         : undefined
     },
-    delimiter: delimiter() || null,
-    separators: [...separators()],
+    delimiter: separatorsConfigured() ? delimiter() || null : null,
+    separators: separatorsConfigured() ? [...separators()] : undefined,
     textSplitterType: chunkStrategy(),
     textSplitter: serializedSplitter(),
     imageUnderstandingEnabled: imageUnderstandingEnabled(),

--- a/apps/cloud/src/app/features/xpert/knowledge/processing/processing-settings.component.html
+++ b/apps/cloud/src/app/features/xpert/knowledge/processing/processing-settings.component.html
@@ -249,6 +249,9 @@
                   {{ i18nPrefix + '.Chunk.Separators' | translate }}
                 </div>
                 <p>{{ i18nPrefix + '.Chunk.SeparatorsDescription' | translate }}</p>
+                @if (form().splitterProvider()?.supportsLanguageHint) {
+                  <p>{{ 'XP.Knowledgebase.Chunking.Language.SeparatorsHelp' | translate }}</p>
+                }
               </div>
               <div class="min-w-0 w-full">
                 <z-tag-select
@@ -374,13 +377,13 @@
                     {{ i18nPrefix + '.Chunk.LanguageHintDescription' | translate }}
                   </p>
                   <p class="mt-1 text-xs leading-5 text-text-tertiary">
-                    {{ i18nPrefix + '.Implemented.LaterOptions' | translate }}
+                    {{ 'XP.Knowledgebase.Chunking.Language.Scope' | translate }}
                   </p>
                 </div>
                 <z-select
                   class="w-full shrink-0 sm:w-60"
                   zSize="lg"
-                  [disabled]="true"
+                  [zDisabled]="!form().splitterProvider()?.supportsLanguageHint"
                   [(ngModel)]="form().chunkLanguageHint"
                 >
                   <z-select-item zValue="auto">{{

--- a/apps/cloud/src/app/features/xpert/knowledge/processing/processing-settings.component.spec.ts
+++ b/apps/cloud/src/app/features/xpert/knowledge/processing/processing-settings.component.spec.ts
@@ -2,6 +2,8 @@ jest.mock('@cloud/app/@shared/copilot', () => ({ CopilotModelSelectComponent: cl
 
 import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
+import { By } from '@angular/platform-browser'
+import { ZardSelectComponent } from '@xpert-ai/headless-ui'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { of } from 'rxjs'
 import { KnowledgebaseService } from '@cloud/app/@core'
@@ -68,6 +70,31 @@ describe('processing settings file-type visibility', () => {
         expect(root.querySelector('[data-chunk-max-tokens]').textContent).toContain('InvalidTokenLimit')
       }
     }
+  })
+
+  it('enables and saves the language selection only for supported splitters', async () => {
+    const { fixture, root, form } = setup()
+    form.splitterProviders.set([{ name: 'auto', supportsLanguageHint: true }, { name: 'parent-child' }])
+    fixture.componentRef.setInput('section', 'chunk')
+    fixture.detectChanges()
+    await fixture.whenStable()
+    root.querySelector<HTMLElement>('z-accordion-header').click()
+    fixture.detectChanges()
+    await fixture.whenStable()
+    const select = fixture.debugElement
+      .query(By.css('[data-chunk-language-hint] z-select'))
+      .injector.get(ZardSelectComponent)
+    const trigger = root.querySelector<HTMLButtonElement>('[data-chunk-language-hint] button[role="combobox"]')
+    expect(trigger.disabled).toBe(false)
+    expect(root.querySelector('[data-chunk-language-hint]').textContent).not.toContain('LaterOptions')
+    select.selectItem('Chinese', 'Chinese')
+    fixture.detectChanges()
+    await fixture.whenStable()
+    expect(form.config().chunkLanguageHint).toBe('Chinese')
+    form.chunkStrategy.set('parent-child')
+    fixture.detectChanges()
+    await fixture.whenStable()
+    expect(trigger.disabled).toBe(true)
   })
 
   it('shows all parser types for knowledgebase defaults', async () => {

--- a/apps/cloud/src/assets/i18n/en-US.json
+++ b/apps/cloud/src/assets/i18n/en-US.json
@@ -769,6 +769,20 @@
         "Failed": "The preview failed. Try again or check the pipeline."
       },
       "Chunking": {
+        "Language": {
+          "Hint": "Language hint",
+          "Detected": "Detected language",
+          "Scope": "Applies to natural text boundaries in automatic, structure-aware, Markdown recursive and recursive character chunking. Parent-child chunking is unchanged.",
+          "SeparatorsHelp": "Custom separators take priority over the language hint. Without custom separators, natural text uses the selected language.",
+          "Values": {
+            "auto": "Auto detect",
+            "Chinese": "Chinese",
+            "English": "English",
+            "Mixed": "Chinese-English mixed",
+            "Unknown": "No identifiable natural text"
+          }
+        },
+
         "TargetSize": "Target chunk size (characters)",
         "TargetHelp": "Combine short paragraphs up to this target. A complete structure may exceed it when it fits the token ceiling.",
         "AutoSizeHelp": "Structure-aware splitting treats this as a target; existing heading and length strategies keep their own size rules. Preview shows the selected strategy.",

--- a/apps/cloud/src/assets/i18n/en.json
+++ b/apps/cloud/src/assets/i18n/en.json
@@ -4569,6 +4569,20 @@
         "Failed": "The preview failed. Try again or check the pipeline."
       },
       "Chunking": {
+        "Language": {
+          "Hint": "Language hint",
+          "Detected": "Detected language",
+          "Scope": "Applies to natural text boundaries in automatic, structure-aware, Markdown recursive and recursive character chunking. Parent-child chunking is unchanged.",
+          "SeparatorsHelp": "Custom separators take priority over the language hint. Without custom separators, natural text uses the selected language.",
+          "Values": {
+            "auto": "Auto detect",
+            "Chinese": "Chinese",
+            "English": "English",
+            "Mixed": "Chinese-English mixed",
+            "Unknown": "No identifiable natural text"
+          }
+        },
+
         "TargetSize": "Target chunk size (characters)",
         "TargetHelp": "Combine short paragraphs up to this target. A complete structure may exceed it when it fits the token ceiling.",
         "AutoSizeHelp": "Structure-aware splitting treats this as a target; existing heading and length strategies keep their own size rules. Preview shows the selected strategy.",

--- a/apps/cloud/src/assets/i18n/zh-Hans.json
+++ b/apps/cloud/src/assets/i18n/zh-Hans.json
@@ -6607,6 +6607,20 @@
         "Failed": "预览失败，请重试或检查流水线。"
       },
       "Chunking": {
+        "Language": {
+          "Hint": "\u8bed\u8a00\u63d0\u793a",
+          "Detected": "\u5b9e\u9645\u8bc6\u522b",
+          "Scope": "\u7528\u4e8e\u81ea\u52a8\u3001\u7ed3\u6784\u611f\u77e5\u3001Markdown \u9012\u5f52\u548c\u9012\u5f52\u5b57\u7b26\u5207\u7247\u7684\u6b63\u6587\u8fb9\u754c\uff1b\u7236\u5b50\u5206\u5757\u6682\u4e0d\u652f\u6301\u3002",
+          "SeparatorsHelp": "\u81ea\u5b9a\u4e49\u5206\u9694\u7b26\u4f18\u5148\u4e8e\u8bed\u8a00\u63d0\u793a\uff1b\u672a\u914d\u7f6e\u81ea\u5b9a\u4e49\u5206\u9694\u7b26\u65f6\uff0c\u6309\u6240\u9009\u8bed\u8a00\u5207\u5206\u6b63\u6587\u3002",
+          "Values": {
+            "auto": "\u81ea\u52a8\u68c0\u6d4b",
+            "Chinese": "\u4e2d\u6587",
+            "English": "\u82f1\u6587",
+            "Mixed": "\u4e2d\u82f1\u6df7\u5408",
+            "Unknown": "\u6682\u65e0\u53ef\u8bc6\u522b\u6b63\u6587"
+          }
+        },
+
         "TargetSize": "目标块大小（字符）",
         "TargetHelp": "组合相邻短段落时参考此大小；完整结构满足 Token 上限时，可以超过目标字符数。",
         "AutoSizeHelp": "结构感知将此值作为目标大小；现有标题和长度策略保留原大小规则。预览会显示实际采用的策略。",

--- a/packages/contracts/src/ai/knowledge-chunking.model.ts
+++ b/packages/contracts/src/ai/knowledge-chunking.model.ts
@@ -2,8 +2,8 @@
 export const DEFAULT_KNOWLEDGE_TEXT_SPLITTER = 'auto'
 
 /** Shared revision for structured execution diagnostics and cache invalidation. */
-export const KNOWLEDGE_CHUNKING_ALGORITHM_VERSION = 3
-export type KnowledgeChunkingAlgorithmVersion = 1 | 2 | typeof KNOWLEDGE_CHUNKING_ALGORITHM_VERSION
+export const KNOWLEDGE_CHUNKING_ALGORITHM_VERSION = 4
+export type KnowledgeChunkingAlgorithmVersion = 1 | 2 | 3 | typeof KNOWLEDGE_CHUNKING_ALGORITHM_VERSION
 
 /** Built-in strategies that auto routing may select. External providers remain manually selectable. */
 export type KnowledgeChunkingStrategy = 'recursive-character' | 'markdown-recursive' | 'structure-aware'
@@ -59,4 +59,21 @@ export interface KnowledgeStructuredChunkOptions {
   chunkSize?: number
   chunkOverlap?: number
   separators?: string | string[]
+}
+
+/** Language affects natural text boundaries, never strategy selection. */
+export type KnowledgeChunkLanguage = 'Chinese' | 'English' | 'Mixed'
+export type KnowledgeChunkLanguageHint = 'auto' | Exclude<KnowledgeChunkLanguage, 'Mixed'>
+
+export interface KnowledgeChunkLanguageDetection {
+  /** Absent when the bounded sample contains no identifiable natural text. */
+  detectedLanguage?: KnowledgeChunkLanguage
+  sampledCodeUnits: number
+  naturalUnits: number
+}
+
+export interface KnowledgeChunkLanguageDecision extends KnowledgeChunkLanguageDetection {
+  sourceIndexes: number[]
+  languageHint: KnowledgeChunkLanguageHint
+  resolvedLanguage: KnowledgeChunkLanguage
 }

--- a/packages/contracts/src/ai/knowledge-doc.model.ts
+++ b/packages/contracts/src/ai/knowledge-doc.model.ts
@@ -1,3 +1,4 @@
+import type { KnowledgeChunkLanguageHint } from './knowledge-chunking.model'
 import type { KnowledgeQuestionGenerationConfig } from './knowledge-question.model'
 import { IBasePerTenantAndOrganizationEntityModel } from '../base-entity.model'
 import { IIntegration } from '../integration.model'
@@ -14,6 +15,8 @@ import { I18nObject } from '../types'
 export type DocumentParserConfig = {
   /** Additional cl100k_base token cap for text retrieval chunks; 0 disables it. Context parents are retained. */
   maxChunkTokens?: number
+  /** Public natural-language boundary hint; absence means auto. */
+  chunkLanguageHint?: KnowledgeChunkLanguageHint
   questionGeneration?: KnowledgeQuestionGenerationConfig
   pages?: number[][]
   replaceWhitespace?: boolean

--- a/packages/contracts/src/ai/knowledge-parser.model.ts
+++ b/packages/contracts/src/ai/knowledge-parser.model.ts
@@ -1,7 +1,7 @@
 import type { DocumentTextParserConfig } from './knowledge-doc.model'
 import type { KnowledgebaseParserConfig } from './knowledgebase.model'
 import type { IKnowledgeDocumentChunk, IDocChunkMetadata } from './knowledge-doc-chunk.model'
-import type { KnowledgeChunkingDecision } from './knowledge-chunking.model'
+import type { KnowledgeChunkingDecision, KnowledgeChunkLanguageDecision } from './knowledge-chunking.model'
 
 export interface KnowledgeChunkPreviewInput {
   text: string
@@ -12,6 +12,7 @@ export interface KnowledgeChunkPreviewInput {
 export interface KnowledgeChunkPreviewResult {
   chunks: IKnowledgeDocumentChunk<IDocChunkMetadata>[]
   decisions?: KnowledgeChunkingDecision[]
+  languages?: KnowledgeChunkLanguageDecision[]
 }
 
 /** Only copy configured defaults; do not turn built-in defaults into document overrides. */
@@ -22,6 +23,7 @@ export function knowledgebaseDocumentParserDefaults(
   if (!config) return {}
   return {
     ...(config.questionGeneration ? { questionGeneration: { ...config.questionGeneration } } : {}),
+    ...(config.chunkLanguageHint !== undefined ? { chunkLanguageHint: config.chunkLanguageHint } : {}),
     ...(config.maxChunkTokens !== undefined ? { maxChunkTokens: config.maxChunkTokens } : {}),
     ...(config.chunkSize != null ? { chunkSize: config.chunkSize } : {}),
     ...(config.chunkOverlap != null ? { chunkOverlap: config.chunkOverlap } : {}),

--- a/packages/contracts/src/ai/knowledge-parser.spec.ts
+++ b/packages/contracts/src/ai/knowledge-parser.spec.ts
@@ -1,6 +1,15 @@
 import { decodeKnowledgeSeparators, knowledgebaseDocumentParserDefaults } from './knowledge-parser.model'
 
 describe('knowledge parser shared configuration', () => {
+  it('copies public language hints while leaving old configurations unset', () => {
+    const defaults = { chunkSize: 512, chunkOverlap: 0, delimiter: null }
+    expect(knowledgebaseDocumentParserDefaults(defaults).chunkLanguageHint).toBeUndefined()
+    for (const chunkLanguageHint of ['auto', 'Chinese', 'English'] as const) {
+      const config = knowledgebaseDocumentParserDefaults({ ...defaults, chunkLanguageHint })
+      expect(config.chunkLanguageHint).toBe(chunkLanguageHint)
+      expect(config.textSplitter).not.toHaveProperty('chunkLanguageHint')
+    }
+  })
   it('copies token budgets including an explicit opt-out without creating an override for old settings', () => {
     const defaults = { chunkSize: 512, chunkOverlap: 0, delimiter: null }
     expect(knowledgebaseDocumentParserDefaults(defaults)).not.toHaveProperty('maxChunkTokens')

--- a/packages/contracts/src/ai/knowledge-pipeline.ts
+++ b/packages/contracts/src/ai/knowledge-pipeline.ts
@@ -57,6 +57,8 @@ export interface IDocumentProcessorProvider extends IDocumentNodeProvider {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IDocumentChunkerProvider extends IDocumentNodeProvider {
   structure?: KnowledgeStructureEnum
+  /** Opt into the public language context without changing legacy token/structure capabilities. */
+  supportsLanguageHint?: boolean
   /** Optional capabilities; absence keeps the legacy provider form and execution behavior. */
   chunkingCapabilities?: {
     size: 'target' | 'strategy-dependent' | 'maximum'

--- a/packages/contracts/src/ai/knowledgebase.model.ts
+++ b/packages/contracts/src/ai/knowledgebase.model.ts
@@ -1,3 +1,4 @@
+import type { KnowledgeChunkLanguageHint } from './knowledge-chunking.model'
 import type { KnowledgeQuestionGenerationConfig } from './knowledge-question.model'
 import type { TKBRetrievalSettings } from './xpert.model'
 import { ICopilotModel } from './copilot-model.model'
@@ -71,6 +72,8 @@ export enum KnowledgeStructureEnum {
 export type KnowledgebaseParserConfig = {
   /** Additional cl100k_base token cap for text retrieval chunks; 0 disables it. Context parents are retained. */
   maxChunkTokens?: number
+  /** Public natural-language boundary hint; absence means auto. */
+  chunkLanguageHint?: KnowledgeChunkLanguageHint
   questionGeneration?: KnowledgeQuestionGenerationConfig
   pages?: number[][]
   embeddingBatchSize?: number

--- a/packages/plugin-sdk/src/lib/rag/textsplitter/strategy.interface.ts
+++ b/packages/plugin-sdk/src/lib/rag/textsplitter/strategy.interface.ts
@@ -1,15 +1,27 @@
-import { IDocumentChunkerProvider, KnowledgeChunkingDecision, KnowledgeStructureEnum } from '@xpert-ai/contracts'
+import {
+  IDocumentChunkerProvider,
+  KnowledgeChunkingDecision,
+  KnowledgeChunkLanguage,
+  KnowledgeChunkLanguageHint,
+  KnowledgeChunkLanguageDecision,
+  KnowledgeStructureEnum
+} from '@xpert-ai/contracts'
 import { DocumentInterface } from '@langchain/core/documents'
 import { ChunkMetadata } from '../types'
 
 export interface TextSplitterExecutionContext {
   /** Public parser-level token cap. Providers must not persist a second copy in their own options. */
   maxChunkTokens?: number
+  languageHint?: KnowledgeChunkLanguageHint
+  /** Resolved once at the execution boundary, shared by all fragments of a document. */
+  resolvedLanguage?: KnowledgeChunkLanguage
+  resolvedLanguages?: ReadonlyMap<DocumentInterface, KnowledgeChunkLanguage>
 }
 
 export interface TextSplitterResult {
   chunks: DocumentInterface<ChunkMetadata>[]
   decisions?: KnowledgeChunkingDecision[]
+  languages?: KnowledgeChunkLanguageDecision[]
 }
 
 /**

--- a/packages/server-ai/src/knowledge-document/chunk-language-execution.spec.ts
+++ b/packages/server-ai/src/knowledge-document/chunk-language-execution.spec.ts
@@ -1,0 +1,226 @@
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+    ...jest.requireActual('../../../plugin-sdk/src/lib/ai-model/utils/tokenizer'),
+    TextSplitterStrategy: () => () => undefined
+}))
+
+import { Document } from '@langchain/core/documents'
+import { KnowledgeStructureEnum, type KnowledgeChunkLanguageHint } from '@xpert-ai/contracts'
+import { countTextTokens, type ChunkMetadata } from '@xpert-ai/plugin-sdk'
+import * as language from './chunk-language'
+import {
+    executeKnowledgeSplitter,
+    resolveKnowledgeLanguage,
+    type KnowledgeSplitterExecutionContext
+} from './execute-splitter'
+import { splitKnowledgeDocuments } from './split-documents'
+import { RecursiveCharacterStrategy } from '../knowledgebase/plugins/textsplitter-common/recursive-character.strategy'
+import { MarkdownRecursiveStrategy } from '../knowledgebase/plugins/textsplitter-common/markdown-recursive.strategy'
+import { StructureAwareStrategy } from '../knowledgebase/plugins/textsplitter-common/structure-aware.strategy'
+import { AutoTextSplitterStrategy } from '../knowledgebase/plugins/textsplitter-common/auto.strategy'
+import { ParentChildStrategy } from '../knowledgebase/plugins/textsplitter-common/parent-child.strategy'
+
+const recursive = new RecursiveCharacterStrategy()
+const markdown = new MarkdownRecursiveStrategy()
+const structured = new StructureAwareStrategy(recursive)
+const auto = new AutoTextSplitterStrategy(structured, markdown, recursive)
+const source = (pageContent: string, documentId = 'doc') =>
+    new Document<ChunkMetadata>({
+        pageContent,
+        metadata: { chunkId: 'source', documentId, contentFormat: 'markdown' }
+    })
+const texts = (result: Awaited<ReturnType<typeof executeKnowledgeSplitter>>) =>
+    result.chunks.map((doc) => doc.pageContent)
+
+afterEach(() => jest.restoreAllMocks())
+
+it.each([auto, structured, recursive])(
+    'keeps implicit separator defaults out of $meta.name pipeline forms',
+    (strategy) => {
+        expect(strategy.meta.configSchema.properties.separators).not.toHaveProperty('default')
+    }
+)
+
+it('detects once for many fragments and chunks and separates explicit hints from actual detection', async () => {
+    const spy = jest.spyOn(language, 'detectChunkLanguage')
+    const docs = Array.from({ length: 10 }, () => source('This is the first sentence. This is the next sentence.'))
+    const result = await executeKnowledgeSplitter(
+        auto,
+        docs,
+        { chunkSize: 40, chunkOverlap: 0 },
+        { languageHint: 'Chinese' }
+    )
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(result.languages).toEqual([
+        expect.objectContaining({ languageHint: 'Chinese', detectedLanguage: 'English', resolvedLanguage: 'Chinese' })
+    ])
+    expect(result.chunks.length).toBeGreaterThan(10)
+})
+
+it('reuses one detection across converter batches within the enclosing document execution', async () => {
+    const spy = jest.spyOn(language, 'detectChunkLanguage')
+    const docs = [source('\u4e2d\u6587\u6b63\u6587\u3002'), source('English content.')]
+    const context: KnowledgeSplitterExecutionContext = {
+        documentId: 'doc',
+        languageDetection: resolveKnowledgeLanguage(recursive, docs)
+    }
+    const first = await executeKnowledgeSplitter(recursive, [docs[0]], {}, context)
+    const second = await executeKnowledgeSplitter(recursive, [docs[1]], {}, context)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(first.languages[0].detectedLanguage).toBe('Mixed')
+    expect(second.languages[0].detectedLanguage).toBe('Mixed')
+})
+
+it('does not share a language vote between unrelated document identities', async () => {
+    const spy = jest.spyOn(language, 'detectChunkLanguage')
+    const result = await executeKnowledgeSplitter(
+        auto,
+        [source('\u4e2d\u6587\u5185\u5bb9\u3002', 'zh'), source('English content.', 'en')],
+        {}
+    )
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(result.languages.map((item) => item.resolvedLanguage)).toEqual(['Chinese', 'English'])
+})
+
+it.each([
+    ['Plain natural text.', 'recursive-character'],
+    ['# Heading\n\nNatural text.', 'markdown-recursive'],
+    ['# Heading\n\n- First item\n- Second item', 'structure-aware']
+])('never uses language to change Auto routing: %s', async (text, strategy) => {
+    for (const languageHint of ['auto', 'Chinese', 'English'] as const) {
+        const result = await executeKnowledgeSplitter(auto, [source(text)], {}, { languageHint })
+        expect(result.decisions[0].resolvedStrategy).toBe(strategy)
+    }
+})
+
+it.each([recursive, markdown, structured])('respects explicit separators with $meta.name', async (strategy) => {
+    const doc = source('# Manual\n\nFirst; second; third; fourth; fifth; sixth; seventh; eighth; ninth; last.')
+    const options = { chunkSize: 28, chunkOverlap: 0, separators: [';'] }
+    const chinese = await executeKnowledgeSplitter(strategy, [doc], options, { languageHint: 'Chinese' })
+    const english = await executeKnowledgeSplitter(strategy, [doc], options, { languageHint: 'English' })
+    expect(texts(chinese)).toEqual(texts(english))
+})
+
+it.each([recursive, markdown, structured])(
+    'splits long Chinese/English prose with hard token limits: $meta.name',
+    async (strategy) => {
+        for (const [languageHint, sentence] of [
+            ['Chinese', '\u8fd9\u662f\u4e00\u4e2a\u81ea\u7136\u7684\u4e2d\u6587\u53e5\u5b50\u3002'],
+            ['English', 'This is one natural English sentence. ']
+        ] satisfies [KnowledgeChunkLanguageHint, string][]) {
+            const result = await executeKnowledgeSplitter(
+                strategy,
+                [source('# Manual\n\n' + sentence.repeat(25))],
+                { chunkSize: 120, chunkOverlap: 0 },
+                { languageHint, maxChunkTokens: 48 }
+            )
+            expect(result.chunks.length).toBeGreaterThan(1)
+            expect(result.chunks.every((chunk) => countTextTokens(chunk.pageContent) <= 48)).toBe(true)
+            const prose = result.chunks.filter((chunk) => chunk.pageContent.includes(sentence.trim()))
+            expect(prose.length).toBeGreaterThan(1)
+            expect(prose.every((chunk) => /[.\u3002]$/.test(chunk.pageContent.trim()))).toBe(true)
+        }
+    }
+)
+
+it.each([recursive, markdown, structured])(
+    'does not introduce language cuts into structural blocks: $meta.name',
+    async (strategy) => {
+        const table = '| A | B |\n| --- | --- |\n| x; y | z. |'
+        const code = '```js\nconst x = "first; second. third";\n```'
+        const formula = '$$\na; b = c.d\n$$'
+        const list = '- first; second.\n- third; fourth.'
+        const doc = source(['# Manual', table, code, formula, list].join('\n\n'))
+        for (const languageHint of ['Chinese', 'English'] as const) {
+            const result = await executeKnowledgeSplitter(
+                strategy,
+                [doc],
+                { chunkSize: 80, chunkOverlap: 0 },
+                { languageHint }
+            )
+            for (const block of [table, code, formula, list])
+                expect(texts(result).some((text) => text.includes(block))).toBe(true)
+        }
+    }
+)
+
+it.each([recursive, markdown, structured, auto])(
+    'preserves bracket formulas that fit the budget beside prose: $meta.name',
+    async (strategy) => {
+        const formula = '\\[\nalpha; beta; gamma; delta = epsilon\n\\]'
+        const doc = source('Short introduction.\n\n' + formula + '\n\nClosing description.')
+        for (const languageHint of ['Chinese', 'English'] as const) {
+            const result = await executeKnowledgeSplitter(
+                strategy,
+                [doc],
+                { chunkSize: 45, chunkOverlap: 0 },
+                { languageHint }
+            )
+            expect(texts(result).some((text) => text.includes(formula))).toBe(true)
+            if (strategy === auto) expect(result.decisions[0].resolvedStrategy).toBe('recursive-character')
+        }
+    }
+)
+
+it('preserves public configuration precedence and rejects invalid hints before executing', async () => {
+    const registry = { get: () => recursive }
+    const result = await splitKnowledgeDocuments(
+        registry,
+        { type: 'txt', parserConfig: { chunkLanguageHint: 'English', textSplitterType: 'recursive-character' } },
+        [source('\u4e2d\u6587\u6b63\u6587\u3002')],
+        { chunkLanguageHint: 'Chinese' }
+    )
+    expect(result.languages[0]).toMatchObject({
+        languageHint: 'English',
+        detectedLanguage: 'Chinese',
+        resolvedLanguage: 'English'
+    })
+    const invalid = { languageHint: 'French' } as unknown as KnowledgeSplitterExecutionContext
+    await expect(executeKnowledgeSplitter(recursive, [source('Text.')], {}, invalid)).rejects.toThrow()
+})
+
+it('defaults old configs to auto without mutating source documents or parser configs', async () => {
+    const doc = source('\u4e2d\u6587\u6b63\u6587\u3002')
+    const config = { chunkSize: 100, chunkOverlap: 0 }
+    const before = JSON.stringify({ doc, config })
+    const result = await executeKnowledgeSplitter(auto, [doc], config)
+    expect(result.languages[0]).toMatchObject({ languageHint: 'auto', resolvedLanguage: 'Chinese' })
+    expect(JSON.stringify({ doc, config })).toBe(before)
+})
+
+it('detects raw document prose once before whitespace preprocessing, just like the loader', async () => {
+    const spy = jest.spyOn(language, 'detectChunkLanguage')
+    const doc = source('\u4e2d\u6587\u6b63\u6587\n\nEnglish prose')
+    doc.metadata.contentFormat = 'text'
+    const result = await splitKnowledgeDocuments(
+        { get: () => recursive },
+        {
+            type: 'txt',
+            parserConfig: { textSplitterType: 'recursive-character', replaceWhitespace: true }
+        },
+        [doc]
+    )
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(result.languages[0].detectedLanguage).toBe('Mixed')
+})
+
+it('preserves fenced code in plain text without changing the auto strategy', async () => {
+    const code = '```js\nconst value = "a; b. C";\n```'
+    const doc = source('An introductory sentence.\n\n' + code + '\n\n' + 'More prose. '.repeat(20))
+    doc.metadata.contentFormat = 'text'
+    const result = await executeKnowledgeSplitter(auto, [doc], { chunkSize: 60, chunkOverlap: 0 })
+    expect(result.decisions[0].resolvedStrategy).toBe('recursive-character')
+    expect(texts(result).some((text) => text.includes(code))).toBe(true)
+})
+
+it('does not invoke detection or alter the parent-child strategy', async () => {
+    const spy = jest.spyOn(language, 'detectChunkLanguage')
+    const parentChild = new ParentChildStrategy()
+    expect(parentChild.structure).toBe(KnowledgeStructureEnum.ParentChild)
+    const doc = source('First sentence. Second sentence. Third sentence.')
+    const options = { parent: { maxChars: 100 }, child: { maxChars: 20 } }
+    const first = await executeKnowledgeSplitter(parentChild, [doc], options, { languageHint: 'Chinese' })
+    const second = await executeKnowledgeSplitter(parentChild, [doc], options, { languageHint: 'English' })
+    expect(texts(first)).toEqual(texts(second))
+    expect(spy).not.toHaveBeenCalled()
+    expect(first.languages).toBeUndefined()
+})

--- a/packages/server-ai/src/knowledge-document/chunk-language.spec.ts
+++ b/packages/server-ai/src/knowledge-document/chunk-language.spec.ts
@@ -1,0 +1,161 @@
+import { Document } from '@langchain/core/documents'
+import type { ChunkMetadata } from '@xpert-ai/plugin-sdk'
+import { detectChunkLanguage, LANGUAGE_SAMPLE_CODE_UNITS } from './chunk-language'
+import { sentenceRanges } from '../knowledgebase/plugins/textsplitter-common/language-boundaries'
+
+const source = (pageContent: string) =>
+    new Document<ChunkMetadata>({
+        pageContent,
+        metadata: { chunkId: 'source', contentFormat: 'markdown' }
+    })
+
+describe('bounded natural-language detection', () => {
+    it.each([
+        [
+            '\u77e5\u8bc6\u5e93\u652f\u6301\u6587\u6863\u5207\u7247\u3002\u8fd9\u662f\u4e00\u4efd\u4e2d\u6587\u8bf4\u660e\u3002',
+            'Chinese'
+        ],
+        ['The document describes how to configure a knowledge base. Keep the original text.', 'English'],
+        [
+            '\u901a\u8fc7 API LLM MCP HTTP JSON REST SDK SQL \u914d\u7f6e\u8bf7\u6c42\u3002\u6b63\u6587\u4fdd\u6301\u4e2d\u6587\u3002',
+            'Chinese'
+        ],
+        ['This document explains the configuration and includes the term \u4e2d\u6587 for reference.', 'English'],
+        ['\u8fd9\u662f\u4e2d\u6587\u6bb5\u843d\u3002\n\nThis is an English paragraph.', 'Mixed'],
+        ['123456789 100.01\n\nhttps://example.com/english/only\n\n$$ x = alphabet $$', undefined]
+    ])('classifies natural units and then votes: %#', (text, language) => {
+        expect(detectChunkLanguage([source(text)]).detectedLanguage).toBe(language)
+    })
+
+    it('ignores fenced code, inline code, formulas, tables and link destinations, including code inside lists', () => {
+        const noise = 'This is an English sentence. '.repeat(60)
+        const text =
+            `# \u4e2d\u6587\u6807\u9898\n\n\u6b63\u6587\u4ecb\u7ecd\u77e5\u8bc6\u5e93\u3002\n\n\`\`\`js\n${noise}\n\`\`\`\n\n` +
+            `- \u4e2d\u6587\u5217\u8868\u5185\u5bb9\u3002\n\n    \`\`\`js\n    ${noise}\n    \`\`\`\n\n` +
+            `\u8bf7\u9605\u8bfb[\u8bf4\u660e](https://example.com/english/path)\uff0c\u5ffd\u7565 \`${noise}\` \u548c $alpha + beta$\u3002\n\n` +
+            `$$\n${noise}\n$$\n\n| English | Values |\n| --- | --- |\n| ${noise} | ${noise} |`
+        expect(detectChunkLanguage([source(text)]).detectedLanguage).toBe('Chinese')
+    })
+
+    it.each(['\u3002', '\uff01', '\uff1f', '\uff1b', '\uff0c', '\u3001'])(
+        'retains Chinese prose immediately after a URL and CJK punctuation: %s',
+        (punctuation) => {
+            const prose = '\u4e2d\u6587\u6b63\u6587\u4ecb\u7ecd\u914d\u7f6e\u6b65\u9aa4\u3002'.repeat(5)
+            const result = detectChunkLanguage([source('# API Guide\n\nhttps://example.com' + punctuation + prose)])
+            expect(result.detectedLanguage).toBe('Chinese')
+            expect(result.naturalUnits).toBeGreaterThanOrEqual(6)
+        }
+    )
+
+    it('does not let the absolute length of a Latin word outvote Chinese prose', () => {
+        const term = 'Internationalization'.repeat(20)
+        expect(
+            detectChunkLanguage([
+                source(`\u4e2d\u6587\u6b63\u6587\u4ecb\u7ecd ${term} \u7684\u4f7f\u7528\u65b9\u6cd5\u3002`)
+            ]).detectedLanguage
+        ).toBe('Chinese')
+    })
+
+    it('does not interpret dollar strings inside code as formula delimiters for the following prose', () => {
+        const text = '```js\nconst marker = "$$";\n```\n\n\u8fd9\u662f\u4e2d\u6587\u6b63\u6587\u3002'
+        expect(detectChunkLanguage([source(text)]).detectedLanguage).toBe('Chinese')
+    })
+
+    it('bounds source reads and parsing even for a multi-megabyte document', () => {
+        const text = '\u8fd9\u662f\u4e2d\u6587\u6bb5\u843d\u3002'.repeat(500_000)
+        const result = detectChunkLanguage([
+            source(text),
+            {
+                get pageContent(): string {
+                    throw new Error('must not read beyond the sample budget')
+                },
+                metadata: { chunkId: 'later' }
+            }
+        ])
+        expect(result.sampledCodeUnits).toBe(LANGUAGE_SAMPLE_CODE_UNITS)
+        expect(Buffer.byteLength(text.slice(0, result.sampledCodeUnits))).toBeLessThanOrEqual(64 * 1024)
+        expect(result.detectedLanguage).toBe('Chinese')
+    })
+
+    it('does not mistake an unfinished code fence at the sampling boundary for prose', () => {
+        const result = detectChunkLanguage([
+            source('```text\n' + 'English source code. '.repeat(5000) + '\n```\n\u4e2d\u6587')
+        ])
+        expect(result.sampledCodeUnits).toBe(LANGUAGE_SAMPLE_CODE_UNITS)
+        expect(result.naturalUnits).toBe(0)
+        expect(result.detectedLanguage).toBeUndefined()
+    })
+
+    it('samples the whole small document across source fragments', () => {
+        const documents = [source('\u4e2d\u6587\u5185\u5bb9\u3002'), source('This is English content.')]
+        const result = detectChunkLanguage(documents)
+        expect(result.sampledCodeUnits).toBe(documents.reduce((sum, doc) => sum + doc.pageContent.length, 0))
+        expect(result.detectedLanguage).toBe('Mixed')
+    })
+
+    it('ignores formulas that exceed the sample budget, and layout blocks explicitly marked as formulas', () => {
+        expect(detectChunkLanguage([source('$$\n' + 'alpha + beta '.repeat(10000) + '\n$$')]).naturalUnits).toBe(0)
+        const formula = source('alpha beta gamma')
+        formula.metadata.documentLayout = {
+            schemaVersion: 1,
+            type: 'formula',
+            blockId: 'formula',
+            page: 1,
+            pageWidth: 600,
+            pageHeight: 800,
+            order: 0
+        }
+        expect(detectChunkLanguage([formula, source('\u4e2d\u6587\u6b63\u6587\u3002')]).detectedLanguage).toBe(
+            'Chinese'
+        )
+    })
+})
+
+describe('sentence boundaries', () => {
+    it('adds Chinese semicolon boundaries without damaging text or quoted sentence endings', () => {
+        const text = '\u7b2c\u4e00\u53e5\uff1b\u7b2c\u4e8c\u53e5\u3002\u201d\u7b2c\u4e09\u53e5\uff01'
+        const parts = sentenceRanges(text, 'Chinese').map((range) => text.slice(range.start, range.end))
+        expect(parts[0]).toBe('\u7b2c\u4e00\u53e5\uff1b')
+        expect(parts).toContain('\u7b2c\u4e8c\u53e5\u3002\u201d')
+        expect(parts.join('')).toBe(text)
+    })
+
+    it('protects inline code, formulas and URLs from newly introduced language boundaries', () => {
+        const text = 'Read `a; b. C` and $a; b$ at https://example.com/a;b before proceeding. Then continue.'
+        const parts = sentenceRanges(text, 'Mixed').map((range) => text.slice(range.start, range.end))
+        expect(parts).toHaveLength(2)
+        expect(parts[0]).toContain('https://example.com/a;b')
+    })
+
+    it('retains Chinese sentence boundaries after a bare URL without whitespace', () => {
+        const url = 'https://example.com/a;b'
+        const prose = '\u7b2c\u4e00\u53e5\u4e2d\u6587\u3002\u7b2c\u4e8c\u53e5\u4e2d\u6587\uff01'
+        const text = url + '\u3002' + prose
+        const parts = sentenceRanges(text, 'Chinese').map((range) => text.slice(range.start, range.end))
+        expect(parts).toEqual([
+            url + '\u3002',
+            '\u7b2c\u4e00\u53e5\u4e2d\u6587\u3002',
+            '\u7b2c\u4e8c\u53e5\u4e2d\u6587\uff01'
+        ])
+        expect(parts.join('')).toBe(text)
+    })
+
+    it('keeps international URL paths and explicit Markdown links protected', () => {
+        const url = 'https://\u4f8b\u5b50.\u6d4b\u8bd5/\u6587\u6863;a?x=1'
+        const link = '[\u8bf4\u660e](https://example.com/\u8def\u5f84\u3002\u7ec8\u70b9)'
+        const text = url + '\u3002' + link + '\u3002'
+        const parts = sentenceRanges(text, 'Chinese').map((range) => text.slice(range.start, range.end))
+        expect(parts).toEqual([url + '\u3002', link + '\u3002'])
+    })
+
+    it('has a deterministic fallback when Intl.Segmenter is unavailable', () => {
+        const original = Object.getOwnPropertyDescriptor(Intl, 'Segmenter')
+        try {
+            Object.defineProperty(Intl, 'Segmenter', { value: undefined, configurable: true })
+            expect(sentenceRanges('One sentence. Another sentence!', 'English')).toHaveLength(2)
+            expect(sentenceRanges('\u4e00\u53e5\u3002\u4e8c\u53e5\uff1b\u4e09\u53e5\uff01', 'Chinese')).toHaveLength(3)
+        } finally {
+            Object.defineProperty(Intl, 'Segmenter', original)
+        }
+    })
+})

--- a/packages/server-ai/src/knowledge-document/chunk-language.ts
+++ b/packages/server-ai/src/knowledge-document/chunk-language.ts
@@ -1,0 +1,54 @@
+import type { DocumentInterface } from '@langchain/core/documents'
+import type { KnowledgeChunkLanguage, KnowledgeChunkLanguageDetection } from '@xpert-ai/contracts'
+import type { ChunkMetadata } from '@xpert-ai/plugin-sdk'
+import { naturalLanguageUnits } from '../knowledgebase/plugins/textsplitter-common/structured-document'
+import { LANGUAGE_URL_PATTERN, sentenceRanges } from '../knowledgebase/plugins/textsplitter-common/language-boundaries'
+
+/** At most 32 KiB UTF-16 / 48 KiB UTF-8, including skipped Markdown syntax. No full-document copy or scan. */
+export const LANGUAGE_SAMPLE_CODE_UNITS = 16 * 1024
+
+export function detectChunkLanguage(
+    documents: Iterable<DocumentInterface<ChunkMetadata>>
+): KnowledgeChunkLanguageDetection {
+    const votes = { Chinese: 0, English: 0, Mixed: 0 }
+    let sampledCodeUnits = 0
+    for (const document of documents) {
+        if (sampledCodeUnits >= LANGUAGE_SAMPLE_CODE_UNITS) break
+        if (document.metadata.mediaType && document.metadata.mediaType !== 'text') continue
+        const layout = document.metadata.documentLayout
+        if (layout && layout.type !== 'text' && layout.type !== 'title') continue
+        let end = Math.min(document.pageContent.length, LANGUAGE_SAMPLE_CODE_UNITS - sampledCodeUnits)
+        if (end < document.pageContent.length && /[\uD800-\uDBFF]/.test(document.pageContent[end - 1] ?? '')) end--
+        const text = document.pageContent.slice(0, end)
+        sampledCodeUnits += end
+        for (const unit of naturalLanguageUnits({ pageContent: text, metadata: document.metadata })) {
+            const natural = unit
+                .replace(LANGUAGE_URL_PATTERN, ' ')
+                .replace(/\b[\w.+-]+@[\w.-]+\.\w+\b|\$[^$\n]*\$|\\\([\s\S]*?\\\)/g, ' ')
+            for (const range of sentenceRanges(natural, 'Mixed')) {
+                const language = classifyNaturalUnit(natural.slice(range.start, range.end))
+                if (language) votes[language]++
+            }
+        }
+    }
+    const naturalUnits = votes.Chinese + votes.English + votes.Mixed
+    const detectedLanguage = !naturalUnits
+        ? undefined
+        : votes.Chinese / naturalUnits >= 0.8
+          ? 'Chinese'
+          : votes.English / naturalUnits >= 0.8
+            ? 'English'
+            : 'Mixed'
+    return { detectedLanguage, sampledCodeUnits, naturalUnits }
+}
+
+function classifyNaturalUnit(text: string): KnowledgeChunkLanguage | undefined {
+    const han = [...text.matchAll(/\p{Script=Han}/gu)].length
+    const latin = [...text.matchAll(/\p{Script=Latin}+/gu)].map((match) => match[0])
+    if (!han) return latin.length ? 'English' : undefined
+    if (!latin.length) return 'Chinese'
+    // Compare Han characters to Latin words, not letters. Short uppercase terms are neutral inside Chinese prose.
+    const words = latin.filter((word) => !/^[A-Z]{2,8}$/.test(word)).length
+    const chineseShare = han / (han + words)
+    return chineseShare >= 0.7 ? 'Chinese' : chineseShare <= 0.2 ? 'English' : 'Mixed'
+}

--- a/packages/server-ai/src/knowledge-document/chunking-revision.ts
+++ b/packages/server-ai/src/knowledge-document/chunking-revision.ts
@@ -1,9 +1,10 @@
 import { KNOWLEDGE_CHUNKING_ALGORITHM_VERSION } from '@xpert-ai/contracts'
 
-/** New strategy revisions participate in processing/cache fingerprints without changing legacy hashes. */
+/** Reprocessing picks up language boundaries; existing chunks and parent-child fingerprints stay untouched. */
 export function knowledgeChunkingRevision(provider?: string): string | undefined {
-    // Version 3 also expires structured-2 entries that incorrectly carried version 1 diagnostics.
     return provider === 'auto' || provider === 'structure-aware'
         ? `structured-${KNOWLEDGE_CHUNKING_ALGORITHM_VERSION}`
-        : undefined
+        : provider === 'recursive-character' || provider === 'markdown-recursive'
+          ? 'language-1'
+          : undefined
 }

--- a/packages/server-ai/src/knowledge-document/commands/handlers/load.handler.spec.ts
+++ b/packages/server-ai/src/knowledge-document/commands/handlers/load.handler.spec.ts
@@ -9,8 +9,64 @@ import { RecursiveCharacterStrategy } from '../../../knowledgebase/plugins/texts
 import { countTextTokens } from '@xpert-ai/plugin-sdk'
 import { computeObjectHash } from '@xpert-ai/server-core'
 import { pick } from '@xpert-ai/server-common'
+import * as language from '../../chunk-language'
 
 describe('KnowledgeDocLoadHandler', () => {
+    it('detects once across batches and invalidates batch caches when the public hint or document language changes', async () => {
+        const detector = jest.spyOn(language, 'detectChunkLanguage')
+        const handler = new KnowledgeDocLoadHandler({} as KnowledgebaseService, {} as CommandBus, {} as QueryBus)
+        const first = new Document({ pageContent: 'Common introduction.', metadata: { chunkId: 'first' } })
+        let body = 'This is the English body. It has multiple sentences. These sentences describe configuration.'
+        const cache = new Map<string, Awaited<ReturnType<KnowledgeDocLoadHandler['splitDocuments']>>>()
+        Object.assign(handler, {
+            knowledgeWorkAreaResolver: { resolve: async () => ({ volume: {}, tmpPath: { serverPath: '/tmp' } }) },
+            transformSnapshotService: {
+                load: async () => [
+                    { chunks: [first] },
+                    { chunks: [new Document({ pageContent: body, metadata: { chunkId: 'body' } })] }
+                ]
+            },
+            textSplitterRegistry: { get: () => new RecursiveCharacterStrategy() },
+            cacheManager: {
+                get: async (key: string) => cache.get(key),
+                set: async (key: string, value: Awaited<ReturnType<KnowledgeDocLoadHandler['splitDocuments']>>) =>
+                    cache.set(key, value)
+            }
+        })
+        const split = jest.spyOn(handler, 'splitDocuments')
+        const run = (chunkLanguageHint: 'auto' | 'Chinese' = 'auto') =>
+            handler.execute(
+                new KnowledgeDocLoadCommand({
+                    doc: {
+                        id: 'doc',
+                        knowledgebaseId: 'kb',
+                        type: 'txt',
+                        name: 'text.txt',
+                        filePath: 'text.txt',
+                        parserConfig: {
+                            chunkLanguageHint,
+                            chunkSize: 80,
+                            chunkOverlap: 0,
+                            imageUnderstandingEnabled: false
+                        }
+                    } as IKnowledgeDocument,
+                    mode: 'rechunk',
+                    stage: 'test'
+                })
+            )
+        await run()
+        expect(detector).toHaveBeenCalledTimes(1)
+        expect(split).toHaveBeenCalledTimes(2)
+        await run()
+        expect(split).toHaveBeenCalledTimes(2)
+        await run('Chinese')
+        expect(split).toHaveBeenCalledTimes(4)
+        body = '\u8fd9\u662f\u4e2d\u6587\u6b63\u6587\u3002'.repeat(10)
+        await run()
+        // Even the unchanged introduction must use the new document-level language decision.
+        expect(split).toHaveBeenCalledTimes(6)
+        expect(detector).toHaveBeenCalledTimes(4)
+    })
     it('reuses chunk cache only while the token cap is unchanged, including when disabling it', async () => {
         const handler = new KnowledgeDocLoadHandler(
             {} as unknown as KnowledgebaseService,
@@ -225,7 +281,7 @@ describe('KnowledgeDocLoadHandler', () => {
             expect.objectContaining({
                 chunkSize: 1000,
                 chunkOverlap: 200,
-                separators: '\\n\\n,\\n, ,'
+                separators: undefined
             })
         )
         expect(result).toEqual({ chunks })

--- a/packages/server-ai/src/knowledge-document/commands/handlers/load.handler.ts
+++ b/packages/server-ai/src/knowledge-document/commands/handlers/load.handler.ts
@@ -1,8 +1,10 @@
 import { splitKnowledgeDocuments } from '../../split-documents'
+import { resolveKnowledgeLanguage, type KnowledgeSplitterExecutionContext } from '../../execute-splitter'
 import { knowledgeChunkingRevision } from '../../chunking-revision'
 import { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import {
     DocumentSheetParserConfig,
+    DEFAULT_KNOWLEDGE_TEXT_SPLITTER,
     DocumentTextParserConfig,
     IKnowledgeDocument,
     IKnowledgeDocumentChunk,
@@ -214,9 +216,18 @@ export class KnowledgeDocLoadHandler implements ICommandHandler<KnowledgeDocLoad
             }
 
             const chunks = []
+            const languageDetection = resolveKnowledgeLanguage(
+                this.textSplitterRegistry?.get(docParserConfig.textSplitterType || DEFAULT_KNOWLEDGE_TEXT_SPLITTER),
+                {
+                    *[Symbol.iterator]() {
+                        for (const item of transformed) yield* item.chunks ?? []
+                    }
+                }
+            )
             for await (const transItem of transformed) {
                 // Chunker with caching
                 const chunkerCacheConfig = {
+                    ...(languageDetection ? { detectedLanguage: languageDetection.detectedLanguage ?? null } : {}),
                     ...(knowledgeChunkingRevision(docParserConfig.textSplitterType)
                         ? { chunkingRevision: knowledgeChunkingRevision(docParserConfig.textSplitterType) }
                         : {}),
@@ -225,6 +236,7 @@ export class KnowledgeDocLoadHandler implements ICommandHandler<KnowledgeDocLoad
                         'textSplitterType',
                         'textSplitter',
                         'maxChunkTokens',
+                        'chunkLanguageHint',
                         'replaceWhitespace',
                         'removeSensitive'
                     ]),
@@ -237,7 +249,9 @@ export class KnowledgeDocLoadHandler implements ICommandHandler<KnowledgeDocLoad
                 if (!splitted) {
                     splitted = await this.splitDocuments(
                         doc,
-                        transItem.chunks as IKnowledgeDocumentChunk<TDocChunkMetadata>[]
+                        transItem.chunks as IKnowledgeDocumentChunk<TDocChunkMetadata>[],
+                        undefined,
+                        { languageDetection }
                     )
                     await this.cacheManager.set(cacheKey, splitted, 60 * 10 * 1000) // 10 min
                 }
@@ -418,9 +432,10 @@ export class KnowledgeDocLoadHandler implements ICommandHandler<KnowledgeDocLoad
     async splitDocuments(
         document: IKnowledgeDocument,
         chunks: IKnowledgeDocumentChunk<TDocChunkMetadata>[],
-        parserConfig?: DocumentTextParserConfig
+        parserConfig?: DocumentTextParserConfig,
+        context?: Pick<KnowledgeSplitterExecutionContext, 'languageDetection'>
     ) {
-        return splitKnowledgeDocuments(this.textSplitterRegistry, document, chunks, parserConfig)
+        return splitKnowledgeDocuments(this.textSplitterRegistry, document, chunks, parserConfig, context)
     }
 
     async loadSheet(doc: IKnowledgeDocument, volumeClient: VolumeHandle): Promise<Record<string, any>[]> {

--- a/packages/server-ai/src/knowledge-document/execute-splitter.spec.ts
+++ b/packages/server-ai/src/knowledge-document/execute-splitter.spec.ts
@@ -86,7 +86,11 @@ it('honors explicit pipeline zero over inherited limits and removes the envelope
         { chunkSize: 1000, chunkOverlap: 0, maxChunkTokens: 0 },
         { maxChunkTokens: 8 }
     )
-    expect(spy).toHaveBeenLastCalledWith(expect.any(Array), { chunkSize: 1000, chunkOverlap: 0 }, { maxChunkTokens: 0 })
+    expect(spy).toHaveBeenLastCalledWith(
+        expect.any(Array),
+        { chunkSize: 1000, chunkOverlap: 0 },
+        expect.objectContaining({ maxChunkTokens: 0 })
+    )
     spy.mockRestore()
 })
 

--- a/packages/server-ai/src/knowledge-document/execute-splitter.ts
+++ b/packages/server-ai/src/knowledge-document/execute-splitter.ts
@@ -1,4 +1,8 @@
-import { KBDocumentCategoryEnum } from '@xpert-ai/contracts'
+import {
+    KBDocumentCategoryEnum,
+    type KnowledgeChunkLanguageDetection,
+    type KnowledgeChunkLanguageDecision
+} from '@xpert-ai/contracts'
 import type {
     ITextSplitterStrategy,
     ChunkMetadata,
@@ -6,15 +10,31 @@ import type {
     TextSplitterResult
 } from '@xpert-ai/plugin-sdk'
 import type { DocumentInterface } from '@langchain/core/documents'
-import { invalidKnowledgeParserConfig, validateMaxChunkTokens } from './parser-validation'
+import { invalidKnowledgeParserConfig, validateMaxChunkTokens, validateChunkLanguageHint } from './parser-validation'
 import { limitChunkTokens } from './token-limited-chunks'
+import { detectChunkLanguage } from './chunk-language'
+
+export interface KnowledgeSplitterExecutionContext extends TextSplitterExecutionContext {
+    category?: KBDocumentCategoryEnum
+    documentId?: string
+    /** Prepared once before preprocessing/cache lookup for all batches of an enclosing document. */
+    languageDetection?: KnowledgeChunkLanguageDetection
+}
+
+/** One preparation owner for raw document samples, including loader batches and settings previews. */
+export function resolveKnowledgeLanguage(
+    strategy: ITextSplitterStrategy,
+    documents: Iterable<DocumentInterface<ChunkMetadata>>
+): KnowledgeChunkLanguageDetection | undefined {
+    return strategy?.meta?.supportsLanguageHint ? detectChunkLanguage(documents) : undefined
+}
 
 /** One execution boundary for the loader, lightweight preview and standalone pipeline chunker. */
 export async function executeKnowledgeSplitter(
     strategy: ITextSplitterStrategy,
     documents: DocumentInterface<ChunkMetadata>[],
     value: unknown,
-    context: TextSplitterExecutionContext & { category?: KBDocumentCategoryEnum; documentId?: string } = {}
+    context: KnowledgeSplitterExecutionContext = {}
 ): Promise<TextSplitterResult> {
     if (!strategy) throw invalidKnowledgeParserConfig('textSplitterType')
     if (value === undefined) value = {}
@@ -22,21 +42,60 @@ export async function executeKnowledgeSplitter(
     const envelope = 'maxChunkTokens' in value ? value.maxChunkTokens : undefined
     const maxChunkTokens = envelope === undefined ? context.maxChunkTokens : envelope
     validateMaxChunkTokens(maxChunkTokens)
+    validateChunkLanguageHint(context.languageHint)
+    const languageHint = context.languageHint ?? 'auto'
     const options = { ...value }
     if ('maxChunkTokens' in options) delete options.maxChunkTokens
+    if ('chunkLanguageHint' in options) delete options.chunkLanguageHint
+    if ('languageHint' in options) delete options.languageHint
     if (strategy.meta?.chunkingCapabilities && context.category === KBDocumentCategoryEnum.Sheet) {
         throw invalidKnowledgeParserConfig('text chunking is not applicable to spreadsheets')
     }
     await strategy.validateConfig?.(options)
-    if (strategy.meta?.chunkingCapabilities && context.documentId) {
+    if ((strategy.meta?.chunkingCapabilities || strategy.meta?.supportsLanguageHint) && context.documentId) {
         documents = documents.map((document) => ({
             ...document,
             metadata: { ...document.metadata, documentId: document.metadata.documentId || context.documentId }
         }))
     }
-    const result = strategy.meta?.chunkingCapabilities?.tokenBudget
-        ? await strategy.splitDocuments(documents, options, { maxChunkTokens })
-        : await strategy.splitDocuments(documents, options)
+    const languages: KnowledgeChunkLanguageDecision[] = []
+    const resolvedLanguages = new Map<
+        DocumentInterface<ChunkMetadata>,
+        KnowledgeChunkLanguageDecision['resolvedLanguage']
+    >()
+    if (strategy.meta?.supportsLanguageHint) {
+        const groups = new Map<string | DocumentInterface<ChunkMetadata>, number[]>()
+        documents.forEach((document, index) => {
+            const key = document.metadata.documentId || context.documentId || document
+            if (!groups.has(key)) groups.set(key, [])
+            groups.get(key).push(index)
+        })
+        for (const sourceIndexes of groups.values()) {
+            const detection =
+                context.languageDetection ??
+                resolveKnowledgeLanguage(
+                    strategy,
+                    sourceIndexes.map((index) => documents[index])
+                )
+            const resolvedLanguage = languageHint === 'auto' ? (detection.detectedLanguage ?? 'Mixed') : languageHint
+            languages.push({ ...detection, sourceIndexes, languageHint, resolvedLanguage })
+            for (const index of sourceIndexes) resolvedLanguages.set(documents[index], resolvedLanguage)
+        }
+    }
+    const executionContext: TextSplitterExecutionContext = {
+        maxChunkTokens,
+        ...(strategy.meta?.supportsLanguageHint
+            ? {
+                  languageHint,
+                  resolvedLanguage: languages.length === 1 ? languages[0].resolvedLanguage : undefined,
+                  resolvedLanguages
+              }
+            : {})
+    }
+    const result =
+        strategy.meta?.chunkingCapabilities?.tokenBudget || strategy.meta?.supportsLanguageHint
+            ? await strategy.splitDocuments(documents, options, executionContext)
+            : await strategy.splitDocuments(documents, options)
     if (strategy.meta?.chunkingCapabilities && result.chunks.length > 10000) {
         throw invalidKnowledgeParserConfig('structured output (at most 10000 chunks)')
     }
@@ -63,5 +122,5 @@ export async function executeKnowledgeSplitter(
             }
         }
     }
-    return { ...result, chunks }
+    return { ...result, chunks, ...(languages.length ? { languages } : {}) }
 }

--- a/packages/server-ai/src/knowledge-document/parser-config.spec.ts
+++ b/packages/server-ai/src/knowledge-document/parser-config.spec.ts
@@ -2,6 +2,16 @@ import { AiModelTypeEnum, KBDocumentCategoryEnum, KnowledgebaseParserConfig } fr
 import { resolveKnowledgeDocumentParserConfig } from './parser-config'
 
 describe('resolveKnowledgeDocumentParserConfig precedence', () => {
+    it('round-trips the public language hint without moving it into splitter options', () => {
+        const document = {
+            type: 'txt',
+            parserConfig: { textSplitterType: 'auto', chunkLanguageHint: 'Chinese' as const }
+        }
+        const config = resolveKnowledgeDocumentParserConfig(document)
+        expect(config).toHaveProperty('chunkLanguageHint', 'Chinese')
+        expect(config.textSplitter).not.toHaveProperty('chunkLanguageHint')
+        expect(resolveKnowledgeDocumentParserConfig({ type: 'txt', parserConfig: config })).toEqual(config)
+    })
     it('defaults text documents to auto while keeping explicit choices and spreadsheet handling', () => {
         for (const type of ['txt', 'md', 'pdf', 'docx']) {
             expect(resolveKnowledgeDocumentParserConfig({ type }).textSplitterType).toBe('auto')

--- a/packages/server-ai/src/knowledge-document/parser-config.ts
+++ b/packages/server-ai/src/knowledge-document/parser-config.ts
@@ -16,8 +16,7 @@ const DEFAULT_RECURSIVE_TEXT_SPLITTER = {
     textSplitterType: 'recursive-character',
     textSplitter: {
         chunkSize: 1000,
-        chunkOverlap: 200,
-        separators: '\\n\\n,\\n, ,'
+        chunkOverlap: 200
     }
 } satisfies DocumentParserConfig
 
@@ -164,6 +163,7 @@ function sanitizeParserConfigForDocument(
     return defined({
         pages: config.pages,
         maxChunkTokens: config.maxChunkTokens,
+        chunkLanguageHint: config.chunkLanguageHint,
         questionGeneration: config.questionGeneration,
         replaceWhitespace: config.replaceWhitespace,
         removeSensitive: config.removeSensitive,

--- a/packages/server-ai/src/knowledge-document/parser-validation.ts
+++ b/packages/server-ai/src/knowledge-document/parser-validation.ts
@@ -1,5 +1,6 @@
 import { BadRequestException } from '@nestjs/common'
 import { t } from 'i18next'
+import type { KnowledgeChunkLanguageHint } from '@xpert-ai/contracts'
 
 export function invalidKnowledgeParserConfig(field: string) {
     return new BadRequestException(
@@ -49,4 +50,10 @@ export function incompatibleKnowledgeChunkStructure() {
                 'This knowledgebase already uses a different chunk structure. Keep its structure or use a new knowledgebase.'
         })
     )
+}
+
+export function validateChunkLanguageHint(value: unknown): asserts value is KnowledgeChunkLanguageHint | undefined {
+    if (value !== undefined && value !== 'auto' && value !== 'Chinese' && value !== 'English') {
+        throw invalidKnowledgeParserConfig('chunkLanguageHint (auto, Chinese, English)')
+    }
 }

--- a/packages/server-ai/src/knowledge-document/split-documents.ts
+++ b/packages/server-ai/src/knowledge-document/split-documents.ts
@@ -8,14 +8,19 @@ import { TextSplitterRegistry } from '@xpert-ai/plugin-sdk'
 import { TDocChunkMetadata } from './types'
 import { resolveKnowledgeDocumentParserConfig } from './parser-config'
 import { invalidKnowledgeParserConfig, validateMaxChunkTokens } from './parser-validation'
-import { executeKnowledgeSplitter } from './execute-splitter'
+import {
+    executeKnowledgeSplitter,
+    resolveKnowledgeLanguage,
+    type KnowledgeSplitterExecutionContext
+} from './execute-splitter'
 
 /** Shared by persisted document processing and the read-only settings preview. */
 export async function splitKnowledgeDocuments(
     registry: Pick<TextSplitterRegistry, 'get'>,
     document: Pick<IKnowledgeDocument, 'type' | 'category' | 'parserConfig'> & { id?: string },
     chunks: IKnowledgeDocumentChunk<TDocChunkMetadata>[],
-    parserConfig?: DocumentTextParserConfig
+    parserConfig?: DocumentTextParserConfig,
+    context: Pick<KnowledgeSplitterExecutionContext, 'languageDetection'> = {}
 ) {
     const documentParserConfig = resolveKnowledgeDocumentParserConfig(document)
     const maxChunkTokens =
@@ -27,6 +32,7 @@ export async function splitKnowledgeDocuments(
         documentParserConfig.textSplitterType || parserConfig?.textSplitterType || DEFAULT_KNOWLEDGE_TEXT_SPLITTER
     const textSplitter = registry.get(textSplitterType)
     if (!textSplitter) throw invalidKnowledgeParserConfig(textSplitterType)
+    const languageDetection = context.languageDetection ?? resolveKnowledgeLanguage(textSplitter, chunks)
     const originalContents = textSplitter.meta?.chunkingCapabilities
         ? chunks.map((chunk) => chunk.pageContent)
         : undefined
@@ -105,7 +111,9 @@ export async function splitKnowledgeDocuments(
             delete options.maxChunkTokens
         }
         return executeKnowledgeSplitter(textSplitter, chunks, options, {
+            languageDetection,
             maxChunkTokens,
+            languageHint: documentParserConfig.chunkLanguageHint ?? parserConfig?.chunkLanguageHint,
             category: document.category,
             documentId: document.id
         })

--- a/packages/server-ai/src/knowledgebase/parser-settings.service.spec.ts
+++ b/packages/server-ai/src/knowledgebase/parser-settings.service.spec.ts
@@ -51,6 +51,31 @@ function setup() {
 }
 
 describe('KnowledgeParserSettingsService', () => {
+    it('returns public language diagnostics and uses the same boundaries as actual document processing', async () => {
+        const { service, splitters } = setup()
+        const text = '\u8fd9\u662f\u4e00\u4e2a\u4e2d\u6587\u53e5\u5b50\u3002'.repeat(30)
+        const parserConfig = {
+            ...defaults,
+            separators: undefined,
+            chunkSize: 80,
+            chunkLanguageHint: 'Chinese' as const,
+            maxChunkTokens: 48
+        }
+        const preview = await service.preview({ type: 'txt', text, parserConfig })
+        const actual = await splitKnowledgeDocuments(splitters, { type: 'txt', parserConfig }, [
+            new Document({ pageContent: text, metadata: { chunkId: 'source', contentFormat: 'text' } })
+        ])
+        expect(preview.languages[0]).toMatchObject({
+            languageHint: 'Chinese',
+            detectedLanguage: 'Chinese',
+            resolvedLanguage: 'Chinese'
+        })
+        expect(preview.chunks.map((chunk) => chunk.pageContent)).toEqual(
+            actual.chunks.map((chunk) => chunk.pageContent)
+        )
+        const invalid = { ...defaults, chunkLanguageHint: 'French' } as unknown as KnowledgebaseParserConfig
+        await expect(service.validateSettings(invalid)).rejects.toThrow()
+    })
     it('previews unconfigured Markdown through auto and preserves an explicit length strategy', async () => {
         const { service } = setup()
         const text = '| Name | Value |\n| --- | --- |\n| A | B |'

--- a/packages/server-ai/src/knowledgebase/parser-settings.service.ts
+++ b/packages/server-ai/src/knowledgebase/parser-settings.service.ts
@@ -14,6 +14,7 @@ import { DocumentTransformerRegistry, TextSplitterRegistry } from '@xpert-ai/plu
 import {
     invalidKnowledgeParserConfig,
     validateMaxChunkTokens,
+    validateChunkLanguageHint,
     validateSeparators
 } from '../knowledge-document/parser-validation'
 import { resolveKnowledgeDocumentParserConfig } from '../knowledge-document/parser-config'
@@ -60,6 +61,7 @@ export class KnowledgeParserSettingsService {
 
     async validateSplitter(config: DocumentParserConfig): Promise<KnowledgeStructureEnum> {
         validateMaxChunkTokens(config.maxChunkTokens)
+        validateChunkLanguageHint(config.chunkLanguageHint)
         validateQuestionGeneration(config.questionGeneration)
         const name = config.textSplitterType || DEFAULT_KNOWLEDGE_TEXT_SPLITTER
         const splitter = this.splitters.get(name)
@@ -90,6 +92,6 @@ export class KnowledgeParserSettingsService {
                 }
             })
         ])
-        return { chunks: buildChunkTree(result.chunks), ...(result.decisions ? { decisions: result.decisions } : {}) }
+        return { ...result, chunks: buildChunkTree(result.chunks) }
     }
 }

--- a/packages/server-ai/src/knowledgebase/plugins/chunker/strategy.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/chunker/strategy.ts
@@ -156,6 +156,7 @@ export class WorkflowChunkerNodeStrategy implements IWorkflowNodeStrategy {
 
                             const result = await executeKnowledgeSplitter(strategy, splitDocs, parameters, {
                                 maxChunkTokens: doc.parserConfig?.maxChunkTokens,
+                                languageHint: doc.parserConfig?.chunkLanguageHint,
                                 category: doc.category,
                                 documentId: doc.id
                             })

--- a/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/MarkdownRecursiveTextSplitter.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/MarkdownRecursiveTextSplitter.ts
@@ -1,8 +1,8 @@
 import { Document, BaseDocumentTransformer } from '@langchain/core/documents'
-import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters'
 import type { DocumentMarkdownSourceMapEntry, TDocumentAsset } from '@xpert-ai/contracts'
-import type { ChunkMetadata } from '@xpert-ai/plugin-sdk'
+import type { ChunkMetadata, TextSplitterExecutionContext } from '@xpert-ai/plugin-sdk'
 import { v4 as uuid } from 'uuid'
+import { createLanguageTextSplitter } from './language-text-splitter'
 
 export interface MarkdownHeader {
     level: number
@@ -15,6 +15,7 @@ export interface MarkdownRecursiveTextSplitterOptions {
     headersToSplitOn?: number[]
     stripHeader?: boolean // Whether to remove the header line in the chunk
     addHeadersToChunk?: boolean // Whether to add the header to the chunk content
+    separators?: string | string[]
 }
 
 /**
@@ -28,7 +29,10 @@ export class MarkdownRecursiveTextSplitter extends BaseDocumentTransformer {
     private stripHeader: boolean
     private addHeadersToChunk: boolean
 
-    constructor(options: MarkdownRecursiveTextSplitterOptions = {}) {
+    constructor(
+        private readonly options: MarkdownRecursiveTextSplitterOptions = {},
+        private readonly context?: TextSplitterExecutionContext
+    ) {
         super()
         this.chunkSize = options.chunkSize ?? 1000
         this.chunkOverlap = options.chunkOverlap ?? 200
@@ -50,10 +54,15 @@ export class MarkdownRecursiveTextSplitter extends BaseDocumentTransformer {
             const { markdownSourceMap, ...sourceMetadata } = doc.metadata as Partial<ChunkMetadata>
             let sectionSearchOffset = 0
 
-            const splitter = new RecursiveCharacterTextSplitter({
-                chunkSize: this.chunkSize,
-                chunkOverlap: this.chunkOverlap
-            })
+            const splitter = createLanguageTextSplitter(
+                {
+                    chunkSize: this.chunkSize,
+                    chunkOverlap: this.chunkOverlap,
+                    separators: this.options.separators
+                },
+                doc,
+                this.context
+            )
 
             for (const section of sections) {
                 const sectionOffset = locateContent(doc.pageContent, section.content, sectionSearchOffset)

--- a/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/auto.strategy.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/auto.strategy.ts
@@ -35,7 +35,7 @@ export class AutoTextSplitterStrategy implements ITextSplitterStrategy<unknown> 
         documents: DocumentInterface<ChunkMetadata>[],
         options?: unknown,
         context: TextSplitterExecutionContext = {}
-    ): Promise<Required<TextSplitterResult>> {
+    ): Promise<TextSplitterResult & Required<Pick<TextSplitterResult, 'decisions'>>> {
         const config = parseStructuredOptions(options)
         validateMaxChunkTokens(context.maxChunkTokens)
         const groups = analyzeStructuredDocuments(documents)
@@ -84,11 +84,16 @@ export class AutoTextSplitterStrategy implements ITextSplitterStrategy<unknown> 
                     .map((source) => source.document)
                 const result =
                     resolved === 'markdown-recursive'
-                        ? await this.markdown.splitDocuments(input, {
-                              chunkSize: config.chunkSize,
-                              chunkOverlap: config.chunkOverlap
-                          })
-                        : await this.recursive.splitDocuments(input, config)
+                        ? await this.markdown.splitDocuments(
+                              input,
+                              {
+                                  chunkSize: config.chunkSize,
+                                  chunkOverlap: config.chunkOverlap,
+                                  separators: config.separators
+                              },
+                              context
+                          )
+                        : await this.recursive.splitDocuments(input, config, context)
                 chunks.push(...result.chunks.map((chunk) => traceLegacyChunk(chunk, decision)))
                 chunks.push(
                     ...group.sources

--- a/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/language-boundaries.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/language-boundaries.ts
@@ -1,0 +1,58 @@
+/// <reference lib="es2022.intl" />
+import type { KnowledgeChunkLanguage } from '@xpert-ai/contracts'
+
+export interface TextRange {
+    start: number
+    end: number
+}
+
+const segmenters = new Map<KnowledgeChunkLanguage, Intl.Segmenter>()
+
+/** CJK prose punctuation ends a bare URL; Han characters remain valid in hosts and paths. */
+export const LANGUAGE_URL_PATTERN =
+    /(?:https?:\/\/|www\.)[^\s<>\u3002\uff01\uff1f\uff1b\uff0c\u3001\u201c\u201d\u2018\u2019\uff08\uff09]+/g
+
+const protectedTextPattern = new RegExp(
+    [
+        /(`+)[\s\S]*?\1|\$[^$\n]+\$|\\\([\s\S]*?\\\)|\\\[[\s\S]*?\\\]|!?\[[^\]\n]*\]\([^\)\n]*\)/.source,
+        LANGUAGE_URL_PATTERN.source
+    ].join('|'),
+    'g'
+)
+
+/** Sentence boundaries are suggestions; callers retain character/token limits and structural ownership. */
+export function sentenceRanges(text: string, language: KnowledgeChunkLanguage): TextRange[] {
+    const ends = new Set<number>()
+    if (typeof Intl.Segmenter === 'function') {
+        let segmenter = segmenters.get(language)
+        if (!segmenter) {
+            segmenter = new Intl.Segmenter(language === 'Chinese' ? 'zh' : 'en', { granularity: 'sentence' })
+            segmenters.set(language, segmenter)
+        }
+        for (const segment of segmenter.segment(text)) ends.add(segment.index + segment.segment.length)
+    } else {
+        for (const match of text.matchAll(/[.!?]+(?:["')\]]*)(?:\s+|$)/g)) ends.add(match.index + match[0].length)
+    }
+    if (language !== 'English') {
+        for (const match of text.matchAll(/[\u3002\uff01\uff1f\uff1b;]+[\u201d\u2019\u300d\u300f"')\]]*/g)) {
+            ends.add(match.index + match[0].length)
+        }
+    }
+    // Do not introduce a language boundary inside inline code, math, links, or URLs.
+    const protectedRanges = [...text.matchAll(protectedTextPattern)].map((match) => ({
+        start: match.index,
+        end: match.index + match[0].length
+    }))
+    const result: TextRange[] = []
+    let start = 0
+    let protectedIndex = 0
+    ends.add(text.length)
+    for (const end of [...ends].sort((a, b) => a - b)) {
+        while (protectedRanges[protectedIndex]?.end <= end) protectedIndex++
+        const protectedRange = protectedRanges[protectedIndex]
+        if (protectedRange && protectedRange.start < end && end < protectedRange.end) continue
+        if (end > start) result.push({ start, end })
+        start = end
+    }
+    return result
+}

--- a/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/language-text-splitter.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/language-text-splitter.ts
@@ -1,0 +1,80 @@
+import type { DocumentInterface } from '@langchain/core/documents'
+import { RecursiveCharacterTextSplitter, type RecursiveCharacterTextSplitterParams } from '@langchain/textsplitters'
+import { decodeKnowledgeSeparators, type KnowledgeChunkLanguage } from '@xpert-ai/contracts'
+import { countTextTokens, type ChunkMetadata, type TextSplitterExecutionContext } from '@xpert-ai/plugin-sdk'
+import { parseMarkdown, parseSource, type StructuredSource } from './structured-document'
+import { sentenceRanges } from './language-boundaries'
+
+type Options = Partial<Omit<RecursiveCharacterTextSplitterParams, 'separators'>> & { separators?: string | string[] }
+
+export function createLanguageTextSplitter(
+    options: Options,
+    document: DocumentInterface<Partial<ChunkMetadata>>,
+    context: TextSplitterExecutionContext = {}
+): RecursiveCharacterTextSplitter {
+    const separators = decodeKnowledgeSeparators(options.separators)
+    if (!separators.includes('')) separators.push('')
+    const config = { ...options, separators }
+    const language = context.resolvedLanguages?.get(document) ?? context.resolvedLanguage
+    return language && options.separators === undefined && !options.lengthFunction
+        ? new LanguageTextSplitter(config, document.metadata, language, context.maxChunkTokens)
+        : new RecursiveCharacterTextSplitter(config)
+}
+
+/** Add sentence boundaries only to natural prose; legacy recursion still handles indivisible/structural text. */
+class LanguageTextSplitter extends RecursiveCharacterTextSplitter {
+    constructor(
+        options: Partial<RecursiveCharacterTextSplitterParams>,
+        private readonly metadata: Partial<ChunkMetadata>,
+        private readonly language: KnowledgeChunkLanguage,
+        private readonly maxTokens?: number
+    ) {
+        super(options)
+    }
+
+    async splitText(text: string): Promise<string[]> {
+        const fits = (value: string) =>
+            value.length <= this.chunkSize && (!this.maxTokens || countTextTokens(value) <= this.maxTokens)
+        if (fits(text)) return text.trim() ? [text.trim()] : []
+        const source: StructuredSource = {
+            document: { pageContent: text, metadata: { ...this.metadata, chunkId: this.metadata.chunkId ?? '' } },
+            index: 0
+        }
+        // Recognize explicit fences even in plain text. This never changes contentFormat or Auto routing.
+        const units = this.metadata.documentLayout ? parseSource(source, []) : parseMarkdown(source, [])
+        const result: string[] = []
+        let pending = ''
+        let cursor = 0
+        const flush = () => {
+            if (pending.trim()) result.push(pending.trim())
+            pending = ''
+        }
+        for (const unit of units) {
+            const body = text.slice(cursor, unit.end)
+            cursor = unit.end
+            if (unit.kind !== 'paragraph') {
+                flush()
+                result.push(...(await super.splitText(body)))
+                continue
+            }
+            for (const range of sentenceRanges(body, this.language)) {
+                const sentence = body.slice(range.start, range.end)
+                if (!fits(sentence)) {
+                    flush()
+                    result.push(...(await super.splitText(sentence)))
+                    continue
+                }
+                if (pending && !fits(pending + sentence)) {
+                    let start = Math.max(0, pending.length - this.chunkOverlap)
+                    if (/[\uDC00-\uDFFF]/.test(pending[start] ?? '')) start++
+                    const overlap = pending.slice(start)
+                    flush()
+                    if (fits(overlap + sentence)) pending = overlap
+                }
+                pending += sentence
+            }
+        }
+        flush()
+        return result
+    }
+}

--- a/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/markdown-recursive.strategy.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/markdown-recursive.strategy.ts
@@ -5,7 +5,12 @@ import {
 } from '../../../knowledge-document/parser-validation'
 import { IconType, KnowledgeStructureEnum } from '@xpert-ai/contracts'
 import { Injectable } from '@nestjs/common'
-import { ChunkMetadata, ITextSplitterStrategy, TextSplitterStrategy } from '@xpert-ai/plugin-sdk'
+import {
+    ChunkMetadata,
+    ITextSplitterStrategy,
+    TextSplitterStrategy,
+    type TextSplitterExecutionContext
+} from '@xpert-ai/plugin-sdk'
 import { Document } from '@langchain/core/documents'
 import { v4 as uuid } from 'uuid'
 import { MarkdownRecursiveTextSplitter, MarkdownRecursiveTextSplitterOptions } from './MarkdownRecursiveTextSplitter'
@@ -19,6 +24,7 @@ export class MarkdownRecursiveStrategy implements ITextSplitterStrategy<
     readonly structure = KnowledgeStructureEnum.General
     readonly meta = {
         name: MarkdownRecursive,
+        supportsLanguageHint: true,
         label: {
             en_US: 'Markdown Recursive',
             zh_Hans: 'Markdown 递归'
@@ -123,12 +129,17 @@ export class MarkdownRecursiveStrategy implements ITextSplitterStrategy<
 
     async splitDocuments(
         documents: Document[],
-        options: Partial<Omit<MarkdownRecursiveTextSplitterOptions, 'headersToSplitOn'> & { headerToSplitOn: number }>
+        options: Partial<Omit<MarkdownRecursiveTextSplitterOptions, 'headersToSplitOn'> & { headerToSplitOn: number }>,
+        context?: TextSplitterExecutionContext
     ) {
-        const splitter = new MarkdownRecursiveTextSplitter({
-            ...options,
-            headersToSplitOn: options.headerToSplitOn && [...Array(options.headerToSplitOn).keys()].map((x) => x + 1)
-        })
+        const splitter = new MarkdownRecursiveTextSplitter(
+            {
+                ...options,
+                headersToSplitOn:
+                    options.headerToSplitOn && [...Array(options.headerToSplitOn).keys()].map((x) => x + 1)
+            },
+            context
+        )
         const chunks = await splitter.transformDocuments(documents)
         return {
             chunks: chunks.map(

--- a/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/recursive-character.strategy.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/recursive-character.strategy.ts
@@ -1,11 +1,17 @@
 import { validateChunkLimits, validateSeparators } from '../../../knowledge-document/parser-validation'
 import { Document } from '@langchain/core/documents'
-import { RecursiveCharacterTextSplitter, RecursiveCharacterTextSplitterParams } from '@langchain/textsplitters'
-import { decodeKnowledgeSeparators, IconType, KnowledgeStructureEnum } from '@xpert-ai/contracts'
+import { RecursiveCharacterTextSplitterParams } from '@langchain/textsplitters'
+import { IconType, KnowledgeStructureEnum } from '@xpert-ai/contracts'
 import { Injectable } from '@nestjs/common'
-import { ChunkMetadata, ITextSplitterStrategy, TextSplitterStrategy } from '@xpert-ai/plugin-sdk'
+import {
+    ChunkMetadata,
+    ITextSplitterStrategy,
+    TextSplitterStrategy,
+    type TextSplitterExecutionContext
+} from '@xpert-ai/plugin-sdk'
 import { v4 as uuid } from 'uuid'
 import { RecursiveCharacter } from './types'
+import { createLanguageTextSplitter } from './language-text-splitter'
 
 @Injectable()
 @TextSplitterStrategy(RecursiveCharacter)
@@ -15,6 +21,7 @@ export class RecursiveCharacterStrategy implements ITextSplitterStrategy<
     readonly structure = KnowledgeStructureEnum.General
     readonly meta = {
         name: RecursiveCharacter,
+        supportsLanguageHint: true,
         label: {
             en_US: 'Recursive Character',
             zh_Hans: '递归字符'
@@ -64,8 +71,7 @@ export class RecursiveCharacterStrategy implements ITextSplitterStrategy<
                     description: {
                         en_US: 'Comma-separated list of delimiters to use for splitting. Double commas are escaped as commas',
                         zh_Hans: '用于拆分的分隔符列表，以逗号分隔。双逗号转义为逗号'
-                    },
-                    default: `\\n\\n,\\n, ,`
+                    }
                 }
             },
             required: []
@@ -83,12 +89,14 @@ export class RecursiveCharacterStrategy implements ITextSplitterStrategy<
 
     async splitDocuments(
         documents: Document[],
-        options: Partial<Omit<RecursiveCharacterTextSplitterParams, 'separators'>> & { separators?: string | string[] }
+        options: Partial<Omit<RecursiveCharacterTextSplitterParams, 'separators'>> & { separators?: string | string[] },
+        context?: TextSplitterExecutionContext
     ): Promise<{ chunks: Document<ChunkMetadata>[] }> {
-        const separators = decodeKnowledgeSeparators(options.separators)
-        if (!separators.includes('')) separators.push('')
-        const splitter = new RecursiveCharacterTextSplitter({ ...options, separators })
-        const chunks = await splitter.splitDocuments(documents)
+        const chunks: Document[] = []
+        for (const document of documents) {
+            const splitter = createLanguageTextSplitter(options, document, context)
+            chunks.push(...(await splitter.splitDocuments([document])))
+        }
         const chunkDocuments: Document<ChunkMetadata>[] = chunks.map(
             (chunk, index) =>
                 new Document<ChunkMetadata>({

--- a/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/structure-aware.strategy.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/structure-aware.strategy.ts
@@ -43,7 +43,7 @@ export class StructureAwareStrategy implements ITextSplitterStrategy<unknown> {
         groups: StructuredDocument[],
         options?: unknown,
         context: TextSplitterExecutionContext = {}
-    ): Promise<Required<TextSplitterResult>> {
+    ): Promise<TextSplitterResult & Required<Pick<TextSplitterResult, 'decisions'>>> {
         const config = parseStructuredOptions(options)
         validateMaxChunkTokens(context.maxChunkTokens)
         const chunks: DocumentInterface<ChunkMetadata>[] = []
@@ -65,7 +65,10 @@ export class StructureAwareStrategy implements ITextSplitterStrategy<unknown> {
                         config.chunkSize,
                         config.chunkOverlap,
                         context.maxChunkTokens,
-                        typeof config.separators === 'string' ? [config.separators] : config.separators
+                        typeof config.separators === 'string' ? [config.separators] : config.separators,
+                        config.separators === undefined
+                            ? (context.resolvedLanguages?.get(group.sources[0].document) ?? context.resolvedLanguage)
+                            : undefined
                     )
                 )
             } else {
@@ -76,7 +79,8 @@ export class StructureAwareStrategy implements ITextSplitterStrategy<unknown> {
                                 !source.document.metadata.mediaType || source.document.metadata.mediaType === 'text'
                         )
                         .map((source) => source.document),
-                    config
+                    config,
+                    context
                 )
                 chunks.push(...result.chunks.map((chunk) => traceLegacyChunk(chunk, decision)))
             }

--- a/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/structure-chunks.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/structure-chunks.ts
@@ -4,6 +4,7 @@ import type {
     KnowledgeChunkingDecision,
     KnowledgeChunkingWarning,
     KnowledgeChunkSourceRange,
+    KnowledgeChunkLanguage,
     TDocumentAsset
 } from '@xpert-ai/contracts'
 import { countTextTokens, type ChunkMetadata } from '@xpert-ai/plugin-sdk'
@@ -11,6 +12,7 @@ import { v4 as uuid } from 'uuid'
 import { splitTextByTokens } from '../../../knowledge-document/token-limited-chunks'
 import { invalidKnowledgeParserConfig } from '../../../knowledge-document/parser-validation'
 import type { StructuredDocument, StructuredSource, StructuredUnit } from './structured-document'
+import { sentenceRanges } from './language-boundaries'
 
 interface Fragment {
     source: StructuredSource
@@ -32,7 +34,8 @@ export function createStructureChunks(
     target: number,
     overlap: number,
     maxTokens?: number,
-    separators: string[] = ['\n\n', '\n', ' ', '']
+    separators: string[] = ['\n\n', '\n', ' ', ''],
+    language?: KnowledgeChunkLanguage
 ): Document<ChunkMetadata>[] {
     const output: Document<ChunkMetadata>[] = []
     let headings: StructuredUnit[] = []
@@ -312,28 +315,36 @@ export function createStructureChunks(
         flushRows()
     }
 
-    function splitParagraph(fragment: Fragment, contexts: Fragment[], priorities: string[]) {
+    function splitParagraph(fragment: Fragment, contexts: Fragment[], priorities: string[], useLanguage = true) {
         if (fits(render([fragment], contexts))) {
             emit([fragment], contexts, ['structure-split'], '', true)
             return
         }
         const text = content(fragment)
+        const sentences = language && useLanguage ? sentenceRanges(text, language) : []
+        const useSentences = sentences.length > 1
         const index = priorities.findIndex((separator) => separator && text.includes(separator))
-        if (index < 0) {
+        if (!useSentences && index < 0) {
             bounded(fragment, contexts, '', true)
             return
         }
         const separator = priorities[index]
-        const parts: Fragment[] = []
+        const parts: Fragment[] = useSentences
+            ? sentences.map((part) => ({
+                  ...fragment,
+                  start: fragment.start + part.start,
+                  end: fragment.start + part.end
+              }))
+            : []
         let start = 0
-        let end = text.indexOf(separator)
+        let end = useSentences ? -1 : text.indexOf(separator)
         while (end >= 0) {
             end += separator.length
             parts.push({ ...fragment, start: fragment.start + start, end: fragment.start + end })
             start = end
             end = text.indexOf(separator, start)
         }
-        if (start < text.length) parts.push({ ...fragment, start: fragment.start + start })
+        if (!useSentences && start < text.length) parts.push({ ...fragment, start: fragment.start + start })
         let pendingPart: Fragment | undefined
         const flushPart = () => {
             if (!pendingPart) return
@@ -347,7 +358,8 @@ export function createStructureChunks(
         for (const part of parts) {
             const combined = pendingPart ? { ...pendingPart, end: part.end } : part
             if (pendingPart && !fits(render([combined], contexts))) flushPart()
-            if (!fits(render([part], contexts))) splitParagraph(part, contexts, priorities.slice(index + 1))
+            if (!fits(render([part], contexts)))
+                splitParagraph(part, contexts, useSentences ? priorities : priorities.slice(index + 1), false)
             else pendingPart = pendingPart ? { ...pendingPart, end: part.end } : part
         }
         flushPart()

--- a/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/structured-document.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/structured-document.ts
@@ -87,7 +87,7 @@ export function analyzeStructuredDocuments(documents: DocumentInterface<ChunkMet
     return groups
 }
 
-function parseSource(source: StructuredSource, warnings: KnowledgeChunkingWarning[]): StructuredUnit[] {
+export function parseSource(source: StructuredSource, warnings: KnowledgeChunkingWarning[]): StructuredUnit[] {
     const { pageContent, metadata } = source.document
     if (!pageContent.trim()) return []
     const format = metadata.contentFormat
@@ -172,7 +172,7 @@ function parseLayout(value: unknown): DocumentLayoutMetadata | undefined {
     return value as DocumentLayoutMetadata
 }
 
-function parseMarkdown(source: StructuredSource, warnings: KnowledgeChunkingWarning[]): StructuredUnit[] {
+export function parseMarkdown(source: StructuredSource, warnings: KnowledgeChunkingWarning[]): StructuredUnit[] {
     const text = source.document.pageContent
     // Marked normalizes line endings. Map every normalized boundary back to the original evidence.
     const offsets: number[] = [0]
@@ -286,6 +286,50 @@ function tokenKind(token: Token): KnowledgeChunkBlockType {
         default:
             return 'other'
     }
+}
+
+/** The caller must bound the source before lexing; use the same Markdown grammar as structural routing. */
+export function* naturalLanguageUnits(document: DocumentInterface<ChunkMetadata>): Generator<string> {
+    const layout = parseLayout(document.metadata.documentLayout)
+    if (layout && !['text', 'title'].includes(layout.type)) return
+    yield* naturalTokens(markdown.lexer(document.pageContent))
+}
+
+function* naturalTokens(tokens: Token[]): Generator<string> {
+    let formulaEnd: string | undefined
+    for (const token of tokens) {
+        // An unclosed formula at the sample boundary must not become prose. Inspect prose tokens
+        // only: dollar strings inside a code fence must not hide the natural text after that fence.
+        if (token.type === 'paragraph' || token.type === 'text') {
+            if (formulaEnd) {
+                if (token.raw.includes(formulaEnd)) formulaEnd = undefined
+                continue
+            }
+            const opening = /^\s*(\$\$|\\\[)/.exec(token.raw)
+            if (opening) {
+                const ending = opening[1] === '$$' ? '$$' : '\\]'
+                if (!token.raw.slice(opening[0].length).includes(ending)) formulaEnd = ending
+                continue
+            }
+        }
+        if (formulaEnd) continue
+        if (token.type === 'list') {
+            for (const item of token.items) yield* naturalTokens(item.tokens)
+        } else if (token.type === 'heading' || token.type === 'paragraph' || token.type === 'text') {
+            yield token.tokens ? inlineNaturalText(token.tokens) : token.text
+        }
+    }
+}
+
+function inlineNaturalText(tokens: Token[]): string {
+    return tokens
+        .map((token) => {
+            if (token.type === 'codespan' || token.type === 'image' || token.type === 'html') return ' '
+            if (token.type === 'escape') return token.raw
+            if ('tokens' in token && token.tokens) return inlineNaturalText(token.tokens)
+            return 'text' in token && typeof token.text === 'string' ? token.text : ' '
+        })
+        .join('')
 }
 
 export function lineRanges(unit: Pick<StructuredUnit, 'text' | 'start'>) {

--- a/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/structured-options.ts
+++ b/packages/server-ai/src/knowledgebase/plugins/textsplitter-common/structured-options.ts
@@ -10,7 +10,10 @@ import {
 } from '../../../knowledge-document/parser-validation'
 
 /** Parse JSON/plugin options once at the strategy boundary; downstream code consumes typed fields. */
-export function parseStructuredOptions(value: unknown): Required<KnowledgeStructuredChunkOptions> {
+export function parseStructuredOptions(
+    value: unknown
+): Required<Pick<KnowledgeStructuredChunkOptions, 'chunkSize' | 'chunkOverlap'>> &
+    Pick<KnowledgeStructuredChunkOptions, 'separators'> {
     if (value === undefined) value = {}
     if (!value || typeof value !== 'object' || Array.isArray(value)) throw invalidKnowledgeParserConfig('textSplitter')
     const chunkSize = 'chunkSize' in value ? value.chunkSize : undefined
@@ -33,19 +36,24 @@ export function parseStructuredOptions(value: unknown): Required<KnowledgeStruct
     return {
         chunkSize: typeof chunkSize === 'number' ? chunkSize : 1000,
         chunkOverlap: typeof chunkOverlap === 'number' ? chunkOverlap : 100,
-        separators: decodeKnowledgeSeparators(
-            typeof separators === 'string'
-                ? separators
-                : Array.isArray(separators) && separators.every((item): item is string => typeof item === 'string')
-                  ? separators
-                  : undefined
-        )
+        separators:
+            separators === undefined
+                ? undefined
+                : decodeKnowledgeSeparators(
+                      typeof separators === 'string'
+                          ? separators
+                          : Array.isArray(separators) &&
+                              separators.every((item): item is string => typeof item === 'string')
+                            ? separators
+                            : undefined
+                  )
     }
 }
 
 export function structuredProvider(name: 'auto' | 'structure-aware'): IDocumentChunkerProvider {
     return {
         name,
+        supportsLanguageHint: true,
         label:
             name === 'auto'
                 ? { en_US: 'Automatic', zh_Hans: '\u81ea\u52a8' }
@@ -91,7 +99,6 @@ export function structuredProvider(name: 'auto' | 'structure-aware'): IDocumentC
                 separators: {
                     type: 'array',
                     items: { type: 'string' },
-                    default: ['\n\n', '\n', ' ', ''],
                     title: {
                         en_US: 'Text fallback separators',
                         zh_Hans: '\u6587\u672c\u56de\u9000\u5206\u9694\u7b26'


### PR DESCRIPTION
# PR

Knowledge chunking now supports a public `chunkLanguageHint` setting (`auto`, `Chinese`, or `English`) that persists at library/document level and is restored when settings reopen. Preview displays both the selected hint and the detected language.

## Behavior

- Resolve language once per document through the shared execution boundary, including converter batches. Use Unicode Han/Latin natural-unit voting with a 16,384 UTF-16 code-unit sample budget (at most 48 KiB UTF-8), without calling an LLM.
- Apply language preferences to natural text boundaries in structure-aware, Markdown recursive, and recursive character splitting. Preserve Auto routing, explicit separators, existing token ceilings, splitter IDs, and parent-child behavior.
- Reuse the existing Markdown grammar, keep default separators distinct from explicit overrides, and include language/revision changes in processing cache keys. Existing stored chunks change only when reprocessed.
- Protect bracket formulas (`\[...\]`) from sentence cuts, and terminate bare URLs at CJK prose punctuation so following Chinese sentences participate in detection and splitting. Regression coverage also preserves international URL paths and explicit Markdown links.

Includes a Changeset for contracts, plugin-sdk, and server-ai. No new dependencies or database migration.

## Validation

- 189 backend tests across 14 focused suites passed, covering detection, execution, three splitters, Auto routing, parent-child compatibility, caching, previews, and token limits.
- 73 frontend tests across 7 focused suites passed, covering controls, serialization, previews, document overrides, and import flows.
- 4 shared-contract tests passed.
- Backend TypeScript check passed: `corepack pnpm exec tsc --noEmit --incremental false --project packages/server-ai/tsconfig.lib.json`.
- New formula and URL regressions were observed failing before the fixes and passed afterward.
- Formatting and diff checks passed; normal commit hooks ran.
- Browser validation was not run. Manual upload/preview verification remains with the requester.

# Checklist

- [x] Have you followed the contributing guidelines?
- [x] Have you explained what your changes do, and why they add value?
